### PR TITLE
feat: 为论坛 Markdown 增加客户端代码高亮

### DIFF
--- a/apps/gooseforum/docs/architecture/markdown-rendering.md
+++ b/apps/gooseforum/docs/architecture/markdown-rendering.md
@@ -8,8 +8,8 @@ dual-implementation rendering strategy:
 - The two implementations are kept aligned by a shared test specification, not
   by embedding a JavaScript runtime in the Go server.
 
-This keeps the runtime simple while still leaving room for richer client-side
-rendering such as diagrams, math, and code highlighting.
+This keeps the runtime simple while supporting client-side code highlighting
+and leaving room for richer rendering such as diagrams and math.
 
 ## Goals
 
@@ -125,11 +125,21 @@ The current client preview renderer is centralized in
 `resource/src/runtime/markdown.ts`. Pages should call this helper instead of
 creating local `MarkdownIt` instances.
 
+Current client enhancement:
+
+- Fenced code blocks with an explicit, recognized language are highlighted
+  with the Highlight.js common-language build.
+- Saved topic/post HTML and Markdown editor previews use the same Vue directive
+  and highlighter adapter. The adapter is loaded dynamically only after a
+  `language-*` code block is detected.
+- Language auto-detection is disabled. Unknown and unlabelled languages remain
+  escaped plain-text code blocks, and a load failure leaves the server or
+  Markdown-it output unchanged.
+
 Potential client enhancements:
 
 - Mermaid for diagrams
 - KaTeX or MathJax for math
-- Prism.js or another highlighter for code blocks
 
 These should be loaded only on pages that need them, preferably by detecting
 matching code fences or inline markers. They should not become part of the base
@@ -157,7 +167,8 @@ GooseForum should continue with dual implementation:
 - `goldmark` for authoritative server rendering.
 - `markdown-it` for client preview.
 - fixture-based compatibility tests to keep them aligned.
-- client-only optional renderers for diagrams, math, and code highlighting.
+- Highlight.js as a client-only, explicit-language code enhancement.
+- client-only optional renderers for diagrams and math.
 
 The `goja` experiment is useful as a reference, but it should not replace the
 current approach unless the Markdown dialect becomes too complex to keep aligned

--- a/apps/gooseforum/resource/package.json
+++ b/apps/gooseforum/resource/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "compressorjs": "^1.3.0",
     "cropperjs": "^2.1.1",
+    "highlight.js": "^11.11.1",
     "linkify-it": "5.0.2",
     "markdown-it": "^14.2.0",
     "markdown-it-anchor": "^9.2.0",

--- a/apps/gooseforum/resource/pnpm-lock.yaml
+++ b/apps/gooseforum/resource/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       cropperjs:
         specifier: ^2.1.1
         version: 2.1.1
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       linkify-it:
         specifier: 5.0.2
         version: 5.0.2
@@ -1338,6 +1341,10 @@ packages:
 
   hey-listen@1.0.8:
     resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3267,6 +3274,8 @@ snapshots:
       function-bind: 1.1.2
 
   hey-listen@1.0.8: {}
+
+  highlight.js@11.11.1: {}
 
   iconv-lite@0.6.3:
     dependencies:

--- a/apps/gooseforum/resource/src/runtime/code-highlight-directive.ts
+++ b/apps/gooseforum/resource/src/runtime/code-highlight-directive.ts
@@ -1,0 +1,58 @@
+import type { ObjectDirective } from 'vue'
+
+type CodeHighlighter = Pick<typeof import('./code-highlighting'), 'highlightCode'>
+type HighlighterLoader = () => Promise<CodeHighlighter>
+
+const languageClassPrefix = 'language-'
+
+export function extractCodeLanguage(element: Pick<HTMLElement, 'className'>): string | null {
+  const languageClass = element.className
+    .split(/\s+/)
+    .find(className => className.startsWith(languageClassPrefix) && className.length > languageClassPrefix.length)
+  return languageClass?.slice(languageClassPrefix.length) || null
+}
+
+export async function enhanceCodeBlocks(
+  root: ParentNode,
+  loadHighlighter: HighlighterLoader = () => import('./code-highlighting'),
+) {
+  const candidates = Array.from(root.querySelectorAll<HTMLElement>('pre > code[class*="language-"]'))
+    .map(element => ({ element, language: extractCodeLanguage(element) }))
+    .filter((candidate): candidate is { element: HTMLElement, language: string } => (
+      Boolean(candidate.language) && !candidate.element.dataset.codeHighlight
+    ))
+
+  if (candidates.length === 0) return
+
+  for (const { element } of candidates) element.dataset.codeHighlight = 'loading'
+
+  let highlighter: CodeHighlighter
+  try {
+    highlighter = await loadHighlighter()
+  }
+  catch {
+    for (const { element } of candidates) delete element.dataset.codeHighlight
+    return
+  }
+
+  for (const { element, language } of candidates) {
+    const highlighted = highlighter.highlightCode(element.textContent || '', language)
+    if (highlighted === null) {
+      element.dataset.codeHighlight = 'unsupported'
+      continue
+    }
+
+    element.innerHTML = highlighted
+    element.classList.add('hljs')
+    element.dataset.codeHighlight = 'done'
+  }
+}
+
+function runCodeHighlighting(element: HTMLElement) {
+  void enhanceCodeBlocks(element)
+}
+
+export const codeHighlightDirective: ObjectDirective<HTMLElement> = {
+  mounted: runCodeHighlighting,
+  updated: runCodeHighlighting,
+}

--- a/apps/gooseforum/resource/src/runtime/code-highlighting.ts
+++ b/apps/gooseforum/resource/src/runtime/code-highlighting.ts
@@ -1,0 +1,16 @@
+import hljs from 'highlight.js/lib/common'
+
+export function highlightCode(source: string, language: string): string | null {
+  const normalizedLanguage = language.trim().toLowerCase()
+  if (!normalizedLanguage || !hljs.getLanguage(normalizedLanguage)) return null
+
+  try {
+    return hljs.highlight(source, {
+      language: normalizedLanguage,
+      ignoreIllegals: true,
+    }).value
+  }
+  catch {
+    return null
+  }
+}

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -437,7 +437,7 @@ function submit() {
                 />
                 <div v-else class="gf-prose gf-prose-post min-h-24 max-w-none px-3 py-2.5">
                   <template v-if="content.trim()">
-                    <div v-html="renderedPreview" />
+                    <div v-code-highlight v-html="renderedPreview" />
                   </template>
                   <p v-else class="text-sm text-base-content/55">{{ t('publish.emptyPreview') }}</p>
                 </div>

--- a/apps/gooseforum/resource/src/site/components/PostReplyReference.vue
+++ b/apps/gooseforum/resource/src/site/components/PostReplyReference.vue
@@ -77,6 +77,7 @@ onBeforeUnmount(() => resizeObserver?.disconnect())
             'reply-reference-content--collapsed': !expanded,
             'reply-reference-content--faded': !expanded && overflowing,
           }"
+          v-code-highlight
           v-html="target.renderedContent"
         />
       </div>

--- a/apps/gooseforum/resource/src/site/main.ts
+++ b/apps/gooseforum/resource/src/site/main.ts
@@ -7,6 +7,7 @@ import { currentLocale, i18n } from '@/runtime/i18n'
 import { hydrateFlashMessages } from '@/runtime/flash-message'
 import { applySiteThemePayload, applyStoredTheme } from '@/runtime/site-theme'
 import PayloadRouteView from '@/site/components/PayloadRouteView.vue'
+import { codeHighlightDirective } from '@/runtime/code-highlight-directive'
 
 const initialPayload = readInitialPayload()
 const initialPage = await preparePayload(initialPayload)
@@ -40,6 +41,7 @@ const app = createApp({
 
 app.use(i18n)
 app.use(router)
+app.directive('code-highlight', codeHighlightDirective)
 await router.isReady()
 app.mount('#goose-app')
 

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -708,7 +708,7 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
                 </div>
               </div>
 
-              <div v-if="preview && content.trim()" class="gf-prose gf-prose-post min-h-80 max-w-none px-1 py-4" v-html="renderedPreview" />
+              <div v-if="preview && content.trim()" v-code-highlight class="gf-prose gf-prose-post min-h-80 max-w-none px-1 py-4" v-html="renderedPreview" />
               <div v-else-if="preview" class="gf-prose gf-prose-post min-h-80 max-w-none px-1 py-4">
                 <p class="text-sm text-base-content/55">{{ t('publish.emptyPreview') }}</p>
               </div>

--- a/apps/gooseforum/resource/src/site/pages/TopicPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/TopicPage.vue
@@ -1758,7 +1758,7 @@ async function removePost(postId: number) {
                 <div v-if="group.root.isHidden && !group.root.canModerate" class="rounded border border-line bg-base-200/60 px-3 py-2 text-sm text-base-content/45">
                   {{ t('topic.hiddenReplyPlaceholder') }}
                 </div>
-                <div v-else class="gf-prose gf-prose-post" v-html="group.root.renderedContent" />
+                <div v-else v-code-highlight class="gf-prose gf-prose-post" v-html="group.root.renderedContent" />
                 <div v-if="group.root.isHidden && group.root.canModerate" class="mt-2 inline-flex rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/45">
                   {{ t('topic.hiddenReplyBadge') }}
                 </div>
@@ -1852,7 +1852,7 @@ async function removePost(postId: number) {
                     <div v-if="reply.isHidden && !reply.canModerate" class="mt-2 rounded border border-line bg-base-100 px-3 py-2 text-sm text-base-content/45">
                       {{ t('topic.hiddenReplyPlaceholder') }}
                     </div>
-                    <div v-else class="gf-prose gf-prose-post mt-2" v-html="reply.renderedContent" />
+                    <div v-else v-code-highlight class="gf-prose gf-prose-post mt-2" v-html="reply.renderedContent" />
                     <div v-if="reply.isHidden && reply.canModerate" class="mt-2 inline-flex rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/45">
                       {{ t('topic.hiddenReplyBadge') }}
                     </div>

--- a/apps/gooseforum/resource/src/styles/code-highlighting.css
+++ b/apps/gooseforum/resource/src/styles/code-highlighting.css
@@ -1,0 +1,58 @@
+@layer components {
+  .gf-prose :where(.hljs-comment, .hljs-quote) {
+    color: color-mix(in oklch, var(--gf-color-base-content) 52%, transparent);
+    font-style: italic;
+  }
+
+  .gf-prose :where(.hljs-keyword, .hljs-selector-tag, .hljs-meta .hljs-keyword) {
+    color: color-mix(in oklch, var(--gf-color-primary) 82%, var(--gf-color-base-content));
+    font-weight: 600;
+  }
+
+  .gf-prose :where(.hljs-title, .hljs-section, .hljs-selector-id, .hljs-selector-class) {
+    color: color-mix(in oklch, var(--gf-color-secondary-content) 78%, var(--gf-color-base-content));
+    font-weight: 600;
+  }
+
+  .gf-prose :where(.hljs-string, .hljs-doctag, .hljs-regexp, .hljs-link) {
+    color: color-mix(in oklch, var(--gf-color-success) 72%, var(--gf-color-base-content));
+  }
+
+  .gf-prose :where(.hljs-number, .hljs-literal, .hljs-symbol, .hljs-bullet) {
+    color: color-mix(in oklch, var(--gf-color-warning) 74%, var(--gf-color-base-content));
+  }
+
+  .gf-prose :where(.hljs-variable, .hljs-template-variable, .hljs-params, .hljs-attr, .hljs-attribute) {
+    color: color-mix(in oklch, var(--gf-color-info) 76%, var(--gf-color-base-content));
+  }
+
+  .gf-prose :where(.hljs-type, .hljs-class .hljs-title, .hljs-built_in, .hljs-builtin-name) {
+    color: color-mix(in oklch, var(--gf-color-accent) 76%, var(--gf-color-base-content));
+  }
+
+  .gf-prose :where(.hljs-tag, .hljs-name, .hljs-meta, .hljs-operator) {
+    color: color-mix(in oklch, var(--gf-color-error) 72%, var(--gf-color-base-content));
+  }
+
+  .gf-prose .hljs-subst {
+    color: var(--gf-color-base-content);
+  }
+
+  .gf-prose .hljs-addition {
+    color: color-mix(in oklch, var(--gf-color-success) 72%, var(--gf-color-base-content));
+    background: color-mix(in oklch, var(--gf-color-success) 12%, transparent);
+  }
+
+  .gf-prose .hljs-deletion {
+    color: color-mix(in oklch, var(--gf-color-error) 76%, var(--gf-color-base-content));
+    background: color-mix(in oklch, var(--gf-color-error) 12%, transparent);
+  }
+
+  .gf-prose .hljs-emphasis {
+    font-style: italic;
+  }
+
+  .gf-prose .hljs-strong {
+    font-weight: 700;
+  }
+}

--- a/apps/gooseforum/resource/src/styles/resource.css
+++ b/apps/gooseforum/resource/src/styles/resource.css
@@ -4,6 +4,7 @@
 @import "./base.css";
 @import "./motion.css";
 @import "./prose.css";
+@import "./code-highlighting.css";
 @import "./components.css";
 @import "./patterns.css";
 @import "./utilities.css";

--- a/apps/gooseforum/resource/test/code-highlighting.test.ts
+++ b/apps/gooseforum/resource/test/code-highlighting.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test, vi } from 'vitest'
+import { enhanceCodeBlocks, extractCodeLanguage } from '../src/runtime/code-highlight-directive'
+import { highlightCode } from '../src/runtime/code-highlighting'
+import { renderMarkdownPreview } from '../src/runtime/markdown'
+
+type FakeCodeElement = HTMLElement & {
+  addedClasses: Set<string>
+}
+
+function fakeCodeElement(className: string, textContent: string, innerHTML = textContent): FakeCodeElement {
+  const addedClasses = new Set<string>()
+  return {
+    className,
+    textContent,
+    innerHTML,
+    dataset: {},
+    addedClasses,
+    classList: {
+      add: (...classes: string[]) => classes.forEach(className => addedClasses.add(className)),
+    },
+  } as unknown as FakeCodeElement
+}
+
+function fakeRoot(elements: HTMLElement[]): ParentNode {
+  return {
+    querySelectorAll: vi.fn(() => elements),
+  } as unknown as ParentNode
+}
+
+describe('highlightCode', () => {
+  test('highlights recognized languages and aliases', () => {
+    expect(highlightCode('package main\nfunc main() {}', 'go')).toContain('hljs-keyword')
+    expect(highlightCode('const total: number = 1', 'ts')).toContain('hljs-keyword')
+  })
+
+  test('does not auto-detect missing or unknown languages', () => {
+    expect(highlightCode('const value = 1', '')).toBeNull()
+    expect(highlightCode('const value = 1', 'madeup')).toBeNull()
+  })
+
+  test('escapes script-like source and tolerates malformed code', () => {
+    const script = highlightCode('const value = "<script>alert(1)</script>"', 'javascript')
+    expect(script).toContain('&lt;script&gt;')
+    expect(script).not.toContain('<script>')
+    expect(highlightCode('func main( {', 'go')).not.toBeNull()
+  })
+})
+
+describe('Markdown preview integration', () => {
+  test('emits enhancement hooks while preserving escaped fallback HTML', () => {
+    const known = renderMarkdownPreview('```go\npackage main\n```')
+    const unknown = renderMarkdownPreview('```madeup\n<script>alert(1)</script>\n```')
+
+    expect(known).toContain('class="language-go"')
+    expect(known).not.toContain('class="hljs-')
+    expect(unknown).toContain('class="language-madeup"')
+    expect(unknown).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(unknown).not.toContain('<script>')
+    expect(unknown).not.toContain('class="hljs-')
+  })
+})
+
+describe('extractCodeLanguage', () => {
+  test('extracts a language class among unrelated classes', () => {
+    expect(extractCodeLanguage({ className: 'hljs language-TypeScript compact' })).toBe('TypeScript')
+  })
+
+  test('rejects empty and missing language classes', () => {
+    expect(extractCodeLanguage({ className: 'language- compact' })).toBeNull()
+    expect(extractCodeLanguage({ className: 'compact' })).toBeNull()
+  })
+})
+
+describe('enhanceCodeBlocks', () => {
+  test('does not load the highlighter without labelled code blocks', async () => {
+    const unlabelled = fakeCodeElement('', 'const plain = true')
+    const loader = vi.fn(async () => ({ highlightCode }))
+
+    await enhanceCodeBlocks(fakeRoot([unlabelled]), loader)
+
+    expect(loader).not.toHaveBeenCalled()
+    expect(unlabelled.innerHTML).toBe('const plain = true')
+  })
+
+  test('highlights recognized blocks once', async () => {
+    const code = fakeCodeElement('language-go', 'package main')
+    const loader = vi.fn(async () => ({ highlightCode }))
+    const root = fakeRoot([code])
+
+    await enhanceCodeBlocks(root, loader)
+    const firstHTML = code.innerHTML
+    await enhanceCodeBlocks(root, loader)
+
+    expect(firstHTML).toContain('hljs-keyword')
+    expect(code.innerHTML).toBe(firstHTML)
+    expect(code.addedClasses).toContain('hljs')
+    expect(code.dataset.codeHighlight).toBe('done')
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+
+  test('leaves unknown and unlabelled blocks plain', async () => {
+    const unknown = fakeCodeElement('language-madeup', '<widget>safe</widget>', '&lt;widget&gt;safe&lt;/widget&gt;')
+    const unlabelled = fakeCodeElement('', 'const plain = true')
+    const loader = vi.fn(async () => ({ highlightCode }))
+
+    await enhanceCodeBlocks(fakeRoot([unknown, unlabelled]), loader)
+
+    expect(unknown.innerHTML).toBe('&lt;widget&gt;safe&lt;/widget&gt;')
+    expect(unknown.dataset.codeHighlight).toBe('unsupported')
+    expect(unlabelled.innerHTML).toBe('const plain = true')
+    expect(unlabelled.dataset.codeHighlight).toBeUndefined()
+  })
+
+  test('preserves original markup when the highlighter cannot load', async () => {
+    const code = fakeCodeElement('language-go', 'package main', 'package main')
+
+    await enhanceCodeBlocks(fakeRoot([code]), async () => {
+      throw new Error('chunk unavailable')
+    })
+
+    expect(code.innerHTML).toBe('package main')
+    expect(code.dataset.codeHighlight).toBeUndefined()
+    expect(code.addedClasses).not.toContain('hljs')
+  })
+})

--- a/apps/gooseforum/testdata/markdown-compat/code.json
+++ b/apps/gooseforum/testdata/markdown-compat/code.json
@@ -1,8 +1,19 @@
 {
   "contains": [
     "<pre><code class=\"language-go\">",
-    "package main",
+    "<pre><code class=\"language-madeup\">",
+    "<pre><code>",
+    "package",
+    "main",
     "println",
-    "const value = 1"
+    "const value = 1",
+    "&lt;widget onclick=",
+    "&lt;/widget&gt;",
+    "&lt;script&gt;alert(",
+    "&lt;/script&gt;"
+  ],
+  "notContains": [
+    "<widget onclick=",
+    "<script>"
   ]
 }

--- a/apps/gooseforum/testdata/markdown-compat/code.md
+++ b/apps/gooseforum/testdata/markdown-compat/code.md
@@ -11,3 +11,15 @@ func main() {
 And an indented code block:
 
     const value = 1
+
+An unknown language stays readable:
+
+```madeup
+<widget onclick="alert(1)">safe text</widget>
+```
+
+An unlabelled block stays plain:
+
+```
+<script>alert("x")</script>
+```


### PR DESCRIPTION
## 变更说明

本 PR 为论坛 Markdown 增加客户端代码高亮能力，覆盖已发布内容与编辑器预览。

- 使用 Highlight.js 的常用语言构建，仅处理显式标注且受支持的语言
- 在主题、回复、引用回复、发布预览和回复预览中复用同一套高亮指令
- 高亮模块按需动态加载；页面没有带语言标记的代码块时不会下载高亮器
- 未标注或未知语言保持转义后的纯文本代码块，不启用自动语言检测
- 使用项目现有语义颜色适配明暗主题，不改变代码块原有布局
- 补充 Markdown 兼容、安全回退、幂等和加载失败测试及架构文档

## 验证结果

- `pnpm exec vitest run test/markdown-compat.test.ts test/code-highlighting.test.ts`：14 项测试通过
- `pnpm typecheck`：通过
- `pnpm build`：通过
- `go test ./app/http/controllers/markdown2html`：通过
- `go vet ./...`：通过
- Go 服务构建及前端嵌入构建：通过
- `go test ./...` 在当前 Windows 环境启动 `localcache` 临时测试程序时遇到权限限制；将该测试程序构建到普通目录后，8 项测试全部通过，其余 Go 包测试均通过

## 关联事项

关联 #27。本 PR 仅实现代码高亮部分，数学公式渲染不在本次范围内。