### PR TITLE
fix(auth): revoke 会话接口畸形/缺失 id 返回参数错误而非 session.notFound

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/sessionController.go
+++ b/apps/gooseforum/app/http/controllers/api/sessionController.go
@@ -45,7 +45,10 @@ func ListSessions(req component.BetterRequest[component.Null]) component.Respons
 }
 
 type RevokeSessionReq struct {
-	Id uint64 `json:"id" binding:"required"`
+	// binding:"required" only applies during Gin's binding phase; the route binds
+	// non-strictly (UpButterReq), so validate:"required" is what actually rejects
+	// malformed JSON / missing id / id 0 before the handler sees a zero value.
+	Id uint64 `json:"id" binding:"required" validate:"required"`
 }
 
 // RevokeSession 吊销指定会话（当前会话不可吊销，避免自锁）

--- a/apps/gooseforum/app/http/routes/session_revoke_test.go
+++ b/apps/gooseforum/app/http/routes/session_revoke_test.go
@@ -1,0 +1,156 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/leancodebox/GooseForum/app/http/controllers/api"
+	"github.com/leancodebox/GooseForum/app/http/controllers/component"
+	"github.com/leancodebox/GooseForum/app/http/middleware"
+	"gorm.io/gorm"
+)
+
+// sessionRevokeItem mirrors the wire shape of one session entry returned by
+// GET /api/user/sessions, used here only to locate the session IDs to revoke.
+type sessionRevokeItem struct {
+	ID        uint64 `json:"id"`
+	IsCurrent bool   `json:"isCurrent"`
+}
+
+func setupSessionRevokeTest(t *testing.T) (*gorm.DB, *gin.Engine) {
+	t.Helper()
+	conn, router := setupHTTPContractTest(t)
+	loginAPI := router.Group("/api").Use(middleware.JWTAuthCheck)
+	loginAPI.GET("/user/sessions", UpButterReq(api.ListSessions))
+	loginAPI.POST("/user/sessions/revoke", UpButterReq(api.RevokeSession))
+	return conn, router
+}
+
+func serveSessionRevokeJSON(router http.Handler, method, path, body, token string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func sessionIDsByCurrency(t *testing.T, router http.Handler, token string) (current uint64, others []uint64) {
+	t.Helper()
+	recorder := serveSessionRevokeJSON(router, http.MethodGet, "/api/user/sessions", "", token)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("list sessions status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Result []sessionRevokeItem `json:"result"`
+		Code   int                 `json:"code"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode session list %q: %v", recorder.Body.String(), err)
+	}
+	for _, item := range envelope.Result {
+		if item.IsCurrent {
+			current = item.ID
+		} else {
+			others = append(others, item.ID)
+		}
+	}
+	if current == 0 {
+		t.Fatal("session list has no current-session entry")
+	}
+	return current, others
+}
+
+func assertMessageCode(t *testing.T, recorder *httptest.ResponseRecorder, want component.MessageCode) {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (legacy envelope): %s", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Code        int    `json:"code"`
+		MessageCode string `json:"messageCode"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode response %q: %v", recorder.Body.String(), err)
+	}
+	if envelope.MessageCode != string(want) {
+		t.Fatalf("messageCode = %q, want %q: %s", envelope.MessageCode, want, recorder.Body.String())
+	}
+}
+
+func TestRevokeSessionValidation(t *testing.T) {
+	t.Run("malformed body is a validation failure, not session.notFound", func(t *testing.T) {
+		conn, router := setupSessionRevokeTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		recorder := serveSessionRevokeJSON(router, http.MethodPost, "/api/user/sessions/revoke", "{", token)
+		assertMessageCode(t, recorder, component.MessageRequestInvalidParams)
+	})
+
+	t.Run("missing id is a validation failure", func(t *testing.T) {
+		conn, router := setupSessionRevokeTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		recorder := serveSessionRevokeJSON(router, http.MethodPost, "/api/user/sessions/revoke", `{}`, token)
+		assertMessageCode(t, recorder, component.MessageRequestInvalidParams)
+	})
+
+	t.Run("zero id is a validation failure", func(t *testing.T) {
+		conn, router := setupSessionRevokeTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		recorder := serveSessionRevokeJSON(router, http.MethodPost, "/api/user/sessions/revoke", `{"id":0}`, token)
+		assertMessageCode(t, recorder, component.MessageRequestInvalidParams)
+	})
+}
+
+func TestRevokeSessionBehaviorPreserved(t *testing.T) {
+	t.Run("unknown session id still reports session.notFound", func(t *testing.T) {
+		conn, router := setupSessionRevokeTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		recorder := serveSessionRevokeJSON(router, http.MethodPost, "/api/user/sessions/revoke", `{"id":999999999}`, token)
+		assertMessageCode(t, recorder, component.MessageSessionNotFound)
+	})
+
+	t.Run("current session is still not revocable", func(t *testing.T) {
+		conn, router := setupSessionRevokeTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		current, _ := sessionIDsByCurrency(t, router, token)
+		body, err := json.Marshal(map[string]uint64{"id": current})
+		if err != nil {
+			t.Fatalf("marshal revoke request: %v", err)
+		}
+		recorder := serveSessionRevokeJSON(router, http.MethodPost, "/api/user/sessions/revoke", string(body), token)
+		assertMessageCode(t, recorder, component.MessageSessionCurrentNotRevocable)
+	})
+
+	t.Run("valid revoke still succeeds and kills the token", func(t *testing.T) {
+		conn, router := setupSessionRevokeTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		otherToken := contractSessionToken(t, user)
+		_, others := sessionIDsByCurrency(t, router, token)
+		if len(others) != 1 {
+			t.Fatalf("non-current session count = %d, want 1", len(others))
+		}
+		body, err := json.Marshal(map[string]uint64{"id": others[0]})
+		if err != nil {
+			t.Fatalf("marshal revoke request: %v", err)
+		}
+		recorder := serveSessionRevokeJSON(router, http.MethodPost, "/api/user/sessions/revoke", string(body), token)
+		assertMessageCode(t, recorder, component.MessageSessionRevokeSuccess)
+
+		revoked := serveSessionRevokeJSON(router, http.MethodGet, "/api/user/sessions", "", otherToken)
+		if revoked.Code != http.StatusUnauthorized {
+			t.Fatalf("revoked token status = %d, want 401", revoked.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

修复 Issue #59：`POST /api/user/sessions/revoke` 对不合法请求体（畸形 JSON / 缺失 `id` / `id:0`）原来返回 `session.notFound`，与"吊销不存在会话"无法区分。该问题由 #58 的路由级契约测试发现。

## Root cause

`RevokeSessionReq.Id` 只有 `binding:"required"`，但路由走 `UpButterReq` 非严格绑定（吞掉绑定错误），独立的 `validate.Valid`（go-playground）只认 `validate:` 标签——零值 `Id=0` 穿透到处理器，查不到会话返回 `session.notFound`。

## Changes

- `sessionController.go`：`RevokeSessionReq.Id` 增加 `validate:"required"`（uint64 的 `required` 拒绝零值），并注释说明两个标签各自的作用阶段
- `session_revoke_test.go`（新增）：6 个路由级用例
  - 修复后行为：畸形 body / 缺失 id / `id:0` → HTTP 200 + `common.request.invalidParams`（legacy envelope，不引入新状态码）
  - 行为保持：未知 id → `session.notFound`；当前会话 → `session.current.notRevocable`；合法吊销成功且被吊销 token 立即 401

## Scope

全仓仅两个 struct 使用 `binding:"required"`：本端点与 `GetUserCardReq`（其路由走 `UpQueryReq` 严格绑定，无此缺陷）。不改 `UpButterReq` 全局行为。

## 与 #58 的联动

本 PR 先合并；`POST /api/user/sessions/revoke` 的契约覆盖在 draft PR #58 中，待本 PR 合并后由 #58 按修复后行为更新（`sessions-revoke-invalid.json` fixture 回归 + 测试断言与 paths 描述更新），再进入评审。

## Testing

- `git diff --check`：通过
- `cd apps/gooseforum && go vet ./... && go test ./...`：全部通过（含 6 个新用例）
- 前端/契约/移动端：无改动，不适用；无 model/migration 变更，PG 迁移测试不适用

Closes #59
