### PR TITLE
ci: deploy pipeline fixes (static build, ssh port, binary perms, init idempotency)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,6 +8,7 @@ on:
       - "research/**"
       - "**.md"
       - ".playwright-mcp/**"
+  workflow_dispatch:
 
 concurrency:
   group: deploy-dev

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Build binary
+      - name: Build binary (static, no cgo for alpine/musl)
         working-directory: apps/gooseforum
-        run: go build -o ../../bin/yourtj-hub .
+        run: CGO_ENABLED=0 go build -o ../../bin/yourtj-hub .
       - uses: actions/upload-artifact@v4
         with:
           name: yourtj-hub

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -59,6 +59,7 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "bin/yourtj-hub"
           target: "/tmp"
           strip_components: 1
@@ -68,6 +69,7 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
             # 1. 同步 main 数据库一致性快照(dev 用 main 真实数据预演迁移)

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Build binary
+      - name: Build binary (static, no cgo for alpine/musl)
         working-directory: apps/gooseforum
-        run: go build -o ../../bin/yourtj-hub .
+        run: CGO_ENABLED=0 go build -o ../../bin/yourtj-hub .
       - uses: actions/upload-artifact@v4
         with:
           name: yourtj-hub

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -8,6 +8,7 @@ on:
       - "research/**"
       - "**.md"
       - ".playwright-mcp/**"
+  workflow_dispatch:
 
 concurrency:
   group: deploy-main

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -60,6 +60,7 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "bin/yourtj-hub"
           target: "/tmp"
           strip_components: 1
@@ -69,6 +70,7 @@ jobs:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
             # 1. 部署前一致性备份(保留最近 7 份)

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -18,7 +18,7 @@ IMAGE="yourtj-hub"
 
 log() { echo "[deploy:$INSTANCE] $*"; }
 
-[ -x "$NEW_BINARY" ] || { log "FATAL: new binary not executable: $NEW_BINARY"; exit 1; }
+[ -f "$NEW_BINARY" ] || { log "FATAL: new binary not found: $NEW_BINARY"; exit 1; }
 [ -f "$ENV_FILE" ] || { log "FATAL: $ENV_FILE missing (run init-server.sh first)"; exit 1; }
 [ -f "$COMPOSE_FILE" ] || { log "FATAL: $COMPOSE_FILE missing (run init-server.sh first)"; exit 1; }
 [ -f "$BUILD_DIR/Dockerfile" ] || { log "FATAL: $BUILD_DIR/Dockerfile missing (run init-server.sh first)"; exit 1; }

--- a/deploy/scripts/init-server.sh
+++ b/deploy/scripts/init-server.sh
@@ -10,17 +10,28 @@ DEV_DOMAIN="${2:-https://dev.yourtj.de}"
 ROOT=/opt/yourtj
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# 1. 目录结构
+# 1. 依赖: 部署脚本需要 sqlite3 CLI 做 .backup 一致性快照
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  apt-get update -qq && apt-get install -y -qq sqlite3
+fi
+
+# 2. 目录结构
 mkdir -p "$ROOT"/{build,scripts,snapshots,main/storage,dev/storage}
 
-# 2. 复制 Dockerfile / compose / 配置模板 / 脚本
-cp "$SCRIPT_DIR/../Dockerfile" "$ROOT/build/Dockerfile"
-cp "$SCRIPT_DIR/../docker-compose.yaml" "$ROOT/docker-compose.yaml"
-cp "$SCRIPT_DIR/../config.toml.example" "$ROOT/config.toml.example"
-cp "$SCRIPT_DIR"/*.sh "$ROOT/scripts/"
+# 3. 复制 Dockerfile / compose / 配置模板 / 脚本(源=目标时跳过)
+copy_if_diff() {
+  local src="$1" dst="$2"
+  [ "$(realpath "$src")" = "$(realpath "$dst")" ] && return 0
+  cp "$src" "$dst"
+}
+copy_if_diff "$SCRIPT_DIR/../Dockerfile" "$ROOT/build/Dockerfile"
+copy_if_diff "$SCRIPT_DIR/../docker-compose.yaml" "$ROOT/docker-compose.yaml"
+copy_if_diff "$SCRIPT_DIR/../config.toml.example" "$ROOT/config.toml.example"
+for f in "$SCRIPT_DIR"/*.sh; do
+  copy_if_diff "$f" "$ROOT/scripts/$(basename "$f")"
+done
 chmod +x "$ROOT/scripts/"*.sh
-
-# 3. 生成 .env(不存在时)
+# 4. 生成 .env(不存在时)
 if [ ! -f "$ROOT/.env" ]; then
   cat > "$ROOT/.env" <<'EOF'
 MAIN_PORT=5234
@@ -31,7 +42,7 @@ EOF
   echo "init: $ROOT/.env created"
 fi
 
-# 4. 生成 config.toml(随机 signingKey, 域名参数化)
+# 5. 生成 config.toml(随机 signingKey, 域名参数化)
 GEN_KEY="$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)"
 for inst in main dev; do
   if [ ! -f "$ROOT/$inst/config.toml" ]; then
@@ -43,11 +54,12 @@ for inst in main dev; do
   fi
 done
 
-# 5. 权限: 容器内进程 uid 1000, 需要可写 storage
-chown -R 1000:1000 "$ROOT/main/storage" "$ROOT/dev/storage" 2>/dev/null || true
+# 6. 权限: 宿主部署用户 yourtj uid=1000 与容器内 app uid=1000 一致,
+#    整体交给 1000:1000, 保证 CI 可写、容器可写 storage
+chown -R 1000:1000 "$ROOT"
 
 echo ""
 echo "=== INIT DONE ==="
-echo "  main: $ROOT/main   (port $MAIN_PORT, domain $MAIN_DOMAIN)"
-echo "  dev:  $ROOT/dev    (port $DEV_PORT, domain $DEV_DOMAIN)"
-echo "  下一步: 在 GitHub 配置 Secrets (VM_HOST/VM_USER/VM_SSH_KEY), 推送 dev 分支触发部署"
+echo "  main: $ROOT/main   (port $(grep '^MAIN_PORT=' "$ROOT/.env" | cut -d= -f2), domain $MAIN_DOMAIN)"
+echo "  dev:  $ROOT/dev    (port $(grep '^DEV_PORT=' "$ROOT/.env" | cut -d= -f2), domain $DEV_DOMAIN)"
+echo "  下一步: 推送 dev 分支触发 CI 部署(需已配置 GitHub Secrets VM_HOST/VM_USER/VM_SSH_KEY)"


### PR DESCRIPTION
## Summary

Dev 分支的 CI/CD 部署管线修复,已通过 dev 实例全链路验证(dev.yourtj.de 已上线):

| 提交 | 修复内容 |
|---|---|
| `da0b0a7` | `CGO_ENABLED=0` 静态编译(二进制可在 alpine/musl 运行);init-server.sh 幂等化(源=目标跳过、端口从 .env 读取) |
| `c3d9641` | SSH 端口可配置(服务器 sshd 在 5522 非 22,由 `VM_SSH_PORT` secret 控制) |
| `61b0ae8` | 增加 `workflow_dispatch` 支持手动部署 |
| `ece124e` | deploy.sh 接受 scp 上传的 0644 二进制(改为存在性检查,install 补执行位) |

## Verification

- dev 实例部署全链路成功:build → scp → 镜像构建 → 容器 healthy → `/health` 200
- https://dev.yourtj.de 公网访问 200,页面正常
- main 合并后将自动部署 forum.yourtj.de(1Panel 反代已指向 127.0.0.1:5234)

## 合并后

- CI 自动触发 deploy-main → main 容器启动 → forum.yourtj.de 上线
- 需要 GitHub secret `VM_SSH_PORT=5522`(已配置)