### PR TITLE
fix: scope CI workflow triggers

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2,16 +2,60 @@ name: ci-backend
 
 on:
   push:
+    branches: [dev, main]
     paths:
       - "apps/gooseforum/app/**"
       - "apps/gooseforum/main.go"
       - "apps/gooseforum/go.mod"
       - "apps/gooseforum/go.sum"
+      - "packages/api-contract/**"
+      - ".github/workflows/ci-backend.yml"
   # PR 无条件触发, 保证 required status check 稳定存在(不会被 paths 跳过卡死)
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      backend_pg: ${{ steps.filter.outputs.backend_pg }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # On dev/main pushes, compare with the commit before this push.
+          # This input is ignored for pull_request, which uses its base branch.
+          base: ${{ github.ref_name }}
+          filters: |
+            backend:
+              - 'apps/gooseforum/app/**'
+              - 'apps/gooseforum/main.go'
+              - 'apps/gooseforum/go.mod'
+              - 'apps/gooseforum/go.sum'
+              - 'packages/api-contract/**'
+              - '.github/workflows/ci-backend.yml'
+            backend_pg:
+              - 'apps/gooseforum/app/bundles/connect/sqlconnect/**'
+              - 'apps/gooseforum/app/migration/**'
+              - 'apps/gooseforum/app/models/**'
+              - 'apps/gooseforum/go.mod'
+              - 'apps/gooseforum/go.sum'
+              - '.github/workflows/ci-backend.yml'
+
   ci-backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +76,8 @@ jobs:
   # 硬编码 MySQL 类型(bigint unsigned/datetime/tinyint)导致 PG 建表失败、
   # 服务带残缺 schema 启动, 登录/注册运行期才报错。此 job 用真实 PG 验证。
   ci-backend-pg:
+    needs: changes
+    if: needs.changes.outputs.backend_pg == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -8,6 +8,10 @@ on:
       - "apps/gooseforum/main.go"
       - "apps/gooseforum/go.mod"
       - "apps/gooseforum/go.sum"
+      - "apps/gooseforum/resource/embed.go"
+      - "apps/gooseforum/resource/embed_test.go"
+      - "apps/gooseforum/resource/templates/**"
+      - "apps/gooseforum/testdata/markdown-compat/**"
       - "packages/api-contract/**"
       - ".github/workflows/ci-backend.yml"
   # PR 无条件触发, 保证 required status check 稳定存在(不会被 paths 跳过卡死)
@@ -22,10 +26,9 @@ permissions:
   pull-requests: read
 
 jobs:
-  changes:
+  ci-backend:
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
       backend_pg: ${{ steps.filter.outputs.backend_pg }}
     steps:
       - uses: actions/checkout@v5
@@ -43,6 +46,10 @@ jobs:
               - 'apps/gooseforum/main.go'
               - 'apps/gooseforum/go.mod'
               - 'apps/gooseforum/go.sum'
+              - 'apps/gooseforum/resource/embed.go'
+              - 'apps/gooseforum/resource/embed_test.go'
+              - 'apps/gooseforum/resource/templates/**'
+              - 'apps/gooseforum/testdata/markdown-compat/**'
               - 'packages/api-contract/**'
               - '.github/workflows/ci-backend.yml'
             backend_pg:
@@ -53,22 +60,20 @@ jobs:
               - 'apps/gooseforum/go.sum'
               - '.github/workflows/ci-backend.yml'
 
-  ci-backend:
-    needs: changes
-    if: needs.changes.outputs.backend == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        if: steps.filter.outputs.backend == 'true'
         with:
           go-version: "1.26"
       - name: Vet
+        if: steps.filter.outputs.backend == 'true'
         working-directory: apps/gooseforum
         run: go vet ./...
       - name: Test
+        if: steps.filter.outputs.backend == 'true'
         working-directory: apps/gooseforum
         run: go test ./...
       - name: Build
+        if: steps.filter.outputs.backend == 'true'
         working-directory: apps/gooseforum
         run: go build .
 
@@ -76,8 +81,8 @@ jobs:
   # 硬编码 MySQL 类型(bigint unsigned/datetime/tinyint)导致 PG 建表失败、
   # 服务带残缺 schema 启动, 登录/注册运行期才报错。此 job 用真实 PG 验证。
   ci-backend-pg:
-    needs: changes
-    if: needs.changes.outputs.backend_pg == 'true'
+    needs: ci-backend
+    if: needs.ci-backend.outputs.backend_pg == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -94,7 +99,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           # On dev/main pushes, compare with the commit before this push.
           # This input is ignored for pull_request, which uses its base branch.
-          base: ${{ github.ref_name }}
+          base: ${{ github.event_name == 'push' && github.ref_name || '' }}
           filters: |
             backend:
               - 'apps/gooseforum/app/**'

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -28,10 +28,10 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       backend_pg: ${{ steps.filter.outputs.backend_pg }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           # On dev/main pushes, compare with the commit before this push.

--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -2,20 +2,48 @@ name: ci-contract
 
 on:
   push:
+    branches: [dev, main]
     paths:
-      - "apps/gooseforum/app/**"
       - "apps/gooseforum/resource/packages/client/package.json"
       - "apps/gooseforum/resource/packages/client/src/gen/**"
       - "packages/api-contract/**"
       - ".github/workflows/ci-contract.yml"
-      - "Makefile"
-      - "docs/architecture/contracts-and-data.md"
-      - "docs/development/testing.md"
   # PR 无条件触发, 保证 required status check 稳定存在
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      contract: ${{ steps.filter.outputs.contract }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # On dev/main pushes, compare with the commit before this push.
+          # This input is ignored for pull_request, which uses its base branch.
+          base: ${{ github.ref_name }}
+          filters: |
+            contract:
+              - 'apps/gooseforum/resource/packages/client/package.json'
+              - 'apps/gooseforum/resource/packages/client/src/gen/**'
+              - 'packages/api-contract/**'
+              - '.github/workflows/ci-contract.yml'
+
   ci-contract:
+    needs: changes
+    if: needs.changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -25,10 +25,10 @@ jobs:
     outputs:
       contract: ${{ steps.filter.outputs.contract }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           # On dev/main pushes, compare with the commit before this push.

--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           # On dev/main pushes, compare with the commit before this push.
           # This input is ignored for pull_request, which uses its base branch.
-          base: ${{ github.ref_name }}
+          base: ${{ github.event_name == 'push' && github.ref_name || '' }}
           filters: |
             contract:
               - 'apps/gooseforum/resource/packages/client/package.json'

--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -20,10 +20,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  changes:
+  ci-contract:
     runs-on: ubuntu-latest
-    outputs:
-      contract: ${{ steps.filter.outputs.contract }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -41,25 +39,24 @@ jobs:
               - 'packages/api-contract/**'
               - '.github/workflows/ci-contract.yml'
 
-  ci-contract:
-    needs: changes
-    if: needs.changes.outputs.contract == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        if: steps.filter.outputs.contract == 'true'
         with:
           version: 11.10.0
       - uses: actions/setup-node@v4
+        if: steps.filter.outputs.contract == 'true'
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: packages/api-contract/pnpm-lock.yaml
       - name: Install contract tooling
+        if: steps.filter.outputs.contract == 'true'
         working-directory: packages/api-contract
         run: pnpm install --frozen-lockfile
       - name: Validate, bundle, and generate TypeScript types
+        if: steps.filter.outputs.contract == 'true'
         working-directory: packages/api-contract
         run: pnpm run check
       - name: Require generated TypeScript types to be committed
+        if: steps.filter.outputs.contract == 'true'
         run: git diff --exit-code -- apps/gooseforum/resource/packages/client/src/gen

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           # On dev/main pushes, compare with the commit before this push.
           # This input is ignored for pull_request, which uses its base branch.
-          base: ${{ github.ref_name }}
+          base: ${{ github.event_name == 'push' && github.ref_name || '' }}
           filters: |
             frontend:
               - 'apps/gooseforum/resource/**'

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -2,13 +2,44 @@ name: ci-frontend
 
 on:
   push:
+    branches: [dev, main]
     paths:
       - "apps/gooseforum/resource/**"
+      - ".github/workflows/ci-frontend.yml"
   # PR 无条件触发, 保证 required status check 稳定存在
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # On dev/main pushes, compare with the commit before this push.
+          # This input is ignored for pull_request, which uses its base branch.
+          base: ${{ github.ref_name }}
+          filters: |
+            frontend:
+              - 'apps/gooseforum/resource/**'
+              - '.github/workflows/ci-frontend.yml'
+
   ci-frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -23,10 +23,10 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           # On dev/main pushes, compare with the commit before this push.

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -5,6 +5,7 @@ on:
     branches: [dev, main]
     paths:
       - "apps/gooseforum/resource/**"
+      - "apps/gooseforum/testdata/markdown-compat/**"
       - ".github/workflows/ci-frontend.yml"
   # PR 无条件触发, 保证 required status check 稳定存在
   pull_request:
@@ -18,10 +19,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  changes:
+  ci-frontend:
     runs-on: ubuntu-latest
-    outputs:
-      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -35,31 +34,32 @@ jobs:
           filters: |
             frontend:
               - 'apps/gooseforum/resource/**'
+              - 'apps/gooseforum/testdata/markdown-compat/**'
               - '.github/workflows/ci-frontend.yml'
 
-  ci-frontend:
-    needs: changes
-    if: needs.changes.outputs.frontend == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        if: steps.filter.outputs.frontend == 'true'
         with:
           version: 11
       - uses: actions/setup-node@v4
+        if: steps.filter.outputs.frontend == 'true'
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: apps/gooseforum/resource/pnpm-lock.yaml
       - name: Install
+        if: steps.filter.outputs.frontend == 'true'
         working-directory: apps/gooseforum/resource
         run: pnpm install --frozen-lockfile
       - name: Typecheck
+        if: steps.filter.outputs.frontend == 'true'
         working-directory: apps/gooseforum/resource
         run: pnpm typecheck
       - name: Test
+        if: steps.filter.outputs.frontend == 'true'
         working-directory: apps/gooseforum/resource
         run: pnpm test
       - name: Build
+        if: steps.filter.outputs.frontend == 'true'
         working-directory: apps/gooseforum/resource
         run: pnpm build

--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -2,10 +2,18 @@ name: ci-mobile
 
 on:
   push:
+    branches: [dev, main]
     paths:
       - "apps/mobile/**"
-  # PR 无条件触发, 保证 required status check 稳定存在(不会被 paths 跳过卡死)
+      - ".github/workflows/ci-mobile.yml"
   pull_request:
+    paths:
+      - "apps/mobile/**"
+      - ".github/workflows/ci-mobile.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci-mobile:

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -51,21 +51,34 @@ make build && ./bin/yourtj-hub serve   # then curl http://localhost:5234
 
 ## CI mapping
 
-- ci-backend.yml: go vet + go test + go build (apps/gooseforum/app/**, main.go, go.mod, go.sum); the
+All CI `push` triggers are limited to `dev` and `main`, so a push to an in-repository
+PR branch is validated once by its `pull_request` run rather than again by a duplicate
+`push` run. CI runs for the same PR or branch supersede older in-progress runs.
+
+The required backend, frontend, and contract workflows start for every PR so their
+required status checks cannot remain pending. Each first detects the changed paths and
+skips its heavy job when its owned inputs are unchanged. `ci-mobile` is not a required
+check and uses path filters directly, so an unrelated PR does not start a Flutter runner.
+
+- ci-backend.yml: changed backend or contract-fixture paths run go vet + go test + go build
+  (apps/gooseforum/app/**, main.go, go.mod, go.sum, packages/api-contract/**); the
   PostgreSQL integration tests in `app/bundles/connect/sqlconnect` are gated by `TEST_PG_DSN` and
   skip when unset (CI stays green without a PG service)
-- ci-backend.yml also runs `ci-backend-pg`: a real `postgres:16-alpine` service + the migration
+- ci-backend.yml also runs `ci-backend-pg` only for model, migration, SQL-connection, or Go module
+  changes: a real `postgres:16-alpine` service + the migration
   schema tests in `app/migration/migration_pg_test.go` (`TestSchemaMigratesOnPostgreSQL`,
   `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL`), gated by `YOURTJ_TEST_PG_URL` (set in CI, skipped
   locally when unset). **Any model/migration change must pass these PG tests** — models must not
   hardcode MySQL-only types (`bigint unsigned` / `datetime` / `tinyint`), which GORM renders verbatim
   and PostgreSQL rejects, silently leaving tables uncreated (issue #8 production regression).
-- ci-frontend.yml: pnpm typecheck + site unit tests + build (apps/gooseforum/resource/**)
-- ci-contract.yml: on every PR, installs the locked `packages/api-contract` pnpm tooling, runs OpenAPI
+- ci-frontend.yml: changed frontend paths run pnpm typecheck + site unit tests + build
+  (apps/gooseforum/resource/**).
+- ci-contract.yml: changed contract inputs install the locked `packages/api-contract` pnpm tooling, run OpenAPI
   lint + bundle + TypeScript generation, then rejects an uncommitted diff below
-  `apps/gooseforum/resource/packages/client/src/gen`. It also runs on push when contract-relevant
-  backend, generated types, contract tooling, CI/Make configuration, or contract/testing documentation
-  changes. The route-level HTTP contract fixture tests run inside the backend `go test ./...` gate.
+  `apps/gooseforum/resource/packages/client/src/gen`. Its inputs are the contract package, generated
+  TypeScript, client package manifest, and its own workflow configuration. The route-level HTTP
+  contract fixture tests run inside the backend `go test ./...` gate.
+- ci-mobile.yml: changed mobile paths run melos bootstrap, analyze, and test (apps/mobile/**).
 
 ## Smoke checklist
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -56,12 +56,14 @@ PR branch is validated once by its `pull_request` run rather than again by a dup
 `push` run. CI runs for the same PR or branch supersede older in-progress runs.
 
 The required backend, frontend, and contract workflows start for every PR so their
-required status checks cannot remain pending. Each first detects the changed paths and
-skips its heavy job when its owned inputs are unchanged. `ci-mobile` is not a required
-check and uses path filters directly, so an unrelated PR does not start a Flutter runner.
+required status checks cannot remain pending. Each required job performs its own path
+detection, so a detection failure fails that required check; its heavy Go or pnpm steps
+run only when its owned inputs changed. `ci-mobile` is not a required check and uses
+path filters directly, so an unrelated PR does not start a Flutter runner.
 
 - ci-backend.yml: changed backend or contract-fixture paths run go vet + go test + go build
-  (apps/gooseforum/app/**, main.go, go.mod, go.sum, packages/api-contract/**); the
+  (apps/gooseforum/app/**, main.go, go.mod, go.sum, embedded resource Go/GoHTML files,
+  markdown compatibility fixtures, packages/api-contract/**); the
   PostgreSQL integration tests in `app/bundles/connect/sqlconnect` are gated by `TEST_PG_DSN` and
   skip when unset (CI stays green without a PG service)
 - ci-backend.yml also runs `ci-backend-pg` only for model, migration, SQL-connection, or Go module
@@ -72,7 +74,7 @@ check and uses path filters directly, so an unrelated PR does not start a Flutte
   hardcode MySQL-only types (`bigint unsigned` / `datetime` / `tinyint`), which GORM renders verbatim
   and PostgreSQL rejects, silently leaving tables uncreated (issue #8 production regression).
 - ci-frontend.yml: changed frontend paths run pnpm typecheck + site unit tests + build
-  (apps/gooseforum/resource/**).
+  (apps/gooseforum/resource/** and shared markdown compatibility fixtures).
 - ci-contract.yml: changed contract inputs install the locked `packages/api-contract` pnpm tooling, run OpenAPI
   lint + bundle + TypeScript generation, then rejects an uncommitted diff below
   `apps/gooseforum/resource/packages/client/src/gen`. Its inputs are the contract package, generated


### PR DESCRIPTION
## Summary

- stop duplicate CI runs on in-repository PR branches by limiting push-triggered CI to `dev` and `main`
- run backend, frontend, and contract jobs only when their owned paths change while keeping their required PR checks visible
- run PostgreSQL migration CI only for model, migration, SQL connection, Go module, or workflow changes; make mobile CI path-triggered because it is not required
- cancel obsolete runs for the same PR or integration branch and document the trigger model

## Verification

- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 -ignore SC2001 .github/workflows/*.yml`

The ignored `SC2001` is an existing ShellCheck finding in `release-to-main.yml`; the changed workflows pass actionlint.

## Documentation

- updated `docs/development/testing.md` CI mapping and trigger behavior.