### PR TITLE
fix: show symmetric top-aligned avatars in messages

### DIFF
--- a/apps/gooseforum/resource/src/site/pages/MessagesPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/MessagesPage.vue
@@ -329,10 +329,14 @@ async function startChat(user: UserConnectionPayload) {
                 <div
                   v-for="message in active.messages"
                   :key="message.id"
-                  class="flex max-w-[88%] gap-2 md:max-w-[82%]"
+                  class="flex max-w-[88%] items-start gap-2 md:max-w-[82%]"
                   :class="message.isSelf ? 'ml-auto flex-row-reverse' : ''"
                 >
-                  <UserAvatar v-if="!message.isSelf" :src="active.peerAvatar" :alt="active.peerUsername" class="mt-auto h-8 w-8 rounded-full object-cover ring-1 ring-line" />
+                  <UserAvatar
+                    :src="message.isSelf ? page.layout.viewer.avatarUrl : active.peerAvatar"
+                    :alt="message.isSelf ? page.layout.viewer.username : active.peerUsername"
+                    class="h-8 w-8 rounded-full object-cover ring-1 ring-line"
+                  />
                   <div class="group relative min-w-0">
                     <div
                       class="whitespace-pre-wrap break-words px-3 py-2 text-sm leading-relaxed shadow-sm [border-radius:var(--gf-radius-box)] md:px-4"


### PR DESCRIPTION
## Motivation

The messages page only rendered peer avatars and pinned them to the bottom of each message row, producing asymmetric rows and visible misalignment for multi-line bubbles.

Closes #37.

## Behavior change

- Render the current viewer avatar for self-authored messages.
- Keep the peer avatar for received messages.
- Align both avatars with the top of their message bubbles while preserving the existing size, rounded shape, and ring styling.

## Verification

- `pnpm typecheck` - passed.
- `pnpm build` - passed; only the existing `@vueuse/core` invalid pure-annotation warnings were emitted.
- `git diff --check` - passed.
- Playwright visual QA at desktop and mobile widths - passed in light and dark color schemes.
- Long self-message interaction - passed; self avatar remained on the right and top-aligned.
- DOM geometry assertions - avatar/bubble top delta was `0px` for every row, with no horizontal overflow.

## Documentation and contract impact

No documentation, OpenAPI, generated client, backend, database, auth, search, or deployment changes are required. This is a presentation-only correction to existing direct-message behavior.

## Known gaps

No dedicated component test harness currently covers `MessagesPage.vue`; verification uses the repository frontend gates plus browser-level visual and geometry checks.