### PR TITLE
docs: rewrite repository README for open-source contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,179 @@
-# YourTJ-Hub
+<p align="center">
+  <img src="./apps/mobile/packages/forum_app/assets/images/brand-default.png" width="520" alt="YourTJHub">
+</p>
 
-Tongji university campus forum platform monorepo (brand: yourtj). Built directly on [GooseForum](https://github.com/leancodebox/GooseForum) (MIT) with a single-binary deployment; unified auth (Casdoor), search (Meilisearch), and points (credit, phase 2) live as shared infrastructure subdomains.
+<h1 align="center">YourTJ Hub</h1>
 
-## Documentation
+<p align="center">
+  面向同济校园的社区平台，以论坛沉淀长期有价值的信息与讨论。<br>
+  <sub>A community platform for Tongji University, built around durable, searchable conversations.</sub>
+</p>
 
-**[Docs center → docs/README.md](docs/README.md)** (fact-source table + status words)
+<p align="center">
+  <a href="https://github.com/YourTongji/YourTJ-Hub/actions/workflows/ci-backend.yml"><img src="https://img.shields.io/github/actions/workflow/status/YourTongji/YourTJ-Hub/ci-backend.yml?branch=dev&amp;style=flat-square&amp;label=backend" alt="Backend CI"></a>
+  <a href="https://github.com/YourTongji/YourTJ-Hub/actions/workflows/ci-frontend.yml"><img src="https://img.shields.io/github/actions/workflow/status/YourTongji/YourTJ-Hub/ci-frontend.yml?branch=dev&amp;style=flat-square&amp;label=frontend" alt="Frontend CI"></a>
+  <a href="https://github.com/YourTongji/YourTJ-Hub/actions/workflows/ci-mobile.yml"><img src="https://img.shields.io/github/actions/workflow/status/YourTongji/YourTJ-Hub/ci-mobile.yml?branch=dev&amp;style=flat-square&amp;label=mobile" alt="Mobile CI"></a>
+  <a href="https://github.com/YourTongji/YourTJ-Hub/actions/workflows/ci-contract.yml"><img src="https://img.shields.io/github/actions/workflow/status/YourTongji/YourTJ-Hub/ci-contract.yml?branch=dev&amp;style=flat-square&amp;label=contract" alt="Contract CI"></a>
+  <a href="https://github.com/YourTongji/YourTJ-Hub/releases"><img src="https://img.shields.io/github/v/release/YourTongji/YourTJ-Hub?display_name=tag&amp;sort=semver&amp;style=flat-square" alt="Latest release"></a>
+</p>
 
-- Product: [Vision & principles](docs/product/vision-and-principles.md) · [Current state & gaps](docs/product/current-state.md) · [Identity & access](docs/product/identity-and-access.md) · [Points & settlement](docs/product/credit-and-escrow.md)
-- Architecture: [System overview & domain boundaries](docs/architecture/system-overview.md) · [Contracts & data](docs/architecture/contracts-and-data.md)
-- Development: [Entry point](docs/development/README.md) · [Local environment](docs/development/local-development.md) · [Testing](docs/development/testing.md) · [Pull requests](docs/development/pull-requests.md) · [Documentation governance](docs/development/documentation.md)
-- Operations: [Deployment & release](docs/operations/deployment.md)
+<p align="center">
+  <a href="https://forum.yourtj.de">线上站点</a> ·
+  <a href="./docs/README.md">项目文档</a> ·
+  <a href="https://github.com/YourTongji/YourTJ-Hub/issues/new?template=bug-report.yml">报告问题</a> ·
+  <a href="https://github.com/YourTongji/YourTJ-Hub/issues/new?template=feature-request.yml">功能建议</a>
+</p>
 
-Read [AGENTS.md](AGENTS.md) and the documents relevant to your change before developing. The repository-level `$yourtj-development` skill lives in `.agents/skills/yourtj-development`.
+## 关于项目
 
-## Layout
+YourTJ Hub 希望让校园经验、问题与观点不再消失在短暂的信息流中。项目以板块化论坛为核心，
+提供搜索、统一身份、内容治理和多端访问能力，并为未来的课程、课评等校园服务保留共享基础设施。
 
+核心论坛直接演进自 [GooseForum](https://github.com/leancodebox/GooseForum)，保留 Go 后端、Vue 前端
+与 GoHTML 模板打包进同一个可执行文件的部署方式。这里不是对上游的薄包装：产品、认证、搜索、
+数据、移动端与运维能力都在本仓库中持续演进，同时保留可合并上游更新的代码结构。
+
+> 本项目仍在积极开发。下表中的 `Current`、`Partial`、`Planned` 是严格的实现状态，定义与完整缺口
+> 见[当前状态](./docs/product/current-state.md)。
+
+## 能力状态
+
+| 领域 | 状态 | 当前能力 |
+|---|---|---|
+| 论坛 | `Current` | 主题与回复、板块、通知、私信、草稿、Markdown、RBAC 管理与多语言界面 |
+| 身份与安全 | `Partial` | 密码、GitHub OAuth、Casdoor OIDC、TOTP 2FA、可撤销会话；Casdoor 侧部署能力仍需完善 |
+| 搜索 | `Partial` | Meilisearch 聚合搜索、拼音匹配与事件驱动索引；搜索服务为可选依赖 |
+| 数据与文件 | `Current` | SQLite 默认，支持 MySQL / PostgreSQL 主库；文件可存于 SQLite BLOB 或 S3 兼容对象存储 |
+| 内容治理 | `Current` | 敏感词审核、限流与验证码、审计、服务条款、数据导入导出 |
+| 移动端 | `Partial` | Flutter 客户端、共享设计语言与 OIDC 登录已实现，尚未发布到应用商店 |
+| API 契约 | `Partial` | OpenAPI 校验、TypeScript 生成与契约测试已落地，尚未覆盖全部接口 |
+| 积分 | `Planned` | 跨服务积分模型尚未提供可用实现 |
+
+## 架构
+
+```mermaid
+flowchart LR
+    Browser["浏览器"] --> Hub["YourTJ Hub 单一二进制<br/>Go · Gin · Vue 3 · GoHTML"]
+    Mobile["Flutter 客户端<br/>Partial"] -->|JSON API| Hub
+    Hub <-->|OIDC| Casdoor["Casdoor"]
+    Hub --> DB["SQLite / MySQL / PostgreSQL"]
+    Hub --> Search["Meilisearch<br/>可选、可重建"]
 ```
-yourtj-hub/
-├── apps/                  # Deployable applications
-│   ├── gooseforum/        # Forum (Go + Vue in one binary; fork of upstream, keeps upstream module name)
-│   │   ├── main.go        # Entry point (cobra CLI: serve / mock / rebuild-index ...)
-│   │   ├── app/           # Go backend (bundles/console/http/models/service/migration)
-│   │   └── resource/      # Vue 3 frontend + gohtml templates (vite output go:embed)
-│   └── mobile/            # Flutter (melos workspace: core/auth/ui_kit/forum_app, planned)
-├── packages/
-│   └── api-contract/      # openapi.yaml contract center (planned)
-├── services/              # Base service deployment configs (casdoor / search / credit)
-├── deploy/                # Per-environment deployment configs
-└── docs/                  # Docs center (product/architecture/development/operations)
-```
 
-## Quick start
+项目遵循四个重要约束：
+
+- **单一二进制**：Vue 构建产物与 GoHTML 模板通过 `go:embed` 进入 Go 可执行文件，生产环境不拆分前后端。
+- **数据库是真相源**：搜索索引、缓存和计数都是可重建投影，不承载唯一业务事实。
+- **身份可互操作**：Casdoor 是统一身份源，用户标识必须保持为数值型 `uint64`。
+- **上游可同步**：`apps/gooseforum` 保留 GooseForum 的 Go module 名称与主要分层，便于持续合并上游更新。
+
+详细的领域边界、关键数据流和契约规则见[系统架构](./docs/architecture/system-overview.md)。
+
+## 技术栈
+
+| 范围 | 技术 |
+|---|---|
+| 后端 | Go 1.26、Gin、GORM、Cobra |
+| Web | Vue 3、TypeScript、Vite、Tailwind CSS、GoHTML |
+| Mobile | Flutter、Dart、Melos、Riverpod |
+| 数据 | SQLite、MySQL、PostgreSQL、Meilisearch |
+| 身份 | Casdoor OIDC、GitHub OAuth、JWT、TOTP |
+| 交付 | `go:embed` 单一二进制、Docker Compose、GitHub Actions |
+
+## 快速开始
+
+需要 Go 1.26+。开发 Web 界面还需要 Node.js 24 与 pnpm 11；运行 Casdoor、Meilisearch 或
+PostgreSQL 等本地依赖时需要 Docker Compose。
 
 ```bash
-# 1. Start local dependencies (postgres + meilisearch + mariadb + casdoor)
-make dev
+git clone --branch dev https://github.com/YourTongji/YourTJ-Hub.git
+cd YourTJ-Hub
 
-# 2. Forum backend (default port 5234; place a config.toml in apps/gooseforum first)
-make server
-
-# 3. Frontend dev server (:3010, vite; run pnpm install in apps/gooseforum/resource first)
-make web
-
-# 4. Production build: resource → static/dist → go build single binary
-make build
+cd apps/gooseforum/resource
+pnpm install --frozen-lockfile
+cd ../../..
 ```
 
-See [docs/development/local-development.md](docs/development/local-development.md).
+分别启动后端与前端开发服务器：
 
-## Reference
+```bash
+# Terminal 1 — Go backend，默认 http://localhost:5234
+make server
 
-We build on [GooseForum](https://github.com/leancodebox/GooseForum) (MIT) — thanks to its author and contributors.
+# Terminal 2 — Vite，打开 http://localhost:3010
+make web
+```
 
-## Decision summary
+论坛默认使用 SQLite；首次启动会生成已被 Git 忽略的 `apps/gooseforum/config.toml`。如需统一身份、
+搜索与其他本地依赖，可先运行：
 
-| Topic | Decision | Record |
-|---|---|---|
-| Code organization | apps/gooseforum single binary (Go+Vue in one, upstream fork), no frontend/backend split | Decision records live in note |
-| Auth | Casdoor unified auth integrated (OIDC + PKCE, numeric user ID enforced server-side, issue #8) | docs/product/identity-and-access.md |
-| Mobile state management | Riverpod | docs/architecture/system-overview.md |
-| Database / Search | PostgreSQL main-db support landed (issue #11, SQLite default retained); Meilisearch aggregate search with event-driven sync (issue #22) | docs/product/current-state.md |
+```bash
+make dev
+```
 
-## Current state
+构建生产形态的单一二进制：
 
-Implementation status and gaps: [docs/product/current-state.md](docs/product/current-state.md) (marked with `Current`/`Partial`/`Planned`/`Decision needed`, no timeline).
+```bash
+make build
+# output: bin/yourtj-hub
+```
+
+不要提交 `config.toml`，其中包含签名密钥和第三方服务凭据。完整配置、服务地址与移动端启动方式
+见[本地开发指南](./docs/development/local-development.md)。
+
+## 仓库结构
+
+```text
+apps/
+  gooseforum/       Go + Vue 论坛，前端最终嵌入后端二进制
+  mobile/           Flutter / Melos 移动端工作区
+packages/
+  api-contract/     OpenAPI、fixtures 与生成脚本
+services/           Casdoor、Meilisearch、积分等服务配置
+deploy/             容器、环境与发布脚本
+docs/               产品、架构、开发和运维文档
+```
+
+业务逻辑、数据访问和 HTTP 层分别位于 `apps/gooseforum/app/service`、`app/models` 与
+`app/http/controllers`。完整边界规则见 [`AGENTS.md`](./AGENTS.md)。
+
+## 文档
+
+[`docs/README.md`](./docs/README.md) 是唯一文档入口，并说明不同事实应以何处为准：
+
+- [产品愿景与原则](./docs/product/vision-and-principles.md)
+- [当前状态与缺口](./docs/product/current-state.md)
+- [系统架构与领域边界](./docs/architecture/system-overview.md)
+- [本地开发](./docs/development/local-development.md)
+- [测试策略](./docs/development/testing.md)
+- [部署与发布](./docs/operations/deployment.md)
+
+## 参与贡献
+
+问题反馈、功能建议和 Pull Request 都很重要。较大的改动建议先通过
+[Issue](https://github.com/YourTongji/YourTJ-Hub/issues) 对齐问题、用户与验收标准。
+
+开始编码前请：
+
+1. 阅读 [`AGENTS.md`](./AGENTS.md)、[开发入口](./docs/development/README.md)及需求直接影响的文档；
+2. 从最新 `origin/dev` 创建 `feat/*`、`fix/*` 或 `docs/*` 分支，Pull Request 目标为 `dev`；
+3. 保持实现、契约、测试与文档同步，并报告实际运行的验证命令。
+
+常用验证命令：
+
+```bash
+make test
+make build
+git diff --check
+```
+
+更细的分支约定、CI 对应关系与测试范围见
+[Pull Request 指南](./docs/development/pull-requests.md)和[测试策略](./docs/development/testing.md)。
+
+## 许可与致谢
+
+`apps/gooseforum` 基于 GooseForum 修改并保留其
+[MIT License](./apps/gooseforum/LICENSE)。感谢 GooseForum 作者和所有上游贡献者提供的坚实基础。
+
+本 monorepo 目前尚未提供覆盖全部目录的根级许可证。在维护者明确整体授权方式前，不应假定
+`apps/gooseforum` 之外的内容自动适用 MIT 许可。

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-07
+> Last verified: 2026-08-09
 
 ## Dependencies
 
@@ -25,7 +25,7 @@
 make dev
 
 # 2. Forum backend (default port 5234)
-#    First-time setup: place a config.toml in apps/gooseforum (gitignored), based on upstream config
+#    First start creates apps/gooseforum/config.toml from the embedded template (gitignored)
 make server        # = cd apps/gooseforum && go run . serve
 
 # 3. Frontend dev server (:3010, vite; run pnpm install first)

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -34,6 +34,7 @@ make web           # = cd apps/gooseforum/resource && pnpm dev
 # 4. Production build: resource → static/dist → go build single binary
 make build
 ```
+```bash
 # 5. Mobile app (Flutter, apps/mobile melos workspace; requires Flutter SDK + melos)
 cd apps/mobile && melos bootstrap   # 首次或依赖变更后
 melos run analyze                    # 全包静态检查

--- a/docs/product/current-state.md
+++ b/docs/product/current-state.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-08
+> Last verified: 2026-08-09
 
 ## What works
 
@@ -29,7 +29,7 @@
 | Database | `Current` | SQLite default, MySQL optional, PostgreSQL main-db support landed (issue #11); file db stays SQLite; data migration from SQLite→PG is manual |
 | Search | `Partial` | Aggregate search landed (issue #22): one search box covers topics, users and categories with grouped sections and scope tabs; pinyin/initials matching for users and categories; index sync via topic/user/category events + migration v13 rebuild; per-scope partial degradation; unavailable-state UI fallback |
 | Auth | `Partial` | GitHub OAuth + Casdoor OIDC (PKCE/nonce/numeric-sub enforced) integrated; TOTP 2FA for password login; session listing/revoke; Casdoor-side MFA/Passkey pending deployment config |
-| Contract | `Partial` | No swagger annotations, no openapi.yaml upstream; packages/api-contract is a placeholder; pipeline not built |
+| Contract | `Partial` | OpenAPI 3.1 currently covers password login, mobile OIDC exchange and topic writing; Redocly lint/bundle, generated TypeScript no-diff checks, committed fixtures and real Gin route tests are in CI; Dart generation and broader route coverage remain `Planned` |
 | Mobile | `Partial` | Flutter client (`apps/mobile`, melos: core/auth/ui_kit/forum_app) implemented: YourTJ token theme bridged into pinned TDesign v1 alpha components, iOS-safe branded navigation, Web-aligned persistent list/card topic feeds, dot-grid auth cards, unified Gf form/dialog/status surfaces, browsing/creation/user/search/notification/IM surfaces, OIDC exchange login; CI `ci-mobile`; not yet deployed to stores (push notifications/custom theme sync/ja-it planned later) |
 | Points | `Planned` | services/credit is a README placeholder; explicitly phase 2, not implemented now |
 | Branding | `Partial` | Default UI copy, activation template, locales and admin brand settings rebranded to YourTJHub (2026-08-07); CLI name (`gooseforum`) and Go module name intentionally kept for upstream merge |
@@ -44,6 +44,7 @@
 
 Before expanding features, close these baselines (avoid building on a wrong foundation):
 
-1. Auth chain closed (Casdoor → exchange → JWT), numeric-ID constraint enforced server-side.
-2. Contract pipeline (swag or manual openapi → TS/Dart generation) before broad API rework, to prevent
-   contract drift.
+1. Complete the remaining Casdoor-side MFA/Passkey deployment configuration without weakening the
+   numeric-ID and revocable-session invariants already enforced by the forum.
+2. Expand OpenAPI and generated-client coverage before broad API rework, so uncovered routes do not
+   become a new source of contract drift.


### PR DESCRIPTION
## Motivation

The root README mainly acted as a documentation index, so new users could not quickly understand the project's value, real implementation status, architecture, or contribution path. This rewrite turns it into a trustworthy repository landing page without copying the archived YourTJ-Platform content structure.

## Changes

- add the repository-owned YourTJHub brand image, CI/release badges, public site, documentation, and issue links
- explain the project purpose, implementation status, architecture, technology stack, quick start, repository layout, and contribution workflow
- document the actual licensing boundary instead of implying a monorepo-wide MIT license
- synchronize the current-state document with the existing OpenAPI/TypeScript/fixture pipeline
- correct local development documentation to reflect automatic `config.toml` generation

## Impact

Documentation only. This PR does not change runtime behavior, API contracts, database schema, authentication, search, or deployment configuration. Existing `Current` / `Partial` / `Planned` status words are preserved and clarified.

## Validation

- `git diff --check` — passed
- checked all relative README links — all targets exist
- checked the public site, CI/release badges, repository, and GooseForum links — all returned HTTP 200
- code tests and builds were not run because this is a documentation-only change

## Known gaps

- the repository still needs a maintainer decision on a root-level license covering the whole monorepo; the README now states the current boundary explicitly
- this PR does not add a Code of Conduct or security reporting policy
