### PR TITLE
fix: restore category picker and unify home feed mode

### DIFF
--- a/apps/gooseforum/resource/src/runtime/home-feed-mode.ts
+++ b/apps/gooseforum/resource/src/runtime/home-feed-mode.ts
@@ -1,0 +1,43 @@
+import { ref } from 'vue'
+
+export type HomeFeedMode = 'table' | 'card'
+
+const feedStorageKey = 'goose:home-feed-mode'
+
+function readFeedMode(): HomeFeedMode {
+  if (typeof window === 'undefined') return 'table'
+
+  try {
+    const stored = window.localStorage.getItem(feedStorageKey)
+    if (stored === 'card' || stored === 'table') return stored
+  } catch {
+    // Storage may be unavailable in private or restricted browsing contexts.
+  }
+
+  // 未手动选择时按设备默认：移动端卡片、桌面端列表（与 Tailwind lg 断点一致）。
+  return typeof window.matchMedia === 'function' && window.matchMedia('(min-width: 1024px)').matches
+    ? 'table'
+    : 'card'
+}
+
+// 首页的最新、热门、流行页面会被 KeepAlive 缓存为多个组件实例，
+// 因此视图模式必须放在模块级别，不能放在 HomePage 的 setup 实例中。
+const sharedFeedMode = ref<HomeFeedMode>(readFeedMode())
+
+function setFeedMode(mode: HomeFeedMode) {
+  sharedFeedMode.value = mode
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(feedStorageKey, mode)
+  } catch {
+    // Storage may be unavailable in private or restricted browsing contexts.
+  }
+}
+
+export function useHomeFeedMode() {
+  return {
+    feedMode: sharedFeedMode,
+    setFeedMode,
+  }
+}

--- a/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
+++ b/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import Vditor from 'vditor'
 import 'vditor/dist/index.css'
 import luteUrl from 'vditor/dist/js/lute/lute.min.js?url'
@@ -67,7 +67,7 @@ const emit = defineEmits<{
   'toggle-header': []
 }>()
 
-const { t, te } = useI18n()
+const { t, te, locale } = useI18n()
 const { isDark } = useSiteTheme()
 const root = ref<HTMLElement | null>(null)
 const editorReady = ref(false)
@@ -450,6 +450,318 @@ function attachTooltipSmartPosition() {
   })
 }
 
+// ===== 语言热切换：替换 window.VditorI18n 后就地刷新文案 DOM =====
+// vditor 无 setI18n API（src/index.ts 公开方法仅 updateToolbarConfig/setTheme/getValue/…），
+// 全部界面文案在构造期由 window.VditorI18n 生成；切换 = 重载目标语言脚本 → 就地改
+// 文本节点/属性（绝不能 innerHTML 重建带事件监听的按钮/面板）。
+
+/** 主行按钮 tooltip（aria-label）文案：宿主自定义项走 t()（与构造期 tip 同源），
+ *  其余回落 vditor 原生 i18n。上传必须用 uploadImageTip 完整 tooltip，
+ *  不能回落 I.upload（vditor 默认「上传图片或文件」会覆盖宿主定制文案）。 */
+const TOOLBAR_TIP_KEYS: Record<string, string> = {
+  upload: 'editor.toolbar.uploadImageTip',
+  'math-inline': 'editor.toolbar.mathInline',
+  'math-block': 'editor.toolbar.mathBlock',
+}
+
+/** 语言热切换竞态令牌：快速连续切换时只应用最后一次 */
+let i18nSeq = 0
+/** 初始化期间（编辑器未 ready）切换语言时置位，after() 就绪后补刷，避免切换被静默丢弃 */
+let pendingLocaleRefresh = false
+
+/** 重载目标语言 i18n 脚本。loadRuntimeScript（runtime-script.ts:6）对
+ *  dataset.loaded='true' 的节点直接 resolve 不重跑 → 切回已加载语言时
+ *  window.VditorI18n 会停在上一个语言，必须先移除节点强制重跑。 */
+async function loadVditorI18n(lang: string, url: string) {
+  const id = `vditorI18nScript${lang}`
+  document.getElementById(id)?.remove()
+  await loadRuntimeScript(url, id)
+}
+
+/** 空态占位符：wysiwyg/ir/sv 的 .element 都是 pre.vditor-reset（HTMLPreElement），
+ *  CSS 用 content:attr(placeholder) 显示，直接改属性即时生效。 */
+function refreshPlaceholder() {
+  if (!editor || !ready || destroyed) return
+  const text = props.placeholder
+  editor.vditor.options.placeholder = text
+  editor.vditor.wysiwyg?.element.setAttribute('placeholder', text)
+  editor.vditor.ir?.element.setAttribute('placeholder', text)
+  editor.vditor.sv?.element.setAttribute('placeholder', text)
+}
+
+/** 主行按钮 hover tooltip：重建 aria-label，保留原热键后缀（跨语言不变）。 */
+function refreshMainRowAriaLabels(I: typeof window.VditorI18n) {
+  root.value
+    ?.querySelectorAll<HTMLElement>('.vditor-toolbar__item > .vditor-tooltipped[data-type]')
+    .forEach((btn) => {
+      const type = btn.getAttribute('data-type') || ''
+      const suffix = (btn.getAttribute('aria-label') || '').match(HOTKEY_PATTERN)?.[0] || ''
+      const tipKey = TOOLBAR_TIP_KEYS[type]
+      const tip = tipKey ? (te(tipKey) ? t(tipKey) : I[type] || '') : I[type] || ''
+      btn.setAttribute('aria-label', tip + suffix)
+    })
+}
+
+/** more 子菜单原生 level-2 项：改首文本节点保留事件监听（MenuItem.ts:23-24 innerHTML 生成）。
+ *  必须用 `type in window.VditorI18n` 排除 content-theme/export 面板——它们的按钮
+ *  data-type 是主题/格式键（dark/light/markdown/pdf/…），不在 vditor i18n 里，否则会把
+ *  面板文字刷成空串。 */
+function refreshHintNativeItems(I: typeof window.VditorI18n) {
+  root.value
+    ?.querySelectorAll<HTMLElement>('.vditor-hint button[data-type]')
+    .forEach((btn) => {
+      if (btn.querySelector('svg')) return // 宿主自定义图标项（公式等）走 refreshToolbarLabelText
+      const type = btn.getAttribute('data-type') || ''
+      if (!type || !(type in window.VditorI18n)) return
+      const suffix = (btn.textContent || '').match(/\s*<[^<>]*>\s*$/)?.[0] || ''
+      if (btn.firstChild?.nodeType === Node.TEXT_NODE) {
+        btn.firstChild.nodeValue = (I[type] || '') + suffix
+      }
+    })
+}
+
+/** Headings 面板：click 事件绑在 button 上（Headings.ts:56-71），只改首文本节点。 */
+const HEADING_KEYS = ['heading1', 'heading2', 'heading3', 'heading4', 'heading5', 'heading6']
+function refreshHeadingsPanel(I: typeof window.VditorI18n) {
+  root.value
+    ?.querySelectorAll<HTMLElement>('.vditor-hint button[data-tag]')
+    .forEach((btn, i) => {
+      const suffix = (btn.textContent || '').match(/\s*<[^<>]*>\s*$/)?.[0] || ''
+      if (btn.firstChild?.nodeType === Node.TEXT_NODE) {
+        btn.firstChild.nodeValue = (I[HEADING_KEYS[i]] || '') + suffix
+      }
+    })
+}
+
+/** EditMode 面板：同规则改首文本节点。 */
+const EDIT_MODE_KEYS: Record<string, string> = {
+  wysiwyg: 'wysiwyg',
+  ir: 'instantRendering',
+  sv: 'splitView',
+}
+function refreshEditModePanel(I: typeof window.VditorI18n) {
+  root.value
+    ?.querySelectorAll<HTMLElement>('.vditor-hint button[data-mode]')
+    .forEach((btn) => {
+      const key = EDIT_MODE_KEYS[btn.getAttribute('data-mode') || '']
+      if (!key) return
+      const suffix = (btn.textContent || '').match(/\s*<[^<>]*>\s*$/)?.[0] || ''
+      if (btn.firstChild?.nodeType === Node.TEXT_NODE) {
+        btn.firstChild.nodeValue = (I[key] || '') + suffix
+      }
+    })
+}
+
+/** 大纲标题 + 开关按钮。标题只改首文本节点：宿主把开关按钮 append 进 title
+ *  （syncOutlineToggleHost L778），textContent 会删掉按钮。开关按钮只查已存在的
+ *  aria-label，绝不调用 outlineToggleButton()/headerToggleButton()——它们缺省会新建
+ *  按钮，非 outline/headerToggle 模式的编辑器会残留悬浮按钮。 */
+function refreshOutlineAndToggles(I: typeof window.VditorI18n) {
+  const title = editor?.vditor.outline.element.querySelector<HTMLElement>('.vditor-outline__title')
+  if (title?.firstChild?.nodeType === Node.TEXT_NODE) title.firstChild.nodeValue = I.outline || ''
+  const scopes = [root.value, props.toggleHost]
+  for (const scope of scopes) {
+    scope
+      ?.querySelector<HTMLElement>(`.${OUTLINE_TOGGLE_CLASS}`)
+      ?.setAttribute('aria-label', I.outline || '大纲')
+    scope
+      ?.querySelector<HTMLElement>(`.${HEADER_TOGGLE_CLASS}`)
+      ?.setAttribute('aria-label', t('publish.collapseHeader'))
+  }
+}
+
+/** 图标下小字就地刷新：只重跑 ensureToolbarButtonLabel（L360 文本 diff 更新）。
+ *  不能复用 attachToolbarLabels（L393-407）——它内部 attachTooltipSmartPosition 会重绑
+ *  mouseenter、guardFullscreenToolbarLabel 会重建 observer，多调几次叠监听器。 */
+function refreshToolbarLabelText() {
+  if (!root.value || window.matchMedia(MOBILE_VIEWPORT_QUERY).matches) return
+  root.value
+    .querySelectorAll<HTMLElement>('.vditor-toolbar__item .vditor-tooltipped')
+    .forEach(ensureToolbarButtonLabel)
+  root.value
+    .querySelectorAll<HTMLElement>('.vditor-hint button[data-type]')
+    .forEach((item) => {
+      if (item.querySelector('svg')) ensureToolbarButtonLabel(item)
+    })
+}
+
+/** 语言切换主流程。 */
+async function refreshVditorLocale() {
+  if (!editor || !ready || destroyed) return
+  // 局部 const 捕获当前实例：跨 await 时模块级 let editor 的收窄会被重置，
+  // 用 const 保证 await 后续体类型安全；卸载由 destroyed + i18nSeq 双重拦截。
+  const current = editor
+  const newLocale = currentLocale()
+  const asset = languageAssets[newLocale]
+  if (!asset) return
+  const seq = ++i18nSeq
+  try {
+    await loadVditorI18n(asset.lang, asset.url)
+  } catch {
+    return // 脚本加载失败：保留旧语言 DOM，下次切换/重载再试
+  }
+  if (destroyed || seq !== i18nSeq || !current.vditor) return // 快速切换竞态：放弃陈旧调用
+  const I = window.VditorI18n
+  current.vditor.options.i18n = I // 与 previewRender.ts:117 保持一致（preview 渲染期读 window.VditorI18n）
+  current.vditor.options.lang = asset.lang
+  refreshPlaceholder()
+  refreshMainRowAriaLabels(I)
+  refreshHintNativeItems(I)
+  refreshHeadingsPanel(I)
+  refreshEditModePanel(I)
+  refreshOutlineAndToggles(I)
+  refreshToolbarLabelText()
+  scheduleMeasure() // 英文文案变宽可能改变折叠收纳 / 图标-only 判定
+}
+
+// ===== 工具栏图标窄屏收纳：溢出的按钮按原次序移入 more 子菜单 =====
+// 方案依据：vditor 无事件委托，监听器直接绑在按钮节点上（Custom.ts/MenuItem.ts/Upload.ts 等），
+// 因此收纳只能「移动整层 .vditor-toolbar__item 包裹 div」进子菜单（节点移动保留监听器与
+// vditor.toolbar.elements[name] 引用），绝不能 display:none 原地隐藏或 clone 重建。
+const OVERFLOW_TOLERANCE = 1 // px：折叠/恢复判定滞回，防抖动
+/** 工具栏容器宽度低于该值时隐藏主行按钮的文字标签（只显示图标）：
+ *  窄屏下英文/多字标签（如 "Block math"）会溢出按钮与相邻图标重叠。
+ *  带滞回：低于 HIDE 才隐藏，需宽到 SHOW 才恢复（页面左边栏折叠会让工具栏宽度
+ *  非单调变化，无滞回会反复跨越阈值导致标签先消失又出现）。
+ *  #7：一旦触发过隐藏即锁存，之后宽度恢复也不再显示（防止侧栏消失→展开闪现）。 */
+const LABEL_HIDE_THRESHOLD = 800
+const LABEL_SHOW_THRESHOLD = 900
+let labelsHidden = false
+let labelsLatched = false // #7：一旦隐藏即永久锁存（直到模块重置），不再恢复文字标签
+/** 带二级面板的项不收纳：它们的 toggleSubMenu 的 exceptElement 逻辑在折叠区内
+ *  会把整个 more 面板关掉（EditMode.ts:172 / Emoji.ts:37 / Headings.ts 证据） */
+const HUB_NO_FOLD_TYPES = new Set(['emoji', 'headings', 'edit-mode'])
+let foldObserver: ResizeObserver | null = null
+let foldRaf = 0
+let toolbarEl: HTMLElement | null = null
+let moreWrapper: HTMLElement | null = null
+let hintPanel: HTMLElement | null = null
+let foldRegion: HTMLElement | null = null
+let mainRowSequence: HTMLElement[] = []
+
+function isFolded(el: HTMLElement) {
+  return el.parentElement === foldRegion
+}
+
+function syncDivider(d: HTMLElement) {
+  const i = mainRowSequence.indexOf(d)
+  const left = mainRowSequence[i - 1]
+  const right = mainRowSequence[i + 1]
+  const leftFolded = left ? isFolded(left) : false
+  const rightFolded = right ? isFolded(right) : false
+  d.style.display = leftFolded && rightFolded ? 'none' : ''
+}
+
+function syncAdjacentDividers(item: HTMLElement) {
+  const i = mainRowSequence.indexOf(item)
+  const left = mainRowSequence[i - 1]
+  const right = mainRowSequence[i + 1]
+  if (left?.classList.contains('vditor-toolbar__divider')) syncDivider(left)
+  if (right?.classList.contains('vditor-toolbar__divider')) syncDivider(right)
+}
+
+function rightmostMainRowItem(): HTMLElement | null {
+  for (let j = toolbarEl!.children.length - 1; j >= 0; j--) {
+    const c = toolbarEl!.children[j] as HTMLElement
+    if (c === moreWrapper || c.classList.contains('vditor-counter')) continue
+    if (!c.classList.contains('vditor-toolbar__item')) continue
+    const type = c.children[0]?.getAttribute('data-type') ?? ''
+    if (HUB_NO_FOLD_TYPES.has(type)) continue
+    return c
+  }
+  return null
+}
+
+function foldItem(item: HTMLElement) {
+  const i = mainRowSequence.indexOf(item)
+  const left = mainRowSequence[i - 1]
+  // 原次序内跨组：左邻是分隔符 → 打组分隔标记（region 首个项由 CSS 抑制顶线）
+  item.classList.toggle('hub-fold-group-start', !!left?.classList.contains('vditor-toolbar__divider'))
+  foldRegion!.insertBefore(item, foldRegion!.firstChild) // 插到最前 → 折叠区保持主行左→右次序
+  syncAdjacentDividers(item)
+}
+
+function unfoldItem(item: HTMLElement) {
+  const i = mainRowSequence.indexOf(item)
+  let anchor: HTMLElement | null = null
+  for (let j = i + 1; j < mainRowSequence.length; j++) {
+    if (mainRowSequence[j].parentElement === toolbarEl) {
+      anchor = mainRowSequence[j]
+      break
+    }
+  }
+  toolbarEl!.insertBefore(item, anchor ?? moreWrapper!) // 放回原次序正确位置
+  item.classList.remove('hub-fold-group-start')
+  syncAdjacentDividers(item)
+}
+
+function measureToolbar() {
+  foldRaf = 0
+  if (destroyed || !toolbarEl?.isConnected || !foldRegion) return
+  // 恒覆盖工具栏左 padding（防 vditor setPadding 按「内容 padding + 大纲宽度」
+  // 在窄屏/大纲展开时把图标挤到右端）；再按宽度滞回切换标签显隐。
+  syncToolbarLeftPadding()
+  if (toolbarEl.clientWidth < LABEL_HIDE_THRESHOLD) {
+    labelsHidden = true
+    labelsLatched = true        // #7：触发一次即锁存，之后宽度恢复不再显示
+  } else if (!labelsLatched && toolbarEl.clientWidth >= LABEL_SHOW_THRESHOLD) {
+    labelsHidden = false
+  }
+  if (root.value && root.value.classList.contains('hub-toolbar-icon-only') !== labelsHidden) {
+    root.value.classList.toggle('hub-toolbar-icon-only', labelsHidden)
+  }
+  for (let g = 0; g < 100; g++) {
+    // 折叠：右→左
+    if (toolbarEl.scrollWidth <= toolbarEl.clientWidth + OVERFLOW_TOLERANCE) break
+    const item = rightmostMainRowItem()
+    if (!item) break
+    foldItem(item)
+  }
+  for (let g = 0; g < 100; g++) {
+    // 恢复：反序尝试放回。主行项 flex-grow 到 clientWidth，scrollWidth 无法反映富余量，
+    // 因此改为「放回→查溢出→溢出则收回」的试放法；收回后停止，避免与折叠来回抖。
+    const item = foldRegion.firstElementChild as HTMLElement | null
+    if (!item) break
+    unfoldItem(item)
+    if (toolbarEl.scrollWidth > toolbarEl.clientWidth + OVERFLOW_TOLERANCE) {
+      foldItem(item)
+      break
+    }
+  }
+}
+
+function scheduleMeasure() {
+  if (destroyed || foldRaf) return
+  foldRaf = requestAnimationFrame(measureToolbar)
+}
+
+function initToolbarFolding() {
+  if (!root.value) return
+  toolbarEl = root.value.querySelector<HTMLElement>('.vditor-toolbar')
+  if (!toolbarEl) return
+  moreWrapper = toolbarEl.querySelector<HTMLElement>(
+    ':scope > .vditor-toolbar__item > [data-type="more"]',
+  )?.parentElement ?? null
+  if (!moreWrapper) return // 无 more（理论不会发生）→ 不做收纳
+  hintPanel = moreWrapper.querySelector<HTMLElement>(':scope > .vditor-hint')
+  if (!hintPanel) return
+  mainRowSequence = Array.from(toolbarEl.children).filter(
+    (c): c is HTMLElement => c !== moreWrapper && !c.classList.contains('vditor-counter'),
+  )
+  foldRegion = document.createElement('div')
+  foldRegion.className = 'hub-fold-region'
+  hintPanel.insertBefore(foldRegion, hintPanel.firstChild) // 折叠区置于子菜单最顶部
+  foldObserver = new ResizeObserver(scheduleMeasure)
+  foldObserver.observe(toolbarEl)
+  window.addEventListener('resize', scheduleMeasure)
+  // vditor setPadding 在窗口缩放时会按「内容 padding + 大纲宽度」重设工具栏 paddingLeft，
+  // 这里覆盖回恒定靠左值，保证缩放后工具栏左缘不变
+  window.addEventListener('resize', syncToolbarLeftPadding)
+  // 初始即定稿恒定靠左值（大纲初始展开后 vditor 可能已写入位移值）
+  syncToolbarLeftPadding()
+  measureToolbar() // 首次同步测量，避免初始闪烁
+}
+
 /**
  * 预置官方 id 的运行时资源，让 vditor 跳过 CDN：
  * - script#vditorHljsScript / #vditorHljsThirdScript：空占位，addScript 直接 resolve
@@ -558,6 +870,8 @@ function animateOutline(show: boolean) {
       outlineEl.style.display = 'none'
     }
     syncOutlineToggleHost()
+    // 大纲动画收尾 paddingLeft 突变后确定性重测折叠
+    scheduleMeasure()
   }
   outlineEndHandler = (event) => {
     if (event.propertyName === 'width') finish()
@@ -593,6 +907,19 @@ function outlineToggleButton(): HTMLButtonElement | null {
   return button
 }
 
+/** 工具栏内容恒定靠左、不随大纲开合移动：
+ *  有悬浮「向上扩展」按钮（headerToggle）时让出 35px（按钮占 0-35px），否则用 vditor 默认 5px。
+ *  显式覆盖 vditor setPadding 的「内容 padding + 大纲宽度」算法（它会让工具栏随大纲位移），
+ *  保证开关大纲 / 窗口缩放后工具栏左缘恒定。仅桌面生效：移动端大纲隐藏、悬浮按钮移入行内。 */
+function syncToolbarLeftPadding() {
+  const toolbar = root.value?.querySelector<HTMLElement>('.vditor-toolbar')
+  if (!toolbar) return
+  // 桌面且有悬浮「向上扩展」按钮 → 让出 35px；移动端按钮移入行内 / 无按钮 → 5px。
+  // 恒覆盖 vditor setPadding：它按「内容 padding + 大纲宽度」计算，大纲展开/窄屏下
+  // 会把 padding-left 推到数百像素（如 260px），把图标挤到工具栏右端。
+  toolbar.style.paddingLeft = !window.matchMedia(MOBILE_VIEWPORT_QUERY).matches && props.headerToggle ? '35px' : '5px'
+}
+
 function syncOutlineToggleHost() {
   const button = outlineToggleButton()
   const outline = editor?.vditor.outline
@@ -626,6 +953,8 @@ function syncOutlineToggleHost() {
 
   // 发布页「向上扩展」按钮跟随大纲显隐（仅大纲展开时浮在大纲上方，收起时隐藏避免遮挡工具栏）
   if (props.headerToggle) syncHeaderToggleHost()
+  // 工具栏恒定靠左（覆盖 vditor setPadding 可能在大纲动画中写下的位移值）
+  syncToolbarLeftPadding()
 }
 
 /** 「向上扩展」按钮：悬浮在大纲列正上方（工具栏左侧空白区），与工具栏工具完全分离；
@@ -672,15 +1001,8 @@ function syncHeaderToggleHost() {
   button.classList.remove('is-hidden')
   button.classList.remove('hub-toggle--inline')
 
-  // 大纲收起时 vditor 会把工具栏 padding-left 恢复为 5px，
-  // 悬浮按钮（header-toggle 0-35px）会盖住第一个工具，这里补偿 35px；
-  // 大纲展开时不动（保留 vditor 设置的大纲占位宽度）
-  const outline = editor?.vditor.outline
-  const outlineShown = props.outline === true && outline?.element.style.display === 'block'
-  const toolbar = root.value?.querySelector<HTMLElement>('.vditor-toolbar')
-  if (toolbar && !outlineShown) {
-    toolbar.style.paddingLeft = '35px'
-  }
+  // 工具栏恒定靠左（见 syncToolbarLeftPadding 注释）
+  syncToolbarLeftPadding()
 }
 
 onMounted(async () => {
@@ -774,12 +1096,21 @@ onMounted(async () => {
           syncOutlineToggleHost()
         }
         if (props.headerToggle) syncHeaderToggleHost()
+        // 工具栏收纳：须在大纲展开/header-toggle 定稿 paddingLeft 后再首次测量
+        initToolbarFolding()
+        // 初始化期间若切换过语言，就绪后按当前语言补刷（防切换被静默丢弃）
+        if (pendingLocaleRefresh) {
+          pendingLocaleRefresh = false
+          void refreshVditorLocale()
+        }
         if (props.modelValue && props.modelValue !== nextEditor?.getValue()) {
           nextEditor?.setValue(props.modelValue, true)
         }
       },
       input(value) {
         emit('update:modelValue', value)
+        // 字数变化改变工具栏末位 counter 宽度，RO 只测 border-box，需显式重测
+        scheduleMeasure()
       },
     })
     editor = nextEditor
@@ -797,10 +1128,34 @@ watch(() => props.modelValue, (value) => {
 
 watch(isDark, syncEditorTheme)
 
+// #8：语言切换 → 重载 vditor i18n 脚本并就地刷新全部界面文案。
+// SPA 内 setLocale 只改 vue-i18n ref，绝不 location.reload()（AppShell.setLang）。
+watch(locale, () => {
+  if (!editor || !ready || destroyed) {
+    // 编辑器初始化期间：标记待补刷，after() 就绪后按当前语言应用
+    pendingLocaleRefresh = true
+    return
+  }
+  void refreshVditorLocale()
+})
+
+// #8：空态占位符。父组件 placeholder 是 computed(t(...))（如 PostComposer L102），
+// locale 一变 prop 即变；vditor 无热 setter，只能同步三个 mode 元素的 placeholder 属性。
+watch(() => props.placeholder, () => { refreshPlaceholder() })
+
 onBeforeUnmount(() => {
   destroyed = true
   fullscreenLabelObserver?.disconnect()
   fullscreenLabelObserver = null
+  // 工具栏收纳清理：观察器/监听/rAF 全部释放，防止陈旧实例泄漏
+  foldObserver?.disconnect()
+  foldObserver = null
+  window.removeEventListener('resize', scheduleMeasure)
+  window.removeEventListener('resize', syncToolbarLeftPadding)
+  if (foldRaf) cancelAnimationFrame(foldRaf)
+  foldRaf = 0
+  toolbarEl = moreWrapper = hintPanel = foldRegion = null
+  mainRowSequence = []
   const currentEditor = editor
   editor = null
   editorReady.value = false
@@ -849,7 +1204,9 @@ defineExpose({ editorFailed, editorReady, focus, getValue, insertMarkdown, setHe
 </script>
 
 <template>
-  <div ref="root" class="vditor-official" />
+  <!-- 用 data-locale 属性而非 :class 驱动语言样式：Vue 动态 class 重渲染会抹掉
+       Vditor 命令式添加的 .vditor 类（编辑器边框/工具栏样式依赖它），属性则不影响 className -->
+  <div ref="root" class="vditor-official" :data-locale="locale" />
 </template>
 
 <style>
@@ -1105,6 +1462,14 @@ defineExpose({ editorFailed, editorReady, focus, getValue, insertMarkdown, setHe
   opacity: 0.9;
 }
 
+/* ===== 英文/意大利文标签更宽：10px 下溢出/截断，缩到 9px 保持单行 =====
+ * 仅命中主行「图标下小字」（选择器粒度与 L1428 图标-only 隐藏规则一致），
+ * 与 more 子菜单 / 折叠区 12px 文字（L1410-1417 / L1459-1466）正交。 */
+.vditor-official[data-locale='en'] .vditor-toolbar > .vditor-toolbar__item > .vditor-tooltipped .vditor-toolbar-label,
+.vditor-official[data-locale='it'] .vditor-toolbar > .vditor-toolbar__item > .vditor-tooltipped .vditor-toolbar-label {
+  font-size: 9px;
+}
+
 /* 上传按钮内嵌 file input：随新按钮高度铺满 */
 .vditor-official .vditor-toolbar__item input[type='file'] {
   width: 100%;
@@ -1246,6 +1611,75 @@ defineExpose({ editorFailed, editorReady, focus, getValue, insertMarkdown, setHe
   font-weight: 400;
   line-height: 1.4;
   vertical-align: middle;
+}
+
+/* ===== 工具栏图标窄屏收纳到 more 子菜单 ===== */
+/* 折叠区容器：位于 more 子菜单最顶部；空时隐藏，不占子菜单空间 */
+.vditor-official .hub-fold-region:empty {
+  display: none;
+}
+
+/* ===== 窄屏只显示图标：主行按钮隐藏文字标签（保留 more 子菜单里的文字行） =====
+ * 仅命中主行按钮（item 直接子级 button 内的 label）；折叠区位于 .vditor-hint 内，
+ * 其 label 不在「item > button」直系，不受影响。 */
+.vditor-official.hub-toolbar-icon-only .vditor-toolbar > .vditor-toolbar__item > .vditor-tooltipped .vditor-toolbar-label {
+  display: none;
+}
+
+/* 折叠项：恢复为纵向堆叠的菜单行（脱离主行 flex 的 21px 均分/横排小字） */
+.vditor-official .hub-fold-region .vditor-toolbar__item {
+  position: relative; /* 官方 .vditor-toolbar__item 本就有，保留给 upload input / 二级面板定位 */
+  flex: none;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/* 折叠项按钮：图标+文字横排，与 hint 内既有自定义项视觉一致 */
+.vditor-official .hub-fold-region .vditor-toolbar__item .vditor-tooltipped {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  height: auto;
+  margin: 0;
+  padding: 5px 10px;
+  box-sizing: border-box;
+  border-radius: 0;
+  font-size: 12px;
+}
+
+.vditor-official .hub-fold-region .vditor-toolbar__item .vditor-toolbar-label {
+  display: inline-block;
+  margin-left: 0; /* 覆盖 hint 通用 6px，用 flex gap 统一间距 */
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+/* 跨组折叠项顶部细线（保持原分组感）；region 首个折叠项不加（其边界由主行 `… | more` 表示） */
+.vditor-official .hub-fold-region .vditor-toolbar__item.hub-fold-group-start .vditor-tooltipped {
+  border-top: 1px solid var(--border-color);
+}
+
+.vditor-official .hub-fold-region .vditor-toolbar__item:first-child .vditor-tooltipped {
+  border-top: 0;
+}
+
+/* 折叠项在子菜单内关闭 hover 气泡（行内已有文字标签，气泡冗余且会与面板重叠） */
+.vditor-official .hub-fold-region .vditor-toolbar__item .vditor-tooltipped::after,
+.vditor-official .hub-fold-region .vditor-toolbar__item .vditor-tooltipped::before {
+  display: none;
+}
+
+/* upload 折叠进子菜单：file input 铺满整行（整行可点开文件选择器） */
+.vditor-official .hub-fold-region .vditor-toolbar__item input[type='file'] {
+  height: 100%;
 }
 
 /*

--- a/apps/gooseforum/resource/src/site/pages/HomePage.vue
+++ b/apps/gooseforum/resource/src/site/pages/HomePage.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMoun
 import { useI18n } from 'vue-i18n'
 import { Bell, LayoutGrid, List, Mail, Plus, UsersRound } from '@lucide/vue'
 import { fetchPage } from '@/runtime/router'
+import { useHomeFeedMode } from '@/runtime/home-feed-mode'
 import EmptyState from '@/site/components/EmptyState.vue'
 import TopicListFooter from '@/site/components/TopicListFooter.vue'
 import TopicList from '@/site/components/TopicList.vue'
@@ -28,31 +29,8 @@ let observer: IntersectionObserver | undefined
 const hasTopics = computed(() => topics.value.length > 0)
 const showPinnedLabels = computed(() => page.props.sort === '' || page.props.sort === 'latest')
 
-// 信息流样式：列表（表格）↔ 卡片，桌面与移动端均可切换，选择记忆在本地；
-// 列表模式下桌面端保留 hover 弹层预览。
-const feedStorageKey = 'goose:home-feed-mode'
-const feedMode = ref<'table' | 'card'>(readFeedMode())
-
-function readFeedMode(): 'table' | 'card' {
-  try {
-    const stored = window.localStorage.getItem(feedStorageKey)
-    if (stored === 'card' || stored === 'table') return stored
-  } catch {
-    // Storage may be unavailable in private or restricted browsing contexts.
-  }
-  // 未手动选择时按设备默认：移动端卡片、桌面端列表（与 Tailwind lg 断点一致）
-  return window.matchMedia('(min-width: 1024px)').matches ? 'table' : 'card'
-}
-
-function setFeedMode(mode: 'table' | 'card') {
-  feedMode.value = mode
-  try {
-    window.localStorage.setItem(feedStorageKey, mode)
-  } catch {
-    // Storage may be unavailable in private or restricted browsing contexts.
-  }
-  void nextTick(updateFeedModePill)
-}
+// 信息流样式由所有首页分页共享；列表模式下桌面端保留 hover 弹层预览。
+const { feedMode, setFeedMode: setSharedFeedMode } = useHomeFeedMode()
 
 // 列表/卡片切换：绝对定位的「药丸」滑到激活按钮下方。
 // 位置按按钮实际渲染尺寸测量（绝对值定位相对于容器的 padding box）；
@@ -64,6 +42,7 @@ const feedModeCardBtn = ref<HTMLElement | null>(null)
 const feedModePillLeft = ref(0)
 const feedModePillWidth = ref(0)
 const feedModePillReady = ref(false)
+const feedModePillShouldAnimate = ref(false)
 const reducedMotion = ref(false)
 let feedModeResizeObserver: ResizeObserver | undefined
 let feedModeMotionQuery: MediaQueryList | undefined
@@ -81,11 +60,22 @@ function updateFeedModePill() {
   feedModePillReady.value = true
 }
 
+function setFeedMode(mode: 'table' | 'card') {
+  // 只有当前可见分页中的主动点击才应播放药丸动画；其他 KeepAlive
+  // 实例在激活时只同步到最终位置，不重复播放同一段过渡。
+  feedModePillShouldAnimate.value = mode !== feedMode.value
+  setSharedFeedMode(mode)
+}
+
+// 最新、热门、流行页面各自是 KeepAlive 实例；任一实例切换模式时，
+// 当前可见实例负责播放动画，其他实例只更新自己的最终位置。
+watch(feedMode, () => void nextTick(updateFeedModePill))
+
 // 激活按钮文字在白药丸到达时（delay 与药丸滑动时长一致，均由 --gf-feed-slide-ms 决定）翻白；
 // 非激活按钮文字立即变灰（随药丸离去淡出）。reduced-motion 下全部瞬时切换。
 function feedModeButtonClass(active: boolean): string[] {
   const base = active ? 'text-primary-content' : 'text-base-content/55 hover:text-base-content'
-  if (reducedMotion.value) return [base]
+  if (reducedMotion.value || !feedModePillShouldAnimate.value) return [base]
   return active
     ? [base, 'transition-colors', 'delay-[var(--gf-feed-slide-ms)]', 'duration-100']
     : [base, 'transition-colors', 'duration-200']
@@ -271,6 +261,9 @@ onMounted(() => {
   if (feedModeCardBtn.value) feedModeResizeObserver.observe(feedModeCardBtn.value)
 })
 onActivated(() => {
+  // KeepAlive 页面重新显示时，药丸已经应该处于共享状态的最终位置，
+  // 不把这次同步误认为用户主动切换。
+  feedModePillShouldAnimate.value = false
   void nextTick(observeSentinel)
   startAnnouncementRotation()
   void nextTick(updateFeedModePill)
@@ -397,7 +390,9 @@ onBeforeUnmount(() => {
               <span
                 aria-hidden="true"
                 class="pointer-events-none absolute bottom-0.5 top-0.5 rounded-full bg-primary"
-                :class="feedModePillReady && !reducedMotion ? 'transition-[left,width] duration-[var(--gf-feed-slide-ms)] ease-out' : ''"
+                :class="feedModePillReady && feedModePillShouldAnimate && !reducedMotion
+                  ? 'transition-[left,width] duration-[var(--gf-feed-slide-ms)] ease-out'
+                  : ''"
                 :style="{ left: `${feedModePillLeft}px`, width: `${feedModePillWidth}px` }"
               />
               <button

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -328,7 +328,10 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
               transition: 'grid-template-rows 0.3s ease, margin-bottom 0.3s ease',
             }"
           >
-            <div class="min-h-0 overflow-hidden">
+            <div
+              class="min-h-0"
+              :class="headerCollapsed ? 'overflow-hidden' : 'overflow-visible'"
+            >
               <div ref="headerSection" :class="headerCollapsed ? 'invisible' : ''" class="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
                 <label class="block min-w-0 flex-1">
                   <span class="text-sm font-semibold text-base-content/75">{{ t('publish.fields.title') }}</span>

--- a/apps/gooseforum/resource/src/site/pages/PublishPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/PublishPage.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { AlertTriangle, Check, FileText, ListChecks, Loader2, Send, X } from '@lucide/vue'
 import { submitTopic, uploadImage } from '@/runtime/api'
 import { processImageFile, validateImageFile } from '@/runtime/image'
 import { useUnsavedDraftGuard } from '@/site/composables/useUnsavedDraftGuard'
 import { useCaptchaChallenge } from '@/site/composables/useCaptchaChallenge'
+import { computePopoverPlacement } from '@/site/utils/popover-position'
 import PageHeader from '@/site/components/PageHeader.vue'
 import VditorOfficial from '@/site/components/VditorOfficial.vue'
 import type { LayoutPayload, PublishPageProps } from '@gooseforum/client'
@@ -45,6 +46,48 @@ const headerSection = ref<HTMLElement | null>(null)
 const editorHost = ref<HTMLElement | null>(null)
 const categoryPickerOpen = ref(false)
 const categoryPickerRoot = ref<HTMLElement | null>(null)
+/** 分类面板 Teleport 到 body 后用 fixed 定位跟随触发按钮，避开 overflow-hidden 裁剪 */
+const panelEl = ref<HTMLElement | null>(null)
+const panelStyle = ref({ top: '0px', left: '0px', width: '0px' })
+let panelOpen = false
+let panelFrame: number | null = null
+function computePanelPosition() {
+  const rect = categoryPickerRoot.value?.getBoundingClientRect()
+  const panel = panelEl.value
+  if (!rect) return
+  const panelHeight = panel ? panel.offsetHeight || panel.getBoundingClientRect().height : 0
+  // 6px = 原 absolute 布局的 0.375rem 间距；下方不足自动向上翻转，并钳制在视口内
+  const pos = computePopoverPlacement({
+    trigger: { top: rect.top, bottom: rect.bottom, left: rect.left, width: rect.width },
+    panel: { width: rect.width, height: panelHeight },
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    gap: 6,
+  })
+  panelStyle.value = { top: `${pos.top}px`, left: `${pos.left}px`, width: `${pos.width}px` }
+}
+function repositionPanel() {
+  if (!panelOpen || panelFrame !== null) return
+  panelFrame = window.requestAnimationFrame(() => {
+    panelFrame = null
+    computePanelPosition()
+  })
+}
+watch(categoryPickerOpen, (open) => {
+  if (open) {
+    panelOpen = true
+    void nextTick(() => {
+      computePanelPosition()
+      // Teleport 后面板位于 body 末尾、远离触发按钮，打开时移焦入面板保证键盘 Tab 可达
+      panelEl.value?.focus({ preventScroll: true })
+    })
+    window.addEventListener('scroll', repositionPanel, { passive: true })
+    window.addEventListener('resize', repositionPanel)
+  } else {
+    panelOpen = false
+    window.removeEventListener('scroll', repositionPanel)
+    window.removeEventListener('resize', repositionPanel)
+  }
+})
 const bodySection = ref<HTMLElement | null>(null)
 /** 移动端 toggle 挂载容器（正文 label 行右侧） */
 const editorToggleHost = ref<HTMLElement | null>(null)
@@ -108,6 +151,8 @@ function toggleCategory(id: number) {
 function handleCategoryPickerPointerDown(event: PointerEvent) {
   const target = event.target
   if (target instanceof Node && categoryPickerRoot.value?.contains(target)) return
+  // 面板已 Teleport 到 body，不再位于 categoryPickerRoot 内，需单独判定内部点击
+  if (target instanceof Node && panelEl.value?.contains(target)) return
   categoryPickerOpen.value = false
 }
 
@@ -128,6 +173,12 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   document.removeEventListener('pointerdown', handleCategoryPickerPointerDown)
+  window.removeEventListener('scroll', repositionPanel)
+  window.removeEventListener('resize', repositionPanel)
+  if (panelFrame !== null) {
+    window.cancelAnimationFrame(panelFrame)
+    panelFrame = null
+  }
 })
 
 async function validateRequiredFields() {
@@ -152,6 +203,8 @@ async function validateRequiredFields() {
 const HEADER_ANIM_MS = 300
 let headerHeightAnimTimer = 0
 function toggleHeaderCollapsed() {
+  // Teleport 面板不随头部折叠而隐藏，折叠前先关闭，避免悬浮在折叠区上
+  categoryPickerOpen.value = false
   const header = headerSection.value
   if (header) {
     collapsedHeaderHeight.value = header.offsetHeight
@@ -328,10 +381,7 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
               transition: 'grid-template-rows 0.3s ease, margin-bottom 0.3s ease',
             }"
           >
-            <div
-              class="min-h-0"
-              :class="headerCollapsed ? 'overflow-hidden' : 'overflow-visible'"
-            >
+            <div class="min-h-0 overflow-hidden">
               <div ref="headerSection" :class="headerCollapsed ? 'invisible' : ''" class="flex flex-col gap-4 sm:flex-row sm:items-start sm:gap-4">
                 <label class="block min-w-0 flex-1">
                   <span class="text-sm font-semibold text-base-content/75">{{ t('publish.fields.title') }}</span>
@@ -386,27 +436,33 @@ async function persistDraft(nextUrl?: string, redirect = true): Promise<boolean>
                       </svg>
                     </button>
 
-                    <Transition name="gf-menu">
-                      <div
-                        v-if="categoryPickerOpen"
-                        class="gf-menu-surface absolute left-0 right-0 top-[calc(100%+0.375rem)] z-[300] max-h-64 overflow-y-auto p-1"
-                      >
-                        <button
-                          v-for="category in props.categories"
-                          :key="category.id"
-                          type="button"
-                          class="flex h-9 w-full items-center gap-2 rounded-md px-2.5 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
-                          :class="categoryIds.includes(category.id) ? 'bg-primary/10 text-primary' : 'text-base-content hover:bg-base-200'"
-                          :disabled="!categoryIds.includes(category.id) && categoriesFull"
-                          @click="toggleCategory(category.id)"
+                    <Teleport to="body">
+                      <Transition name="gf-menu">
+                        <div
+                          v-if="categoryPickerOpen"
+                          ref="panelEl"
+                          tabindex="-1"
+                          class="gf-menu-surface fixed z-[300] max-h-64 overflow-y-auto p-1 outline-none"
+                          :style="panelStyle"
+                          @keydown.esc="categoryPickerOpen = false"
                         >
-                          <span class="h-2 w-2 shrink-0 rounded-[3px]" :style="{ backgroundColor: category.color }" />
-                          <span class="min-w-0 flex-1 truncate">{{ category.name }}</span>
-                          <Check v-if="categoryIds.includes(category.id)" class="h-4 w-4 shrink-0" />
-                        </button>
-                        <p v-if="categoriesFull" class="px-2.5 py-1.5 text-xs text-base-content/55">{{ t('publish.maxCategories') }}</p>
-                      </div>
-                    </Transition>
+                          <button
+                            v-for="category in props.categories"
+                            :key="category.id"
+                            type="button"
+                            class="flex h-9 w-full items-center gap-2 rounded-md px-2.5 text-left text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
+                            :class="categoryIds.includes(category.id) ? 'bg-primary/10 text-primary' : 'text-base-content hover:bg-base-200'"
+                            :disabled="!categoryIds.includes(category.id) && categoriesFull"
+                            @click="toggleCategory(category.id)"
+                          >
+                            <span class="h-2 w-2 shrink-0 rounded-[3px]" :style="{ backgroundColor: category.color }" />
+                            <span class="min-w-0 flex-1 truncate">{{ category.name }}</span>
+                            <Check v-if="categoryIds.includes(category.id)" class="h-4 w-4 shrink-0" />
+                          </button>
+                          <p v-if="categoriesFull" class="px-2.5 py-1.5 text-xs text-base-content/55">{{ t('publish.maxCategories') }}</p>
+                        </div>
+                      </Transition>
+                    </Teleport>
                   </div>
                   <p v-if="categoryMissing" class="mt-1 text-xs text-error/80">{{ t('publish.validation.categoryRequired') }}</p>
                 </div>

--- a/apps/gooseforum/resource/src/site/utils/popover-position.ts
+++ b/apps/gooseforum/resource/src/site/utils/popover-position.ts
@@ -1,0 +1,69 @@
+export interface PopoverTrigger {
+  top: number
+  bottom: number
+  left: number
+  width: number
+}
+
+export interface PopoverPanel {
+  width: number
+  height: number
+}
+
+export interface PopoverViewport {
+  width: number
+  height: number
+}
+
+export interface PopoverPlacement {
+  top: number
+  left: number
+  width: number
+}
+
+export interface PopoverPlacementOptions {
+  trigger: PopoverTrigger
+  panel: PopoverPanel
+  viewport: PopoverViewport
+  /** 触发元素与面板之间的间距（px），默认 6 */
+  gap?: number
+  /** 面板与视口边缘的最小边距（px），默认 8 */
+  padding?: number
+  /** 面板最大宽度（px）；触发元素超宽时收窄，默认不限 */
+  maxWidth?: number
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * 弹层定位纯函数：默认在触发元素下方展开；下方空间不足时向上翻转；
+ * 上下都不足时钳制在视口内；水平方向保证面板完整可见，超宽时收窄。
+ * 返回视口坐标（top/left/width），供 position: fixed 使用。
+ */
+export function computePopoverPlacement(options: PopoverPlacementOptions): PopoverPlacement {
+  const { trigger, panel, viewport } = options
+  const gap = options.gap ?? 6
+  const padding = options.padding ?? 8
+  const maxWidth = options.maxWidth ?? Number.POSITIVE_INFINITY
+
+  // 水平：面板不宽于触发元素 / maxWidth / 视口（扣除两侧边距）；超宽时收窄
+  const width = clamp(Math.min(trigger.width, maxWidth, viewport.width - padding * 2), 0, viewport.width - padding * 2)
+  let left = trigger.left
+  left = clamp(left, padding, viewport.width - width - padding)
+
+  // 垂直：优先向下展开，下方放不下则向上翻转，再不行则向下钳制保底
+  const below = trigger.bottom + gap
+  const above = trigger.top - gap - panel.height
+  let top: number
+  if (below + panel.height <= viewport.height - padding) {
+    top = below
+  } else if (above >= padding) {
+    top = above
+  } else {
+    top = clamp(below, padding, viewport.height - panel.height - padding)
+  }
+
+  return { top, left, width }
+}

--- a/apps/gooseforum/resource/test/home-feed-mode.test.ts
+++ b/apps/gooseforum/resource/test/home-feed-mode.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { useHomeFeedMode } from '../src/runtime/home-feed-mode'
+
+describe('useHomeFeedMode', () => {
+  const localStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+  }
+
+  beforeEach(() => {
+    localStorage.getItem.mockReset()
+    localStorage.setItem.mockReset()
+    vi.stubGlobal('window', { localStorage })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('shares one reactive mode between cached homepage instances', () => {
+    const latestPage = useHomeFeedMode()
+    const popularPage = useHomeFeedMode()
+
+    latestPage.setFeedMode('table')
+    latestPage.setFeedMode('card')
+
+    expect(popularPage.feedMode).toBe(latestPage.feedMode)
+    expect(popularPage.feedMode.value).toBe('card')
+    expect(localStorage.setItem).toHaveBeenLastCalledWith('goose:home-feed-mode', 'card')
+  })
+})

--- a/apps/gooseforum/resource/test/popover-position.test.ts
+++ b/apps/gooseforum/resource/test/popover-position.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest'
+import { computePopoverPlacement } from '../src/site/utils/popover-position'
+
+// 通用触发元素：宽 240、位于 (100, 200)
+const TRIGGER = { top: 200, bottom: 244, left: 100, width: 240 }
+const PANEL = { width: 240, height: 256 }
+const VIEWPORT = { width: 390, height: 844 }
+
+describe('computePopoverPlacement', () => {
+  test('默认在触发元素下方展开，间距为 gap', () => {
+    expect(computePopoverPlacement({ trigger: TRIGGER, panel: PANEL, viewport: VIEWPORT, gap: 6 })).toEqual({
+      top: 250, // 244 + 6
+      left: 100,
+      width: 240,
+    })
+  })
+
+  test('下方空间不足时向上翻转', () => {
+    // 触发元素贴近屏底，下方放不下 256px 面板，改为在触发元素上方展开
+    const nearBottom = { top: 600, bottom: 644, left: 100, width: 240 }
+    expect(computePopoverPlacement({ trigger: nearBottom, panel: PANEL, viewport: VIEWPORT, gap: 6 })).toEqual({
+      top: 338, // 600 - 6(gap) - 256(panelHeight)
+      left: 100,
+      width: 240,
+    })
+  })
+
+  test('上下空间都不足时向下钳制在视口内', () => {
+    // 视口较矮：下方放不下、上方也不够，钳制在「保底边距」与「视口下缘」之间
+    const shortViewport = { width: 390, height: 300 }
+    const result = computePopoverPlacement({ trigger: TRIGGER, panel: PANEL, viewport: shortViewport, gap: 6 })
+    expect(result).toEqual({
+      top: 36, // clamp(244+6, 8, 300-256-8)
+      left: 100,
+      width: 240,
+    })
+    expect(result.top).toBeGreaterThanOrEqual(8)
+    expect(result.top + PANEL.height).toBeLessThanOrEqual(shortViewport.height)
+  })
+
+  test('水平方向钳制，触发元素贴近右缘时面板不越界', () => {
+    const nearRight = { top: 200, bottom: 244, left: 370, width: 40 }
+    const result = computePopoverPlacement({ trigger: nearRight, panel: { width: 240, height: 256 }, viewport: VIEWPORT, gap: 6 })
+    expect(result.left).toBeLessThanOrEqual(VIEWPORT.width - 8) // 不超出右缘
+    expect(result.left).toBeGreaterThanOrEqual(8)
+    expect(result.left + result.width).toBeLessThanOrEqual(VIEWPORT.width - 8)
+  })
+
+  test('触发元素超宽时面板收窄到视口内', () => {
+    const wide = { top: 200, bottom: 244, left: -100, width: 590 } // 590 > 390 视口
+    const result = computePopoverPlacement({ trigger: wide, panel: { width: 590, height: 256 }, viewport: VIEWPORT, gap: 6 })
+    expect(result.width).toBeLessThanOrEqual(VIEWPORT.width - 16)
+    expect(result.left).toBeGreaterThanOrEqual(8)
+    expect(result.left + result.width).toBeLessThanOrEqual(VIEWPORT.width - 8)
+  })
+})


### PR DESCRIPTION
## Summary

- Restore the publish page category picker visibility by keeping `overflow-hidden` only during the header-collapse animation and using `overflow-visible` while expanded.
- Share the home feed list/card preference across the latest, hot, and popular tabs, including the existing localStorage persistence.
- Suppress duplicate feed-mode pill and text transitions when navigating between cached tabs; animate only when the user explicitly changes the mode.

## Root causes

- The category menu was clipped by `overflow-hidden`, introduced in `c35a79b` (`feat: 完善发布页编辑器大纲交互与折叠动画`).
- KeepAlive created separate HomePage instances for each sort URL, so each instance owned an independent feed-mode state.
- Activating another cached HomePage instance re-measured the shared mode and replayed the transition even though the user had not changed the mode there.

## Validation

- `pnpm typecheck`
- `pnpm test` — 13 test files, 96 tests passed
- `pnpm build`
- `git diff --check`
- Browser smoke check: category picker changed `aria-expanded=false -> true`; menu was visible at `240x226px`.
- Browser smoke check: explicit feed-mode clicks retain the `left, width` transition; switching tabs synchronizes the final position without the transition class; `localStorage['goose:home-feed-mode']` remains persisted.

## Follow-up

This PR remains a **Draft** because the publish editor still has additional issues to address. The PR now includes the requested home feed state and animation follow-up alongside the original category-picker fix; further editor fixes can be added here or split into separate PRs after review.