### PR TITLE
feat: 完善发布页编辑器大纲交互与折叠动画

### DIFF
--- a/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
+++ b/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
@@ -428,6 +428,82 @@ function syncEditorTheme() {
 /** 大纲开关：随面板移动的展开/收起按钮；
  *  移动端收起态移入宿主行内容器（toggleHost）后不在 .vditor 内，查找需同时覆盖 host */
 const OUTLINE_TOGGLE_CLASS = 'hub-outline-toggle'
+/** 大纲展开/收起动画：宽度 250↔0 + 透明度过渡（0.3s < 0.5s）。
+ *  宽度过渡让 flex 编辑区平滑重排，正文 padding 由 JS 同步设为目标值，正文平滑不跳转。 */
+const OUTLINE_WIDTH = 250
+const OUTLINE_ANIM_MS = 300
+let outlineVisible = true
+let outlineAnimTimer = 0
+let outlineEndHandler: ((event: TransitionEvent) => void) | null = null
+
+/**
+ * 大纲显隐动画：设目标宽度/透明度与正文 padding，过渡完成后收尾（display 切到终态）。
+ * 宽度从 250→0（收起）会让 flex 中编辑区平滑变宽，正文 padding 同步过渡到居中值，
+ * 避免 outline display:none 瞬间重排导致正文「先猛跳、再回移」。
+ */
+function animateOutline(show: boolean) {
+  const vditor = editor?.vditor
+  const outlineEl = vditor?.outline.element
+  const rootEl = root.value
+  if (!vditor || !outlineEl || !rootEl) {
+    syncOutlineToggleHost()
+    return
+  }
+  const reset = rootEl.querySelector<HTMLElement>('.vditor-wysiwyg pre.vditor-reset')
+  if (!reset) {
+    syncOutlineToggleHost()
+    return
+  }
+  const maxWidth = vditor.options.preview?.maxWidth ?? 800
+  const contentEl = rootEl.querySelector<HTMLElement>('.vditor-content')
+  const fullWidth = contentEl?.clientWidth ?? reset.clientWidth
+  // 与 vditor setPadding 同款公式：outline 占位（250）与否决定编辑区内容居中 padding
+  const targetPad = Math.max(35, (fullWidth - (show ? OUTLINE_WIDTH : 0) - maxWidth) / 2)
+
+  window.clearTimeout(outlineAnimTimer)
+  if (outlineEndHandler) outlineEl.removeEventListener('transitionend', outlineEndHandler)
+
+  if (show) {
+    const wasHidden = outlineEl.style.display === 'none'
+    outlineEl.style.display = 'block'
+    if (wasHidden) {
+      // 完全收起→展开：从 width:0 起播（强制 reflow 保证 transition 从 0 开始）
+      outlineEl.style.width = '0px'
+      outlineEl.style.opacity = '0'
+      vditor.outline.render(vditor)
+      void outlineEl.offsetWidth
+    }
+    reset.style.padding = `10px ${targetPad}px`
+    outlineEl.style.width = `${OUTLINE_WIDTH}px`
+    outlineEl.style.opacity = '1'
+  } else {
+    reset.style.padding = `10px ${targetPad}px`
+    outlineEl.style.width = '0px'
+    outlineEl.style.opacity = '0'
+  }
+
+  const finish = () => {
+    window.clearTimeout(outlineAnimTimer)
+    if (outlineEndHandler) {
+      outlineEl.removeEventListener('transitionend', outlineEndHandler)
+      outlineEndHandler = null
+    }
+    if (show) {
+      outlineEl.style.width = `${OUTLINE_WIDTH}px`
+      outlineEl.style.opacity = '1'
+      outlineEl.style.display = 'block'
+    } else {
+      outlineEl.style.display = 'none'
+    }
+    syncOutlineToggleHost()
+  }
+  outlineEndHandler = (event) => {
+    if (event.propertyName === 'width') finish()
+  }
+  outlineEl.addEventListener('transitionend', outlineEndHandler)
+  outlineAnimTimer = window.setTimeout(finish, OUTLINE_ANIM_MS + 80)
+}
+
 function outlineToggleButton(): HTMLButtonElement | null {
   const existing =
     root.value?.querySelector<HTMLButtonElement>(`.${OUTLINE_TOGGLE_CLASS}`) ||
@@ -444,12 +520,12 @@ function outlineToggleButton(): HTMLButtonElement | null {
   button.innerHTML = '<svg><use xlink:href="#vditor-icon-align-center"></use></svg>'
   button.addEventListener('click', () => {
     if (!editor || !ready || !editor.vditor.outline) return
-    const show = editor.vditor.outline.element.style.display !== 'block'
-    if (editor.vditor.options.outline) {
-      editor.vditor.options.outline.enable = show
+    const currentEditor = editor
+    if (currentEditor.vditor.options.outline) {
+      currentEditor.vditor.options.outline.enable = !outlineVisible
     }
-    editor.vditor.outline.toggle(editor.vditor, show)
-    syncOutlineToggleHost()
+    outlineVisible = !outlineVisible
+    animateOutline(outlineVisible)
   })
   root.value.appendChild(button)
   return button
@@ -780,20 +856,41 @@ defineExpose({ focus, getValue, insertMarkdown, setHeight, syncValue })
   color: var(--toolbar-icon-hover-color, var(--toolbar-icon-color));
 }
 
-/* 收起态：悬浮在左侧大纲原位置 */
+/* 收起态：悬浮在编辑区左上角内侧，距左边框与上边框（编辑区顶部）各 6px，两距离相等。
+   边框对齐编辑框 1px，小圆角，无阴影。 */
 .vditor-official .hub-outline-toggle--float {
   position: absolute;
-  top: var(--toolbar-height, 35px);
-  left: 0;
+  top: calc(var(--toolbar-height, 35px) + 6px);
+  left: 6px;
   z-index: 5;
   margin-left: 0;
-  border-right: 1px solid var(--border-color);
-  border-radius: 0;
-  background: var(--panel-background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--textarea-background-color);
+  box-shadow: none;
 }
 
 .vditor-official .hub-outline-toggle--float:hover {
   background: var(--toolbar-background-color);
+}
+
+/*
+ * 大纲展开/收起动画：宽度 250↔0 + 透明度过渡（0.3s < 0.5s）。
+ * 宽度过渡驱动 flex 布局平滑重排（编辑区随大纲平滑变宽/变窄），
+ * 配合 pre.vditor-reset 的 padding 过渡（JS 同步设目标值），
+ * 正文始终在居中区域内平滑移动，无瞬间跳转。
+ * 收起由 JS 在宽度过渡结束后再 display:none。
+ */
+.vditor-official .vditor-outline {
+  transition: width 0.3s ease, opacity 0.3s ease;
+  /* 宽度过渡期间横向裁剪；纵向保留 vditor 原有滚动能力 */
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+/* 编辑区内容随大纲显隐平滑左右移动（padding 由 JS 动画设为最终目标值） */
+.vditor-official .vditor-wysiwyg pre.vditor-reset {
+  transition: padding 0.3s ease;
 }
 
 /* 标题栏改为 flex：让开关按钮靠右对齐 */
@@ -940,6 +1037,13 @@ defineExpose({ focus, getValue, insertMarkdown, setHeight, syncValue })
   display: flex;
   flex-wrap: nowrap;
   height: var(--toolbar-height);
+}
+
+/* 字数统计垂直居中：vditor 默认 margin(上 8px 下 0)+flex stretch 会把背景块
+   拉到紧贴工具栏底边（上方留 8px、下方几乎贴边），改为 flex 垂直居中上下对称 */
+.vditor-official .vditor-counter {
+  align-self: center;
+  margin: 0 3px 0 0;
 }
 
 /* 按钮间距：margin 实现 5px 均匀空隙；最后一个按钮不追加 margin（右边 padding 已够） */

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -148,7 +148,9 @@ async function validateRequiredFields() {
   return false
 }
 
-/** 工具栏「向上扩展」：折叠/展开标题+分类区，并把高度让给编辑器 */
+/** 工具栏「向上扩展」：折叠/展开标题+分类区，并把高度让给编辑器（带 0.3s 动画） */
+const HEADER_ANIM_MS = 300
+let headerHeightAnimTimer = 0
 function toggleHeaderCollapsed() {
   const header = headerSection.value
   if (header) {
@@ -157,6 +159,17 @@ function toggleHeaderCollapsed() {
   headerCollapsed.value = !headerCollapsed.value
   void nextTick(() => {
     if (editor.value) {
+      // 编辑器高度平滑过渡：临时开启 transition 后 setHeight，动画完移除。
+      // PostComposer 拖拽依赖实时跟随，故不能对 .vditor 全局加 height transition。
+      const vditorEl = editorHost.value?.querySelector<HTMLElement>('.vditor')
+      if (vditorEl) {
+        vditorEl.classList.add('hub-height-anim')
+        window.clearTimeout(headerHeightAnimTimer)
+        headerHeightAnimTimer = window.setTimeout(
+          () => vditorEl.classList.remove('hub-height-anim'),
+          HEADER_ANIM_MS + 100,
+        )
+      }
       // 折叠：编辑器高度 = 默认 480 + 头部高度 + 间距；展开：回到 480
       const target = headerCollapsed.value ? 480 + collapsedHeaderHeight.value + 20 : 480
       editor.value.setHeight(target)
@@ -303,84 +316,98 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
       <!-- 单栏全宽：发布检查并入页脚，正文区吃满主列宽度 -->
       <section class="gf-card p-4 sm:p-5">
         <div class="space-y-5">
-          <!-- 标题 + 分类同一行（better-layout：主输入吃满、元数据靠右共享边缘；可整体折叠给编辑区腾空间） -->
-          <div ref="headerSection" v-show="!headerCollapsed" class="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
-            <label class="block min-w-0 flex-1">
-              <span class="text-sm font-semibold text-base-content/75">{{ t('publish.fields.title') }}</span>
-              <input
-                ref="titleInput"
-                v-model="title"
-                class="mt-1 h-11 w-full rounded-md border border-line px-3 text-lg font-semibold outline-none transition focus:border-primary focus:ring-4 focus:ring-primary/20"
-                :placeholder="t('publish.titlePlaceholder')"
-              />
-            </label>
+          <!-- 标题 + 分类同一行（better-layout：主输入吃满、元数据靠右共享边缘；可整体折叠给编辑区腾空间）。
+               折叠动画：外层 grid-template-rows 0fr↔1fr + 内层 min-h-0/overflow-hidden 高度平滑塌陷 -->
+          <!-- space-y 会给非最后子元素加 20px margin-bottom；原 v-show（display:none）折叠时该 margin 不渲染，
+                grid 高度 0 时 margin 仍占位，故折叠时把 margin-bottom 归零（带过渡），保持与折叠前布局一致 -->
+          <div
+            class="grid"
+            :style="{
+              gridTemplateRows: headerCollapsed ? '0fr' : '1fr',
+              marginBottom: headerCollapsed ? '0px' : '',
+              transition: 'grid-template-rows 0.3s ease, margin-bottom 0.3s ease',
+            }"
+          >
+            <div class="min-h-0 overflow-hidden">
+              <div ref="headerSection" :class="headerCollapsed ? 'invisible' : ''" class="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
+                <label class="block min-w-0 flex-1">
+                  <span class="text-sm font-semibold text-base-content/75">{{ t('publish.fields.title') }}</span>
+                  <input
+                    ref="titleInput"
+                    v-model="title"
+                    class="mt-1 h-11 w-full rounded-md border border-line px-3 text-lg font-semibold outline-none transition focus:border-primary focus:ring-4 focus:ring-primary/20"
+                    :placeholder="t('publish.titlePlaceholder')"
+                  />
+                </label>
 
-            <div ref="categorySection" class="shrink-0 sm:w-60">
-              <div class="flex items-center justify-between gap-2">
-                <span class="text-sm font-semibold text-base-content/75">{{ t('publish.fields.category') }}</span>
-                <span class="text-xs text-base-content/55">{{ t('publish.maxCategories') }}</span>
-              </div>
-              <div ref="categoryPickerRoot" class="relative mt-1">
-                <button
-                  type="button"
-                  class="gf-input flex h-11 w-full items-center gap-2 text-left"
-                  :class="categoryMissing ? '!border-error' : ''"
-                  :aria-expanded="categoryPickerOpen"
-                  :aria-label="t('publish.fields.category')"
-                  @click="categoryPickerOpen = !categoryPickerOpen"
-                  @keydown="handleCategoryPickerKeydown"
-                >
-                  <span v-if="selectedCategories.length" class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 overflow-hidden">
-                    <span
-                      v-for="category in selectedCategories"
-                      :key="category.id"
-                      class="inline-flex max-w-full items-center gap-1.5 truncate rounded-md px-2 py-0.5 text-xs font-semibold"
-                      :style="{ backgroundColor: category.color + '22', color: category.color }"
-                    >
-                      <span class="h-1.5 w-1.5 shrink-0 rounded-full" :style="{ backgroundColor: category.color }" />
-                      <span class="truncate">{{ category.name }}</span>
-                    </span>
-                  </span>
-                  <span v-else class="flex-1 text-sm text-base-content/45">{{ t('publish.selectCategory') }}</span>
-                  <span class="text-xs tabular-nums text-base-content/55">{{ categoryIds.length }}/3</span>
-                  <svg
-                    class="h-4 w-4 shrink-0 text-base-content/45 transition-transform duration-150"
-                    :class="{ 'rotate-180': categoryPickerOpen }"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    aria-hidden="true"
-                  >
-                    <path d="m6 9 6 6 6-6" />
-                  </svg>
-                </button>
-
-                <Transition name="gf-menu">
-                  <div
-                    v-if="categoryPickerOpen"
-                    class="gf-menu-surface absolute left-0 right-0 top-[calc(100%+0.375rem)] z-[300] max-h-64 overflow-y-auto p-1"
-                  >
-                    <button
-                      v-for="category in props.categories"
-                      :key="category.id"
-                      type="button"
-                      class="flex h-9 w-full items-center gap-2 rounded-md px-2.5 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
-                      :class="categoryIds.includes(category.id) ? 'bg-primary/10 text-primary' : 'text-base-content hover:bg-base-200'"
-                      :disabled="!categoryIds.includes(category.id) && categoriesFull"
-                      @click="toggleCategory(category.id)"
-                    >
-                      <span class="h-2 w-2 shrink-0 rounded-[3px]" :style="{ backgroundColor: category.color }" />
-                      <span class="min-w-0 flex-1 truncate">{{ category.name }}</span>
-                      <Check v-if="categoryIds.includes(category.id)" class="h-4 w-4 shrink-0" />
-                    </button>
-                    <p v-if="categoriesFull" class="px-2.5 py-1.5 text-xs text-base-content/55">{{ t('publish.maxCategories') }}</p>
+                <div ref="categorySection" class="shrink-0 sm:w-60">
+                  <div class="flex items-center justify-between gap-2">
+                    <span class="text-sm font-semibold text-base-content/75">{{ t('publish.fields.category') }}</span>
+                    <span class="text-xs text-base-content/55">{{ t('publish.maxCategories') }}</span>
                   </div>
-                </Transition>
+                  <div ref="categoryPickerRoot" class="relative mt-1">
+                    <button
+                      type="button"
+                      class="gf-input flex h-11 w-full items-center gap-2 text-left"
+                      :class="categoryMissing ? '!border-error' : ''"
+                      :aria-expanded="categoryPickerOpen"
+                      :aria-label="t('publish.fields.category')"
+                      @click="categoryPickerOpen = !categoryPickerOpen"
+                      @keydown="handleCategoryPickerKeydown"
+                    >
+                      <span v-if="selectedCategories.length" class="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 overflow-hidden">
+                        <span
+                          v-for="category in selectedCategories"
+                          :key="category.id"
+                          class="inline-flex max-w-full items-center gap-1.5 truncate rounded-md px-2 py-0.5 text-xs font-semibold"
+                          :style="{ backgroundColor: category.color + '22', color: category.color }"
+                        >
+                          <span class="h-1.5 w-1.5 shrink-0 rounded-full" :style="{ backgroundColor: category.color }" />
+                          <span class="truncate">{{ category.name }}</span>
+                        </span>
+                      </span>
+                      <span v-else class="flex-1 text-sm text-base-content/45">{{ t('publish.selectCategory') }}</span>
+                      <span class="text-xs tabular-nums text-base-content/55">{{ categoryIds.length }}/3</span>
+                      <svg
+                        class="h-4 w-4 shrink-0 text-base-content/45 transition-transform duration-150"
+                        :class="{ 'rotate-180': categoryPickerOpen }"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="m6 9 6 6 6-6" />
+                      </svg>
+                    </button>
+
+                    <Transition name="gf-menu">
+                      <div
+                        v-if="categoryPickerOpen"
+                        class="gf-menu-surface absolute left-0 right-0 top-[calc(100%+0.375rem)] z-[300] max-h-64 overflow-y-auto p-1"
+                      >
+                        <button
+                          v-for="category in props.categories"
+                          :key="category.id"
+                          type="button"
+                          class="flex h-9 w-full items-center gap-2 rounded-md px-2.5 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
+                          :class="categoryIds.includes(category.id) ? 'bg-primary/10 text-primary' : 'text-base-content hover:bg-base-200'"
+                          :disabled="!categoryIds.includes(category.id) && categoriesFull"
+                          @click="toggleCategory(category.id)"
+                        >
+                          <span class="h-2 w-2 shrink-0 rounded-[3px]" :style="{ backgroundColor: category.color }" />
+                          <span class="min-w-0 flex-1 truncate">{{ category.name }}</span>
+                          <Check v-if="categoryIds.includes(category.id)" class="h-4 w-4 shrink-0" />
+                        </button>
+                        <p v-if="categoriesFull" class="px-2.5 py-1.5 text-xs text-base-content/55">{{ t('publish.maxCategories') }}</p>
+                      </div>
+                    </Transition>
+                  </div>
+                  <p v-if="categoryMissing" class="mt-1 text-xs text-error/80">{{ t('publish.validation.categoryRequired') }}</p>
+                </div>
               </div>
-              <p v-if="categoryMissing" class="mt-1 text-xs text-error/80">{{ t('publish.validation.categoryRequired') }}</p>
             </div>
           </div>
 
@@ -557,3 +584,11 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
       </Transition>
     </main>
 </template>
+
+<style>
+/* 发布页「收起标题分类」时编辑器高度平滑过渡：临时类，动画后移除。
+   PostComposer 拖拽依赖实时跟随，故不能对 .vditor 全局加 height transition。 */
+.hub-height-anim {
+  transition: height 0.3s ease;
+}
+</style>


### PR DESCRIPTION
## 动机

发布页编辑器存在几处交互细节问题：

- 大纲折叠后「展开大纲」按钮盖住编辑框左边框
- 大纲展开/收起与「收起标题分类」为瞬间切换，缺少动画；正文区切换时还会「突然跳转、移过头再跳回来」
- 字数统计背景块紧贴工具栏底边，上下间距不对称

## 行为变化

- **大纲折叠按钮**：右移避开编辑框左边框；样式对齐编辑框（编辑框灰底、同粗细 1px 边框、4px 圆角、无阴影），距上下边框距离相等
- **字数统计**：在工具栏垂直居中，上下间距对称
- **大纲展开/收起动画**：由 `display:none` 瞬间切换改为宽度 250↔0 + 透明度过渡（0.3s），正文区随 flex 平滑联动、内容始终居中，消除瞬间跳转；收起动画结束才真正隐藏
- **「收起标题分类」动画**：标题/分类区用 `grid-template-rows` 0fr↔1fr 高度平滑塌陷/撑开，编辑器高度平滑过渡；折叠后消除 `space-y` 残留间距，正文位置与折叠前一致
- 连点防抖：动画进行中再次点击会取消收起/反向，状态稳定

## 验证

- `pnpm typecheck`：通过
- `pnpm test`：11 个文件 / 89 个用例全部通过
- `pnpm build`：构建成功（仅 node_modules 依赖的 PURE 注解警告，与本次改动无关）
- 浏览器实测（localhost:5234，test_user 登录发布页）：
  - 大纲展开/收起平滑（宽度+透明度 0.3s），正文位置轨迹平滑无跳变
  - 标题区折叠/展开平滑（grid 高度动画 + 编辑器高度过渡）
  - 折叠后正文 label 距卡片顶部 21px，与折叠前一致
  - 控制台无错误

## 契约/文档影响

无。纯前端样式与动画改动，不涉及 OpenAPI 契约、设计 token（`tokens.css`）或移动端。

## 已知缺口

- 大纲宽度动画依赖 `grid-template-rows`/`transition` 的现代浏览器支持（当前实测 Chrome 正常）
- 初始加载时大纲/标题区无入场动画（仅在交互展开/收起时有动画）
