### PR TITLE
feat(editor): improve link insertion UX

### DIFF
--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -64,6 +64,7 @@ const toolbarOpen = ref(false)
 const toolbarCloseTimer = ref<ReturnType<typeof setTimeout> | null>(null)
 const linkPickerOpen = ref(false)
 const linkUrl = ref('')
+const linkInput = ref<HTMLInputElement | null>(null)
 const visualEditor = ref<InstanceType<typeof VisualMarkdownEditor> | null>(null)
 const markdownEditor = ref<HTMLTextAreaElement | null>(null)
 const uploadingImage = ref(false)
@@ -98,19 +99,20 @@ function closeComposer() {
   emit('update:open', false)
 }
 
-function openLinkPicker() {
-  if (editorMode.value === 'markdown') {
-    insert('[', '](https://)', t('publish.placeholder.link'))
-    return
-  }
+async function openLinkPicker() {
   linkPickerOpen.value = !linkPickerOpen.value
+  if (!linkPickerOpen.value) return
+  if (!linkUrl.value) linkUrl.value = 'https://'
+  await nextTick()
+  linkInput.value?.focus()
+  linkInput.value?.select()
 }
 
 async function applyLink() {
   const url = linkUrl.value.trim()
   if (!url) return
   if (editorMode.value === 'visual') {
-    visualEditor.value?.setLink(url, url)
+    visualEditor.value?.setLink(url, t('publish.placeholder.link'))
     linkPickerOpen.value = false
     linkUrl.value = ''
     await nextTick()
@@ -118,7 +120,10 @@ async function applyLink() {
     return
   }
   insert('[', `](${url})`, t('publish.placeholder.link'))
+  linkPickerOpen.value = false
   linkUrl.value = ''
+  await nextTick()
+  markdownEditor.value?.focus()
 }
 
 function scheduleToolbarClose() {
@@ -397,7 +402,7 @@ function submit() {
                   <div class="relative">
                     <button type="button" class="rounded p-1.5 text-base-content/55 transition hover:bg-base-200 hover:text-base-content" :title="t('publish.toolbar.link')" :aria-expanded="linkPickerOpen" @mousedown.prevent @click="openLinkPicker"><Link class="h-4 w-4" /></button>
                     <form v-if="linkPickerOpen" class="gf-menu-surface absolute bottom-full left-0 z-30 mb-1.5 flex w-72 max-w-[calc(100vw-5rem)] items-center gap-1.5 p-2 shadow-lg" @submit.prevent="applyLink">
-                      <input v-model="linkUrl" type="text" inputmode="url" class="h-8 min-w-0 flex-1 rounded border border-line bg-base-100 px-2 text-sm outline-none focus:border-primary" :placeholder="t('publish.toolbar.linkUrl')" />
+                      <input ref="linkInput" v-model="linkUrl" type="text" inputmode="url" class="h-8 min-w-0 flex-1 rounded border border-line bg-base-100 px-2 text-sm outline-none focus:border-primary" :placeholder="t('publish.toolbar.linkUrl')" />
                       <button type="submit" class="gf-button gf-button-primary h-8 px-2.5" :disabled="!linkUrl.trim()">{{ t('publish.toolbar.applyLink') }}</button>
                     </form>
                   </div>

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -401,7 +401,7 @@ function submit() {
                   <button type="button" class="rounded p-1.5 text-base-content/55 transition hover:bg-base-200 hover:text-base-content" :title="t('publish.toolbar.inlineCode')" @mousedown.prevent @click="applyToolbarAction('inlineCode')"><Code class="h-4 w-4" /></button>
                   <div class="relative">
                     <button type="button" class="rounded p-1.5 text-base-content/55 transition hover:bg-base-200 hover:text-base-content" :title="t('publish.toolbar.link')" :aria-expanded="linkPickerOpen" @mousedown.prevent @click="openLinkPicker"><Link class="h-4 w-4" /></button>
-                    <form v-if="linkPickerOpen" class="gf-menu-surface absolute bottom-full left-0 z-30 mb-1.5 flex w-72 max-w-[calc(100vw-5rem)] items-center gap-1.5 p-2 shadow-lg" @submit.prevent="applyLink">
+                    <form v-if="linkPickerOpen" class="gf-menu-surface absolute left-0 top-full z-30 mt-1.5 flex w-72 max-w-[calc(100vw-5rem)] items-center gap-1.5 p-2 shadow-lg" @submit.prevent="applyLink">
                       <input ref="linkInput" v-model="linkUrl" type="text" inputmode="url" class="h-8 min-w-0 flex-1 rounded border border-line bg-base-100 px-2 text-sm outline-none focus:border-primary" :placeholder="t('publish.toolbar.linkUrl')" />
                       <button type="submit" class="gf-button gf-button-primary h-8 px-2.5" :disabled="!linkUrl.trim()">{{ t('publish.toolbar.applyLink') }}</button>
                     </form>

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -276,7 +276,7 @@ async function openLinkPicker() {
   linkInput.value?.select()
 }
 
-function applyLink() {
+async function applyLink() {
   const href = linkUrl.value.trim()
   if (!href) return
   if (editorMode.value === 'markdown') {
@@ -286,7 +286,10 @@ function applyLink() {
     return
   }
   linkPickerOpen.value = false
+  linkUrl.value = ''
   visualEditor.value?.setLink(href, t('publish.placeholder.link'))
+  await nextTick()
+  visualEditor.value?.focus()
 }
 
 function openTablePicker() {
@@ -467,7 +470,7 @@ function handleEditorKeydown(event: KeyboardEvent) {
     insert('*', '*', t('publish.placeholder.italic'))
   } else if (key === 'k') {
     event.preventDefault()
-    insert('[', '](https://)', t('publish.placeholder.link'))
+    openLinkPicker()
   }
 }
 

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -266,10 +266,6 @@ function setMarkdownLineType(block: Exclude<MarkdownBlockType, 'code_block'>) {
 }
 
 async function openLinkPicker() {
-  if (editorMode.value === 'markdown') {
-    insert('[', '](https://)', t('publish.placeholder.link'))
-    return
-  }
   blockPickerOpen.value = false
   tablePickerOpen.value = false
   linkPickerOpen.value = !linkPickerOpen.value
@@ -283,6 +279,12 @@ async function openLinkPicker() {
 function applyLink() {
   const href = linkUrl.value.trim()
   if (!href) return
+  if (editorMode.value === 'markdown') {
+    insert('[', `](${href})`, t('publish.placeholder.link'))
+    linkPickerOpen.value = false
+    linkUrl.value = ''
+    return
+  }
   linkPickerOpen.value = false
   visualEditor.value?.setLink(href, t('publish.placeholder.link'))
 }


### PR DESCRIPTION
## 目标

改善发布页和回复编辑器里“插入链接”的交互，让 Markdown 模式不再点击后直接插入 `https://` 占位，而是和 Visual 模式一样先输入 URL，再生成链接。

## 改动

- 回复编辑器：`PostComposer.vue` 增加链接输入框 `ref`，打开弹层时自动聚焦并全选 URL 输入。
- Markdown 模式：不再直接插入 `[链接文本](https://)`，而是先打开链接弹层，输入 URL 后插入链接并关闭弹层。
- Visual 模式：回复编辑器使用统一的 `publish.placeholder.link`，空选状态下插入“链接文本”占位供用户直接输入。
- 发布页：`PublishPage.vue` 的 Markdown 模式也改为走同一个链接弹层流程。

## 验证

- `pnpm typecheck`：通过
- `pnpm build`：通过
- `vitest` 全量仍有 `dev` 上既有的 2 个 page-component 失败，与本 PR 无关