### PR TITLE
fix(auth): repair PostgreSQL schema migration for issue #8 session/TOTP tables

### DIFF
--- a/.agents/skills/yourtj-development/SKILL.md
+++ b/.agents/skills/yourtj-development/SKILL.md
@@ -88,6 +88,18 @@ Then run the exact gates for changed paths:
 
 - Backend: `cd apps/gooseforum && go vet ./... && go test ./...` (use `GOPROXY=https://goproxy.cn,direct`
   if module fetch times out).
+- **PostgreSQL migration gate (mandatory for any model/migration change):** run the PG migration
+  tests against a real PostgreSQL. The models must not hardcode MySQL-only types
+  (`bigint unsigned` / `datetime` / `tinyint`) — GORM generates `bigint unsigned` from such tags and
+  PG rejects it, the table is never created, and the service starts with a broken schema (issue #8
+  regression). Verify with:
+  ```bash
+  docker run -d --name yourtj-pg-verify -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+    -e POSTGRES_DB=postgres -p 55432:5432 postgres:16-alpine
+  cd apps/gooseforum && YOURTJ_TEST_PG_URL="host=127.0.0.1 port=55432 user=postgres password=postgres \
+    dbname=postgres sslmode=disable" go test ./app/migration/ -run TestSchemaMigratesOnPostgreSQL -v
+  ```
+  CI runs the same gate in the `ci-backend-pg` job; do not rely on it passing locally — run it.
 - Web: `cd apps/gooseforum/resource && pnpm typecheck && pnpm build` (output lands in static/dist).
 - Full build: `make build` then smoke-test the binary (`./bin/yourtj-hub serve`, then curl the
   configured port, default 5234).

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -56,4 +56,4 @@ jobs:
         working-directory: apps/gooseforum
         env:
           YOURTJ_TEST_PG_URL: "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable"
-        run: go test ./app/migration/ -run TestSchemaMigratesOnPostgreSQL -v
+        run: go test ./app/migration/ -run 'TestSchema' -v

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -27,3 +27,33 @@ jobs:
       - name: Build
         working-directory: apps/gooseforum
         run: go build .
+
+  # 全部主库模型必须在 PostgreSQL 上可迁移。回归背景: issue #8 曾因模型里
+  # 硬编码 MySQL 类型(bigint unsigned/datetime/tinyint)导致 PG 建表失败、
+  # 服务带残缺 schema 启动, 登录/注册运行期才报错。此 job 用真实 PG 验证。
+  ci-backend-pg:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - name: Test (PostgreSQL migration)
+        working-directory: apps/gooseforum
+        env:
+          YOURTJ_TEST_PG_URL: "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable"
+        run: go test ./app/migration/ -run TestSchemaMigratesOnPostgreSQL -v

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,10 @@ docs/        Docs center (product/architecture/development/operations)
 ## 4. Verification
 
 - Backend: `cd apps/gooseforum && go vet ./... && go test ./...` (use `GOPROXY=https://goproxy.cn,direct`
-  if module fetch times out)
+  if module fetch times out). **Any model/migration change must also pass the PostgreSQL migration
+  test**: `YOURTJ_TEST_PG_URL="host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable" go test ./app/migration/ -run TestSchemaMigratesOnPostgreSQL -v`
+  (spin up `postgres:16-alpine` locally; CI runs the same test in `ci-backend-pg`). MySQL-only type
+  tags (`bigint unsigned` / `datetime` / `tinyint`) break PG and are forbidden in models.
 - Web: `cd apps/gooseforum/resource && pnpm typecheck && pnpm build` (output into resource/static/dist)
 - Full build: `make build` (resource → go build single binary `bin/yourtj-hub`)
 - Smoke: run `./bin/yourtj-hub serve` then curl the homepage/API (port from config.toml, default 5234)

--- a/apps/gooseforum/app/migration/migration.go
+++ b/apps/gooseforum/app/migration/migration.go
@@ -3,6 +3,7 @@ package migration
 import (
 	_ "embed"
 	"log/slog"
+	"os"
 
 	"github.com/leancodebox/GooseForum/app/bundles/connect/db4fileconnect"
 	"github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
@@ -55,7 +56,29 @@ func migrateSchema() {
 	var err error
 
 	db := dbconnect.Connect()
-	if err = db.AutoMigrate(
+	if err = db.AutoMigrate(SchemaModels()...); err != nil {
+		// 迁移失败必须立即退出（非零码），否则服务会带着残缺 schema 继续启动，
+		// 登录/注册等依赖新表的接口在运行期才会报错，故障被发现时已影响线上。
+		// 进程管理器会因此把实例标记为启动失败，触发回滚或告警。
+		slog.Error("dbconnect migration err", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("dbconnect migration end")
+
+	db4file := db4fileconnect.Connect()
+	if err = db4file.AutoMigrate(
+		&filedata.Entity{},
+	); err != nil {
+		slog.Error("db4fileconnect migration err", "err", err)
+		os.Exit(1)
+	}
+	slog.Info("db4fileconnect migration end")
+}
+
+// SchemaModels 返回主库（db.default）的全部迁移模型。
+// 迁移与 PostgreSQL 兼容性测试共用同一份清单，避免两处维护漂移。
+func SchemaModels() []any {
+	return []any{
 		&badges.Entity{},
 		&eventNotification.Entity{},
 		&fileUsage.Entity{},
@@ -89,19 +112,5 @@ func migrateSchema() {
 		&messages.Entity{},
 		&dailyStats.Entity{},
 		&userActivities.Entity{},
-	); err != nil {
-		slog.Error("dbconnect migration err", "err", err)
-	} else {
-		slog.Info("dbconnect migration end")
 	}
-
-	db4file := db4fileconnect.Connect()
-	if err = db4file.AutoMigrate(
-		&filedata.Entity{},
-	); err != nil {
-		slog.Error("db4fileconnect migration err", "err", err)
-	} else {
-		slog.Info("db4fileconnect migration end")
-	}
-
 }

--- a/apps/gooseforum/app/migration/migration_pg_test.go
+++ b/apps/gooseforum/app/migration/migration_pg_test.go
@@ -1,0 +1,97 @@
+package migration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/leancodebox/GooseForum/app/models/forum/topics"
+	"github.com/leancodebox/GooseForum/app/models/forum/userOAuth"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// TestSchemaMigratesOnPostgreSQL 验证全部主库模型能在 PostgreSQL 上完成 AutoMigrate。
+//
+// 回归背景（issue #8）：user_sessions / user_totp / user_totp_recovery_codes 曾硬编码
+// MySQL 专用类型（bigint unsigned / datetime / tinyint），在 PostgreSQL 上建表失败，
+// 而迁移错误只记日志不退出，服务带着残缺 schema 启动，登录/注册接口运行期才报错。
+//
+// 通过环境变量 YOURTJ_TEST_PG_URL 提供 PostgreSQL DSN；未设置时跳过。
+// 测试使用独立数据库，会重建 public schema，不会触碰业务数据。
+func TestSchemaMigratesOnPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL migration test")
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+
+	// 清空 schema 保证幂等，然后全量迁移
+	if err := db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`).Error; err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if err := db.AutoMigrate(SchemaModels()...); err != nil {
+		t.Fatalf("AutoMigrate on postgres failed: %v", err)
+	}
+
+	// 关键新表必须存在（issue #8 回归点）
+	for _, table := range []string{
+		"user_sessions",
+		"user_totp",
+		"user_totp_recovery_codes",
+		"user_o_auth",
+		"users",
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Errorf("table %q missing after postgres migration", table)
+		}
+	}
+}
+
+// TestSchemaUpgradeCreatesNewTablesOnPostgreSQL 模拟存量实例升级场景：
+// 旧库（如 main 的 v0.0.6）没有 issue #8 新增的表，部署新二进制后
+// AutoMigrate 必须自动补齐这些表。这是 main 未来自动部署不出问题的直接保障。
+func TestSchemaUpgradeCreatesNewTablesOnPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL migration test")
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+
+	// 先只迁移旧版已有的部分表，模拟 issue #8 之前的 main 库
+	if err := db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`).Error; err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	legacy := []any{&users.EntityComplete{}, &userOAuth.Entity{}, &topics.Entity{}}
+	if err := db.AutoMigrate(legacy...); err != nil {
+		t.Fatalf("AutoMigrate legacy subset failed: %v", err)
+	}
+	if db.Migrator().HasTable("user_sessions") {
+		t.Fatal("precondition failed: legacy schema should not have user_sessions")
+	}
+
+	// 部署新二进制：全量 AutoMigrate 应补齐新表且不破坏旧表
+	if err := db.AutoMigrate(SchemaModels()...); err != nil {
+		t.Fatalf("upgrade AutoMigrate on postgres failed: %v", err)
+	}
+	for _, table := range []string{
+		"user_sessions",
+		"user_totp",
+		"user_totp_recovery_codes",
+		"user_o_auth",
+		"users",
+		"topics",
+	} {
+		if !db.Migrator().HasTable(table) {
+			t.Errorf("table %q missing after upgrade migration", table)
+		}
+	}
+}

--- a/apps/gooseforum/app/models/forum/userSessions/userSessions.go
+++ b/apps/gooseforum/app/models/forum/userSessions/userSessions.go
@@ -31,14 +31,14 @@ const fieldCreatedAt = "created_at"
 const fieldUpdatedAt = "updated_at"
 
 type Entity struct {
-	Id        uint64    `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                           // id
-	UserId    uint64    `gorm:"column:user_id;type:bigint unsigned;not null;default:0;index" json:"userId"`       // 关联用户id
-	Jti       string    `gorm:"column:jti;type:varchar(64);not null;default:'';uniqueIndex" json:"jti"`           // 会话唯一ID（JWT jti claim）
-	UserAgent string    `gorm:"column:user_agent;type:varchar(512);not null;default:'';" json:"userAgent"`        // 用户代理
-	Ip        string    `gorm:"column:ip;type:varchar(64);not null;default:'';" json:"ip"`                        // 登录IP
-	ExpiresAt time.Time `gorm:"column:expires_at;type:datetime;index;" json:"expiresAt"`                          // 会话过期时间
-	CreatedAt time.Time `gorm:"column:created_at;type:datetime;index;autoCreateTime;<-:create;" json:"createdAt"` //
-	UpdatedAt time.Time `gorm:"column:updated_at;type:datetime;autoUpdateTime;" json:"updatedAt"`                 //
+	Id        uint64    `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                    // id
+	UserId    uint64    `gorm:"column:user_id;not null;default:0;index" json:"userId"`                     // 关联用户id
+	Jti       string    `gorm:"column:jti;type:varchar(64);not null;default:'';uniqueIndex" json:"jti"`    // 会话唯一ID（JWT jti claim）
+	UserAgent string    `gorm:"column:user_agent;type:varchar(512);not null;default:'';" json:"userAgent"` // 用户代理
+	Ip        string    `gorm:"column:ip;type:varchar(64);not null;default:'';" json:"ip"`                 // 登录IP
+	ExpiresAt time.Time `gorm:"column:expires_at;index;" json:"expiresAt"`                                 // 会话过期时间
+	CreatedAt time.Time `gorm:"column:created_at;index;autoCreateTime;<-:create;" json:"createdAt"`        //
+	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`                        //
 }
 
 func (itself *Entity) TableName() string {

--- a/apps/gooseforum/app/models/forum/userTotp/userTotp.go
+++ b/apps/gooseforum/app/models/forum/userTotp/userTotp.go
@@ -25,12 +25,12 @@ const fieldCreatedAt = "created_at"
 const fieldUpdatedAt = "updated_at"
 
 type Entity struct {
-	Id              uint64    `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                           // id
-	UserId          uint64    `gorm:"column:user_id;type:bigint unsigned;not null;default:0;uniqueIndex" json:"userId"` // 关联用户id
-	SecretEncrypted string    `gorm:"column:secret_encrypted;type:varchar(512);not null;default:'';" json:"-"`          // 加密后的TOTP密钥
-	Enabled         int8      `gorm:"column:enabled;type:tinyint;not null;default:0;" json:"enabled"`                   // 是否已启用
-	CreatedAt       time.Time `gorm:"column:created_at;type:datetime;index;autoCreateTime;<-:create;" json:"createdAt"` //
-	UpdatedAt       time.Time `gorm:"column:updated_at;type:datetime;autoUpdateTime;" json:"updatedAt"`                 //
+	Id              uint64    `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                  // id
+	UserId          uint64    `gorm:"column:user_id;not null;default:0;uniqueIndex" json:"userId"`             // 关联用户id
+	SecretEncrypted string    `gorm:"column:secret_encrypted;type:varchar(512);not null;default:'';" json:"-"` // 加密后的TOTP密钥
+	Enabled         int8      `gorm:"column:enabled;not null;default:0;" json:"enabled"`                       // 是否已启用
+	CreatedAt       time.Time `gorm:"column:created_at;index;autoCreateTime;<-:create;" json:"createdAt"`      //
+	UpdatedAt       time.Time `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`                      //
 }
 
 func (itself *Entity) TableName() string {

--- a/apps/gooseforum/app/models/forum/userTotpRecoveryCodes/userTotpRecoveryCodes.go
+++ b/apps/gooseforum/app/models/forum/userTotpRecoveryCodes/userTotpRecoveryCodes.go
@@ -22,11 +22,11 @@ const fieldUsedAt = "used_at"
 const fieldCreatedAt = "created_at"
 
 type Entity struct {
-	Id        uint64     `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                           // id
-	UserId    uint64     `gorm:"column:user_id;type:bigint unsigned;not null;default:0;index" json:"userId"`       // 关联用户id
-	CodeHash  string     `gorm:"column:code_hash;type:varchar(128);not null;default:'';uniqueIndex" json:"-"`      // 恢复码SHA-256哈希
-	UsedAt    *time.Time `gorm:"column:used_at;type:datetime;" json:"usedAt"`                                      // 使用时间，为空表示未使用
-	CreatedAt time.Time  `gorm:"column:created_at;type:datetime;index;autoCreateTime;<-:create;" json:"createdAt"` //
+	Id        uint64     `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                      // id
+	UserId    uint64     `gorm:"column:user_id;not null;default:0;index" json:"userId"`                       // 关联用户id
+	CodeHash  string     `gorm:"column:code_hash;type:varchar(128);not null;default:'';uniqueIndex" json:"-"` // 恢复码SHA-256哈希
+	UsedAt    *time.Time `gorm:"column:used_at;" json:"usedAt"`                                               // 使用时间，为空表示未使用
+	CreatedAt time.Time  `gorm:"column:created_at;index;autoCreateTime;<-:create;" json:"createdAt"`          //
 }
 
 func (itself *Entity) TableName() string {

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -52,6 +52,12 @@ make build && ./bin/yourtj-hub serve   # then curl http://localhost:5234
 - ci-backend.yml: go vet + go test + go build (apps/gooseforum/app/**, main.go, go.mod, go.sum); the
   PostgreSQL integration tests in `app/bundles/connect/sqlconnect` are gated by `TEST_PG_DSN` and
   skip when unset (CI stays green without a PG service)
+- ci-backend.yml also runs `ci-backend-pg`: a real `postgres:16-alpine` service + the migration
+  schema tests in `app/migration/migration_pg_test.go` (`TestSchemaMigratesOnPostgreSQL`,
+  `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL`), gated by `YOURTJ_TEST_PG_URL` (set in CI, skipped
+  locally when unset). **Any model/migration change must pass these PG tests** — models must not
+  hardcode MySQL-only types (`bigint unsigned` / `datetime` / `tinyint`), which GORM renders verbatim
+  and PostgreSQL rejects, silently leaving tables uncreated (issue #8 production regression).
 - ci-frontend.yml: pnpm typecheck + build (apps/gooseforum/resource/**)
 - ci-contract.yml: openapi validation + no-diff generation + fixture (apps/gooseforum/app/**, packages/**)
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -105,6 +105,12 @@ make build     # cd apps/gooseforum/resource && pnpm build → cd apps/gooseforu
 ## DB migration execution and rollback
 
 - Migrations run at startup (`[db] migration = "on"`); append-only upstream style.
+- **Migration failures now abort startup** (since the issue #8 PG fix): if `AutoMigrate` errors,
+  `serve` exits non-zero instead of continuing with a partial schema. This makes deploy.sh's
+  health-check rollback and container restart policies catch schema problems immediately instead of
+  surfacing as runtime API failures (the original issue #8 login/register outage). It also means a
+  deploy with an incompatible schema change will roll back — rehearse on dev (which syncs main's db)
+  before main.
 - Rollback: `deploy.sh` tags the previous image `yourtj-hub:prev` and re-points the instance on
   health-check failure; forward-compatible migrations mean an older binary can still start.
 - Pre-deploy snapshot in `snapshots/main/` is the data-level restore point (SQLite).


### PR DESCRIPTION
## Summary

Fixes the dev-site login/register outage ("登录异常，请稍后重试") caused by issue #8's new tables
failing to migrate on PostgreSQL.

**Root cause:** `user_sessions` / `user_totp` / `user_totp_recovery_codes` hardcoded MySQL-only GORM
type tags (`bigint unsigned` / `datetime` / `tinyint`). PostgreSQL rejects `unsigned`, so AutoMigrate
failed at startup — but the error was only logged and the service kept serving with missing tables,
breaking login/register at runtime.

## Changes

- **models** (`userSessions.go`, `userTotp.go`, `userTotpRecoveryCodes.go`): removed MySQL-only
  `type:` tags; GORM now maps to dialect-native types (`bigint`, `smallint`, `timestamp`).
- **migration** (`migration.go`): extracted `SchemaModels()` (single source of truth for migration +
  tests) and made schema migration **fail-fast** — `os.Exit(1)` on AutoMigrate error, so a broken
  schema can never silently ship again (deploy health-check rollback now catches it).
- **tests** (`migration_pg_test.go`): two PostgreSQL integration tests —
  - `TestSchemaMigratesOnPostgreSQL`: full schema migrates on a fresh PG 16.
  - `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL`: legacy schema (main v0.0.6, no issue #8 tables)
    upgrades cleanly — directly proves main's next auto-deploy will create the tables.
  - Gated by `YOURTJ_TEST_PG_URL` (skips when unset).
- **CI** (`ci-backend.yml`): new `ci-backend-pg` job runs the PG migration tests against a real
  `postgres:16-alpine` service.
- **docs**: AGENTS.md, yourtj-development skill, testing.md, deployment.md now mandate the PostgreSQL
  migration gate for any model/migration change and forbid MySQL-only type tags.

## Verification

- `go vet ./...` — PASS
- `go test ./...` — PASS (EXIT=0)
- PG migration tests (both) against local `postgres:16-alpine` — PASS
- Dev instance (PostgreSQL): manually created the 3 missing tables from fixed-code DDL; end-to-end
  login via encrypted password returned `auth.login.success` and persisted a `user_sessions` row;
  test data cleaned up after.
- main DB preflight: `user_o_auth (provider, provider_uid)` has no duplicates → unique index will
  create cleanly on main's next deploy.

## Notes

- Dev was already repaired manually (tables created) so dev keeps working; this PR makes the fix
  permanent and protects main's future auto-deploy.
- No frontend/contract changes.