### PR TITLE
fix(deploy): sync file.db media db in PostgreSQL dev deploy

### DIFF
--- a/deploy/scripts/sync-db-from-main.sh
+++ b/deploy/scripts/sync-db-from-main.sh
@@ -33,28 +33,6 @@ pg_dbname() {
 MAIN_MODE="$(db_mode "$ROOT/main/config.toml")"
 DEV_MODE="$(db_mode "$ROOT/dev/config.toml")"
 
-if [ "$MAIN_MODE" = "postgres" ] && [ "$DEV_MODE" = "postgres" ]; then
-  MAIN_PG="$(pg_dbname "$ROOT/main/config.toml")"
-  DEV_PG="$(pg_dbname "$ROOT/dev/config.toml")"
-  if [ -z "$MAIN_PG" ] || [ -z "$DEV_PG" ]; then
-    echo "sync-db: cannot parse PG dbnames from configs" >&2
-    exit 1
-  fi
-  echo "sync-db: PG mode ($MAIN_PG -> $DEV_PG)"
-  docker exec yourtj-postgres psql -U yourtj -d postgres \
-    -c "DROP DATABASE IF EXISTS \"$DEV_PG\";" -c "CREATE DATABASE \"$DEV_PG\";" >/dev/null
-  docker exec yourtj-postgres sh -c "pg_dump -U yourtj -d \"$MAIN_PG\" | psql -U yourtj -d \"$DEV_PG\"" >/dev/null
-  echo "sync-db: dev PG db synced from main"
-  exit 0
-fi
-
-# 保留 dev 旧库一份(排查用)
-if [ -f "$DEV_DB" ]; then
-  mkdir -p "$ROOT/snapshots/dev-prev"
-  cp -f "$DEV_DB" "$ROOT/snapshots/dev-prev/sqlite-$(date +%Y%m%d_%H%M%S).db"
-  [ -f "$DEV_FILE_DB" ] && cp -f "$DEV_FILE_DB" "$ROOT/snapshots/dev-prev/file-$(date +%Y%m%d_%H%M%S).db"
-fi
-
 sync_one() {
   local src="$1" dst="$2" label="$3"
   if [ ! -f "$src" ]; then
@@ -68,6 +46,35 @@ sync_one() {
   rm -f "$TMP"
   echo "sync-db: $label synced from main"
 }
+
+if [ "$MAIN_MODE" = "postgres" ] && [ "$DEV_MODE" = "postgres" ]; then
+  MAIN_PG="$(pg_dbname "$ROOT/main/config.toml")"
+  DEV_PG="$(pg_dbname "$ROOT/dev/config.toml")"
+  if [ -z "$MAIN_PG" ] || [ -z "$DEV_PG" ]; then
+    echo "sync-db: cannot parse PG dbnames from configs" >&2
+    exit 1
+  fi
+  echo "sync-db: PG mode ($MAIN_PG -> $DEV_PG)"
+  if [ -f "$DEV_FILE_DB" ]; then
+    mkdir -p "$ROOT/snapshots/dev-prev"
+    cp -f "$DEV_FILE_DB" "$ROOT/snapshots/dev-prev/file-$(date +%Y%m%d_%H%M%S).db"
+  fi
+  docker exec yourtj-postgres psql -U yourtj -d postgres \
+    -c "DROP DATABASE IF EXISTS \"$DEV_PG\";" -c "CREATE DATABASE \"$DEV_PG\";" >/dev/null
+  docker exec yourtj-postgres sh -c "pg_dump -U yourtj -d \"$MAIN_PG\" | psql -U yourtj -d \"$DEV_PG\"" >/dev/null
+  echo "sync-db: dev PG db synced from main"
+  sync_one "$MAIN_FILE_DB" "$DEV_FILE_DB" "file"
+  chown -R 1000:1000 "$ROOT/dev/storage" 2>/dev/null || true
+  echo "sync-db: dev file db synced from main"
+  exit 0
+fi
+
+# 保留 dev 旧库一份(排查用)
+if [ -f "$DEV_DB" ]; then
+  mkdir -p "$ROOT/snapshots/dev-prev"
+  cp -f "$DEV_DB" "$ROOT/snapshots/dev-prev/sqlite-$(date +%Y%m%d_%H%M%S).db"
+  [ -f "$DEV_FILE_DB" ] && cp -f "$DEV_FILE_DB" "$ROOT/snapshots/dev-prev/file-$(date +%Y%m%d_%H%M%S).db"
+fi
 
 sync_one "$MAIN_DB" "$DEV_DB" "sqlite"
 sync_one "$MAIN_FILE_DB" "$DEV_FILE_DB" "file"

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -199,6 +199,7 @@ instance:
   - PostgreSQL: `backup-db.sh` runs `pg_dump` into `snapshots/<instance>/pg-<db>-<ts>.sql`;
     `sync-db-from-main.sh` drops/recreates `yourtj_dev` and pipes
     `pg_dump -d yourtj_main | psql -d yourtj_dev` (dev is a clean one-way snapshot of main).
+  - PostgreSQL mode also snapshots dev's existing `file.db` and copies main's `file.db` to dev, because `[db.file]` remains SQLite even when the main database is PostgreSQL.
 - Manual equivalent inside the postgres container:
   ```bash
   docker compose exec postgres sh -c \


### PR DESCRIPTION
## 问题

dev 从 main 同步 PostgreSQL 主库时，只同步了 PG 数据，没有同步 `file.db`，导致 dev 环境媒体/头像预览丢失。

## 修复

- `deploy/scripts/sync-db-from-main.sh` 在 PG 模式下：
  - 先给 dev 旧 `file.db` 做快照备份；
  - 通过 `sync_one` 将 main 的 `file.db` 同步到 dev；
  - 同步后修正 dev storage 权限；
  - 再退出。
- `docs/operations/deployment.md` 补充 PG 模式下仍会同步 `[db.file]` 的说明。

## 验证

- `bash -n deploy/scripts/sync-db-from-main.sh`：通过
- `git diff --check`：通过

Closes #43