### PR TITLE
feat(web): render Markdown math ($...$ / $$...$$) with KaTeX

### DIFF
--- a/apps/gooseforum/docs/architecture/markdown-rendering.md
+++ b/apps/gooseforum/docs/architecture/markdown-rendering.md
@@ -135,11 +135,19 @@ Current client enhancement:
 - Language auto-detection is disabled. Unknown and unlabelled languages remain
   escaped plain-text code blocks, and a load failure leaves the server or
   Markdown-it output unchanged.
+- Inline `$...$` and block `$$...$$` math is rendered with KaTeX by the
+  `v-math-render` directive. The KaTeX chunk (JS, CSS and fonts) is loaded
+  lazily only after a math marker is detected outside code blocks, and ships
+  inside the single binary via the go:embed asset pipeline. Detection uses a
+  brace-balanced scan with MathJax-style inline guards (delimiters must not sit
+  next to whitespace, inline math cannot span lines) so prices and shell
+  variables stay literal; render failures leave the original text unchanged.
+- KaTeX renders from text input only — `trust`/raw-HTML output is never
+  enabled — so math content stays escaped and cannot execute script.
 
 Potential client enhancements:
 
 - Mermaid for diagrams
-- KaTeX or MathJax for math
 
 These should be loaded only on pages that need them, preferably by detecting
 matching code fences or inline markers. They should not become part of the base

--- a/apps/gooseforum/resource/package.json
+++ b/apps/gooseforum/resource/package.json
@@ -26,6 +26,7 @@
     "compressorjs": "^1.3.0",
     "cropperjs": "^2.1.1",
     "highlight.js": "^11.11.1",
+    "katex": "^0.18.1",
     "linkify-it": "5.0.2",
     "markdown-it": "^14.2.0",
     "markdown-it-anchor": "^9.2.0",

--- a/apps/gooseforum/resource/pnpm-lock.yaml
+++ b/apps/gooseforum/resource/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      katex:
+        specifier: ^0.18.1
+        version: 0.18.1
       linkify-it:
         specifier: 5.0.2
         version: 5.0.2
@@ -55,7 +58,7 @@ importers:
         version: 14.2.0
       markdown-it-anchor:
         specifier: ^9.2.0
-        version: 9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.2.0)
+        version: 9.2.1(@types/markdown-it@14.1.2)(markdown-it@14.2.0)
       markdown-it-task-lists:
         specifier: ^2.1.1
         version: 2.1.1
@@ -67,7 +70,7 @@ importers:
         version: 1.4.0
       prosemirror-commands:
         specifier: ^1.7.1
-        version: 1.7.1
+        version: 1.7.2
       prosemirror-history:
         specifier: ^1.5.0
         version: 1.5.0
@@ -140,7 +143,7 @@ importers:
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.19
-        version: 0.5.19(tailwindcss@4.3.0)
+        version: 0.5.20(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.3.0(vite@8.1.0(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -590,10 +593,10 @@ packages:
     resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/typography@0.5.19':
-    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+  '@tailwindcss/typography@0.5.20':
+    resolution: {integrity: sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==}
     peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+      tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
   '@tailwindcss/vite@4.3.0':
     resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
@@ -853,6 +856,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue/compiler-core@3.5.34':
     resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
@@ -1019,6 +1027,10 @@ packages:
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   compressorjs@1.3.0:
     resolution: {integrity: sha512-TsvzkRgDm/6mIRUdxJbrTH7kfSW3oJzOw8b1xU60fziQSosTML5TczpO6Z4H1LGF0yRmTotk6r5UNhuRxEwA1A==}
@@ -1400,6 +1412,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  katex@0.18.1:
+    resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
+    hasBin: true
+
   kdbush@3.0.0:
     resolution: {integrity: sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==}
 
@@ -1503,8 +1519,8 @@ packages:
   maplibre-gl@2.4.0:
     resolution: {integrity: sha512-csNFylzntPmHWidczfgCZpvbTSmhaWvLRj9e1ezUDBEPizGgshgm3ea1T5TCNEEBq0roauu7BPuRZjA3wO4KqA==}
 
-  markdown-it-anchor@9.2.0:
-    resolution: {integrity: sha512-sa2ErMQ6kKOA4l31gLGYliFQrMKkqSO0ZJgGhDHKijPf0pNFM9vghjAh3gn26pS4JDRs7Iwa9S36gxm3vgZTzg==}
+  markdown-it-anchor@9.2.1:
+    resolution: {integrity: sha512-p6APiLJDFAW2GEvaavDvhIBn7jrX2jLv77NkBGgNacFTurbORYc4pyYySg/mI6mpR6cHQuAtzKtmqgQr4K8dsQ==}
     peerDependencies:
       '@types/markdown-it': '*'
       markdown-it: '*'
@@ -1629,8 +1645,8 @@ packages:
   potpack@1.0.2:
     resolution: {integrity: sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==}
 
-  prosemirror-commands@1.7.1:
-    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+  prosemirror-commands@1.7.2:
+    resolution: {integrity: sha512-q6Q6szxqdu9Xd6EcdKsqXghu5nQdZTpB4Q9yd04WRc7/jt763e/rT60Owh0L1GYY+T46o5rD+9lEN36dZS43tw==}
 
   prosemirror-history@1.5.0:
     resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
@@ -2439,7 +2455,7 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.0)':
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
@@ -2821,11 +2837,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@vue/compiler-core@3.5.34':
     dependencies:
@@ -2972,6 +2990,8 @@ snapshots:
   commander@2.20.3: {}
 
   commander@7.2.0: {}
+
+  commander@8.3.0: {}
 
   compressorjs@1.3.0:
     dependencies:
@@ -3314,6 +3334,10 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  katex@0.18.1:
+    dependencies:
+      commander: 8.3.0
+
   kdbush@3.0.0: {}
 
   kind-of@6.0.3: {}
@@ -3412,7 +3436,7 @@ snapshots:
       tinyqueue: 2.0.3
       vt-pbf: 3.1.3
 
-  markdown-it-anchor@9.2.0(@types/markdown-it@14.1.2)(markdown-it@14.2.0):
+  markdown-it-anchor@9.2.1(@types/markdown-it@14.1.2)(markdown-it@14.2.0):
     dependencies:
       '@types/markdown-it': 14.1.2
       markdown-it: 14.2.0
@@ -3528,7 +3552,7 @@ snapshots:
 
   potpack@1.0.2: {}
 
-  prosemirror-commands@1.7.1:
+  prosemirror-commands@1.7.2:
     dependencies:
       prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
@@ -3821,7 +3845,7 @@ snapshots:
 
   vue-tsc@3.3.7(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
       '@vue/language-core': 3.3.7
       typescript: 6.0.3
 

--- a/apps/gooseforum/resource/src/runtime/math-render-directive.ts
+++ b/apps/gooseforum/resource/src/runtime/math-render-directive.ts
@@ -1,0 +1,71 @@
+import type { ObjectDirective } from 'vue'
+import { extractMathSegments } from './math-segments'
+
+/**
+ * Vue directive that renders Markdown math ($...$ / $$...$$) as KaTeX.
+ *
+ * Mirrors the code-highlight directive: content is decorated in place, KaTeX
+ * is loaded lazily only after a marker is detected, and a load failure leaves
+ * the original rendered HTML unchanged. Text nodes inside code blocks and
+ * previously-rendered KaTeX output are skipped.
+ */
+
+type MathEnhancerModule = Pick<
+  typeof import('./math-rendering'),
+  'renderMath' | 'splitIntoMathParts' | 'buildFragment'
+>
+
+export interface TextNodeLike {
+  readonly data: string
+  replaceWith(node: Node | DocumentFragment): void
+}
+
+const SKIP_SELECTOR = 'pre, code, script, style, textarea, .katex, .katex-display, .katex-error'
+
+export function collectTextNodes(root: ParentNode): TextNodeLike[] {
+  const textNodes: TextNodeLike[] = []
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = (node as Text).parentElement
+      if (!parent || parent.closest(SKIP_SELECTOR)) return NodeFilter.FILTER_REJECT
+      return NodeFilter.FILTER_ACCEPT
+    },
+  })
+  let current: Node | null
+  while ((current = walker.nextNode())) textNodes.push(current as Text)
+  return textNodes
+}
+
+export async function enhanceMathText(
+  root: ParentNode,
+  loadEnhancer: () => Promise<MathEnhancerModule> = () => import('./math-rendering'),
+  collectTextNodesFn: (root: ParentNode) => TextNodeLike[] = collectTextNodes,
+): Promise<boolean> {
+  const textNodes = collectTextNodesFn(root)
+  if (!textNodes.some((node) => extractMathSegments(node.data).length > 0)) return false
+
+  let enhancer: MathEnhancerModule
+  try {
+    enhancer = await loadEnhancer()
+  } catch {
+    return false
+  }
+
+  let changed = false
+  for (const node of textNodes) {
+    const parts = enhancer.splitIntoMathParts(node.data, enhancer.renderMath)
+    if (parts.length === 1 && parts[0].type === 'text' && parts[0].value === node.data) continue
+    node.replaceWith(enhancer.buildFragment(parts))
+    changed = true
+  }
+  return changed
+}
+
+function runMathRendering(element: HTMLElement) {
+  void enhanceMathText(element)
+}
+
+export const mathRenderDirective: ObjectDirective<HTMLElement> = {
+  mounted: runMathRendering,
+  updated: runMathRendering,
+}

--- a/apps/gooseforum/resource/src/runtime/math-rendering.ts
+++ b/apps/gooseforum/resource/src/runtime/math-rendering.ts
@@ -1,0 +1,75 @@
+import katex from 'katex'
+import 'katex/dist/katex.min.css'
+import { extractMathSegments } from './math-segments'
+
+/**
+ * Lazily-loaded KaTeX renderer for Markdown math. This module is imported only
+ * after a math marker is detected, so KaTeX (JS, CSS and fonts) stays out of
+ * the base forum bundle.
+ */
+
+export type RenderedPart =
+  | { type: 'text'; value: string }
+  | { type: 'math'; html: string; display: boolean }
+
+/** Upper bound for a single math segment; longer content is kept as literal text. */
+export const MAX_MATH_LENGTH = 5000
+
+/** Cap on KaTeX-generated rule/matrix sizes (em) to prevent layout bombs. */
+const MAX_RULE_SIZE = 10
+
+export function renderMath(source: string, displayMode: boolean): string | null {
+  if (source.length > MAX_MATH_LENGTH) return null
+  try {
+    return katex.renderToString(source, { displayMode, throwOnError: false, maxSize: MAX_RULE_SIZE })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Splits a source string into plain-text and math parts. KaTeX output is HTML
+ * that must be escaped (renderToString escapes its input by design); a render
+ * failure falls back to the raw delimited text so nothing is ever lost.
+ */
+export function splitIntoMathParts(
+  source: string,
+  render: (source: string, displayMode: boolean) => string | null = renderMath,
+): RenderedPart[] {
+  const segments = extractMathSegments(source)
+  if (segments.length === 0) return [{ type: 'text', value: source }]
+
+  const parts: RenderedPart[] = []
+  let index = 0
+  for (const segment of segments) {
+    if (segment.start > index) {
+      parts.push({ type: 'text', value: source.slice(index, segment.start) })
+    }
+    const html = render(segment.text, segment.display)
+    if (html === null) {
+      parts.push({ type: 'text', value: source.slice(segment.start, segment.end) })
+    } else {
+      parts.push({ type: 'math', html, display: segment.display })
+    }
+    index = segment.end
+  }
+  if (index < source.length) {
+    parts.push({ type: 'text', value: source.slice(index) })
+  }
+  return parts
+}
+
+/** Builds a document fragment from rendered parts (browser only). */
+export function buildFragment(parts: RenderedPart[]): DocumentFragment {
+  const fragment = document.createDocumentFragment()
+  for (const part of parts) {
+    if (part.type === 'text') {
+      fragment.appendChild(document.createTextNode(part.value))
+    } else {
+      const holder = document.createElement('span')
+      holder.innerHTML = part.html
+      fragment.appendChild(holder.firstElementChild ?? holder)
+    }
+  }
+  return fragment
+}

--- a/apps/gooseforum/resource/src/runtime/math-segments.ts
+++ b/apps/gooseforum/resource/src/runtime/math-segments.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure delimiter detection for Markdown math ($...$ and $$...$$).
+ *
+ * The detection rules are a port of KaTeX auto-render's brace-balanced scan,
+ * plus MathJax-style inline guards (delimiters must not sit next to whitespace
+ * and inline math cannot span lines) to keep prices and shell variables literal.
+ *
+ * This module must stay free of DOM and KaTeX imports so the directive can use
+ * it as a cheap loading gate without pulling the KaTeX chunk into the bundle.
+ */
+
+export interface MathSegment {
+  /** TeX source without the surrounding delimiters. */
+  text: string
+  /** True for block math ($$...$$), false for inline ($...$). */
+  display: boolean
+  /** Offset of the opening delimiter in the source string. */
+  start: number
+  /** Offset just after the closing delimiter. */
+  end: number
+}
+
+const BLOCK_DELIMITER = '$$'
+const INLINE_DELIMITER = '$'
+
+function isEscaped(source: string, index: number): boolean {
+  let backslashes = 0
+  for (let i = index - 1; i >= 0 && source[i] === '\\'; i--) backslashes++
+  return backslashes % 2 === 1
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char !== undefined && /\s/.test(char)
+}
+
+/**
+ * Scans for a closing `delimiter`, tracking `{}` nesting and skipping
+ * backslash-escaped characters (port of KaTeX auto-render's findEndOfMath).
+ */
+function findClosingDelimiter(source: string, delimiter: string, startIndex: number): number {
+  const delimLength = delimiter.length
+  let braceLevel = 0
+  let index = startIndex
+  while (index < source.length) {
+    if (braceLevel <= 0 && source.startsWith(delimiter, index)) return index
+    const char = source[index]
+    if (char === '\\') {
+      index++
+    } else if (char === '{') {
+      braceLevel++
+    } else if (char === '}') {
+      braceLevel--
+    }
+    index++
+  }
+  return -1
+}
+
+/**
+ * Scans for a closing inline `$`. A closing dollar must not be adjacent to
+ * whitespace; an interior dollar that cannot close the segment means the
+ * construct is not well-formed inline math and the whole candidate is rejected.
+ */
+function findInlineClosing(source: string, startIndex: number): number {
+  let braceLevel = 0
+  let index = startIndex
+  while (index < source.length) {
+    const char = source[index]
+    if (braceLevel <= 0 && char === INLINE_DELIMITER) {
+      if (index > startIndex && !isWhitespace(source[index - 1])) return index
+      return -1
+    }
+    if (char === '\\') {
+      index++
+    } else if (char === '{') {
+      braceLevel++
+    } else if (char === '}') {
+      braceLevel--
+    }
+    index++
+  }
+  return -1
+}
+
+export function extractMathSegments(source: string): MathSegment[] {
+  const segments: MathSegment[] = []
+  let index = 0
+
+  while (index < source.length) {
+    const dollarIndex = source.indexOf(INLINE_DELIMITER, index)
+    if (dollarIndex === -1) break
+
+    if (isEscaped(source, dollarIndex)) {
+      index = dollarIndex + 1
+      continue
+    }
+
+    if (source.startsWith(BLOCK_DELIMITER, dollarIndex)) {
+      const close = findClosingDelimiter(source, BLOCK_DELIMITER, dollarIndex + BLOCK_DELIMITER.length)
+      if (close !== -1) {
+        const text = source.slice(dollarIndex + BLOCK_DELIMITER.length, close)
+        if (text.trim().length > 0) {
+          segments.push({ text, display: true, start: dollarIndex, end: close + BLOCK_DELIMITER.length })
+          index = close + BLOCK_DELIMITER.length
+          continue
+        }
+      }
+      index = dollarIndex + 1
+      continue
+    }
+
+    if (isWhitespace(source[dollarIndex + 1])) {
+      index = dollarIndex + 1
+      continue
+    }
+
+    const close = findInlineClosing(source, dollarIndex + 1)
+    if (close !== -1) {
+      const text = source.slice(dollarIndex + 1, close)
+      if (text.length > 0 && !text.includes('\n')) {
+        segments.push({ text, display: false, start: dollarIndex, end: close + 1 })
+        index = close + 1
+        continue
+      }
+    }
+    index = dollarIndex + 1
+  }
+
+  return segments
+}
+

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -437,7 +437,7 @@ function submit() {
                 />
                 <div v-else class="gf-prose gf-prose-post min-h-24 max-w-none px-3 py-2.5">
                   <template v-if="content.trim()">
-                    <div v-code-highlight v-html="renderedPreview" />
+                    <div v-code-highlight v-math-render v-html="renderedPreview" />
                   </template>
                   <p v-else class="text-sm text-base-content/55">{{ t('publish.emptyPreview') }}</p>
                 </div>

--- a/apps/gooseforum/resource/src/site/components/PostReplyReference.vue
+++ b/apps/gooseforum/resource/src/site/components/PostReplyReference.vue
@@ -78,6 +78,7 @@ onBeforeUnmount(() => resizeObserver?.disconnect())
             'reply-reference-content--faded': !expanded && overflowing,
           }"
           v-code-highlight
+          v-math-render
           v-html="target.renderedContent"
         />
       </div>

--- a/apps/gooseforum/resource/src/site/main.ts
+++ b/apps/gooseforum/resource/src/site/main.ts
@@ -8,6 +8,7 @@ import { hydrateFlashMessages } from '@/runtime/flash-message'
 import { applySiteThemePayload, applyStoredTheme } from '@/runtime/site-theme'
 import PayloadRouteView from '@/site/components/PayloadRouteView.vue'
 import { codeHighlightDirective } from '@/runtime/code-highlight-directive'
+import { mathRenderDirective } from '@/runtime/math-render-directive'
 
 const initialPayload = readInitialPayload()
 const initialPage = await preparePayload(initialPayload)
@@ -42,6 +43,7 @@ const app = createApp({
 app.use(i18n)
 app.use(router)
 app.directive('code-highlight', codeHighlightDirective)
+app.directive('math-render', mathRenderDirective)
 await router.isReady()
 app.mount('#goose-app')
 

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -708,7 +708,7 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
                 </div>
               </div>
 
-              <div v-if="preview && content.trim()" v-code-highlight class="gf-prose gf-prose-post min-h-80 max-w-none px-1 py-4" v-html="renderedPreview" />
+              <div v-if="preview && content.trim()" v-code-highlight v-math-render class="gf-prose gf-prose-post min-h-80 max-w-none px-1 py-4" v-html="renderedPreview" />
               <div v-else-if="preview" class="gf-prose gf-prose-post min-h-80 max-w-none px-1 py-4">
                 <p class="text-sm text-base-content/55">{{ t('publish.emptyPreview') }}</p>
               </div>

--- a/apps/gooseforum/resource/src/site/pages/TopicPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/TopicPage.vue
@@ -1758,7 +1758,7 @@ async function removePost(postId: number) {
                 <div v-if="group.root.isHidden && !group.root.canModerate" class="rounded border border-line bg-base-200/60 px-3 py-2 text-sm text-base-content/45">
                   {{ t('topic.hiddenReplyPlaceholder') }}
                 </div>
-                <div v-else v-code-highlight class="gf-prose gf-prose-post" v-html="group.root.renderedContent" />
+                <div v-else v-code-highlight v-math-render class="gf-prose gf-prose-post" v-html="group.root.renderedContent" />
                 <div v-if="group.root.isHidden && group.root.canModerate" class="mt-2 inline-flex rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/45">
                   {{ t('topic.hiddenReplyBadge') }}
                 </div>
@@ -1852,7 +1852,7 @@ async function removePost(postId: number) {
                     <div v-if="reply.isHidden && !reply.canModerate" class="mt-2 rounded border border-line bg-base-100 px-3 py-2 text-sm text-base-content/45">
                       {{ t('topic.hiddenReplyPlaceholder') }}
                     </div>
-                    <div v-else v-code-highlight class="gf-prose gf-prose-post mt-2" v-html="reply.renderedContent" />
+                    <div v-else v-code-highlight v-math-render class="gf-prose gf-prose-post mt-2" v-html="reply.renderedContent" />
                     <div v-if="reply.isHidden && reply.canModerate" class="mt-2 inline-flex rounded bg-base-200 px-2 py-1 text-xs font-semibold text-base-content/45">
                       {{ t('topic.hiddenReplyBadge') }}
                     </div>

--- a/apps/gooseforum/resource/test/math-rendering.test.ts
+++ b/apps/gooseforum/resource/test/math-rendering.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test, vi } from 'vitest'
+import { extractMathSegments } from '../src/runtime/math-segments'
+import { MAX_MATH_LENGTH, renderMath, splitIntoMathParts } from '../src/runtime/math-rendering'
+import { enhanceMathText } from '../src/runtime/math-render-directive'
+import type { TextNodeLike } from '../src/runtime/math-render-directive'
+
+describe('extractMathSegments', () => {
+  test('detects a simple inline segment', () => {
+    expect(extractMathSegments('$x$')).toEqual([
+      { text: 'x', display: false, start: 0, end: 3 },
+    ])
+  })
+
+  test('detects a block segment with priority over inline', () => {
+    expect(extractMathSegments('$$x$$')).toEqual([
+      { text: 'x', display: true, start: 0, end: 5 },
+    ])
+  })
+
+  test('detects inline and block segments in mixed text in order', () => {
+    expect(extractMathSegments('a $x$ and $$y$$ end')).toEqual([
+      { text: 'x', display: false, start: 2, end: 5 },
+      { text: 'y', display: true, start: 10, end: 15 },
+    ])
+  })
+
+  test('detects multiple inline segments', () => {
+    expect(extractMathSegments('$a$ and $b$')).toEqual([
+      { text: 'a', display: false, start: 0, end: 3 },
+      { text: 'b', display: false, start: 8, end: 11 },
+    ])
+  })
+
+  test('balances braces inside inline math', () => {
+    expect(extractMathSegments('$a_{x}$')).toEqual([
+      { text: 'a_{x}', display: false, start: 0, end: 7 },
+    ])
+    expect(extractMathSegments('$a {b}$').map((s) => s.text)).toEqual(['a {b}'])
+  })
+
+  test('allows block math to span newlines', () => {
+    const [segment] = extractMathSegments('$$\na\nb\n$$')
+    expect(segment.display).toBe(true)
+    expect(segment.text).toContain('\n')
+  })
+
+  test('ignores an escaped opening dollar sign', () => {
+    expect(extractMathSegments('\\$x$')).toEqual([])
+  })
+
+  test('rejects inline math adjacent to whitespace', () => {
+    expect(extractMathSegments('$ x$')).toEqual([])
+    expect(extractMathSegments('$x $')).toEqual([])
+    expect(extractMathSegments('x $ x$')).toEqual([])
+  })
+
+  test('rejects inline math spanning a newline', () => {
+    expect(extractMathSegments('$x\ny$')).toEqual([])
+  })
+
+  test('does not treat prices or shell variables as math', () => {
+    expect(extractMathSegments('a $5 discount')).toEqual([])
+    expect(extractMathSegments('$PATH and $HOME are set')).toEqual([])
+    expect(extractMathSegments('cost $5 and $10 each')).toEqual([])
+  })
+
+  test('resolves an ambiguous candidate to a later well-formed segment', () => {
+    expect(extractMathSegments('$5 and $x$')).toEqual([
+      { text: 'x', display: false, start: 7, end: 10 },
+    ])
+  })
+
+  test('leaves empty or unclosed delimiters as literal text', () => {
+    expect(extractMathSegments('$$$$')).toEqual([])
+    expect(extractMathSegments('$')).toEqual([])
+    expect(extractMathSegments('$$x')).toEqual([])
+    expect(extractMathSegments('plain text without math')).toEqual([])
+  })
+})
+
+describe('renderMath', () => {
+  test('renders inline math with a katex span', () => {
+    const html = renderMath('x^2', false)
+    expect(html).not.toBeNull()
+    expect(html).toContain('katex')
+  })
+
+  test('renders block math in display mode', () => {
+    const html = renderMath('\\frac{a}{b}', true)
+    expect(html).not.toBeNull()
+    expect(html).toContain('katex-display')
+  })
+
+  test('escapes script-like source instead of injecting it', () => {
+    const html = renderMath('<script>alert(1)</script>', false)
+    expect(html).not.toBeNull()
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('onerror=')
+    expect(html).not.toContain('<img')
+    expect(html).toContain('&lt;script')
+  })
+
+  test('escapes event-handler attributes in malformed input', () => {
+    const html = renderMath('x onerror="alert(1)"', false)
+    expect(html).not.toContain('<script')
+    expect(html).not.toContain('onerror="')
+    expect(html).not.toContain('javascript:')
+  })
+
+  test('refuses over-long segments to avoid client-side jank', () => {
+    expect(renderMath(`x`.repeat(MAX_MATH_LENGTH + 1), false)).toBeNull()
+    expect(renderMath(`x`.repeat(MAX_MATH_LENGTH), false)).not.toBeNull()
+  })
+})
+
+describe('splitIntoMathParts', () => {
+  test('returns a single text part without math', () => {
+    expect(splitIntoMathParts('plain text')).toEqual([{ type: 'text', value: 'plain text' }])
+  })
+
+  test('interleaves text and math parts', () => {
+    const parts = splitIntoMathParts('a $x$ b', () => '<span class="katex"></span>')
+    expect(parts).toEqual([
+      { type: 'text', value: 'a ' },
+      { type: 'math', html: '<span class="katex"></span>', display: false },
+      { type: 'text', value: ' b' },
+    ])
+  })
+
+  test('keeps the raw delimited text when rendering fails', () => {
+    const parts = splitIntoMathParts('a $x$ b', () => null)
+    expect(parts).toEqual([
+      { type: 'text', value: 'a ' },
+      { type: 'text', value: '$x$' },
+      { type: 'text', value: ' b' },
+    ])
+  })
+
+  test('keeps an over-long math segment as literal text', () => {
+    const longMath = `$${`x`.repeat(MAX_MATH_LENGTH + 1)}$`
+    const parts = splitIntoMathParts(longMath)
+    expect(parts).toEqual([{ type: 'text', value: longMath }])
+  })
+})
+
+describe('enhanceMathText', () => {
+  function fakeNode(data: string, replaceWith = vi.fn()): TextNodeLike {
+    return { data, replaceWith }
+  }
+
+  test('does not load the renderer without math markers', async () => {
+    const nodes = [fakeNode('plain text')]
+    const loader = vi.fn(async () => ({
+      renderMath,
+      splitIntoMathParts,
+      buildFragment: (parts: unknown) => parts,
+    }))
+
+    const changed = await enhanceMathText({} as ParentNode, loader, () => nodes)
+
+    expect(changed).toBe(false)
+    expect(loader).not.toHaveBeenCalled()
+    expect(nodes[0].replaceWith).not.toHaveBeenCalled()
+  })
+
+  test('does not load the renderer for dollar signs that are not math', async () => {
+    const nodes = [fakeNode('a $5 discount and a $HOME path')]
+    const loader = vi.fn(async () => ({
+      renderMath,
+      splitIntoMathParts,
+      buildFragment: (parts: unknown) => parts,
+    }))
+
+    const changed = await enhanceMathText({} as ParentNode, loader, () => nodes)
+
+    expect(changed).toBe(false)
+    expect(loader).not.toHaveBeenCalled()
+    expect(nodes[0].replaceWith).not.toHaveBeenCalled()
+  })
+
+  test('preserves content when the renderer cannot load', async () => {
+    const node = fakeNode('$x$')
+    const loader = vi.fn(async () => {
+      throw new Error('chunk unavailable')
+    })
+
+    const changed = await enhanceMathText({} as ParentNode, loader, () => [node])
+
+    expect(changed).toBe(false)
+    expect(node.replaceWith).not.toHaveBeenCalled()
+  })
+
+  test('replaces math-bearing text nodes and returns true', async () => {
+    const node = fakeNode('$x$')
+    const buildFragment = vi.fn((parts: unknown) => parts)
+    const loader = vi.fn(async () => ({ renderMath, splitIntoMathParts, buildFragment }))
+
+    const changed = await enhanceMathText({} as ParentNode, loader, () => [node])
+
+    expect(changed).toBe(true)
+    expect(node.replaceWith).toHaveBeenCalledTimes(1)
+    expect(buildFragment).toHaveBeenCalled()
+  })
+
+  test('skips nodes without math even when siblings contain it', async () => {
+    const plain = fakeNode('plain')
+    const math = fakeNode('$x$')
+    const loader = vi.fn(async () => ({
+      renderMath,
+      splitIntoMathParts,
+      buildFragment: (parts: unknown) => parts,
+    }))
+
+    const changed = await enhanceMathText({} as ParentNode, loader, () => [plain, math])
+
+    expect(changed).toBe(true)
+    expect(plain.replaceWith).not.toHaveBeenCalled()
+    expect(math.replaceWith).toHaveBeenCalledTimes(1)
+  })
+
+  test('loads the renderer only once across re-enhancement passes', async () => {
+    const node = fakeNode('$x$')
+    const replaced = new Set<TextNodeLike>()
+    const nodes: TextNodeLike[] = [node]
+    node.replaceWith = vi.fn((fragment: unknown) => {
+      replaced.add(node)
+    })
+    const loader = vi.fn(async () => ({
+      renderMath,
+      splitIntoMathParts,
+      buildFragment: (parts: unknown) => parts,
+    }))
+
+    await enhanceMathText({} as ParentNode, loader, () => nodes.filter((n) => !replaced.has(n)))
+    await enhanceMathText({} as ParentNode, loader, () => nodes.filter((n) => !replaced.has(n)))
+
+    expect(loader).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/gooseforum/testdata/markdown-compat/math.json
+++ b/apps/gooseforum/testdata/markdown-compat/math.json
@@ -1,0 +1,14 @@
+{
+  "contains": [
+    "$x^2 + y^2 = z^2$",
+    "$\\alpha + \\beta$",
+    "$$",
+    "E = mc^2",
+    "$5 discount",
+    "$HOME"
+  ],
+  "notContains": [
+    "<script>",
+    "onerror="
+  ]
+}

--- a/apps/gooseforum/testdata/markdown-compat/math.md
+++ b/apps/gooseforum/testdata/markdown-compat/math.md
@@ -1,0 +1,9 @@
+Inline math delimiters stay literal: $x^2 + y^2 = z^2$ and $\alpha + \beta$.
+
+Block math delimiters stay literal:
+
+$$
+E = mc^2
+$$
+
+Dollar signs in ordinary text also stay literal: a $5 discount and a $HOME path.


### PR DESCRIPTION
## Motivation

Closes #27. Users requested Markdown math rendering in forum posts (QQ group feedback). Code highlighting was delivered in #30; this PR completes the remaining scope: inline `$...$` and block `$$...$$` math via KaTeX, following the same client-side enhancement pattern (explicit marker, on-demand loading, graceful fallback).

## Behavior change

- Topic/reply bodies, reply-reference quotes, and publish/reply previews now render `$...$` / `$$...$$` as KaTeX math.
- Detection uses a brace-balanced scan (ported from KaTeX auto-render) plus MathJax-style guards: delimiters must not sit next to whitespace and inline math cannot span lines, so prices (`$5`) and shell variables (`$HOME`) stay literal. Code blocks and already-rendered KaTeX output are skipped.
- The KaTeX chunk (JS + CSS + fonts) is loaded lazily only when a real math segment is detected outside code blocks, and ships inside the single binary via the existing go:embed asset pipeline.
- Math is rendered from text input only (`trust`/raw-HTML never enabled, verified against `\href{javascript:}` / `\htmlData` / `\includegraphics`), with a 5000-char per-segment cap and a KaTeX rule-size cap to prevent client-side jank. Load/render failures leave the original text unchanged.

## Verification

- `cd apps/gooseforum && go vet ./... && go test ./...` → pass (78 packages)
- `cd apps/gooseforum/resource && pnpm typecheck` → 0 errors
- `vitest run test/math-rendering.test.ts test/markdown-compat.test.ts test/code-highlighting.test.ts` → 42 pass (27 math + 5 compat + 10 highlight)
- Full `vitest run` → 73 pass; 2 pre-existing failures in `packages/client/test/client.test.ts` (`drafts.index` page-component list) unrelated to this change
- `pnpm build` → KaTeX emitted as a lazy chunk (~78 KB gzip); CSS + fonts in the manifest
- `make build` → single binary builds; `go test ./resource -run TestAssetsFSMatchesViteManifestPaths` passes (embedded FS serves the KaTeX assets)
- Local smoke: ran `./bin/yourtj-hub serve` (SQLite), registered a user, published a topic with inline/block math, a price, a shell variable and a code block; confirmed via browser that math renders, `$5`/`$HOME` and code-block dollars stay literal, and no residual delimiters remain in rendered content.

## Documentation / contract impact

- No server-side change: `GetPostVersion()` unchanged, no DB migration, no re-render required (`$...$` passes through both renderers verbatim — locked by the new `testdata/markdown-compat/math` fixtures).
- `docs/architecture/markdown-rendering.md` updated: math moved from "potential" to "current client enhancement".

## Known gaps

- Editor toolbar math button (listed as optional in #27) not added.
- Inline `$...$` shares the inherent ambiguity of the `$` delimiter (e.g. `cost $5 and $10 each` renders `5`); guarded by whitespace rules and documented in the fixture contract.
- KaTeX fonts are bundled untrimmed (≈1.1 MB on disk, lazy-loaded); woff2-only trimming is a possible follow-up.
- The full vitest suite is not wired into CI (frontend CI runs typecheck + build only); the new unit tests run locally.
