### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: '🐛 Bug Report / 问题反馈'
+title: '[Bug] '
+description: Submit a bug report to help us improve the platform. / 提交问题反馈帮助我们改进平台。
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report this issue! Please fill in the information below to help us locate and fix the problem quickly. / 感谢您抽出时间报告问题！请填写以下信息以帮助我们快速定位和修复问题。
+
+  - type: textarea
+    attributes:
+      label: Environment / 环境
+      description: Please provide your device, browser, and page URL. / 请提供您的设备、浏览器和页面地址。
+      placeholder: |
+        Device:
+        Browser:
+        Page URL:
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Problem Description / 问题描述
+      description: A clear and concise description of what the bug is. / 清晰简洁地描述这个 Bug 是什么。
+      placeholder: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior / 预期行为
+      description: What did you expect to happen instead? / 您期望发生什么？
+      placeholder: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Reproduction Steps / 复现步骤
+      description: Steps to reproduce the issue. / 复现问题的步骤。
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Screenshots / 截图
+      description: If applicable, add screenshots to help explain the problem. / 如果有，添加截图以帮助解释问题。
+      placeholder: Drag and drop images here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct / 我同意遵守本项目的行为准则
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,75 @@
+name: '✨ Feature Request / 功能需求'
+title: '[Feature] '
+description: Suggest an idea for this platform. / 为平台提出一个功能建议。
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for sharing your idea! Please provide as much detail as possible. / 感谢您分享想法！请尽可能提供详细信息。
+
+  - type: textarea
+    attributes:
+      label: Background / 背景
+      description: What problem does the current platform have that needs to be solved? / 当前存在什么问题？为什么需要解决？
+      placeholder: Describe the current pain points.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Target Users / 目标用户
+      description: Which users will use this feature? / 哪些用户会使用该功能？
+      placeholder: e.g., students, teachers, administrators
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: User Story / 用户故事
+      description: As a [type of user], I want [some goal] so that [some reason]. / 作为[某类用户]，我希望[某个目标]，从而[某个原因]。
+      placeholder: As a..., I want..., so that...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Scope / 范围
+      description: What should be implemented in this feature? / 本次需要实现什么？
+      placeholder: List the key deliverables.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Out of Scope / 不做什么
+      description: What is explicitly not included to prevent scope creep. / 明确本次不包含的内容，防止范围扩大。
+      placeholder: What won't be covered this time.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Acceptance Criteria / 验收标准
+      description: Define the conditions that must be met for this feature to be considered complete. / 定义该功能完成的验收条件。
+      placeholder: |
+        - [ ] Users can...
+        - [ ] When..., the system should...
+        - [ ] Works correctly on both mobile and desktop
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Supplementary Materials / 补充材料
+      description: Prototypes, screenshots, discussion records, or related issues. / 原型、截图、讨论记录或相关 Issue。
+      placeholder: Links, designs, or references.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct / 我同意遵守本项目的行为准则
+          required: true


### PR DESCRIPTION
## Summary
- 从 YourTJ-Platform 迁移 2 个 issue 模板到本仓库，统一两个仓库的 issue 提交规范：
  - `.github/ISSUE_TEMPLATE/bug-report.yml`（Bug Report / 问题反馈）
  - `.github/ISSUE_TEMPLATE/feature-request.yml`（Feature Request / 功能需求）
- 模板字段结构、必填校验与 Code of Conduct 复选与 Platform 一致。

## Test plan
- [ ] PR 合并后，在仓库 "New issue" 页面能看到两个模板选项
- [ ] 提交 feature 类 issue 时表单必填字段正确渲染