### PR TITLE
fix(auth): harden session lifecycle and OIDC numeric sub

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -30,6 +30,8 @@ func Logout(c *gin.Context) {
 	if claims, _, err := jwt.VerifyTokenWithFreshClaims(token); err == nil && claims.Jti != "" {
 		if err := sessionservice.RevokeByJti(claims.UserId, claims.Jti); err != nil {
 			slog.Error("Logout revoke session failed", "userId", claims.UserId, "jti", claims.Jti, "error", err)
+			c.JSON(http.StatusOK, component.FailDataCode(component.MessageSessionRevokeFailed, nil))
+			return
 		}
 	}
 	jwt.TokenClean(c)

--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -26,10 +26,14 @@ import (
 )
 
 func Logout(c *gin.Context) {
+	token := jwt.GetGinAccessToken(c)
+	if claims, _, err := jwt.VerifyTokenWithFreshClaims(token); err == nil && claims.Jti != "" {
+		if err := sessionservice.RevokeByJti(claims.UserId, claims.Jti); err != nil {
+			slog.Error("Logout revoke session failed", "userId", claims.UserId, "jti", claims.Jti, "error", err)
+		}
+	}
 	jwt.TokenClean(c)
-	c.JSON(http.StatusOK, component.SuccessData(
-		"👋",
-	))
+	c.JSON(http.StatusOK, component.SuccessData("logout"))
 }
 
 // Register 注册

--- a/apps/gooseforum/app/http/controllers/api/logout_test.go
+++ b/apps/gooseforum/app/http/controllers/api/logout_test.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
+	jwt "github.com/leancodebox/GooseForum/app/bundles/jwtopt"
+	"github.com/leancodebox/GooseForum/app/http/controllers/component"
+	"github.com/leancodebox/GooseForum/app/models/forum/userSessions"
+	"github.com/leancodebox/GooseForum/app/models/forum/userStatistics"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/service/sessionservice"
+	"github.com/leancodebox/GooseForum/app/service/userservice"
+)
+
+func setupLogoutTestDB(t *testing.T) {
+	t.Helper()
+	conn := db.Connect()
+	if err := conn.AutoMigrate(
+		&users.EntityComplete{},
+		&userStatistics.Entity{},
+		&userSessions.Entity{},
+	); err != nil {
+		t.Fatalf("migrate logout tables: %v", err)
+	}
+	conn.Where("1 = 1").Delete(&userSessions.Entity{})
+	conn.Where("1 = 1").Delete(&userStatistics.Entity{})
+	conn.Where("1 = 1").Delete(&users.EntityComplete{})
+}
+
+func newLogoutContext(token string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/api/logout", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	c.Request = req
+	return c, recorder
+}
+
+// TestLogoutRevokesSession 验证登出会删除当前会话行，之后原 token 不再映射到有效会话。
+func TestLogoutRevokesSession(t *testing.T) {
+	setupLogoutTestDB(t)
+
+	user, err := userservice.CreateUser("logoutuser", "password", "logout@example.com", false)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	token, jti, err := jwt.CreateSessionToken(user.Id, user.TokenVersion)
+	if err != nil {
+		t.Fatalf("CreateSessionToken() error = %v", err)
+	}
+	if err := sessionservice.Create(user.Id, jti, "test-agent", "127.0.0.1"); err != nil {
+		t.Fatalf("sessionservice.Create() error = %v", err)
+	}
+	if sessionservice.GetValidByJti(jti) == nil {
+		t.Fatal("session row missing before logout")
+	}
+
+	c, recorder := newLogoutContext(token)
+	Logout(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var res component.ResultStruct
+	if err := json.Unmarshal(recorder.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if res.Code != component.SUCCESS {
+		t.Fatalf("response code = %v, want SUCCESS", res.Code)
+	}
+	if sessionservice.GetValidByJti(jti) != nil {
+		t.Fatal("session row still valid after logout")
+	}
+}
+
+// TestLogoutWithoutTokenStillClearsCookie 验证未登录的登出请求仅清 cookie 并返回成功。
+func TestLogoutWithoutTokenStillClearsCookie(t *testing.T) {
+	c, recorder := newLogoutContext("")
+	Logout(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", recorder.Code)
+	}
+	var res component.ResultStruct
+	if err := json.Unmarshal(recorder.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if res.Code != component.SUCCESS {
+		t.Fatalf("response code = %v, want SUCCESS", res.Code)
+	}
+}

--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -83,7 +83,11 @@ func ProviderCallback(c *gin.Context) {
 			forum.RenderInternalOAuthErrorPage(c, component.MessageOAuthTokenFailed)
 			return
 		}
-		_ = sessionservice.Create(user.Id, jti, c.Request.UserAgent(), c.ClientIP())
+		if err = sessionservice.Create(user.Id, jti, c.Request.UserAgent(), c.ClientIP()); err != nil {
+			slog.Error("Create OAuth session failed", "userId", user.Id, "error", err)
+			forum.RenderInternalOAuthErrorPage(c, component.MessageOAuthProcessFailed)
+			return
+		}
 
 		jwtopt.TokenSetting(c, token)
 		c.Redirect(http.StatusFound, "/")

--- a/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
+++ b/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
@@ -20,6 +20,11 @@ func GetByJti(jti string) *Entity {
 }
 
 // DeleteByID 根据id删除会话记录（限用户）
+// DeleteByJtiAndUserID deletes one session owned by the user, keyed by jti.
+func DeleteByJtiAndUserID(userID uint64, jti string) error {
+	return builder().Where(fieldJti, jti).Where(fieldUserId, userID).Delete(&Entity{}).Error
+}
+
 func DeleteByID(userID uint64, id uint64) error {
 	return builder().Where(pid, id).Where(fieldUserId, userID).Delete(&Entity{}).Error
 }

--- a/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
+++ b/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
@@ -19,12 +19,12 @@ func GetByJti(jti string) *Entity {
 	return &entity
 }
 
-// DeleteByID 根据id删除会话记录（限用户）
 // DeleteByJtiAndUserID deletes one session owned by the user, keyed by jti.
 func DeleteByJtiAndUserID(userID uint64, jti string) error {
 	return builder().Where(fieldJti, jti).Where(fieldUserId, userID).Delete(&Entity{}).Error
 }
 
+// DeleteByID 根据id删除会话记录（限用户）
 func DeleteByID(userID uint64, id uint64) error {
 	return builder().Where(pid, id).Where(fieldUserId, userID).Delete(&Entity{}).Error
 }

--- a/apps/gooseforum/app/service/oidcservice/oidc.go
+++ b/apps/gooseforum/app/service/oidcservice/oidc.go
@@ -247,6 +247,7 @@ func HandleCallback(c *gin.Context) (CallbackResult, error) {
 	if err != nil {
 		return CallbackResult{}, ErrNonNumericSub
 	}
+	// 0 is the logged-out/absent-user sentinel; never treat it as a real user.
 	if sub == 0 {
 		return CallbackResult{}, ErrNonNumericSub
 	}

--- a/apps/gooseforum/app/service/oidcservice/oidc.go
+++ b/apps/gooseforum/app/service/oidcservice/oidc.go
@@ -247,6 +247,9 @@ func HandleCallback(c *gin.Context) (CallbackResult, error) {
 	if err != nil {
 		return CallbackResult{}, ErrNonNumericSub
 	}
+	if sub == 0 {
+		return CallbackResult{}, ErrNonNumericSub
+	}
 	username := claims.PreferredUsername
 	if username == "" {
 		username = claims.Name

--- a/apps/gooseforum/app/service/oidcservice/oidc_test.go
+++ b/apps/gooseforum/app/service/oidcservice/oidc_test.go
@@ -227,6 +227,18 @@ func TestHandleCallbackRejectsNonNumericSub(t *testing.T) {
 	}
 }
 
+func TestHandleCallbackRejectsZeroSub(t *testing.T) {
+	m := newMockOIDC(t)
+	configureOIDC(m.issuer())
+
+	_, err := runCallback(t, m, jwt.MapClaims{
+		"sub": "0",
+	})
+	if !errors.Is(err, ErrNonNumericSub) {
+		t.Fatalf("error = %v, want ErrNonNumericSub", err)
+	}
+}
+
 func TestHandleCallbackRejectsNonceMismatch(t *testing.T) {
 	m := newMockOIDC(t)
 	configureOIDC(m.issuer())

--- a/apps/gooseforum/app/service/sessionservice/sessionservice.go
+++ b/apps/gooseforum/app/service/sessionservice/sessionservice.go
@@ -55,12 +55,12 @@ func List(userID uint64) ([]userSessions.Entity, error) {
 	return userSessions.ListByUserID(userID)
 }
 
-// RevokeByID deletes one session owned by the user.
 // RevokeByJti deletes one session owned by the user, keyed by its jti.
 func RevokeByJti(userID uint64, jti string) error {
 	return userSessions.DeleteByJtiAndUserID(userID, jti)
 }
 
+// RevokeByID deletes one session owned by the user.
 func RevokeByID(userID uint64, id uint64) error {
 	return userSessions.DeleteByID(userID, id)
 }

--- a/apps/gooseforum/app/service/sessionservice/sessionservice.go
+++ b/apps/gooseforum/app/service/sessionservice/sessionservice.go
@@ -56,6 +56,11 @@ func List(userID uint64) ([]userSessions.Entity, error) {
 }
 
 // RevokeByID deletes one session owned by the user.
+// RevokeByJti deletes one session owned by the user, keyed by its jti.
+func RevokeByJti(userID uint64, jti string) error {
+	return userSessions.DeleteByJtiAndUserID(userID, jti)
+}
+
 func RevokeByID(userID uint64, id uint64) error {
 	return userSessions.DeleteByID(userID, id)
 }


### PR DESCRIPTION
Follow-up fixes after PR #18.

- Handle GitHub OAuth session-create errors instead of issuing an unusable token.
- Revoke the current session row on logout.
- Reject OIDC sub=0 so the sentinel/unauth value cannot be treated as a valid user.