### PR TITLE
chore(deploy): activate postgres + meilisearch services and PG-aware db scripts

### DIFF
--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -34,30 +34,39 @@ services:
       retries: 30
       start_period: 10s
 
-  # 可选 PostgreSQL 服务（仅当主库 [db.default] connection="postgres" 时需要）。
-  # 默认注释掉；启用后需在 /opt/yourtj/.env 中配置 POSTGRES_USER/POSTGRES_PASSWORD，
-  # 并在 main/config.toml / dev/config.toml 的 [db.default] 中把 url 指向本服务
-  # （host=postgres，Compose 网络内服务名；容器内 127.0.0.1 指向论坛自身，无法连接）。
-  # main 与 dev 必须使用两个独立数据库（yourtj_main / yourtj_dev），
-  # 保持生产/测试隔离（见 docs/operations/deployment.md「PostgreSQL support」）。
-  # 文件库 [db.file] 固定使用 SQLite，不受影响。
-  # postgres:
-  #   image: postgres:16-alpine
-  #   container_name: yourtj-postgres
-  #   restart: unless-stopped
-  #   environment:
-  #     POSTGRES_USER: ${POSTGRES_USER:-yourtj}
-  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-yourtj}
-  #     POSTGRES_DB: ${POSTGRES_DB:-yourtj}
-  #   volumes:
-  #     - pgdata:/var/lib/postgresql/data
-  #   healthcheck:
-  #     test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-yourtj}"]
-  #     interval: 10s
-  #     timeout: 5s
-  #     retries: 10
-  #   networks:
-  #     - default
+  postgres:
+    image: postgres:16-alpine
+    container_name: yourtj-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-yourtj}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-yourtj}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.11
+    container_name: yourtj-meilisearch
+    restart: unless-stopped
+    environment:
+      MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}
+      MEILI_NO_ANALYTICS: "true"
+    ports:
+      - "127.0.0.1:7700:7700"
+    volumes:
+      - meilidata:/meili_data
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:7700/health >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
 volumes:
   pgdata:
+  meilidata:

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -10,6 +10,12 @@ YOURTJ_PORT=5234
 MEILI_URL=http://localhost:7700
 MEILI_MASTER_KEY=yourtj-dev-master-key
 
+# PostgreSQL (main db, matches config.toml [db.default] when connection="postgres").
+# main/dev use two separate databases (yourtj_main / yourtj_dev) to keep instances isolated.
+POSTGRES_USER=yourtj
+POSTGRES_PASSWORD=
+POSTGRES_DB=postgres
+
 # Auth (Casdoor, unified auth planned)
 CASDOOR_ISSUER=http://localhost:8001
 CASDOOR_CLIENT_ID=

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# backup-db.sh — 实例部署前数据库一致性备份(主库 + 文件库), 保留最近 KEEP 份。
+# backup-db.sh — 实例部署前数据库一致性备份, 保留最近 KEEP 份。
+# 主库模式自动检测: SQLite(.backup) 或 PostgreSQL(pg_dump)。
 # usage: backup-db.sh [instance]
 set -euo pipefail
 
@@ -10,12 +11,48 @@ DB_DIR="$ROOT/$INSTANCE/storage/database"
 BACKUP_DIR="$ROOT/snapshots/$INSTANCE"
 TS="$(date +%Y%m%d_%H%M%S)"
 
+mkdir -p "$BACKUP_DIR"
+
+# 检测主库模式: 读 config.toml [db.default] connection
+db_mode() {
+  local cfg="$ROOT/$INSTANCE/config.toml"
+  [ -f "$cfg" ] || { echo sqlite; return; }
+  if grep -E '^\s*connection\s*=\s*"postgres"' "$cfg" >/dev/null 2>&1; then
+    echo postgres
+  else
+    echo sqlite
+  fi
+}
+
+pg_dbname() {
+  grep -E '^\s*url\s*=' "$ROOT/$INSTANCE/config.toml" | grep -oE 'dbname=[^ ]+' | cut -d= -f2 || true
+}
+
+if [ "$(db_mode)" = "postgres" ]; then
+  PG_DB="$(pg_dbname)"
+  if [ -z "$PG_DB" ]; then
+    echo "backup-db: cannot parse dbname from $ROOT/$INSTANCE/config.toml" >&2
+    exit 1
+  fi
+  TMP="/tmp/backup-${PG_DB}-$$.sql"
+  if docker exec yourtj-postgres pg_dump -U yourtj -d "$PG_DB" > "$TMP"; then
+    mv -f "$TMP" "$BACKUP_DIR/pg-${PG_DB}-${TS}.sql"
+    echo "backup-db: $INSTANCE pg dump ($PG_DB) backed up"
+  else
+    echo "backup-db: pg_dump failed for $PG_DB" >&2
+    rm -f "$TMP"
+    exit 1
+  fi
+  # 清理旧 PG 备份(每库保留 KEEP 份)
+  ls -1t "$BACKUP_DIR"/pg-${PG_DB}-*.sql 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
+  echo "backup-db: $INSTANCE pg backups done (keep $KEEP)"
+  exit 0
+fi
+
 if [ ! -d "$DB_DIR" ]; then
   echo "backup-db: $DB_DIR not found, skip"
   exit 0
 fi
-
-mkdir -p "$BACKUP_DIR"
 
 backup_one() {
   local db="$1" label="$2"

--- a/deploy/scripts/sync-db-from-main.sh
+++ b/deploy/scripts/sync-db-from-main.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# sync-db-from-main.sh — dev 实例从 main 同步 SQLite 一致性快照(单向)。
-# 同步主库(sqlite.db)+ 文件库(file.db, 媒体 BLOB), 保证 dev 有完整媒体数据。
-# 先停止 dev 容器避免文件句柄冲突, 替换后由 deploy.sh 重新拉起。
+# sync-db-from-main.sh — dev 实例从 main 同步一致性数据快照(单向)。
+# 主库模式自动检测: SQLite(.backup) 或 PostgreSQL(pg_dump|psql, 重建 dev 库)。
 # usage: sync-db-from-main.sh
 set -euo pipefail
 
@@ -15,6 +14,39 @@ COMPOSE_FILE="$ROOT/docker-compose.yaml"
 
 # 停 dev 容器, 避免覆盖已打开数据库文件导致数据写丢
 docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" stop dev >/dev/null 2>&1 || true
+
+db_mode() {
+  local cfg="$1"
+  [ -f "$cfg" ] || { echo sqlite; return; }
+  if grep -E '^\s*connection\s*=\s*"postgres"' "$cfg" >/dev/null 2>&1; then
+    echo postgres
+  else
+    echo sqlite
+  fi
+}
+
+pg_dbname() {
+  local cfg="$1"
+  grep -E '^\s*url\s*=' "$cfg" | grep -oE 'dbname=[^ ]+' | cut -d= -f2 || true
+}
+
+MAIN_MODE="$(db_mode "$ROOT/main/config.toml")"
+DEV_MODE="$(db_mode "$ROOT/dev/config.toml")"
+
+if [ "$MAIN_MODE" = "postgres" ] && [ "$DEV_MODE" = "postgres" ]; then
+  MAIN_PG="$(pg_dbname "$ROOT/main/config.toml")"
+  DEV_PG="$(pg_dbname "$ROOT/dev/config.toml")"
+  if [ -z "$MAIN_PG" ] || [ -z "$DEV_PG" ]; then
+    echo "sync-db: cannot parse PG dbnames from configs" >&2
+    exit 1
+  fi
+  echo "sync-db: PG mode ($MAIN_PG -> $DEV_PG)"
+  docker exec yourtj-postgres psql -U yourtj -d postgres \
+    -c "DROP DATABASE IF EXISTS \"$DEV_PG\";" -c "CREATE DATABASE \"$DEV_PG\";" >/dev/null
+  docker exec yourtj-postgres sh -c "pg_dump -U yourtj -d \"$MAIN_PG\" | psql -U yourtj -d \"$DEV_PG\"" >/dev/null
+  echo "sync-db: dev PG db synced from main"
+  exit 0
+fi
 
 # 保留 dev 旧库一份(排查用)
 if [ -f "$DEV_DB" ]; then

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -26,7 +26,7 @@
 
 ```
 /opt/yourtj/
-  .env                    # MAIN_PORT/DEV_PORT/MAIN_TAG/DEV_TAG (created by init-server.sh)
+  .env                    # MAIN_PORT/DEV_PORT/MAIN_TAG/DEV_TAG + POSTGRES_USER/POSTGRES_PASSWORD/MEILI_MASTER_KEY (created by init-server.sh)
   docker-compose.yaml     # main + dev services (created by init-server.sh)
   config.toml.example     # template with REPLACE_* placeholders
   build/
@@ -39,8 +39,8 @@
     config.toml           # dev config
     storage/
   snapshots/
-    main/sqlite-*.db      # pre-deploy backups (keep 7)
-    dev-prev/             # previous dev db before sync (troubleshooting)
+    main/sqlite-*.db      # pre-deploy backups (keep 7) — SQLite 部署
+    main/pg-*.sql         # pre-deploy pg_dump backups (keep 7) — PostgreSQL 部署
 ```
 
 ## Branch model & CI/CD
@@ -48,7 +48,8 @@
 - `dev` is the default branch and the main development line; merges to `dev` trigger
   `.github/workflows/deploy-dev.yml`:
   1. Build single binary (frontend + go build) on GitHub Actions.
-  2. Upload binary via scp; SSH: `sync-db-from-main.sh` (SQLite `.backup` snapshot of main db → dev db).
+  2. Upload binary via scp; SSH: `sync-db-from-main.sh` (auto-detects mode: SQLite `.backup` snapshot
+     or PG `pg_dump|psql` rebuild of dev db).
   3. SSH: `deploy.sh dev <binary> dev-<sha> 5235` → build image, compose up, health check, rollback.
 - `main` is the production site; merges to `main` trigger `.github/workflows/deploy-main.yml`:
   1. Build single binary on GitHub Actions.
@@ -149,16 +150,18 @@ instance:
 
 ### Backup and sync scripts under PostgreSQL
 
-- `backup-db.sh` / `snapshot-db.sh` / `sync-db-from-main.sh` use the SQLite `.backup` API and only
-  apply to SQLite deployments. For a PG deployment, back up main with `pg_dump` (e.g. nightly cron)
-  and sync dev from main with:
+- `backup-db.sh` / `sync-db-from-main.sh` auto-detect the main-db mode from each instance's
+  `config.toml`:
+  - SQLite: use the SQLite `.backup` API (unchanged legacy path).
+  - PostgreSQL: `backup-db.sh` runs `pg_dump` into `snapshots/<instance>/pg-<db>-<ts>.sql`;
+    `sync-db-from-main.sh` drops/recreates `yourtj_dev` and pipes
+    `pg_dump -d yourtj_main | psql -d yourtj_dev` (dev is a clean one-way snapshot of main).
+- Manual equivalent inside the postgres container:
   ```bash
-  # 在 postgres 容器内执行: dev 库重建 + 从 main 库一致性恢复
   docker compose exec postgres sh -c \
     'pg_dump -U yourtj -d yourtj_main | psql -U yourtj -d yourtj_dev'
   ```
-  (drop/recreate `yourtj_dev` first if it must be a clean snapshot). SQLite deployments are
-  unaffected.
+- `snapshot-db.sh` remains a generic SQLite snapshot helper; it is not used by PG deployments.
 
 ### Logging configuration (issue #11)
 


### PR DESCRIPTION
## Summary

部署基础设施同步（与生产服务器实际状态一致，Issue #11 落地的运维配套）：

1. **`deploy/docker-compose.yaml`**：激活 `postgres`（16-alpine）+ `meilisearch`（v1.11）两个服务，凭据从 `.env` 注入（`POSTGRES_USER`/`POSTGRES_PASSWORD`/`MEILI_MASTER_KEY`），main/dev 实例使用两个独立数据库（`yourtj_main`/`yourtj_dev`）保持隔离。
2. **`deploy/env.example`**：补充 PG/Meilisearch 凭据字段说明。
3. **`deploy/scripts/backup-db.sh` / `sync-db-from-main.sh`**：自动检测主库模式（读各实例 `config.toml`）——
   - SQLite：沿用 `.backup` API（不变）
   - PostgreSQL：`backup-db.sh` 用 `pg_dump` 生成 `snapshots/<instance>/pg-<db>-<ts>.sql`；`sync-db-from-main.sh` 重建 `yourtj_dev` 并 `pg_dump | psql` 从 main 单向同步
4. **`docs/operations/deployment.md`**：更新备份/同步脚本双模式说明与 PG 快照路径。

## 验证

- 两个脚本的 PG 分支已在生产服务器实测通过：
  - `backup-db.sh main` → 生成 `pg-yourtj_main-20260806_215419.sql`
  - `sync-db-from-main.sh` → `PG mode (yourtj_main -> yourtj_dev)`，重建后 dev 数据与 main 一致（users 2 / topics 1 / posts 1 / page_config 8），dev health 200
- SQLite 分支逻辑保持不变（原 `.backup` 路径）

## 说明

- 无凭据进入 git：服务器 `.env` 与 `config.toml` 均 gitignored
- 纯部署/文档改动，不含应用代码