### PR TITLE
docs: sync status docs with v0.0.7 feature wave

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,11 @@ be changed, but the "Go + Vue in one binary, frontend go:embed into the binary" 
   `resource/static/dist` go:embed; GoHTML templates in `resource/templates` keep server-side rendering (three-mode).
 - Database: SQLite default, MySQL optional (`config.toml [db]`); **PostgreSQL supported for the main
   database since issue #11** (file db stays SQLite).
-- Search: **Meilisearch** (`config.toml [meilisearch]`, optional; index sync incomplete, to be improved).
+- Search: **Meilisearch** (`config.toml [meilisearch]`, optional); aggregate search (topics/users/
+  categories, pinyin/initials) landed (issue #22); event-driven index sync, rebuildable projection.
 - Mobile: **Flutter** (`apps/mobile`, melos workspace, Riverpod, planned).
-- Auth: GitHub OAuth (goth) today; **Casdoor OIDC planned**, `sub` = numeric user ID (verified).
+- Auth: GitHub OAuth (goth) + **Casdoor OIDC integrated** (PKCE, numeric `sub` enforced server-side);
+  TOTP 2FA and session management (`jti` + `user_sessions`) in place (issue #8).
 - Contract: `packages/api-contract/openapi.yaml` contract center (planned; upstream has no swagger
   annotations — needs manual or annotation-based work).
 - Points: credit (linux-do) phase 2, merchant model, not implemented this phase.
@@ -82,9 +84,11 @@ docs/        Docs center (product/architecture/development/operations)
 
 - Backend: `cd apps/gooseforum && go vet ./... && go test ./...` (use `GOPROXY=https://goproxy.cn,direct`
   if module fetch times out). **Any model/migration change must also pass the PostgreSQL migration
-  test**: `YOURTJ_TEST_PG_URL="host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable" go test ./app/migration/ -run TestSchemaMigratesOnPostgreSQL -v`
-  (spin up `postgres:16-alpine` locally; CI runs the same test in `ci-backend-pg`). MySQL-only type
-  tags (`bigint unsigned` / `datetime` / `tinyint`) break PG and are forbidden in models.
+  tests**: `YOURTJ_TEST_PG_URL="host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable" go test ./app/migration/ -run 'TestSchema' -v`
+  (both `TestSchemaMigratesOnPostgreSQL` and `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL` in
+  `app/migration/migration_pg_test.go`; spin up `postgres:16-alpine` locally — CI runs the same
+  command in `ci-backend-pg`). MySQL-only type tags (`bigint unsigned` / `datetime` / `tinyint`)
+  break PG and are forbidden in models.
 - Web: `cd apps/gooseforum/resource && pnpm typecheck && pnpm build` (output into resource/static/dist)
 - Full build: `make build` (resource → go build single binary `bin/yourtj-hub`)
 - Smoke: run `./bin/yourtj-hub serve` then curl the homepage/API (port from config.toml, default 5234)

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ We build on [GooseForum](https://github.com/leancodebox/GooseForum) (MIT) — th
 | Topic | Decision | Record |
 |---|---|---|
 | Code organization | apps/gooseforum single binary (Go+Vue in one, upstream fork), no frontend/backend split | Decision records live in note |
-| Auth | Planned: Casdoor unified auth (OIDC, numeric user ID, verified) | docs/product/identity-and-access.md |
+| Auth | Casdoor unified auth integrated (OIDC + PKCE, numeric user ID enforced server-side, issue #8) | docs/product/identity-and-access.md |
 | Mobile state management | Riverpod | docs/architecture/system-overview.md |
-| Database / Search | Pending (recommend PostgreSQL + Meilisearch) | Pending decision, recorded in note |
+| Database / Search | PostgreSQL main-db support landed (issue #11, SQLite default retained); Meilisearch aggregate search with event-driven sync (issue #22) | docs/product/current-state.md |
 
 ## Current state
 

--- a/apps/gooseforum/app/service/eventhandlers/topic_deleted_e2e_test.go
+++ b/apps/gooseforum/app/service/eventhandlers/topic_deleted_e2e_test.go
@@ -68,17 +68,18 @@ func TestHandleTopicDeletedEndToEnd(t *testing.T) {
 	t.Fatalf("topic %d (%s) still present in index 10s after delete event", topicID, title)
 }
 
-// topicExists 通过 SearchTopics 搜索标题并检查命中。
+// topicExists 通过 AggregateSearch 搜索标题并检查命中。
 func topicExists(t *testing.T, id uint64, title string) bool {
 	t.Helper()
-	resp, err := searchservice.SearchTopics(searchservice.SearchRequest{
+	resp, err := searchservice.AggregateSearch(searchservice.AggregateSearchRequest{
 		Query: title,
+		Scope: searchservice.ScopeTopics,
 		Limit: 10,
 	})
 	if err != nil {
-		t.Fatalf("SearchTopics error: %v", err)
+		t.Fatalf("AggregateSearch error: %v", err)
 	}
-	for _, hit := range resp.Results {
+	for _, hit := range resp.Topics {
 		if hit.ID == id {
 			return true
 		}

--- a/apps/gooseforum/app/service/searchservice/searchservice.go
+++ b/apps/gooseforum/app/service/searchservice/searchservice.go
@@ -1,125 +1,12 @@
 package searchservice
 
-import (
-	"errors"
-	"fmt"
-	"log/slog"
-	"strings"
-
-	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
-	"github.com/leancodebox/GooseForum/app/bundles/connect/meiliconnect"
-	"github.com/leancodebox/GooseForum/app/models/forum/topics"
-	"github.com/meilisearch/meilisearch-go"
-	"github.com/samber/lo"
-)
+import "errors"
 
 // ErrSearchUnavailable 表示搜索服务不可用
 var ErrSearchUnavailable = errors.New("search service unavailable")
 
-// SearchRequest is a topic search request.
-type SearchRequest struct {
-	Query      string   `json:"query"`
-	Categories []uint64 `json:"categories"`
-	Limit      int      `json:"limit"`
-	Offset     int      `json:"offset"`
-}
-
-// SearchResult is one search hit.
+// SearchResult is one search hit (topic scope).
 type SearchResult struct {
 	ID    uint64 `json:"id"`
 	Title string `json:"title"`
-}
-
-// SearchResponse is the topic search response.
-type SearchResponse struct {
-	Results []SearchResult `json:"results"`
-	Total   int64          `json:"total"`
-}
-
-// SearchTopics returns topic IDs and titles directly from Meilisearch.
-func SearchTopics(req SearchRequest) (*SearchResponse, error) {
-	if !meiliconnect.IsAvailable() {
-		return searchTopicsFromDatabase(req)
-	}
-
-	client := meiliconnect.GetClient()
-	index := client.Index(TopicIndex)
-
-	searchReq := &meilisearch.SearchRequest{
-		Query:  req.Query,
-		Limit:  int64(req.Limit),
-		Offset: int64(req.Offset),
-	}
-
-	if len(req.Categories) > 0 {
-		filters := lo.Map(req.Categories, func(categoryID uint64, _ int) string {
-			return fmt.Sprintf("category = %d", categoryID)
-		})
-		filterStr := fmt.Sprintf("(%s)", strings.Join(filters, " OR "))
-		searchReq.Filter = filterStr
-	}
-
-	searchReq.AttributesToRetrieve = []string{"id", "title"}
-
-	searchResp, err := index.Search(req.Query, searchReq)
-	if err != nil {
-		return nil, fmt.Errorf("搜索失败: %w", err)
-	}
-
-	results := lo.FilterMap(searchResp.Hits, func(hit meilisearch.Hit, _ int) (SearchResult, bool) {
-		itemResult := SearchResult{}
-		if err := hit.Decode(&itemResult); err != nil {
-			slog.Error("failed to decode search hit", "err", err)
-			return SearchResult{}, false
-		}
-		return itemResult, itemResult.ID > 0
-	})
-
-	return &SearchResponse{
-		Results: results,
-		Total:   searchResp.EstimatedTotalHits,
-	}, nil
-}
-
-// searchTopicsFromDatabase 在未配置 Meilisearch 时退化为数据库 LIKE 搜索，
-// 保证搜索功能开箱可用；仅匹配公开主题（status=1 且 process_status=0）
-// 的标题与摘要，按置顶权重和最近更新排序。
-func searchTopicsFromDatabase(req SearchRequest) (*SearchResponse, error) {
-	query := strings.TrimSpace(req.Query)
-	if query == "" {
-		return &SearchResponse{Results: []SearchResult{}, Total: 0}, nil
-	}
-	keyword := "%" + query + "%"
-	condition := "status = ? AND process_status = ? AND (title LIKE ? OR excerpt LIKE ?)"
-	tableName := (&topics.Entity{}).TableName()
-
-	var total int64
-	countDB := db.Connect().Table(tableName).Where(condition, 1, 0, keyword, keyword)
-	// 与 Meilisearch 路径一致：categories 过滤走 topic_category_index 关联表
-	if len(req.Categories) > 0 {
-		countDB = countDB.Where("EXISTS (SELECT 1 FROM topic_category_index idx WHERE idx.topic_id = topics.id AND idx.category_id IN (?) AND idx.effective = 1)", req.Categories)
-	}
-	if err := countDB.Count(&total).Error; err != nil {
-		return nil, fmt.Errorf("搜索计数失败: %w", err)
-	}
-
-	entities := make([]topics.Entity, 0)
-	resultDB := db.Connect().Table(tableName).
-		Where(condition, 1, 0, keyword, keyword)
-	if len(req.Categories) > 0 {
-		resultDB = resultDB.Where("EXISTS (SELECT 1 FROM topic_category_index idx WHERE idx.topic_id = topics.id AND idx.category_id IN (?) AND idx.effective = 1)", req.Categories)
-	}
-	resultDB = resultDB.
-		Order("pin_weight DESC, updated_at DESC").
-		Limit(req.Limit).
-		Offset(req.Offset).
-		Find(&entities)
-	if resultDB.Error != nil {
-		return nil, fmt.Errorf("搜索失败: %w", resultDB.Error)
-	}
-
-	results := lo.Map(entities, func(item topics.Entity, _ int) SearchResult {
-		return SearchResult{ID: item.Id, Title: item.Title}
-	})
-	return &SearchResponse{Results: results, Total: total}, nil
 }

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -6,13 +6,13 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-07
 
 ## System shape
 
 ```
                         ┌─────────────────────┐
-                        │     Casdoor (OIDC)   │  Unified auth (numeric user ID, planned)
+                        │     Casdoor (OIDC)   │  Unified auth (numeric user ID)
                         └──────────┬──────────┘
               OIDC/PKCE            │            OIDC browser flow
        ┌───────────────────────────┼───────────────────────────┐
@@ -27,12 +27,12 @@
                   │ JSON API (JWT Bearer)
            ┌──────▼──────┐     ┌──────────────┐
            │ apps/gooseforum │──▶│ services/    │  Meilisearch index sync
-           │  Go backend     │   │ search       │  (optional, to be improved)
+           │  Go backend     │   │ search       │  (optional, event-driven)
            └──────┬──────┘   └──────────────┘
                   │
-           ┌──────▼──────┐
-           │ SQLite/MySQL │ (PostgreSQL migration pending)
-           └─────────────┘
+           ┌──────▼────────────┐
+           │ SQLite/MySQL/PG   │ (PG main-db supported, issue #11; file db stays SQLite)
+           └───────────────────┘
 ```
 
 ## Deployment shape
@@ -46,7 +46,7 @@
 
 | Layer | Responsibility |
 |---|---|
-| `app/console` | cobra CLI (serve / mock / rebuild-search-index ...) |
+| `app/console` | cobra CLI (serve / mock / rebuild-search-index / migrate-files ...) |
 | `app/bundles` | Utilities (connect/eventbus/jwtopt/i18n/captcha/logging/cache ...) |
 | `app/models` | GORM models + migrations (app/migration) |
 | `app/service` | Business logic (users/topics/mail/oauth/theme ...) |
@@ -65,17 +65,20 @@
 
 ## Key flows
 
-### Auth (planned)
+### Auth
 
-- Today: GitHub OAuth (goth, config [github]).
-- Planned: Casdoor OIDC unified login (Web standard authorization code; Mobile appauth+PKCE →
-  id_token → `POST /api/auth/oidc/exchange` → forum JWT); numeric-ID constraint enforced server-side
-  (see identity-and-access.md).
+- Web: password login (optional forum-side TOTP 2FA), GitHub OAuth (goth, config [github]), and
+  Casdoor OIDC unified login (PKCE + state + nonce, numeric `sub` enforced server-side). Sessions
+  are `jti` + `user_sessions` backed and revocable (see identity-and-access.md).
+- Mobile (planned): appauth+PKCE → id_token → `POST /api/auth/oidc/exchange` → forum JWT.
 
 ### Search (Partial)
 
-- Meilisearch optionally enabled (config [meilisearch]); index sync and search UX incomplete, to be
-  improved.
+- Meilisearch optionally enabled (config [meilisearch]). Aggregate search (one box covering
+  topics/users/categories with scope tabs; pinyin/initials matching for users and categories) landed
+  in issue #22. Index sync is event-driven (topic/user/category events) with per-scope SQL fallback
+  when Meilisearch is unavailable; the index is a rebuildable projection (`rebuild-search-index`
+  CLI).
 
 ### Points (phase 2)
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -76,9 +76,9 @@
 
 - Meilisearch optionally enabled (config [meilisearch]). Aggregate search (one box covering
   topics/users/categories with scope tabs; pinyin/initials matching for users and categories) landed
-  in issue #22. Index sync is event-driven (topic/user/category events) with per-scope SQL fallback
-  when Meilisearch is unavailable; the index is a rebuildable projection (`rebuild-search-index`
-  CLI).
+  in issue #22. Index sync is event-driven (topic/user/category events). When Meilisearch is
+  unavailable the search page shows a full unavailable state; per-index failures degrade partially
+  via `failedScopes`. The index is a rebuildable projection (`rebuild-search-index` CLI).
 
 ### Points (phase 2)
 

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -64,9 +64,11 @@ GooseForum is configured by `apps/gooseforum/config.toml` (not environment varia
 | `[log]` | log type/rolling/slow SQL; `level` (debug/info/warn/error), `format` (json/console), `errorPath` (WARN/ERROR separate file), `logIp` (access-log IP, default off) — all require restart |
 | `[github]` | GitHub OAuth client |
 
-Casdoor OIDC is not a config.toml section: it is configured from the admin panel and stored in
-preferences (`casdoor.endpoint` / `casdoor.client_id` / `casdoor.client_secret`). The OIDC login entry
-only appears once these are set (`oidcservice.IsConfigured()` gates it).
+Casdoor OIDC is configured from the `[casdoor]` section in `config.toml`
+(`endpoint` / `client_id` / `client_secret`, see `deploy/config.toml.example`); the values are read at
+startup via preferences and there is no admin-panel UI to change them (set them in the file and
+restart). The OIDC login entry only appears once these are set (`oidcservice.IsConfigured()` gates
+it).
 
 To run the forum against the local PostgreSQL instead of SQLite, set in `config.toml`:
 

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-07
 
 ## Dependencies
 
@@ -62,7 +62,11 @@ GooseForum is configured by `apps/gooseforum/config.toml` (not environment varia
 | `[db]` / `[db.default]` / `[db.file]` | SQLite default; main db (`[db.default]`) also supports MySQL and PostgreSQL (issue #11); file db stays SQLite; migration, backup, pool |
 | `[meilisearch]` | url, masterkey (optional search) |
 | `[log]` | log type/rolling/slow SQL; `level` (debug/info/warn/error), `format` (json/console), `errorPath` (WARN/ERROR separate file), `logIp` (access-log IP, default off) — all require restart |
-| `[github]` | GitHub OAuth client (currently the only third-party login) |
+| `[github]` | GitHub OAuth client |
+
+Casdoor OIDC is not a config.toml section: it is configured from the admin panel and stored in
+preferences (`casdoor.endpoint` / `casdoor.client_id` / `casdoor.client_secret`). The OIDC login entry
+only appears once these are set (`oidcservice.IsConfigured()` gates it).
 
 To run the forum against the local PostgreSQL instead of SQLite, set in `config.toml`:
 
@@ -74,7 +78,8 @@ url = "host=127.0.0.1 user=yourtj password=yourtj dbname=yourtj port=5432 sslmod
 
 The binary AutoMigrates all main-db models and runs the versioned data migrations on first boot.
 `TEST_PG_DSN` can be set to run the gated PostgreSQL integration tests
-(`go test ./app/bundles/connect/sqlconnect/...`).
+(`go test ./app/bundles/connect/sqlconnect/...`); `YOURTJ_TEST_PG_URL` gates the migration schema
+tests (`go test ./app/migration/ -run 'TestSchema' -v`, see [testing.md](testing.md)).
 
 > config.toml contains signingKey — sensitive; it is gitignored, never commit it.
 

--- a/docs/product/current-state.md
+++ b/docs/product/current-state.md
@@ -6,14 +6,16 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-07
 
 ## What works
 
 - **Feature coverage**: Markdown topics/replies, categories, notifications, direct messages, drafts,
   RBAC moderation, admin panel, theme workbench, i18n (en/zh/ja/it), GitHub OAuth + Casdoor OIDC
   (PKCE), TOTP 2FA + recovery codes, session management (jti + user_sessions, per-session revoke),
-  scheduled SQLite backup, slow-SQL logging.
+  scheduled SQLite backup, slow-SQL logging, aggregate search (topics/users/categories with scope
+  tabs, pinyin/initials), sensitive-word moderation with review queue, terms-of-service page, data
+  import/export, pluggable file storage (SQLite BLOB / S3-compatible).
 - **Unified-auth verification**: Casdoor numeric-ID path verified during research (sub = numeric ID,
   Incremental rule + explicit numeric ids); OIDC login/binding now wired into the forum with
   server-side numeric-sub enforcement.
@@ -30,7 +32,7 @@
 | Contract | `Partial` | No swagger annotations, no openapi.yaml upstream; packages/api-contract is a placeholder; pipeline not built |
 | Mobile | `Planned` | `apps/mobile` is a placeholder dir; Flutter/melos/Riverpod not set up |
 | Points | `Planned` | services/credit is a README placeholder; explicitly phase 2, not implemented now |
-| Branding | `Partial` | GooseForum branding not yet replaced with yourtj (CLI name, UI copy, config keys) |
+| Branding | `Partial` | Default UI copy, activation template, locales and admin brand settings rebranded to YourTJHub (2026-08-07); CLI name (`gooseforum`) and Go module name intentionally kept for upstream merge |
 | Structural governance | `Partial` | Upstream giant controllers (payload.go 72KB etc.) not split; architecture decisions in note |
 | Storage (files) | `Current` | Pluggable storage: local SQLite BLOB default + S3-compatible object storage (MinIO/COS/OSS/R2), admin panel config + connection test, cursor-driven BLOB→object migration task + `migrate-files` CLI (2026-08-06) |
 | Moderation policy | `Current` | Reserved/banned usernames, sensitive-word block or review (ProcessStatus=2 pending queue with admin approve/reject), banned username auto-freezes existing accounts, moderation audit logs (2026-08-06) |

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers, Security reviewer
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-07
 
 ## Identity model
 
@@ -15,7 +15,7 @@
   available.
 - **Numeric ID is a hard constraint**: credit's `GetID()` parses sub with `strconv.ParseUint`. A UUID
   fails to parse and falls back to 0, making all users collide. The OIDC callback enforces this
-  server-side (`ParseUint` failure rejects the login). Casdoor must:
+  server-side (`ParseUint` failure or a zero `sub` rejects the login). Casdoor must:
   1. set the app SignupItems ID rule to `Incremental` (self-registered users get auto-increment numeric
      IDs); and
   2. explicitly pass numeric `id` when admins create accounts.
@@ -30,6 +30,8 @@
 - Password login: RSA-OAEP encrypted password → forum `users.Verify` → if the user enabled TOTP 2FA,
   the server issues a 5-minute `totp_challenge` token instead of a session token; the client posts the
   code (or a one-time recovery code) to `/api/auth/totp/verify`, which issues the real session token.
+  A challenge token can mint at most one session: it is atomically consumed on successful verification
+  (`totpservice.ConsumeChallenge`), so replaying it cannot create a second session.
 - GitHub OAuth (goth): unchanged; callback binds or signs in and issues a session token.
 - Casdoor OIDC: `GET /api/auth/oidc/login` (PKCE + state + nonce) → Casdoor → callback exchanges code
   for id_token → verify (iss/aud/nonce/exp) → find or create local user → issue forum JWT. The callback
@@ -60,7 +62,8 @@
   missing or expired, so revocation is immediate.
 - Revocation: users can list sessions (IP masked, device/UA) in Settings → Security, revoke a single
   session, or sign out of all devices. "Sign out of all devices" also bumps `TokenVersion`, which
-  invalidates every previously issued token as a second line of defense.
+  invalidates every previously issued token as a second line of defense. Ordinary logout deletes the
+  current session row as well, and fails loudly when the revoke errors (no silently surviving token).
 - Password change: `TokenVersion` bumps, invalidating old tokens (existing behavior preserved).
 - Ban/disable: Casdoor's active/forbidden is authoritative; server syncs at exchange and every check.
 - Deletion/export: `Planned` (per product principle 12: answer purpose, visibility, retention, export,

--- a/docs/product/vision-and-principles.md
+++ b/docs/product/vision-and-principles.md
@@ -6,7 +6,7 @@
 >
 > Owner: Product owner, Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-07
 
 yourtj is a community platform for Tongji campus members. The forum is the core public discussion space;
 unified auth (Casdoor), search (Meilisearch), and points (credit, phase 2) are shared identity,
@@ -30,7 +30,9 @@ services (course selection, course reviews, etc.).
 
 - `Current`: monorepo skeleton; the forum runs (three-mode rendering + JSON API, single binary).
 - `Current`: database selection (PostgreSQL main-db support landed, issue #11; SQLite default retained);
-  search shape via Meilisearch (optional, event-synced index). `Planned`: unified auth integration.
+  search shape via Meilisearch (optional, event-synced index).
+- `Current`: unified auth integration (Casdoor OIDC, issue #8; Casdoor-side MFA/Passkey deployment
+  config pending).
 - Points (credit) are explicitly **phase 2**; not claimed usable in UI or marketing now.
 
 ### Explicitly out of scope
@@ -75,10 +77,10 @@ services (course selection, course reviews, etc.).
 
 | Decision | Recommended default | Impact if undecided |
 |---|---|---|
-| Database | PostgreSQL 15+ | Migration, queries, deployment |
-| Search shape | Meilisearch standalone | Topology, index sync, Chinese tokenization |
+| Database | PostgreSQL 15+ (support landed, issue #11; SQLite stays default until the production default call) | Migration, queries, deployment |
+| Search shape | Meilisearch standalone (landed: aggregate search + event sync, issue #22) | Topology, Chinese tokenization |
 | Anonymous visibility | Board-declared visibility | Search index, SEO, privacy settings |
-| Login method | Casdoor unified login (OIDC), numeric ID | credit & mobile exchange integration |
+| Login method | Casdoor unified login (OIDC), numeric ID (integrated, issue #8) | credit & mobile exchange integration |
 | Points source | credit merchant distribution (forum event-driven) | Settlement model, anti-abuse, audit |
 
 Undecided items may be researched but must not be irreversibly decided by a local UI or migration.


### PR DESCRIPTION
## Summary

Documentation sync after the #18-#26 merge wave + the YourTJHub rebrand commits, plus two review-driven corrections (one of which removed newly-confirmed dead code in searchservice). Several governing docs still described Casdoor OIDC / PostgreSQL / Meilisearch sync as planned or pending while the code had already landed; this PR brings them in line with dev@49ff9a0.

## Changes (each claim verified against code)

- **README.md**: Decision summary — Auth now "Casdoor integrated (issue #8)"; Database/Search now "PG landed (#11) / Meilisearch aggregate search (#22)" instead of Pending.
- **AGENTS.md**: §1 auth/search bullets updated to integrated state; §4 PG gate now runs both migration tests via `-run 'TestSchema'`, mirroring `ci-backend.yml` (`TestSchemaMigratesOnPostgreSQL` + `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL` in `app/migration/migration_pg_test.go`).
- **docs/architecture/system-overview.md**: diagram (Casdoor no longer "planned", DB box SQLite/MySQL/PG, search event-driven); `app/console` row adds `migrate-files`; "Auth (planned)" section rewritten to current Web reality (password+TOTP / GitHub OAuth / Casdoor OIDC, revocable `jti` sessions) with only the mobile exchange left planned; Search section describes aggregate search and its real degradation model (full unavailable state when Meilisearch is down; per-index partial degradation via `failedScopes` — corrected in review, 06b9abf).
- **docs/development/local-development.md**: `[github]` no longer "the only third-party login"; documents the `[casdoor]` config.toml section (`endpoint/client_id/client_secret`, see `deploy/config.toml.example`; read at startup, no admin-panel UI — corrected in review, a807599); adds `YOURTJ_TEST_PG_URL` next to `TEST_PG_DSN`.
- **docs/product/identity-and-access.md**: TOTP challenge is single-use (atomically consumed on success, `totpservice.ConsumeChallenge`); ordinary logout revokes the session row and fails loudly on error; OIDC rejects zero `sub` (`oidc.go` ParseUint + zero check).
- **docs/product/current-state.md**: Branding row narrowed after the YourTJHub rebrand (CLI/module names intentionally kept); feature-coverage list completed with aggregate search, moderation queue, ToS, import/export, pluggable storage.
- **docs/product/vision-and-principles.md**: unified auth moved to `Current`; decisions table keeps owner-decision rows but annotates the three whose implementation already landed (production default DB remains an owner call).
- **apps/gooseforum searchservice (review follow-up, 06b9abf)**: removed dead `SearchTopics`/`SearchRequest`/`SearchResponse`/`searchTopicsFromDatabase` (SQL LIKE fallback) — no callers since aggregate search landed (issue #22); e2e `topicExists` now uses `AggregateSearch`.

## Verification

- `git diff --check`: pass
- Dead-code removal verified caller-free on dev@49ff9a0 (only `payload.go` → `AggregateSearch` remains); degradation wording verified against `aggregatesearch.go` (`ErrSearchUnavailable` on total failure, `FailedScopes` per-index partial degradation); `preferences` confirmed to be a viper wrapper over config.toml with no `Set` callers.
- CI: ci-backend / ci-backend-pg / ci-frontend / ci-contract all green on branch tip a807599.

## Notes / known gaps

- The "Decisions pending product owner" table is annotated, not re-decided — the product owner may want to formally move those rows to the ADR note.
- Casdoor production runbook in deployment.md remains "to write" (unchanged, still accurate).