### PR TITLE
修复 securestore 篡改密文测试随机失败

### DIFF
--- a/apps/gooseforum/app/bundles/securestore/securestore_test.go
+++ b/apps/gooseforum/app/bundles/securestore/securestore_test.go
@@ -1,7 +1,7 @@
 package securestore
 
 import (
-	"strings"
+	"encoding/base64"
 	"testing"
 )
 
@@ -61,7 +61,12 @@ func TestDecryptRejectsTamperedPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Encrypt() error = %v", err)
 	}
-	tampered := "A" + strings.TrimPrefix(encoded, string(encoded[0]))
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	raw[len(raw)-1] ^= 0x01
+	tampered := base64.StdEncoding.EncodeToString(raw)
 	if _, err := Decrypt(tampered); err == nil {
 		t.Fatal("Decrypt() accepted tampered payload")
 	}


### PR DESCRIPTION
## 变更说明

修复 `securestore` 篡改密文测试的随机失败问题。

原测试通过将 Base64 密文的首字符替换为 `A` 来构造篡改数据。当随机 nonce 使原始密文恰好以 `A` 开头时，替换操作不会改变 payload，测试实际解密的是未篡改的密文，因此会偶发报告 `Decrypt() accepted tampered payload`。

本 PR 改为：

- 先 Base64 解码加密结果；
- 翻转最后一个字节，确保认证 tag 一定发生变化；
- 再编码后调用 `Decrypt`，验证篡改数据被拒绝；
- 不修改生产加密逻辑。

## 验证

- `go test ./app/bundles/securestore -count=1000 -run 'TestDecryptRejectsTamperedPayload$'` 通过；
- `go vet ./...` 通过；
- `go test ./...` 通过；
- `git diff --check` 通过。

Closes #32