### PR TITLE
feat: 回复编辑器弹簧上弹动画与收回时气泡同步

### DIFF
--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -170,12 +170,13 @@ function submit() {
 </script>
 
 <template>
-  <Teleport v-if="open" to="body">
+  <Teleport to="body">
     <div class="pointer-events-none fixed inset-x-0 z-[90] px-3 sm:px-6" :style="{ bottom: `calc(${keyboardOffset}px + 1rem)` }">
       <div class="relative mx-auto flex w-full max-w-full justify-center">
-        <Transition name="floating-reply">
+        <!-- appear：覆盖首次打开时组件刚挂载、Transition 与其子元素同帧出现的场景 -->
+        <Transition name="composer-rise" appear>
           <div
-            v-if="authenticated"
+            v-if="open && authenticated"
             class="gf-floating-surface pointer-events-auto relative flex max-h-[calc(100dvh-1rem)] w-[min(42rem,calc(100vw-1.5rem))] flex-col overflow-hidden p-3"
             :style="{
               height: isMobileComposer() ? undefined : `${composerHeight}px`,

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -39,13 +39,15 @@ const { bottomOffset: keyboardOffset } = useKeyboardVisualViewportOffset()
 
 const editor = ref<InstanceType<typeof VditorOfficial> | null>(null)
 const editorReady = ref(false)
+const editorInitFailed = ref(false)
 const uploadingImage = ref(false)
 
-// Vditor 异步就绪（after()）前在编辑区显示加载占位，避免首开时面板内是空白框、Vditor 随后突兀注入
+// Vditor 异步就绪（after()）前在编辑区显示加载占位；初始化失败时结束 loading，避免转圈不止
 watch(
-  () => editor.value?.editorReady,
-  (ready) => {
+  () => [editor.value?.editorReady, editor.value?.editorFailed] as const,
+  ([ready, failed]) => {
     editorReady.value = !!ready
+    editorInitFailed.value = !!failed
   },
   { immediate: true },
 )
@@ -108,9 +110,11 @@ watch(
   () => props.open,
   async (open) => {
     if (!open) return
+    // 面板关闭会卸载内层 Vditor；再次打开时清失败态，重新走 loading → ready/error
+    editorInitFailed.value = false
     await nextTick()
     window.requestAnimationFrame(() => {
-      editor.value?.focus()
+      if (!editorInitFailed.value) editor.value?.focus()
     })
   },
   { immediate: true },
@@ -122,7 +126,9 @@ function closeComposer() {
 }
 
 function handleEditorError(editorError: Error) {
-  emit('imageError', editorError.message)
+  // 兜底：即使子组件尚未 expose editorFailed，也立刻结束 loading 遮罩
+  editorInitFailed.value = true
+  emit('imageError', editorError.message || t('common.loadFailed'))
 }
 
 function insertMarkdownBlock(text: string) {
@@ -226,15 +232,16 @@ function submit() {
             </div>
 
             <div ref="editorArea" class="relative min-h-0 flex-1 overflow-y-auto">
-              <!-- Vditor 异步就绪（after()）前显示加载占位，避免首开时编辑区为空白框、Vditor 随后突兀注入 -->
+              <!-- Vditor 异步就绪前显示加载占位；初始化失败则结束转圈并提示失败（可关面板重开重试） -->
               <div
-                v-if="!editorReady"
-                class="absolute inset-0 z-10 flex items-center justify-center gap-2 bg-base-100/50 text-sm text-base-content/55"
-                role="status"
+                v-if="!editorReady || editorInitFailed"
+                class="absolute inset-0 z-10 flex items-center justify-center gap-2 bg-base-100/50 text-sm"
+                :class="editorInitFailed ? 'text-error' : 'text-base-content/55'"
+                :role="editorInitFailed ? 'alert' : 'status'"
                 aria-live="polite"
               >
-                <Loader2 class="h-4 w-4 animate-spin" />
-                <span>{{ t('common.loadingShort') }}</span>
+                <Loader2 v-if="!editorInitFailed" class="h-4 w-4 animate-spin" />
+                <span>{{ editorInitFailed ? t('common.loadFailed') : t('common.loadingShort') }}</span>
               </div>
               <!-- 与发布页同款官版编辑器（紧凑工具栏）：粘贴/拖拽图片走官方 upload.handler → uploadImageFiles -->
               <VditorOfficial

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -38,7 +38,17 @@ const { t } = useI18n()
 const { bottomOffset: keyboardOffset } = useKeyboardVisualViewportOffset()
 
 const editor = ref<InstanceType<typeof VditorOfficial> | null>(null)
+const editorReady = ref(false)
 const uploadingImage = ref(false)
+
+// Vditor 异步就绪（after()）前在编辑区显示加载占位，避免首开时面板内是空白框、Vditor 随后突兀注入
+watch(
+  () => editor.value?.editorReady,
+  (ready) => {
+    editorReady.value = !!ready
+  },
+  { immediate: true },
+)
 const composerBusy = computed(() => props.submitting || uploadingImage.value)
 
 /** 桌面端浮动面板高度：默认更高，顶部手柄可拖拽调整 */
@@ -216,6 +226,16 @@ function submit() {
             </div>
 
             <div ref="editorArea" class="relative min-h-0 flex-1 overflow-y-auto">
+              <!-- Vditor 异步就绪（after()）前显示加载占位，避免首开时编辑区为空白框、Vditor 随后突兀注入 -->
+              <div
+                v-if="!editorReady"
+                class="absolute inset-0 z-10 flex items-center justify-center gap-2 bg-base-100/50 text-sm text-base-content/55"
+                role="status"
+                aria-live="polite"
+              >
+                <Loader2 class="h-4 w-4 animate-spin" />
+                <span>{{ t('common.loadingShort') }}</span>
+              </div>
               <!-- 与发布页同款官版编辑器（紧凑工具栏）：粘贴/拖拽图片走官方 upload.handler → uploadImageFiles -->
               <VditorOfficial
                 ref="editor"

--- a/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
+++ b/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
@@ -71,6 +71,8 @@ const { t, te } = useI18n()
 const { isDark } = useSiteTheme()
 const root = ref<HTMLElement | null>(null)
 const editorReady = ref(false)
+/** 资源预载 / 构造失败时为 true；宿主可据此结束 loading，避免遮罩永远转圈 */
+const editorFailed = ref(false)
 let editor: Vditor | null = null
 let destroyed = false
 let ready = false
@@ -699,6 +701,8 @@ onMounted(async () => {
     ])
     await loadRuntimeScript(katexChemUrl, 'vditorKatexChemScript')
   } catch (error) {
+    editorFailed.value = true
+    editorReady.value = false
     emit('error', error instanceof Error ? error : new Error(String(error)))
     return
   }
@@ -755,6 +759,7 @@ onMounted(async () => {
           return
         }
         ready = true
+        editorFailed.value = false
         editorReady.value = true
         syncContentTheme()
         syncHighlightTheme()
@@ -779,6 +784,8 @@ onMounted(async () => {
     })
     editor = nextEditor
   } catch (error) {
+    editorFailed.value = true
+    editorReady.value = false
     emit('error', error instanceof Error ? error : new Error(String(error)))
   }
 })
@@ -797,6 +804,7 @@ onBeforeUnmount(() => {
   const currentEditor = editor
   editor = null
   editorReady.value = false
+  editorFailed.value = false
   // 与官方 beforeDestroy 一致：ready 后直接 destroy；未 ready 时由 after() 兜底。
   if (!ready) return
   ready = false
@@ -837,7 +845,7 @@ function syncValue() {
   return value
 }
 
-defineExpose({ editorReady, focus, getValue, insertMarkdown, setHeight, syncValue })
+defineExpose({ editorFailed, editorReady, focus, getValue, insertMarkdown, setHeight, syncValue })
 </script>
 
 <template>

--- a/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
+++ b/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
@@ -70,6 +70,7 @@ const emit = defineEmits<{
 const { t, te } = useI18n()
 const { isDark } = useSiteTheme()
 const root = ref<HTMLElement | null>(null)
+const editorReady = ref(false)
 let editor: Vditor | null = null
 let destroyed = false
 let ready = false
@@ -754,6 +755,7 @@ onMounted(async () => {
           return
         }
         ready = true
+        editorReady.value = true
         syncContentTheme()
         syncHighlightTheme()
         attachToolbarLabels()
@@ -794,6 +796,7 @@ onBeforeUnmount(() => {
   fullscreenLabelObserver = null
   const currentEditor = editor
   editor = null
+  editorReady.value = false
   // 与官方 beforeDestroy 一致：ready 后直接 destroy；未 ready 时由 after() 兜底。
   if (!ready) return
   ready = false
@@ -834,7 +837,7 @@ function syncValue() {
   return value
 }
 
-defineExpose({ focus, getValue, insertMarkdown, setHeight, syncValue })
+defineExpose({ editorReady, focus, getValue, insertMarkdown, setHeight, syncValue })
 </script>
 
 <template>

--- a/apps/gooseforum/resource/src/site/pages/TopicPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/TopicPage.vue
@@ -92,7 +92,12 @@ const mobileHeaderTitleVisible = ref(false)
 const effectiveShowHeaderTitle = computed(() => showHeaderTitle.value && (!isMobileHeaderViewport.value || mobileHeaderTitleVisible.value))
 const composerOpen = ref(false)
 const composerMode = computed(() => editingPostId.value ? 'edit' : 'create')
-const composerMounted = computed(() => composerOpen.value)
+// PostComposer 首次打开后保持挂载：若随开合销毁重建，内层 <Transition> 首次挂载不播 enter、
+// leave 也会被整体销毁绕过，弹簧上弹/收回动画将失效。此值只在首次打开时置 true，永不重置。
+const composerMounted = ref(false)
+watch(composerOpen, (open) => {
+  if (open) composerMounted.value = true
+}, { immediate: true })
 const mobilePostRailOpen = ref(false)
 const activePostNo = ref(firstPostNo(initialPosts) || 1)
 const postRailProgressCurrent = ref(0)

--- a/apps/gooseforum/resource/src/styles/motion.css
+++ b/apps/gooseforum/resource/src/styles/motion.css
@@ -317,8 +317,12 @@
     transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-.composer-rise-leave-active {
+/* 双类提高优先级：面板本身带 Tailwind pointer-events-auto，leave 必须盖过它 */
+.composer-rise-leave-active,
+.composer-rise-leave-active.pointer-events-auto {
   will-change: transform;
+  /* leave 期间禁用命中，避免 ~300ms 半透明面板挡住下方气泡点击 */
+  pointer-events: none;
   transition:
     opacity 0.3s cubic-bezier(0.22, 1, 0.36, 1),
     transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);

--- a/apps/gooseforum/resource/src/styles/motion.css
+++ b/apps/gooseforum/resource/src/styles/motion.css
@@ -293,17 +293,41 @@
   transform: translateY(6px) scale(0.98);
 }
 
+/* 底部气泡/回复位置轨道：与 composer 收回同时上弹，轻量淡入 + 上滑 12px */
 .floating-reply-enter-active,
 .floating-reply-leave-active {
+  will-change: transform;
   transition:
-    opacity 0.18s cubic-bezier(0.22, 1, 0.36, 1),
-    transform 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+    opacity 0.2s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .floating-reply-enter-from,
 .floating-reply-leave-to {
   opacity: 0;
-  transform: translateY(10px) scale(0.98);
+  transform: translateY(12px) scale(0.98);
+}
+
+/* 回复编辑器：仿 MacOS 弹簧上弹（enter 400ms 带回弹过冲），收回为其逆操作（300ms 平滑）。
+   enter 曲线 y 峰值约 1.098：面板略微越过落点再回位，scale 峰值约 1.004（短暂柔和、落定锐利）。 */
+.composer-rise-enter-active {
+  will-change: transform;
+  transition:
+    opacity 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
+    transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.composer-rise-leave-active {
+  will-change: transform;
+  transition:
+    opacity 0.3s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.composer-rise-enter-from,
+.composer-rise-leave-to {
+  opacity: 0;
+  transform: translateY(32px) scale(0.96);
 }
 
 .user-card-pop-enter-active,
@@ -349,6 +373,8 @@
   .gf-flash-move,
   .floating-reply-enter-active,
   .floating-reply-leave-active,
+  .composer-rise-enter-active,
+  .composer-rise-leave-active,
   .user-card-pop-enter-active,
   .user-card-pop-leave-active,
   .user-card-content-enter-active,
@@ -365,6 +391,8 @@
   .gf-modal-leave-to > *,
   .floating-reply-enter-from,
   .floating-reply-leave-to,
+  .composer-rise-enter-from,
+  .composer-rise-leave-to,
   .user-card-pop-enter-from,
   .user-card-pop-leave-to,
   .user-card-content-enter-from,


### PR DESCRIPTION
## 动机

帖子页点击「参与讨论」打开回复编辑器（Vditor）时面板瞬现、无动画；关闭时面板瞬间销毁，随后底部气泡（TopicFloatingControls）才从底部冒出，时序违反直觉。

根因：`composerMounted` 由 `computed(() => composerOpen.value)` 控制，每次打开整个组件（含 `<Teleport v-if="open">` 与内层 `<Transition>`）与子元素一起首次挂载——Vue 默认首次挂载不播 enter 动画；关闭时整棵子树瞬间销毁，leave 被整体销毁绕过。

## 行为变化

- 打开：面板从下方弹簧上弹（`translateY(32px→0)` + `scale(0.96→1)` + 淡入，enter 400ms `cubic-bezier(.34,1.56,.64,1)` 带回弹过冲）
- 收回：逆操作（300ms 平滑下滑），底部气泡在**同一帧**上弹出现，不再等面板完全消失
- Vditor 异步就绪前编辑区显示「加载中...」占位，避免首开时空白框 + Vditor 突兀注入
- 尊重 `prefers-reduced-motion`（无位移、瞬时）

## 验证

| 检查 | 结果 |
|---|---|
| `pnpm typecheck` | ✅ |
| `pnpm test` | ✅ 89 通过 |
| `pnpm build` | ✅ |
| `pnpm client:test` | ✅ 9 通过 |
| 浏览器实测（Playwright 轨迹采样） | ✅ enter 弹簧轨迹（scale 过冲 1.004、translateY 过冲 -3.1px）、leave 300ms、气泡与 leave 同帧启动、reduced-motion 无位移、移动端正常 |

## 文档 / 契约影响

- 无文档变更。
- `VditorOfficial.vue` 新增 `defineExpose({ editorReady })`（additive，向后兼容），仅 `PostComposer` 使用。
- 无设计 token 变更，无 `apps/mobile` mirror 需求（回复编辑器为 web 专属，Flutter 端为独立实现）。

## 已知缺口

- 首次冷打开（async chunk + Vditor 5 个运行时脚本下载）时面板可能先于编辑器就绪，已用加载占位缓解；热缓存下无感知。
- 发布回复成功后 `postContent` 清空与 leave 动画同时发生，面板正在移出故不可见（较原瞬隐为改进）。

## Test plan

- [x] 首次打开：弹簧上弹 + 编辑区加载占位，Vditor 就绪后占位消失
- [x] 再次打开（脚本已缓存）：弹簧上弹正常
- [x] 收回：面板 300ms 下滑，气泡同帧上弹
- [x] 系统减弱动效（prefers-reduced-motion）：面板瞬现、无位移
- [x] 移动端视口：行为一致
- [x] 编辑回复关闭后重开：草稿正常恢复
- [ ] reviewer 复核（本 PR 不自行 merge）
