### PR TITLE
fix(mobile): 登出/换账号时清空 drift 离线缓存,防止跨账号数据泄漏

### DIFF
--- a/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
@@ -96,6 +96,7 @@
   "authResetEmailSent": "Reset email sent, please check your inbox",
   "authLoading": "Processing…",
   "authCacheClearFailed": "Failed to clear the previous account's offline data. Please retry.",
+  "authSessionSaveFailed": "Failed to save the new session securely. Please retry.",
   "loginWelcome": "Welcome back to yourtj",
   "loginModeLogin": "Sign in",
   "loginModeRegister": "Sign up",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
@@ -95,6 +95,7 @@
   "authRegisterSuccess": "Registered successfully, please sign in",
   "authResetEmailSent": "Reset email sent, please check your inbox",
   "authLoading": "Processing…",
+  "authCacheClearFailed": "Failed to clear the previous account's offline data. Please retry.",
   "loginWelcome": "Welcome back to yourtj",
   "loginModeLogin": "Sign in",
   "loginModeRegister": "Sign up",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
@@ -416,6 +416,12 @@ abstract class AppLocalizations {
   /// **'Processing…'**
   String get authLoading;
 
+  /// No description provided for @authCacheClearFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to clear the previous account\'s offline data. Please retry.'**
+  String get authCacheClearFailed;
+
   /// No description provided for @loginWelcome.
   ///
   /// In en, this message translates to:

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
@@ -422,6 +422,12 @@ abstract class AppLocalizations {
   /// **'Failed to clear the previous account\'s offline data. Please retry.'**
   String get authCacheClearFailed;
 
+  /// No description provided for @authSessionSaveFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to save the new session securely. Please retry.'**
+  String get authSessionSaveFailed;
+
   /// No description provided for @loginWelcome.
   ///
   /// In en, this message translates to:

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
@@ -187,6 +187,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Failed to clear the previous account\'s offline data. Please retry.';
 
   @override
+  String get authSessionSaveFailed =>
+      'Failed to save the new session securely. Please retry.';
+
+  @override
   String get loginWelcome => 'Welcome back to yourtj';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
@@ -183,6 +183,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authLoading => 'Processing…';
 
   @override
+  String get authCacheClearFailed =>
+      'Failed to clear the previous account\'s offline data. Please retry.';
+
+  @override
   String get loginWelcome => 'Welcome back to yourtj';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
@@ -183,6 +183,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authCacheClearFailed => '清除上一账号离线数据失败,请重试';
 
   @override
+  String get authSessionSaveFailed => '安全保存新会话失败,请重试';
+
+  @override
   String get loginWelcome => '欢迎回到 yourtj';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
@@ -180,6 +180,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get authLoading => '处理中…';
 
   @override
+  String get authCacheClearFailed => '清除上一账号离线数据失败,请重试';
+
+  @override
   String get loginWelcome => '欢迎回到 yourtj';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
@@ -95,6 +95,7 @@
   "authRegisterSuccess": "注册成功,请登录",
   "authResetEmailSent": "重置邮件已发送,请查收",
   "authLoading": "处理中…",
+  "authCacheClearFailed": "清除上一账号离线数据失败,请重试",
   "loginWelcome": "欢迎回到 yourtj",
   "loginModeLogin": "登录",
   "loginModeRegister": "注册",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
@@ -96,6 +96,7 @@
   "authResetEmailSent": "重置邮件已发送,请查收",
   "authLoading": "处理中…",
   "authCacheClearFailed": "清除上一账号离线数据失败,请重试",
+  "authSessionSaveFailed": "安全保存新会话失败,请重试",
   "loginWelcome": "欢迎回到 yourtj",
   "loginModeLogin": "登录",
   "loginModeRegister": "注册",

--- a/apps/mobile/packages/forum_app/lib/main.dart
+++ b/apps/mobile/packages/forum_app/lib/main.dart
@@ -2,12 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'src/app.dart';
-import 'src/router.dart';
 
-Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  // 装载跨重启缓存门禁:标记存在(上次缓存清理失败且令牌可能残留)时,
-  // appRouter 会强制重定向到登录页,残留会话无法进入 shell。
-  await initStartupGate();
+void main() {
   runApp(const ProviderScope(child: GfApp()));
 }

--- a/apps/mobile/packages/forum_app/lib/main.dart
+++ b/apps/mobile/packages/forum_app/lib/main.dart
@@ -2,7 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'src/app.dart';
+import 'src/router.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  // 装载跨重启缓存门禁:标记存在(上次缓存清理失败且令牌可能残留)时,
+  // appRouter 会强制重定向到登录页,残留会话无法进入 shell。
+  await initStartupGate();
   runApp(const ProviderScope(child: GfApp()));
 }

--- a/apps/mobile/packages/forum_app/lib/src/offline/drift_cache.dart
+++ b/apps/mobile/packages/forum_app/lib/src/offline/drift_cache.dart
@@ -182,25 +182,28 @@ class DriftOfflineCache implements OfflineTopicCache, OfflineChatCache {
     }
   }
 
-  /// 保存单会话消息列表。
+  /// 保存单会话消息列表(单事务提交,避免与清库语句交错)。
   @override
   Future<void> putMessages(
     int convId,
     List<ChatMessagePayload> messages,
   ) async {
-    for (final m in messages) {
-      await _db.customStatement(
-        'INSERT OR REPLACE INTO cached_messages (conv_id, msg_id, payload, cached_at) '
-        'VALUES (?, ?, ?, ?)',
-        [
-          convId,
-          m.id,
-          jsonEncode(m.toJson()),
-          DateTime.now().toUtc().toIso8601String(),
-        ],
-      );
-    }
-    await _trimMessages(convId);
+    if (messages.isEmpty) return;
+    await _db.transaction(() async {
+      for (final m in messages) {
+        await _db.customStatement(
+          'INSERT OR REPLACE INTO cached_messages (conv_id, msg_id, payload, cached_at) '
+          'VALUES (?, ?, ?, ?)',
+          [
+            convId,
+            m.id,
+            jsonEncode(m.toJson()),
+            DateTime.now().toUtc().toIso8601String(),
+          ],
+        );
+      }
+      await _trimMessages(convId);
+    });
   }
 
   /// 读取单会话已缓存消息(按消息 id 升序)。
@@ -246,12 +249,15 @@ class DriftOfflineCache implements OfflineTopicCache, OfflineChatCache {
     }
   }
 
-  /// 清除全部缓存(登出/清理)。
+  /// 清除全部缓存(登出/清理),三条 DELETE 单事务提交,
+  /// 与页面写入互斥,避免清库与写入交错产生残留。
   @override
   Future<void> clear() async {
-    await _db.customStatement('DELETE FROM cached_topics');
-    await _db.customStatement('DELETE FROM cached_conversations');
-    await _db.customStatement('DELETE FROM cached_messages');
+    await _db.transaction(() async {
+      await _db.customStatement('DELETE FROM cached_topics');
+      await _db.customStatement('DELETE FROM cached_conversations');
+      await _db.customStatement('DELETE FROM cached_messages');
+    });
   }
 
   @override

--- a/apps/mobile/packages/forum_app/lib/src/offline/drift_cache.dart
+++ b/apps/mobile/packages/forum_app/lib/src/offline/drift_cache.dart
@@ -19,6 +19,7 @@ abstract class OfflineChatCache {
   Future<List<ChatItemPayload>> getConversations();
   Future<void> putMessages(int convId, List<ChatMessagePayload> messages);
   Future<List<ChatMessagePayload>> getMessages(int convId);
+  Future<void> clear();
 }
 
 /// 已浏览话题/会话的 drift 离线缓存。

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -265,6 +265,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       // 新 token 已接受:使缓存的当前用户身份失效,新 shell 重新从
       // 新令牌解析账号 id,避免 ProfilePage 仍用上一账号的 id 请求数据。
       ref.invalidate(currentUserProvider);
+      // 会话边界:重建主 API client。旧 client 捕获的是上一会话的 epoch,
+      // 其 New-Token 续期与 401 回调已永久失效;新 shell 首次读取时重建
+      // 并捕获当前 epoch,恢复新账号的滑动续期与 401 清理。
+      ref.invalidate(apiClientProvider);
       // 用 go('/') 替换整个导航栈,销毁 401 保留的旧 shell(及其内存态),
       // 避免新账号返回后看到上一账号的会话/消息数据。
       context.go('/');

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -48,6 +49,14 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       authRepository: AuthRepository(ref.read(apiClientProvider)),
       apiClient: ref.read(apiClientProvider),
       tokenStorage: ref.read(tokenStorageProvider),
+    );
+    // 进入登录页即清空上一账号的离线缓存(话题/会话/私信),防止同一设备
+    // 换账号后读到上一账号的缓存数据;失败静默。
+    unawaited(
+      clearOfflineCacheQuietly(
+        ref.read(offlineTopicCacheProvider),
+        ref.read(offlineChatCacheProvider),
+      ),
     );
   }
 

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -11,6 +11,7 @@ import 'package:core/core.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../app_config.dart';
 import '../../providers.dart';
+import '../../current_user.dart';
 import '../../theme_mode.dart';
 
 /// 登录页模式。
@@ -68,6 +69,9 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(offlineCacheEpochProvider.notifier).invalidate();
+      // 进入登录页即会话边界:使缓存的当前用户身份失效(旧账号 id 不再
+      // 被后续新 shell 读取)。
+      ref.invalidate(currentUserProvider);
       _cacheClearFuture = _clearOfflineCacheOnce();
     });
   }
@@ -191,9 +195,14 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     if (!await _ensureCacheCleared()) {
       // 新 token 已在登录流程中持久化,这里必须丢弃,否则用户可带着
       // 新会话返回 401 保留的旧 shell(内存态含上一账号数据)。
-      // 直接清本地令牌即可:登录刚完成,服务端会话尚无使用价值,
-      // 失败后重试登录会重新认证。
-      await ref.read(tokenStorageProvider).clear();
+      // clear() 自身也可能抛异常(secure storage 多次删除),必须
+      // fail-closed:无论令牌是否清除成功都进入 blocked 状态,禁止
+      // 离开登录页;重试登录会重新认证覆盖旧令牌。
+      try {
+        await ref.read(tokenStorageProvider).clear();
+      } catch (_) {
+        // 令牌清除失败:仍保持 blocked,用户无法带着新令牌进入应用。
+      }
       if (!mounted) return;
       setState(() {
         _authBlocked = true;
@@ -203,6 +212,9 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     }
     if (!mounted) return;
     _authBlocked = false;
+    // 新 token 已接受:使缓存的当前用户身份失效,新 shell 重新从
+    // 新令牌解析账号 id,避免 ProfilePage 仍用上一账号的 id 请求数据。
+    ref.invalidate(currentUserProvider);
     // 用 go('/') 替换整个导航栈,销毁 401 保留的旧 shell(及其内存态),
     // 避免新账号返回后看到上一账号的会话/消息数据。
     context.go('/');

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -72,7 +72,15 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       // 进入登录页即会话边界:使缓存的当前用户身份失效(旧账号 id 不再
       // 被后续新 shell 读取)。
       ref.invalidate(currentUserProvider);
-      _cacheClearFuture = _clearOfflineCacheOnce();
+      _cacheClearFuture = _clearOfflineCacheOnce().then((bool ok) async {
+        if (!mounted) return ok;
+        // 进入登录页即重新执行缓存清理:成功后清除跨重启门禁标记,
+        // 让后续登录能正常放行(即使上次进程被杀时标记仍残留)。
+        if (ok) {
+          await ref.read(pendingCacheClearProvider.notifier).clear();
+        }
+        return ok;
+      });
     });
   }
 
@@ -196,13 +204,16 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       // 新 token 已在登录流程中持久化,这里必须丢弃,否则用户可带着
       // 新会话返回 401 保留的旧 shell(内存态含上一账号数据)。
       // clear() 自身也可能抛异常(secure storage 多次删除),必须
-      // fail-closed:无论令牌是否清除成功都进入 blocked 状态,禁止
-      // 离开登录页;重试登录会重新认证覆盖旧令牌。
+      // fail-closed:无论令牌是否清除成功都进入 blocked 状态,并置位
+      // 跨重启门禁标记——即使进程被杀后重启,残留令牌与未清空的旧
+      // 账号离线缓存也无法进入 shell(由 appRouter redirect 强制回登录页)。
       try {
         await ref.read(tokenStorageProvider).clear();
       } catch (_) {
         // 令牌清除失败:仍保持 blocked,用户无法带着新令牌进入应用。
       }
+      // 置位持久化门禁(缓存未清空,重启后也必须留在登录页重试)。
+      await ref.read(pendingCacheClearProvider.notifier).set();
       if (!mounted) return;
       setState(() {
         _authBlocked = true;
@@ -212,6 +223,9 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     }
     if (!mounted) return;
     _authBlocked = false;
+    // 缓存清理成功:清除跨重启门禁标记。
+    await ref.read(pendingCacheClearProvider.notifier).clear();
+    if (!mounted) return;
     // 新 token 已接受:使缓存的当前用户身份失效,新 shell 重新从
     // 新令牌解析账号 id,避免 ProfilePage 仍用上一账号的 id 请求数据。
     ref.invalidate(currentUserProvider);

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -17,16 +17,33 @@ import '../../theme_mode.dart';
 /// 登录页模式。
 enum _AuthMode { login, register, forgotPassword }
 
-/// 登录/注册/找回密码页(web auth.login 的移动端形态)。
+/// 登录流程专用的内存令牌暂存区。
 ///
-/// 密码登录:公钥 → RSA-OAEP 加密 → 登录 → (验证码/TOTP 挑战)。
-/// 统一身份：论坛内建 OIDC Provider 经 AppAuth + 后端 exchange 兑换。
-/// 注册/找回密码:复用 AuthController 的 register/forgotPassword。
+/// Password/TOTP 的 `New-Token` 与 OIDC exchange 返回的论坛 JWT 在旧账号
+/// 离线缓存清理成功前只写入这里，绝不提前进入 Keychain/Keystore。这样即使
+/// 清库失败或进程被杀，也不存在“新账号持久化令牌 + 旧账号离线缓存”的组合。
+class _StagedTokenStorage implements TokenStorage {
+  String? _token;
+
+  @override
+  Future<String?> read() async => _token;
+
+  @override
+  Future<void> write(String token) async => _token = token;
+
+  @override
+  Future<void> clear() async => _token = null;
+}
+
 class LoginPage extends ConsumerStatefulWidget {
-  const LoginPage({super.key, this.authController});
+  const LoginPage({super.key, this.authController, this.authTokenStorage})
+    : assert(authController == null || authTokenStorage != null);
 
   /// 测试注入:默认 null 时页面内部构造 [AuthController]。
   final AuthController? authController;
+
+  /// 测试注入:认证成功令牌的内存暂存区,必须与 [authController] 使用同一实例。
+  final TokenStorage? authTokenStorage;
   @override
   ConsumerState<LoginPage> createState() => _LoginPageState();
 }
@@ -40,6 +57,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
   _AuthMode _mode = _AuthMode.login;
   bool _oidcBusy = false;
+  bool _finishingAuthentication = false;
   String _oidcError = '';
   // 登录放行前缓存清理失败的错误(清理成功或重试成功后清空)。
   String _cacheError = '';
@@ -47,6 +65,8 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   bool _authBlocked = false;
 
   late final AuthController _authController;
+  late final GfApiClient _authClient;
+  late final TokenStorage _authTokenStorage;
 
   // 进入登录页时启动的缓存清理;登录放行前必须成功。
   Future<bool>? _cacheClearFuture;
@@ -54,13 +74,23 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   @override
   void initState() {
     super.initState();
+    _authTokenStorage = widget.authTokenStorage ?? _StagedTokenStorage();
+    _authClient = GfApiClient(
+      dio: ref.read(authDioProvider),
+      tokenStorage: _authTokenStorage,
+      baseUrl: AppConfig.apiBaseUrl.isNotEmpty
+          ? AppConfig.apiBaseUrl
+          : GfApiClient.defaultBaseUrl,
+      onTokenRenewed: _authTokenStorage.write,
+    );
     _authController =
         widget.authController ??
         AuthController(
-          authRepository: AuthRepository(ref.read(apiClientProvider)),
-          apiClient: ref.read(apiClientProvider),
-          tokenStorage: ref.read(tokenStorageProvider),
+          authRepository: AuthRepository(_authClient),
+          apiClient: _authClient,
+          tokenStorage: _authTokenStorage,
         );
+
     // 进入登录页即进入新会话边界:先使旧会话在途写入失效,再清空缓存。
     // 两者都延迟到首帧后执行(避免在 widget 构建期修改 provider),且
     // 世代失效必须先于清库,保证不变量:
@@ -72,15 +102,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       // 进入登录页即会话边界:使缓存的当前用户身份失效(旧账号 id 不再
       // 被后续新 shell 读取)。
       ref.invalidate(currentUserProvider);
-      _cacheClearFuture = _clearOfflineCacheOnce().then((bool ok) async {
-        if (!mounted) return ok;
-        // 进入登录页即重新执行缓存清理:成功后清除跨重启门禁标记,
-        // 让后续登录能正常放行(即使上次进程被杀时标记仍残留)。
-        if (ok) {
-          await ref.read(pendingCacheClearProvider.notifier).clear();
-        }
-        return ok;
-      });
+      _cacheClearFuture = _clearOfflineCacheOnce();
     });
   }
 
@@ -177,8 +199,8 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       _oidcError = '';
     });
     final controller = OidcController(
-      authRepository: AuthRepository(ref.read(apiClientProvider)),
-      tokenStorage: ref.read(tokenStorageProvider),
+      authRepository: AuthRepository(_authClient),
+      tokenStorage: _authTokenStorage,
       issuer: AppConfig.oidcIssuer,
       clientId: AppConfig.oidcClientId,
     );
@@ -196,48 +218,65 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     }
   }
 
-  /// 认证成功后的收尾:确保旧账号缓存已清空再放行;清理失败则丢弃新会话
-  /// 并留在登录页提示重试,防止新账号读到上一账号的离线/内存数据。
+  /// 认证成功后的收尾:先确保旧账号缓存已清空,再把暂存的新会话提交到
+  /// 安全存储。清理失败时新 token 从未持久化,因此重启也无法以新账号读取
+  /// 旧账号离线数据。
   Future<void> _finishAuthentication() async {
-    if (!mounted) return;
-    if (!await _ensureCacheCleared()) {
-      // 新 token 已在登录流程中持久化,这里必须丢弃,否则用户可带着
-      // 新会话返回 401 保留的旧 shell(内存态含上一账号数据)。
-      // clear() 自身也可能抛异常(secure storage 多次删除),必须
-      // fail-closed:无论令牌是否清除成功都进入 blocked 状态,并置位
-      // 跨重启门禁标记——即使进程被杀后重启,残留令牌与未清空的旧
-      // 账号离线缓存也无法进入 shell(由 appRouter redirect 强制回登录页)。
-      try {
-        await ref.read(tokenStorageProvider).clear();
-      } catch (_) {
-        // 令牌清除失败:仍保持 blocked,用户无法带着新令牌进入应用。
+    if (!mounted || _finishingAuthentication) return;
+    setState(() => _finishingAuthentication = true);
+    try {
+      if (!await _ensureCacheCleared()) {
+        await _authTokenStorage.clear();
+        if (!mounted) return;
+        setState(() {
+          _authBlocked = true;
+          _cacheError = AppLocalizations.of(context).authCacheClearFailed;
+        });
+        return;
       }
-      // 置位持久化门禁(缓存未清空,重启后也必须留在登录页重试)。
-      await ref.read(pendingCacheClearProvider.notifier).set();
+
+      final String? token = await _authTokenStorage.read();
+      if (token == null || token.isEmpty) {
+        if (!mounted) return;
+        setState(() {
+          _authBlocked = true;
+          _cacheError = AppLocalizations.of(context).authSessionSaveFailed;
+        });
+        return;
+      }
+
+      try {
+        await ref.read(tokenStorageProvider).write(token);
+      } catch (_) {
+        // 安全存储写入可能在落盘后抛错,结果不确定。缓存已经清空,所以重启
+        // 不会泄漏旧数据;当前进程仍禁止返回旧 shell,避免其内存态被新令牌复用。
+        await _authTokenStorage.clear();
+        if (!mounted) return;
+        setState(() {
+          _authBlocked = true;
+          _cacheError = AppLocalizations.of(context).authSessionSaveFailed;
+        });
+        return;
+      }
+      await _authTokenStorage.clear();
       if (!mounted) return;
-      setState(() {
-        _authBlocked = true;
-        _cacheError = AppLocalizations.of(context).authCacheClearFailed;
-      });
-      return;
+      _authBlocked = false;
+      _cacheError = '';
+      // 新 token 已接受:使缓存的当前用户身份失效,新 shell 重新从
+      // 新令牌解析账号 id,避免 ProfilePage 仍用上一账号的 id 请求数据。
+      ref.invalidate(currentUserProvider);
+      // 用 go('/') 替换整个导航栈,销毁 401 保留的旧 shell(及其内存态),
+      // 避免新账号返回后看到上一账号的会话/消息数据。
+      context.go('/');
+    } finally {
+      if (mounted) setState(() => _finishingAuthentication = false);
     }
-    if (!mounted) return;
-    _authBlocked = false;
-    // 缓存清理成功:清除跨重启门禁标记。
-    await ref.read(pendingCacheClearProvider.notifier).clear();
-    if (!mounted) return;
-    // 新 token 已接受:使缓存的当前用户身份失效,新 shell 重新从
-    // 新令牌解析账号 id,避免 ProfilePage 仍用上一账号的 id 请求数据。
-    ref.invalidate(currentUserProvider);
-    // 用 go('/') 替换整个导航栈,销毁 401 保留的旧 shell(及其内存态),
-    // 避免新账号返回后看到上一账号的会话/消息数据。
-    context.go('/');
   }
 
   void _leaveAuth() {
     // 缓存清理失败后会话已丢弃:禁止返回旧 shell(内存态可能含上一账号
     // 数据),只能重试登录。
-    if (_authBlocked) return;
+    if (_authBlocked || _finishingAuthentication) return;
     final NavigatorState navigator = Navigator.of(context);
     if (navigator.canPop()) {
       navigator.pop();
@@ -274,7 +313,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
 
     // 缓存清理失败后禁止任何返回(含系统返回手势),只能重试登录。
     return PopScope(
-      canPop: !_authBlocked,
+      canPop: !_authBlocked && !_finishingAuthentication,
       child: Scaffold(
         backgroundColor: colors.base200,
         body: Stack(
@@ -479,8 +518,11 @@ class _LoginPageState extends ConsumerState<LoginPage> {
           variant: GfButtonVariant.primary,
           size: GfButtonSize.extraLarge,
           expanded: true,
-          loading: _authController.busy,
-          onPressed: _authController.busy || _oidcBusy ? null : _submit,
+          loading: _authController.busy || _finishingAuthentication,
+          onPressed:
+              _authController.busy || _oidcBusy || _finishingAuthentication
+              ? null
+              : _submit,
         ),
         if (_mode == _AuthMode.login) ...<Widget>[
           const SizedBox(height: 12),
@@ -489,8 +531,11 @@ class _LoginPageState extends ConsumerState<LoginPage> {
             variant: GfButtonVariant.outline,
             size: GfButtonSize.extraLarge,
             expanded: true,
-            loading: _oidcBusy,
-            onPressed: _authController.busy || _oidcBusy ? null : _loginOidc,
+            loading: _oidcBusy || _finishingAuthentication,
+            onPressed:
+                _authController.busy || _oidcBusy || _finishingAuthentication
+                ? null
+                : _loginOidc,
           ),
         ],
         if (_mode == _AuthMode.forgotPassword) ...<Widget>[

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -42,6 +42,8 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   String _oidcError = '';
   // 登录放行前缓存清理失败的错误(清理成功或重试成功后清空)。
   String _cacheError = '';
+  // 缓存清理失败后禁止返回旧 shell(其内存态可能含上一账号数据)。
+  bool _authBlocked = false;
 
   late final AuthController _authController;
 
@@ -182,27 +184,34 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     }
   }
 
-  /// 认证成功后的收尾:确保旧账号缓存已清空再放行;清理失败则留在登录页
-  /// 提示重试,防止新账号读到上一账号的离线数据(跨账号数据泄漏)。
+  /// 认证成功后的收尾:确保旧账号缓存已清空再放行;清理失败则丢弃新会话
+  /// 并留在登录页提示重试,防止新账号读到上一账号的离线/内存数据。
   Future<void> _finishAuthentication() async {
     if (!mounted) return;
     if (!await _ensureCacheCleared()) {
+      // 新 token 已在登录流程中持久化,这里必须丢弃,否则用户可带着
+      // 新会话返回 401 保留的旧 shell(内存态含上一账号数据)。
+      // 直接清本地令牌即可:登录刚完成,服务端会话尚无使用价值,
+      // 失败后重试登录会重新认证。
+      await ref.read(tokenStorageProvider).clear();
       if (!mounted) return;
-      setState(
-        () => _cacheError = AppLocalizations.of(context).authCacheClearFailed,
-      );
+      setState(() {
+        _authBlocked = true;
+        _cacheError = AppLocalizations.of(context).authCacheClearFailed;
+      });
       return;
     }
     if (!mounted) return;
-    final NavigatorState navigator = Navigator.of(context);
-    if (navigator.canPop()) {
-      navigator.pop(true);
-      return;
-    }
+    _authBlocked = false;
+    // 用 go('/') 替换整个导航栈,销毁 401 保留的旧 shell(及其内存态),
+    // 避免新账号返回后看到上一账号的会话/消息数据。
     context.go('/');
   }
 
   void _leaveAuth() {
+    // 缓存清理失败后会话已丢弃:禁止返回旧 shell(内存态可能含上一账号
+    // 数据),只能重试登录。
+    if (_authBlocked) return;
     final NavigatorState navigator = Navigator.of(context);
     if (navigator.canPop()) {
       navigator.pop();
@@ -237,59 +246,63 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     final AppLocalizations l10n = AppLocalizations.of(context);
     final Brightness brightness = Theme.of(context).brightness;
 
-    return Scaffold(
-      backgroundColor: colors.base200,
-      body: Stack(
-        fit: StackFit.expand,
-        children: <Widget>[
-          const GfDotGridBackground(),
-          SafeArea(
-            child: Stack(
-              children: <Widget>[
-                Positioned(
-                  top: 4,
-                  left: 8,
-                  child: GfIconButton(
-                    icon: Icons.arrow_back,
-                    tooltip: l10n.commonBack,
-                    size: 44,
-                    onPressed: _leaveAuth,
+    // 缓存清理失败后禁止任何返回(含系统返回手势),只能重试登录。
+    return PopScope(
+      canPop: !_authBlocked,
+      child: Scaffold(
+        backgroundColor: colors.base200,
+        body: Stack(
+          fit: StackFit.expand,
+          children: <Widget>[
+            const GfDotGridBackground(),
+            SafeArea(
+              child: Stack(
+                children: <Widget>[
+                  Positioned(
+                    top: 4,
+                    left: 8,
+                    child: GfIconButton(
+                      icon: Icons.arrow_back,
+                      tooltip: l10n.commonBack,
+                      size: 44,
+                      onPressed: _leaveAuth,
+                    ),
                   ),
-                ),
-                Positioned(
-                  top: 4,
-                  right: 8,
-                  child: GfIconButton(
-                    icon: brightness == Brightness.dark
-                        ? Icons.light_mode_outlined
-                        : Icons.dark_mode_outlined,
-                    onPressed: () => ref
-                        .read(themeModeProvider.notifier)
-                        .toggleDark(brightness != Brightness.dark),
+                  Positioned(
+                    top: 4,
+                    right: 8,
+                    child: GfIconButton(
+                      icon: brightness == Brightness.dark
+                          ? Icons.light_mode_outlined
+                          : Icons.dark_mode_outlined,
+                      onPressed: () => ref
+                          .read(themeModeProvider.notifier)
+                          .toggleDark(brightness != Brightness.dark),
+                    ),
                   ),
-                ),
-                Center(
-                  child: SingleChildScrollView(
-                    padding: const EdgeInsets.fromLTRB(20, 64, 20, 32),
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 520),
-                      child: GfCard(
-                        emphasized: true,
-                        padding: const EdgeInsets.fromLTRB(24, 28, 24, 24),
-                        child: ListenableBuilder(
-                          listenable: _authController,
-                          builder: (BuildContext context, Widget? child) {
-                            return _buildCardContent(context, l10n, colors);
-                          },
+                  Center(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(20, 64, 20, 32),
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 520),
+                        child: GfCard(
+                          emphasized: true,
+                          padding: const EdgeInsets.fromLTRB(24, 28, 24, 24),
+                          child: ListenableBuilder(
+                            listenable: _authController,
+                            builder: (BuildContext context, Widget? child) {
+                              return _buildCardContent(context, l10n, colors);
+                            },
+                          ),
                         ),
                       ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/auth/login_page.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -23,8 +22,10 @@ enum _AuthMode { login, register, forgotPassword }
 /// 统一身份：论坛内建 OIDC Provider 经 AppAuth + 后端 exchange 兑换。
 /// 注册/找回密码:复用 AuthController 的 register/forgotPassword。
 class LoginPage extends ConsumerStatefulWidget {
-  const LoginPage({super.key});
+  const LoginPage({super.key, this.authController});
 
+  /// 测试注入:默认 null 时页面内部构造 [AuthController]。
+  final AuthController? authController;
   @override
   ConsumerState<LoginPage> createState() => _LoginPageState();
 }
@@ -39,25 +40,56 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   _AuthMode _mode = _AuthMode.login;
   bool _oidcBusy = false;
   String _oidcError = '';
+  // 登录放行前缓存清理失败的错误(清理成功或重试成功后清空)。
+  String _cacheError = '';
 
   late final AuthController _authController;
+
+  // 进入登录页时启动的缓存清理;登录放行前必须成功。
+  Future<bool>? _cacheClearFuture;
 
   @override
   void initState() {
     super.initState();
-    _authController = AuthController(
-      authRepository: AuthRepository(ref.read(apiClientProvider)),
-      apiClient: ref.read(apiClientProvider),
-      tokenStorage: ref.read(tokenStorageProvider),
-    );
-    // 进入登录页即清空上一账号的离线缓存(话题/会话/私信),防止同一设备
-    // 换账号后读到上一账号的缓存数据;失败静默。
-    unawaited(
-      clearOfflineCacheQuietly(
+    _authController =
+        widget.authController ??
+        AuthController(
+          authRepository: AuthRepository(ref.read(apiClientProvider)),
+          apiClient: ref.read(apiClientProvider),
+          tokenStorage: ref.read(tokenStorageProvider),
+        );
+    // 进入登录页即进入新会话边界:先使旧会话在途写入失效,再清空缓存。
+    // 两者都延迟到首帧后执行(避免在 widget 构建期修改 provider),且
+    // 世代失效必须先于清库,保证不变量:
+    //   - 失效前提交的旧会话写入会被随后的清库清掉;
+    //   - 失效后提交的写入会被世代守卫拦截。
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(offlineCacheEpochProvider.notifier).invalidate();
+      _cacheClearFuture = _clearOfflineCacheOnce();
+    });
+  }
+
+  /// 执行一次离线缓存清理;成功返回 true,失败返回 false(不抛出)。
+  Future<bool> _clearOfflineCacheOnce() async {
+    try {
+      await clearOfflineCache(
         ref.read(offlineTopicCacheProvider),
         ref.read(offlineChatCacheProvider),
-      ),
-    );
+      );
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// 登录放行前确保上一账号缓存已清空:首次清理失败(SQLite 慢/锁)时
+  /// 重试一次;仍失败返回 false,由调用方留在登录页提示重试。
+  Future<bool> _ensureCacheCleared() async {
+    Future<bool> attempt = _cacheClearFuture ??= _clearOfflineCacheOnce();
+    if (await attempt) return true;
+    attempt = _cacheClearFuture = _clearOfflineCacheOnce();
+    return attempt;
   }
 
   @override
@@ -84,7 +116,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
       await _authController.loadCaptcha();
     }
     if (mounted && _authController.phase == LoginPhase.authenticated) {
-      _finishAuthentication();
+      await _finishAuthentication();
     }
   }
 
@@ -143,14 +175,24 @@ class _LoginPageState extends ConsumerState<LoginPage> {
         setState(() => _oidcError = controller.error);
         return;
       }
-      _finishAuthentication();
+      await _finishAuthentication();
     } finally {
       controller.dispose();
       if (mounted) setState(() => _oidcBusy = false);
     }
   }
 
-  void _finishAuthentication() {
+  /// 认证成功后的收尾:确保旧账号缓存已清空再放行;清理失败则留在登录页
+  /// 提示重试,防止新账号读到上一账号的离线数据(跨账号数据泄漏)。
+  Future<void> _finishAuthentication() async {
+    if (!mounted) return;
+    if (!await _ensureCacheCleared()) {
+      if (!mounted) return;
+      setState(
+        () => _cacheError = AppLocalizations.of(context).authCacheClearFailed,
+      );
+      return;
+    }
     if (!mounted) return;
     final NavigatorState navigator = Navigator.of(context);
     if (navigator.canPop()) {
@@ -381,10 +423,15 @@ class _LoginPageState extends ConsumerState<LoginPage> {
           ),
         ],
         if (_authController.error.isNotEmpty ||
-            _oidcError.isNotEmpty) ...<Widget>[
+            _oidcError.isNotEmpty ||
+            _cacheError.isNotEmpty) ...<Widget>[
           const SizedBox(height: 12),
           GfStatusMessage(
-            message: _oidcError.isNotEmpty ? _oidcError : _authController.error,
+            message: _cacheError.isNotEmpty
+                ? _cacheError
+                : _oidcError.isNotEmpty
+                ? _oidcError
+                : _authController.error,
           ),
         ],
         const SizedBox(height: 20),
@@ -433,7 +480,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
     if (_authController.phase == LoginPhase.needsTotp) {
       await _authController.submitTotp(_totp.text.trim());
       if (mounted && _authController.phase == LoginPhase.authenticated) {
-        _finishAuthentication();
+        await _finishAuthentication();
       }
       return;
     }

--- a/apps/mobile/packages/forum_app/lib/src/pages/messages/messages_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/messages/messages_page.dart
@@ -107,13 +107,15 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
   }
 
   Future<void> _load({bool silent = false}) async {
+    // 记录发起时的缓存世代;401/登出/换账号后世代自增,返回时丢弃旧会话数据。
+    final int epoch = ref.read(offlineCacheEpochProvider);
     try {
       final props = await ref.read(pageRepositoryProvider).fetch('/messages');
       final MessagesPageProps? parsed = parsePageProps<MessagesPageProps>(
         props,
       );
       final List<ChatItemPayload> items = parsed?.conversations ?? [];
-      if (mounted) {
+      if (mounted && epoch == ref.read(offlineCacheEpochProvider)) {
         setState(() {
           _conversations = AsyncValue.data(items);
           _suggestedUsers = parsed?.suggestedUsers ?? const [];
@@ -121,25 +123,29 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
           _targetConversation = _targetConversationFor(items);
         });
       }
-      // 会话列表在单事务中批量写入离线缓存(断网可读)。
-      await ref.read(offlineChatCacheProvider).putConversations(items);
+      // 会话列表在单事务中批量写入离线缓存(断网可读);仅当前世代允许写入,
+      // 避免 401/登出后旧会话在途响应把上一账号数据写回刚清空的缓存。
+      if (epoch == ref.read(offlineCacheEpochProvider)) {
+        await ref.read(offlineChatCacheProvider).putConversations(items);
+      }
     } catch (e, st) {
       // 网络失败:回退离线缓存的会话列表。
-      if (mounted) {
-        try {
-          final cached = await ref
-              .read(offlineChatCacheProvider)
-              .getConversations();
-          if (cached.isNotEmpty) {
-            setState(() {
-              _conversations = AsyncValue.data(cached);
-              _targetConversation = _targetConversationFor(cached);
-            });
-            return;
-          }
-        } catch (_) {
-          // 缓存不可用时继续走错误态。
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
+      try {
+        final cached = await ref
+            .read(offlineChatCacheProvider)
+            .getConversations();
+        // 读缓存期间会话可能已切换,再次校验世代再更新 UI。
+        if (epoch != ref.read(offlineCacheEpochProvider)) return;
+        if (cached.isNotEmpty) {
+          setState(() {
+            _conversations = AsyncValue.data(cached);
+            _targetConversation = _targetConversationFor(cached);
+          });
+          return;
         }
+      } catch (_) {
+        // 缓存不可用时继续走错误态。
       }
       if (!silent && mounted) {
         setState(() => _conversations = AsyncValue.error(e, st));
@@ -406,6 +412,8 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
       if (mounted) setState(() => _loading = false);
       return;
     }
+    // 记录发起时的缓存世代;401/登出/换账号后世代自增,返回时丢弃旧会话数据。
+    final int epoch = ref.read(offlineCacheEpochProvider);
     try {
       final bool initial = _latestId == 0;
       final bool pinnedToBottom =
@@ -422,7 +430,7 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
       final List<ChatMessagePayload> newMessages = resp.list
           .where((ChatMessagePayload message) => seenIds.add(message.id))
           .toList();
-      if (mounted) {
+      if (mounted && epoch == ref.read(offlineCacheEpochProvider)) {
         setState(() {
           if (newMessages.isNotEmpty) {
             _messages.addAll(newMessages);
@@ -435,7 +443,8 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
         });
         if (initial || pinnedToBottom) _scrollToBottom();
       }
-      if (newMessages.isNotEmpty) {
+      if (newMessages.isNotEmpty &&
+          epoch == ref.read(offlineCacheEpochProvider)) {
         // 只持久化真正新增的消息，避免轮询重复写缓存和重复上报已读。
         await ref
             .read(offlineChatCacheProvider)
@@ -444,23 +453,24 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
       }
     } catch (_) {
       // 网络失败:回退离线缓存消息。
-      if (mounted) {
-        try {
-          final cached = await ref
-              .read(offlineChatCacheProvider)
-              .getMessages(_convId);
-          if (cached.isNotEmpty) {
-            setState(() {
-              _messages
-                ..clear()
-                ..addAll(cached);
-              _loading = false;
-            });
-            return;
-          }
-        } catch (_) {
-          // 缓存不可用。
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
+      try {
+        final cached = await ref
+            .read(offlineChatCacheProvider)
+            .getMessages(_convId);
+        // 读缓存期间会话可能已切换,再次校验世代再更新 UI。
+        if (epoch != ref.read(offlineCacheEpochProvider)) return;
+        if (cached.isNotEmpty) {
+          setState(() {
+            _messages
+              ..clear()
+              ..addAll(cached);
+            _loading = false;
+          });
+          return;
         }
+      } catch (_) {
+        // 缓存不可用。
       }
       if (mounted && !silent) setState(() => _loading = false);
     }
@@ -468,6 +478,7 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
 
   Future<void> _loadOlder() async {
     if (_loadingOlder || !_hasMoreBefore || _nextBeforeId <= 0) return;
+    final int epoch = ref.read(offlineCacheEpochProvider);
     setState(() => _loadingOlder = true);
     final double previousExtent = _scrollController.hasClients
         ? _scrollController.position.maxScrollExtent
@@ -476,7 +487,7 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
       final ChatMessagesResponse resp = await ref
           .read(chatRepositoryProvider)
           .getMessages(convId: _convId, beforeId: _nextBeforeId);
-      if (!mounted) return;
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
       setState(() {
         final Set<int> existing = _messages.map((m) => m.id).toSet();
         _messages.addAll(resp.list.where((m) => !existing.contains(m.id)));

--- a/apps/mobile/packages/forum_app/lib/src/pages/messages/messages_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/messages/messages_page.dart
@@ -131,6 +131,13 @@ class _MessagesPageState extends ConsumerState<MessagesPage> {
     } catch (e, st) {
       // 网络失败:回退离线缓存的会话列表。
       if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
+      // 无会话令牌(如 401 后进程被杀重启)时不得回退上一账号残留缓存。
+      if (!await hasSessionToken(ref.read(tokenStorageProvider))) {
+        if (!silent && mounted) {
+          setState(() => _conversations = AsyncValue.error(e, st));
+        }
+        return;
+      }
       try {
         final cached = await ref
             .read(offlineChatCacheProvider)
@@ -454,6 +461,11 @@ class _ConversationPageState extends ConsumerState<_ConversationPage> {
     } catch (_) {
       // 网络失败:回退离线缓存消息。
       if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
+      // 无会话令牌(如 401 后进程被杀重启)时不得回退上一账号残留缓存。
+      if (!await hasSessionToken(ref.read(tokenStorageProvider))) {
+        if (mounted && !silent) setState(() => _loading = false);
+        return;
+      }
       try {
         final cached = await ref
             .read(offlineChatCacheProvider)

--- a/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
@@ -996,7 +996,10 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     );
   }
 
-  /// 登出:确认 → 服务端失效 → 清 token → 跳登录页。
+  /// 登出:确认 → 服务端失效 → 清 token → 清离线缓存 → 跳登录页。
+  ///
+  /// 离线缓存(drift)保存私信与已浏览话题,登出必须清空,否则同一设备
+  /// 换账号后仍可读到上一账号的缓存数据(跨账号数据泄漏)。
   Future<void> _logout() async {
     final AppLocalizations l10n = AppLocalizations.of(context);
     final bool? ok = await showGfAlertDialog<bool>(
@@ -1024,6 +1027,11 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       // 服务端失效失败不阻塞本地登出(会话已不可信)。
     }
     await ref.read(tokenStorageProvider).clear();
+    // 清空话题/会话/私信离线缓存;失败静默(下次登出/登录会重试)。
+    await clearOfflineCacheQuietly(
+      ref.read(offlineTopicCacheProvider),
+      ref.read(offlineChatCacheProvider),
+    );
     if (mounted) context.go('/login');
   }
 

--- a/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
@@ -1027,6 +1027,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       // 服务端失效失败不阻塞本地登出(会话已不可信)。
     }
     await ref.read(tokenStorageProvider).clear();
+    // 登出即进入新会话边界:先使旧会话在途写入失效,再清空缓存。
+    ref.read(offlineCacheEpochProvider.notifier).invalidate();
     // 清空话题/会话/私信离线缓存;失败静默(下次登出/登录会重试)。
     await clearOfflineCacheQuietly(
       ref.read(offlineTopicCacheProvider),

--- a/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
@@ -14,6 +14,7 @@ import '../../providers.dart';
 import '../../format.dart';
 import '../../theme_mode.dart';
 import '../../widgets/status_views.dart';
+import '../../current_user.dart';
 import '../../widgets/skeletons.dart';
 
 enum _SettingsTab {
@@ -1027,8 +1028,10 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       // 服务端失效失败不阻塞本地登出(会话已不可信)。
     }
     await ref.read(tokenStorageProvider).clear();
-    // 登出即进入新会话边界:先使旧会话在途写入失效,再清空缓存。
+    // 登出即进入新会话边界:先使旧会话在途写入失效、当前用户身份失效,
+    // 再清空缓存。
     ref.read(offlineCacheEpochProvider.notifier).invalidate();
+    ref.invalidate(currentUserProvider);
     // 清空话题/会话/私信离线缓存;失败静默(下次登出/登录会重试)。
     await clearOfflineCacheQuietly(
       ref.read(offlineTopicCacheProvider),

--- a/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
@@ -106,6 +106,12 @@ class _TopicPageState extends ConsumerState<TopicPage> {
     } catch (e, st) {
       // 网络失败:回退 drift 离线缓存(已浏览话题离线可读)。
       if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
+      // 无会话令牌(如 401 后进程被杀重启)时不得回退上一账号残留缓存。
+      if (!await hasSessionToken(ref.read(tokenStorageProvider))) {
+        // 静默刷新失败时保留当前内容,不打断阅读。
+        if (!silent) setState(() => _page = AsyncValue.error(e, st));
+        return;
+      }
       final PagePayload? cached = await _cacheGet(widget.topicId);
       // 读缓存期间会话可能已切换,再次校验世代再更新 UI。
       if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;

--- a/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
@@ -67,12 +67,14 @@ class _TopicPageState extends ConsumerState<TopicPage> {
   }
 
   Future<void> _load({bool silent = false}) async {
+    // 记录发起时的缓存世代;401/登出/换账号后世代自增,返回时丢弃旧会话数据。
+    final int epoch = ref.read(offlineCacheEpochProvider);
     if (!silent) setState(() => _page = const AsyncValue.loading());
     try {
       final PagePayload payload = await ref
           .read(pageRepositoryProvider)
           .topicDetail(widget.topicId);
-      if (!mounted) return;
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
       final props = parsePageProps<TopicDetailProps>(payload);
       if (props == null) {
         setState(
@@ -84,8 +86,12 @@ class _TopicPageState extends ConsumerState<TopicPage> {
         return;
       }
       // 写入 drift 离线缓存(供断网时回读);缓存失败静默降级。
-      await _cachePut(widget.topicId, payload.toJson());
-      if (!mounted) return;
+      // 仅当前世代允许写入,避免旧会话在途响应写回上一账号数据。
+      if (epoch == ref.read(offlineCacheEpochProvider)) {
+        await _cachePut(widget.topicId, payload.toJson());
+      }
+      // 写入期间会话可能已切换,再次校验世代再更新 UI。
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
       setState(() {
         _page = AsyncValue.data(props);
         _posts.clear();
@@ -99,8 +105,10 @@ class _TopicPageState extends ConsumerState<TopicPage> {
       });
     } catch (e, st) {
       // 网络失败:回退 drift 离线缓存(已浏览话题离线可读)。
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
       final PagePayload? cached = await _cacheGet(widget.topicId);
-      if (!mounted) return;
+      // 读缓存期间会话可能已切换,再次校验世代再更新 UI。
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
       final props = cached == null
           ? null
           : parsePageProps<TopicDetailProps>(cached);

--- a/apps/mobile/packages/forum_app/lib/src/providers.dart
+++ b/apps/mobile/packages/forum_app/lib/src/providers.dart
@@ -27,6 +27,23 @@ final unauthorizedEventsProvider = NotifierProvider<UnauthorizedNotifier, int>(
   UnauthorizedNotifier.new,
 );
 
+/// 离线缓存写入世代。
+///
+/// 会话边界(401 会话失效、登出、进入登录页)自增一次;页面在网络响应返回后
+/// 校验世代,不一致说明会话已切换,必须丢弃 setState 与缓存写入,防止旧会话
+/// 在途响应把上一账号数据写回刚清空的离线库(跨账号数据泄漏)。
+class OfflineCacheEpoch extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  /// 使所有在途缓存写入失效(自增世代)。
+  void invalidate() => state++;
+}
+
+final offlineCacheEpochProvider = NotifierProvider<OfflineCacheEpoch, int>(
+  OfflineCacheEpoch.new,
+);
+
 /// Dio 实例(测试可 override 注入 mock adapter)。
 final dioProvider = Provider<Dio>((ref) => Dio());
 
@@ -85,10 +102,13 @@ final apiClientProvider = Provider<GfApiClient>((ref) {
         : GfApiClient.defaultBaseUrl,
     // New-Token 滑动续期:写回 tokenStorage 持久化新令牌。
     onTokenRenewed: (newToken) => storage.write(newToken),
-    // 401 会话失效:清空令牌、清离线缓存并通知 UI 跳转登录页。
+    // 401 会话失效:清空令牌、使旧会话在途写入失效、清离线缓存并通知 UI 跳转登录页。
     onUnauthorized: () {
       storage.clear();
       ref.read(unauthorizedEventsProvider.notifier).trigger();
+      // 先自增世代,让已发出的旧会话请求在返回后丢弃 setState 与缓存写入;
+      // 再异步清库(清库入队晚于已在途写入的提交,不产生交错)。
+      ref.read(offlineCacheEpochProvider.notifier).invalidate();
       unawaited(
         clearOfflineCacheQuietly(
           ref.read(offlineTopicCacheProvider),

--- a/apps/mobile/packages/forum_app/lib/src/providers.dart
+++ b/apps/mobile/packages/forum_app/lib/src/providers.dart
@@ -5,7 +5,6 @@ import 'package:core/core.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:shared_preferences/shared_preferences.dart';
 import 'offline/drift_cache.dart';
 import 'app_config.dart';
 
@@ -39,52 +38,21 @@ class OfflineCacheEpoch extends Notifier<int> {
 
   /// 使所有在途缓存写入失效(自增世代)。
   void invalidate() => state++;
+
+  /// 判断回调是否仍属于当前会话。
+  bool isCurrent(int epoch) => state == epoch;
 }
 
 final offlineCacheEpochProvider = NotifierProvider<OfflineCacheEpoch, int>(
   OfflineCacheEpoch.new,
 );
 
-/// 跨重启"待清缓存"门禁标记键(SharedPreferences,与 token/离线库独立)。
-const String pendingCacheClearKey = 'yourtj.auth.pendingCacheClear';
-
-/// 读取持久化的待清缓存标记(启动门禁用,不依赖 Riverpod 状态)。
-Future<bool> readPendingCacheClearFlag() async {
-  final SharedPreferences prefs = await SharedPreferences.getInstance();
-  return prefs.getBool(pendingCacheClearKey) ?? false;
-}
-
-/// 跨重启的会话缓存边界门禁。
-///
-/// 缓存清理失败且令牌可能残留时置位;登录页缓存清理成功后清除。
-/// 标记存在时 [appRouter] 强制重定向到登录页:即使进程被杀后重启,
-/// 残留的令牌与未清空的旧账号离线缓存也无法进入 shell 展示
-/// (跨账号数据泄漏的最后防线)。
-class PendingCacheClear extends Notifier<bool> {
-  @override
-  bool build() => false;
-
-  /// 置位门禁(缓存清理失败,令牌可能残留)。
-  Future<void> set() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(pendingCacheClearKey, true);
-    state = true;
-  }
-
-  /// 清除门禁(缓存清理成功)。
-  Future<void> clear() async {
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.remove(pendingCacheClearKey);
-    state = false;
-  }
-}
-
-final pendingCacheClearProvider = NotifierProvider<PendingCacheClear, bool>(
-  PendingCacheClear.new,
-);
-
 /// Dio 实例(测试可 override 注入 mock adapter)。
 final dioProvider = Provider<Dio>((ref) => Dio());
+
+/// 登录流程专用 Dio:不复用 [dioProvider],避免主客户端安装的旧会话
+/// Bearer interceptor 污染 password/TOTP/OIDC 认证请求。
+final authDioProvider = Provider<Dio>((ref) => Dio());
 
 /// drift 数据库单例(话题 + IM 会话缓存共用)。
 final offlineDatabaseProvider = Provider<AppDatabase>((ref) {
@@ -128,8 +96,26 @@ Future<void> clearOfflineCacheQuietly(
   }
 }
 
+/// 是否持有会话令牌。
+///
+/// 离线回退读取前的认证门槛:无令牌(如启动时上一会话已失效但离线缓存
+/// 残留)时不得读取缓存,防止未登录态渲染上一账号的私信/话题。
+Future<bool> hasSessionToken(TokenStorage storage) async {
+  try {
+    final String? token = await storage.read();
+    return token != null && token.isNotEmpty;
+  } catch (_) {
+    return false;
+  }
+}
+
 final apiClientProvider = Provider<GfApiClient>((ref) {
   final storage = ref.watch(tokenStorageProvider);
+  // 只读捕获创建时的会话世代:该 client 固定属于此会话,边界变化后其
+  // 续期/401 回调一律失效。不能 watch,否则每次边界都会重建 client。
+  final int sessionEpoch = ref.read(offlineCacheEpochProvider);
+  final epochNotifier = ref.read(offlineCacheEpochProvider.notifier);
+  final unauthorizedNotifier = ref.read(unauthorizedEventsProvider.notifier);
   return GfApiClient(
     dio: ref.watch(dioProvider),
     tokenStorage: storage,
@@ -139,21 +125,30 @@ final apiClientProvider = Provider<GfApiClient>((ref) {
     baseUrl: AppConfig.apiBaseUrl.isNotEmpty
         ? AppConfig.apiBaseUrl
         : GfApiClient.defaultBaseUrl,
-    // New-Token 滑动续期:写回 tokenStorage 持久化新令牌。
-    onTokenRenewed: (newToken) => storage.write(newToken),
-    // 401 会话失效:清空令牌、使旧会话在途写入失效、清离线缓存并通知 UI 跳转登录页。
+    // 旧会话请求可能在新账号登录后才带着 New-Token 返回。client 创建时
+    // 捕获会话世代,边界变化后直接丢弃续期,避免覆盖新账号 token。
+    onTokenRenewed: (newToken) async {
+      if (!epochNotifier.isCurrent(sessionEpoch)) return;
+      await storage.write(newToken);
+    },
+    // 仅当前会话的首个 401 可启动 teardown。同步自增世代后,同一旧
+    // client 的重复 401 与迟到 New-Token 都立即失效。离线缓存按需读取,
+    // 避免 client 构造时初始化 drift 数据库。
     onUnauthorized: () {
-      storage.clear();
-      ref.read(unauthorizedEventsProvider.notifier).trigger();
-      // 先自增世代,让已发出的旧会话请求在返回后丢弃 setState 与缓存写入;
-      // 再异步清库(清库入队晚于已在途写入的提交,不产生交错)。
-      ref.read(offlineCacheEpochProvider.notifier).invalidate();
-      unawaited(
-        clearOfflineCacheQuietly(
+      if (!epochNotifier.isCurrent(sessionEpoch)) return;
+      epochNotifier.invalidate();
+      unawaited(() async {
+        try {
+          await storage.clear();
+        } catch (_) {
+          // 清理失败仍进入登录页;新登录会在缓存清理成功后覆盖旧 token。
+        }
+        await clearOfflineCacheQuietly(
           ref.read(offlineTopicCacheProvider),
           ref.read(offlineChatCacheProvider),
-        ),
-      );
+        );
+        unauthorizedNotifier.trigger();
+      }());
     },
   );
 });

--- a/apps/mobile/packages/forum_app/lib/src/providers.dart
+++ b/apps/mobile/packages/forum_app/lib/src/providers.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:auth/auth.dart';
 import 'package:core/core.dart';
 import 'package:dio/dio.dart';
@@ -45,6 +47,31 @@ final offlineChatCacheProvider = Provider<OfflineChatCache>((ref) {
   return DriftOfflineCache(ref.watch(offlineDatabaseProvider));
 });
 
+/// 清除全部离线缓存(话题 + 会话 + 消息)。
+///
+/// 登出、401 会话失效、重新登录(进入登录页)时必须清空,否则同一设备上
+/// 下一账号可读到上一账号缓存的私信/话题,造成跨账号数据泄漏。
+Future<void> clearOfflineCache(
+  OfflineTopicCache topicCache,
+  OfflineChatCache chatCache,
+) async {
+  await topicCache.clear();
+  await chatCache.clear();
+}
+
+/// 尽力清除离线缓存,失败静默(清理失败不阻塞登出/会话失效流程,
+/// 下次登出或进入登录页会重试)。
+Future<void> clearOfflineCacheQuietly(
+  OfflineTopicCache topicCache,
+  OfflineChatCache chatCache,
+) async {
+  try {
+    await clearOfflineCache(topicCache, chatCache);
+  } catch (_) {
+    // 缓存不可用时忽略。
+  }
+}
+
 final apiClientProvider = Provider<GfApiClient>((ref) {
   final storage = ref.watch(tokenStorageProvider);
   return GfApiClient(
@@ -58,10 +85,16 @@ final apiClientProvider = Provider<GfApiClient>((ref) {
         : GfApiClient.defaultBaseUrl,
     // New-Token 滑动续期:写回 tokenStorage 持久化新令牌。
     onTokenRenewed: (newToken) => storage.write(newToken),
-    // 401 会话失效:清空令牌并通知 UI 跳转登录页。
+    // 401 会话失效:清空令牌、清离线缓存并通知 UI 跳转登录页。
     onUnauthorized: () {
       storage.clear();
       ref.read(unauthorizedEventsProvider.notifier).trigger();
+      unawaited(
+        clearOfflineCacheQuietly(
+          ref.read(offlineTopicCacheProvider),
+          ref.read(offlineChatCacheProvider),
+        ),
+      );
     },
   );
 });

--- a/apps/mobile/packages/forum_app/lib/src/providers.dart
+++ b/apps/mobile/packages/forum_app/lib/src/providers.dart
@@ -5,6 +5,7 @@ import 'package:core/core.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:shared_preferences/shared_preferences.dart';
 import 'offline/drift_cache.dart';
 import 'app_config.dart';
 
@@ -42,6 +43,44 @@ class OfflineCacheEpoch extends Notifier<int> {
 
 final offlineCacheEpochProvider = NotifierProvider<OfflineCacheEpoch, int>(
   OfflineCacheEpoch.new,
+);
+
+/// 跨重启"待清缓存"门禁标记键(SharedPreferences,与 token/离线库独立)。
+const String pendingCacheClearKey = 'yourtj.auth.pendingCacheClear';
+
+/// 读取持久化的待清缓存标记(启动门禁用,不依赖 Riverpod 状态)。
+Future<bool> readPendingCacheClearFlag() async {
+  final SharedPreferences prefs = await SharedPreferences.getInstance();
+  return prefs.getBool(pendingCacheClearKey) ?? false;
+}
+
+/// 跨重启的会话缓存边界门禁。
+///
+/// 缓存清理失败且令牌可能残留时置位;登录页缓存清理成功后清除。
+/// 标记存在时 [appRouter] 强制重定向到登录页:即使进程被杀后重启,
+/// 残留的令牌与未清空的旧账号离线缓存也无法进入 shell 展示
+/// (跨账号数据泄漏的最后防线)。
+class PendingCacheClear extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  /// 置位门禁(缓存清理失败,令牌可能残留)。
+  Future<void> set() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(pendingCacheClearKey, true);
+    state = true;
+  }
+
+  /// 清除门禁(缓存清理成功)。
+  Future<void> clear() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(pendingCacheClearKey);
+    state = false;
+  }
+}
+
+final pendingCacheClearProvider = NotifierProvider<PendingCacheClear, bool>(
+  PendingCacheClear.new,
 );
 
 /// Dio 实例(测试可 override 注入 mock adapter)。

--- a/apps/mobile/packages/forum_app/lib/src/router.dart
+++ b/apps/mobile/packages/forum_app/lib/src/router.dart
@@ -21,24 +21,6 @@ import 'pages/topic/topic_page.dart';
 import 'providers.dart';
 import 'current_user.dart';
 
-/// 启动门禁状态:缓存清理失败且令牌可能残留时为 true,强制重定向到登录页。
-/// 由 [initStartupGate] 在启动时从持久化标记装载(跨重启防线)。
-bool _startupGateBlocked = false;
-
-/// 启动时读取持久化"待清缓存"门禁标记;必须在构造/使用 [appRouter] 前调用。
-///
-/// 进程被杀后重启时,残留令牌与未清空的旧账号离线缓存不得进入 shell,
-/// 否则断网回退会以新账号身份展示旧账号私信(跨账号数据泄漏)。
-Future<void> initStartupGate() async {
-  _startupGateBlocked = await readPendingCacheClearFlag();
-}
-
-/// 门禁重定向:标记存在时,除登录页外一律强制跳转登录页。
-String? _pendingCacheRedirect(BuildContext context, GoRouterState state) {
-  if (!_startupGateBlocked) return null;
-  return state.uri.path == '/login' ? null : '/login';
-}
-
 extension on GfShellDestination {
   IconData get icon => switch (this) {
     GfShellDestination.home => Icons.home_outlined,
@@ -82,6 +64,7 @@ class _GfShellState extends ConsumerState<GfShell> {
   @override
   void initState() {
     super.initState();
+    unawaited(_purgeStaleOfflineCacheOnBoot());
     _pollUnread();
     _unreadTimer = Timer.periodic(
       const Duration(seconds: 30),
@@ -93,6 +76,20 @@ class _GfShellState extends ConsumerState<GfShell> {
   void dispose() {
     _unreadTimer?.cancel();
     super.dispose();
+  }
+
+  /// 启动兜底:无令牌(上次 401 清库可能被进程中断)时清空离线缓存,
+  /// 防止未登录态读取上一账号残留的私信/话题。清理失败不影响启动。
+  Future<void> _purgeStaleOfflineCacheOnBoot() async {
+    try {
+      if (await hasSessionToken(ref.read(tokenStorageProvider))) return;
+      await clearOfflineCacheQuietly(
+        ref.read(offlineTopicCacheProvider),
+        ref.read(offlineChatCacheProvider),
+      );
+    } catch (_) {
+      // 兜底清理失败(缓存不可用)不阻塞启动。
+    }
   }
 
   Future<void> _pollUnread() async {
@@ -182,7 +179,6 @@ int? publishTopicIdFromUri(Uri uri) {
 
 final GoRouter appRouter = GoRouter(
   initialLocation: '/',
-  redirect: _pendingCacheRedirect,
   routes: <RouteBase>[
     StatefulShellRoute.indexedStack(
       builder:

--- a/apps/mobile/packages/forum_app/lib/src/router.dart
+++ b/apps/mobile/packages/forum_app/lib/src/router.dart
@@ -21,6 +21,24 @@ import 'pages/topic/topic_page.dart';
 import 'providers.dart';
 import 'current_user.dart';
 
+/// 启动门禁状态:缓存清理失败且令牌可能残留时为 true,强制重定向到登录页。
+/// 由 [initStartupGate] 在启动时从持久化标记装载(跨重启防线)。
+bool _startupGateBlocked = false;
+
+/// 启动时读取持久化"待清缓存"门禁标记;必须在构造/使用 [appRouter] 前调用。
+///
+/// 进程被杀后重启时,残留令牌与未清空的旧账号离线缓存不得进入 shell,
+/// 否则断网回退会以新账号身份展示旧账号私信(跨账号数据泄漏)。
+Future<void> initStartupGate() async {
+  _startupGateBlocked = await readPendingCacheClearFlag();
+}
+
+/// 门禁重定向:标记存在时,除登录页外一律强制跳转登录页。
+String? _pendingCacheRedirect(BuildContext context, GoRouterState state) {
+  if (!_startupGateBlocked) return null;
+  return state.uri.path == '/login' ? null : '/login';
+}
+
 extension on GfShellDestination {
   IconData get icon => switch (this) {
     GfShellDestination.home => Icons.home_outlined,
@@ -164,6 +182,7 @@ int? publishTopicIdFromUri(Uri uri) {
 
 final GoRouter appRouter = GoRouter(
   initialLocation: '/',
+  redirect: _pendingCacheRedirect,
   routes: <RouteBase>[
     StatefulShellRoute.indexedStack(
       builder:

--- a/apps/mobile/packages/forum_app/lib/src/router.dart
+++ b/apps/mobile/packages/forum_app/lib/src/router.dart
@@ -118,8 +118,11 @@ class _GfShellState extends ConsumerState<GfShell> {
     ref.listen(unauthorizedEventsProvider, (int? previous, int next) {
       if (next > (previous ?? 0) &&
           mounted &&
-          appRouter.state.uri.path != '/login') {
-        context.push('/login');
+          GoRouter.of(context).state.uri.path != '/login') {
+        // 401 即会话边界:用 go 替换导航栈,销毁保留旧账号内存态
+        // (会话/消息列表)的 shell;重新登录后 go('/') 得到全新 shell,
+        // 旧账号数据不会残留在屏幕上。
+        context.go('/login');
       }
     });
 

--- a/apps/mobile/packages/forum_app/lib/src/router.dart
+++ b/apps/mobile/packages/forum_app/lib/src/router.dart
@@ -19,6 +19,7 @@ import 'pages/search/search_page.dart';
 import 'pages/settings/settings_page.dart';
 import 'pages/topic/topic_page.dart';
 import 'providers.dart';
+import 'current_user.dart';
 
 extension on GfShellDestination {
   IconData get icon => switch (this) {
@@ -119,9 +120,10 @@ class _GfShellState extends ConsumerState<GfShell> {
       if (next > (previous ?? 0) &&
           mounted &&
           GoRouter.of(context).state.uri.path != '/login') {
-        // 401 即会话边界:用 go 替换导航栈,销毁保留旧账号内存态
-        // (会话/消息列表)的 shell;重新登录后 go('/') 得到全新 shell,
-        // 旧账号数据不会残留在屏幕上。
+        // 401 即会话边界:使缓存的当前用户身份失效(旧账号 id 不再被
+        // 后续新 shell 读取),用 go 替换导航栈销毁保留旧账号内存态的
+        // shell;重新登录后 go('/') 得到全新 shell。
+        ref.invalidate(currentUserProvider);
         context.go('/login');
       }
     });

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -98,7 +98,7 @@ class RecordingCache implements OfflineTopicCache, OfflineChatCache {
   Future<PagePayload?> get(int topicId) async => null;
 
   @override
-  Future<void> putConversation(ChatItemPayload conv) async {}
+  Future<void> putConversations(List<ChatItemPayload> conversations) async {}
 
   @override
   Future<List<ChatItemPayload>> getConversations() async => const [];

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
@@ -42,6 +43,27 @@ class MemTokenStorage implements TokenStorage {
 
   @override
   Future<void> clear() async => _token = null;
+}
+
+/// clear() 抛异常的 TokenStorage(登录失败路径的 fail-closed 断言)。
+class ThrowingClearTokenStorage implements TokenStorage {
+  String? _token;
+
+  @override
+  Future<String?> read() async => _token;
+
+  @override
+  Future<void> write(String token) async => _token = token;
+
+  @override
+  Future<void> clear() async => throw StateError('secure storage unavailable');
+}
+
+/// 构造携带指定 UserId 的伪 JWT(header.payload.sig,payload 为 base64url JSON)。
+String _jwtForUser(int userId) {
+  String b64url(String json) =>
+      base64UrlEncode(utf8.encode(json)).replaceAll('=', '');
+  return '${b64url('{"alg":"none"}')}.${b64url('{"UserId":$userId}')}.sig';
 }
 
 /// no-op 离线缓存。
@@ -187,6 +209,35 @@ class InstantLoginController extends AuthController {
     String? captchaCode,
   }) async {
     await _storage.write('session-token');
+    await init();
+  }
+}
+
+/// 登录时写入携带指定 UserId 伪 JWT 的 AuthController 替身(不触网)。
+class TokenWritingLoginController extends AuthController {
+  // ignore: use_super_parameters — authRepository 依赖 apiClient,无法用 super 参数。
+  TokenWritingLoginController({
+    required GfApiClient apiClient,
+    required TokenStorage tokenStorage,
+    required this.userId,
+  }) : _storage = tokenStorage,
+       super(
+         authRepository: AuthRepository(apiClient),
+         apiClient: apiClient,
+         tokenStorage: tokenStorage,
+       );
+
+  final TokenStorage _storage;
+  final int userId;
+
+  @override
+  Future<void> login({
+    required String username,
+    required String password,
+    String? captchaId,
+    String? captchaCode,
+  }) async {
+    await _storage.write(_jwtForUser(userId));
     await init();
   }
 }
@@ -2744,6 +2795,193 @@ void main() {
       expect(router.state.uri.path, '/messages');
       expect(find.text('bob'), findsNothing, reason: 'B 看不到 A 的会话');
       expect(find.byType(GfErrorRetry), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
+    testWidgets('TokenStorage.clear() 抛异常时登录仍被阻止(fail-closed)', (tester) async {
+      final topicCache = ThrowingCache();
+      final chatCache = ThrowingCache();
+      final storage = ThrowingClearTokenStorage();
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: storage,
+        baseUrl: 'http://fake.local',
+      );
+      final controller = InstantLoginController(
+        apiClient: client,
+        tokenStorage: storage,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+      final router = GoRouter(
+        initialLocation: '/login',
+        routes: [
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => LoginPage(authController: controller),
+          ),
+          GoRoute(
+            path: '/',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('home-page'))),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).at(0), 'alice');
+      await tester.enterText(find.byType(TextField).at(1), 'secret');
+      await tester.tap(find.widgetWithText(GfButton, '登录账号'));
+      await tester.pumpAndSettle();
+
+      // clear() 抛异常:仍必须 fail-closed,不得带着新令牌进入应用。
+      expect(
+        router.state.uri.path,
+        '/login',
+        reason: 'TokenStorage.clear() 抛异常时不得放行登录',
+      );
+      expect(find.text('清除上一账号离线数据失败,请重试'), findsOneWidget);
+      await tester.tap(find.byTooltip('返回'));
+      await tester.pumpAndSettle();
+      expect(
+        router.state.uri.path,
+        '/login',
+        reason: 'TokenStorage.clear() 抛异常时禁止返回旧 shell',
+      );
+    });
+
+    testWidgets('A profile→401→B 登录:shell profile 使用 B 的 id', (tester) async {
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: MemTokenStorage(),
+        baseUrl: 'http://fake.local',
+      );
+      final pageRepo = CountingPageRepository(client);
+      // A 的令牌携带 UserId=1;currentUserProvider 走真实 JWT 解析(不 override)。
+      final storage = MemTokenStorage()..write(_jwtForUser(1));
+      final controller = TokenWritingLoginController(
+        apiClient: client,
+        tokenStorage: storage,
+        userId: 2, // B 登录写入 UserId=2 的 JWT。
+      );
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          pageRepositoryProvider.overrideWithValue(pageRepo),
+          topicRepositoryProvider.overrideWithValue(
+            PagingTopicRepository(client),
+          ),
+          postRepositoryProvider.overrideWithValue(PostRepository(client)),
+          notificationRepositoryProvider.overrideWithValue(
+            FilteringNotificationRepository(client),
+          ),
+          authRepositoryProvider.overrideWithValue(
+            LogoutAuthRepository(client),
+          ),
+          userRepositoryProvider.overrideWithValue(
+            EmptySessionsUserRepository(client),
+          ),
+          offlineTopicCacheProvider.overrideWithValue(NoopCache()),
+          offlineChatCacheProvider.overrideWithValue(NoopCache()),
+        ],
+      );
+      addTearDown(container.dispose);
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: <RouteBase>[
+          StatefulShellRoute.indexedStack(
+            builder:
+                (
+                  BuildContext context,
+                  GoRouterState state,
+                  StatefulNavigationShell navigationShell,
+                ) {
+                  return GfShell(navigationShell: navigationShell);
+                },
+            branches: <StatefulShellBranch>[
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(path: '/', builder: (_, _) => const HomePage()),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/search',
+                    builder: (_, _) => const SearchPage(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/messages',
+                    builder: (_, _) => const MessagesPage(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/profile',
+                    builder: (_, _) => const ProfilePage(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => LoginPage(authController: controller),
+          ),
+        ],
+      );
+      await tester.pumpWidget(routerApp(container, router));
+      await tester.pumpAndSettle();
+
+      // A 打开 profile:从 A 的令牌解析 id=1,显示 Alice。
+      router.go('/profile');
+      await tester.pumpAndSettle();
+      expect(
+        find.text('Alice'),
+        findsOneWidget,
+        reason: 'A 的 profile 应显示 Alice',
+      );
+
+      // 401 → 登录页(同时使 currentUserProvider 失效)。
+      container.read(unauthorizedEventsProvider.notifier).trigger();
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/login');
+
+      // B 登录:写入 UserId=2 的 JWT。
+      await tester.enterText(find.byType(TextField).at(0), 'bob');
+      await tester.enterText(find.byType(TextField).at(1), 'secret');
+      await tester.tap(find.widgetWithText(GfButton, '登录账号'));
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/', reason: 'B 登录后进入全新 shell');
+
+      // B 打开 profile:必须用 B 的 id(=2)请求,显示 Bob,而非缓存的 A。
+      router.go('/profile');
+      await tester.pumpAndSettle();
+      expect(find.text('Bob'), findsOneWidget, reason: 'B 的 profile 应显示 Bob');
+      expect(find.text('Alice'), findsNothing, reason: '不得残留 A 的 profile');
 
       await tester.pumpWidget(const SizedBox.shrink());
     });

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -2867,6 +2867,71 @@ void main() {
       );
     });
 
+    testWidgets('跨重启门禁:标记存在时启动/导航均被强制留在登录页', (tester) async {
+      // 模拟上次会话缓存清理失败且令牌残留:持久化标记已置位,
+      // 且本次进入登录页的清理仍失败(ThrowingCache),标记保持。
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        pendingCacheClearKey: true,
+      });
+      await initStartupGate();
+      addTearDown(() async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        await initStartupGate();
+      });
+
+      final storage = MemTokenStorage()..write(_jwtForUser(1));
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: storage,
+        baseUrl: 'http://fake.local',
+      );
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          pageRepositoryProvider.overrideWithValue(
+            CountingPageRepository(client),
+          ),
+          topicRepositoryProvider.overrideWithValue(
+            PagingTopicRepository(client),
+          ),
+          postRepositoryProvider.overrideWithValue(PostRepository(client)),
+          notificationRepositoryProvider.overrideWithValue(
+            FilteringNotificationRepository(client),
+          ),
+          authRepositoryProvider.overrideWithValue(
+            LogoutAuthRepository(client),
+          ),
+          userRepositoryProvider.overrideWithValue(
+            EmptySessionsUserRepository(client),
+          ),
+          // 清理失败:跨重启标记不会被登录页清除,门禁保持生效。
+          offlineTopicCacheProvider.overrideWithValue(ThrowingCache()),
+          offlineChatCacheProvider.overrideWithValue(ThrowingCache()),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // 重建 App:初始路径 / 被门禁重定向到登录页,残留令牌与旧缓存
+      // 无法进入 shell。
+      await tester.pumpWidget(routerApp(container, appRouter));
+      await tester.pumpAndSettle();
+      expect(appRouter.state.uri.path, '/login', reason: '门禁标记存在时启动必须落在登录页');
+      expect(find.byType(LoginPage), findsOneWidget);
+      expect(find.byType(HomePage), findsNothing, reason: '不得进入 shell');
+
+      // 即使显式导航到其它路径,仍被强制留在登录页。
+      appRouter.go('/messages');
+      await tester.pumpAndSettle();
+      expect(
+        appRouter.state.uri.path,
+        '/login',
+        reason: '门禁标记存在时任何导航都被重定向到登录页',
+      );
+      expect(find.byType(HomePage), findsNothing);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    });
+
     testWidgets('A profile→401→B 登录:shell profile 使用 B 的 id', (tester) async {
       final client = GfApiClient(
         dio: Dio(),

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -45,18 +45,17 @@ class MemTokenStorage implements TokenStorage {
   Future<void> clear() async => _token = null;
 }
 
-/// clear() 抛异常的 TokenStorage(登录失败路径的 fail-closed 断言)。
-class ThrowingClearTokenStorage implements TokenStorage {
-  String? _token;
+/// write() 抛异常的真实 TokenStorage(安全存储提交失败断言)。
+class ThrowingWriteTokenStorage implements TokenStorage {
+  @override
+  Future<String?> read() async => null;
 
   @override
-  Future<String?> read() async => _token;
+  Future<void> write(String token) async =>
+      throw StateError('secure storage unavailable');
 
   @override
-  Future<void> write(String token) async => _token = token;
-
-  @override
-  Future<void> clear() async => throw StateError('secure storage unavailable');
+  Future<void> clear() async {}
 }
 
 /// 构造携带指定 UserId 的伪 JWT(header.payload.sig,payload 为 base64url JSON)。
@@ -174,6 +173,37 @@ class ThrowingCache implements OfflineTopicCache, OfflineChatCache {
 
   @override
   Future<void> close() async {}
+}
+
+/// clear() 等待测试放行的缓存,用于证明真实 token 只能在清库完成后提交。
+class GatedClearCache extends NoopCache {
+  final clearStarted = Completer<void>();
+  final allowClear = Completer<void>();
+
+  @override
+  Future<void> clear() async {
+    if (!clearStarted.isCompleted) clearStarted.complete();
+    await allowClear.future;
+  }
+}
+
+/// fetch 总是失败(无令牌离线回退门槛断言)。
+class FailingPageRepository extends PageRepository {
+  FailingPageRepository(super.client);
+
+  @override
+  Future<PagePayload> fetch(String path) async =>
+      throw StateError('network down');
+}
+
+/// getConversations 返回预置数据的会话缓存(无令牌回退门槛断言)。
+class SeededConversationCache extends NoopCache {
+  SeededConversationCache(this.conversations);
+
+  final List<ChatItemPayload> conversations;
+
+  @override
+  Future<List<ChatItemPayload>> getConversations() async => conversations;
 }
 
 /// 记录 putConversations 调用次数的会话缓存(在途写回断言)。
@@ -1124,8 +1154,9 @@ void main() {
     OfflineTopicCache? topicCache,
     OfflineChatCache? chatCache,
     int? currentUserId,
+    TokenStorage? tokenStorage,
   }) async {
-    final storage = MemTokenStorage()..write('token');
+    final storage = tokenStorage ?? (MemTokenStorage()..write('token'));
     final client = GfApiClient(
       dio: Dio(),
       tokenStorage: storage,
@@ -2550,19 +2581,20 @@ void main() {
     testWidgets('缓存清理失败时登录被阻止并提示重试', (tester) async {
       final topicCache = ThrowingCache();
       final chatCache = ThrowingCache();
-      final storage = MemTokenStorage();
+      final realStorage = MemTokenStorage();
+      final stagedStorage = MemTokenStorage();
       final client = GfApiClient(
         dio: Dio(),
-        tokenStorage: storage,
+        tokenStorage: stagedStorage,
         baseUrl: 'http://fake.local',
       );
       final controller = InstantLoginController(
         apiClient: client,
-        tokenStorage: storage,
+        tokenStorage: stagedStorage,
       );
       final container = ProviderContainer(
         overrides: [
-          tokenStorageProvider.overrideWithValue(storage),
+          tokenStorageProvider.overrideWithValue(realStorage),
           offlineTopicCacheProvider.overrideWithValue(topicCache),
           offlineChatCacheProvider.overrideWithValue(chatCache),
         ],
@@ -2573,7 +2605,10 @@ void main() {
         routes: [
           GoRoute(
             path: '/login',
-            builder: (_, _) => LoginPage(authController: controller),
+            builder: (_, _) => LoginPage(
+              authController: controller,
+              authTokenStorage: stagedStorage,
+            ),
           ),
           GoRoute(
             path: '/',
@@ -2601,7 +2636,8 @@ void main() {
 
       expect(router.state.uri.path, '/login', reason: '上一账号缓存清理失败时不得放行登录');
       expect(find.text('清除上一账号离线数据失败,请重试'), findsOneWidget);
-      expect(await storage.read(), isNull, reason: '缓存清理失败应丢弃已持久化的新令牌');
+      expect(await realStorage.read(), isNull, reason: '缓存清理失败前新令牌从未进入真实安全存储');
+      expect(await stagedStorage.read(), isNull, reason: '失败后应丢弃内存中的暂存令牌');
       // 返回按钮被拦截,无法回到 401 保留的旧 shell。
       await tester.tap(find.byTooltip('返回'));
       await tester.pumpAndSettle();
@@ -2611,19 +2647,20 @@ void main() {
     testWidgets('缓存清理成功后登录放行并离开登录页', (tester) async {
       final topicCache = RecordingCache();
       final chatCache = RecordingCache();
-      final storage = MemTokenStorage();
+      final realStorage = MemTokenStorage();
+      final stagedStorage = MemTokenStorage();
       final client = GfApiClient(
         dio: Dio(),
-        tokenStorage: storage,
+        tokenStorage: stagedStorage,
         baseUrl: 'http://fake.local',
       );
       final controller = InstantLoginController(
         apiClient: client,
-        tokenStorage: storage,
+        tokenStorage: stagedStorage,
       );
       final container = ProviderContainer(
         overrides: [
-          tokenStorageProvider.overrideWithValue(storage),
+          tokenStorageProvider.overrideWithValue(realStorage),
           offlineTopicCacheProvider.overrideWithValue(topicCache),
           offlineChatCacheProvider.overrideWithValue(chatCache),
         ],
@@ -2634,7 +2671,10 @@ void main() {
         routes: [
           GoRoute(
             path: '/login',
-            builder: (_, _) => LoginPage(authController: controller),
+            builder: (_, _) => LoginPage(
+              authController: controller,
+              authTokenStorage: stagedStorage,
+            ),
           ),
           GoRoute(
             path: '/',
@@ -2661,11 +2701,73 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(router.state.uri.path, '/', reason: '清理成功应放行登录');
+      expect(await realStorage.read(), 'session-token', reason: '清库成功后才提交真实会话');
+      expect(await stagedStorage.read(), isNull, reason: '提交后清除暂存令牌');
       expect(
         topicCache.clears + chatCache.clears,
         2,
         reason: '登录页应清空话题与私信离线缓存',
       );
+    });
+
+    testWidgets('缓存清理完成前新令牌不会进入真实安全存储', (tester) async {
+      final gatedCache = GatedClearCache();
+      final realStorage = MemTokenStorage();
+      final stagedStorage = MemTokenStorage();
+      final authClient = GfApiClient(
+        dio: Dio(),
+        tokenStorage: stagedStorage,
+        baseUrl: 'http://fake.local',
+      );
+      final controller = InstantLoginController(
+        apiClient: authClient,
+        tokenStorage: stagedStorage,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(realStorage),
+          offlineTopicCacheProvider.overrideWithValue(gatedCache),
+          offlineChatCacheProvider.overrideWithValue(NoopCache()),
+        ],
+      );
+      addTearDown(container.dispose);
+      final router = GoRouter(
+        initialLocation: '/login',
+        routes: [
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => LoginPage(
+              authController: controller,
+              authTokenStorage: stagedStorage,
+            ),
+          ),
+          GoRoute(
+            path: '/',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('home-page'))),
+          ),
+        ],
+      );
+      await tester.pumpWidget(routerApp(container, router));
+      await tester.pump();
+      await gatedCache.clearStarted.future;
+
+      await tester.enterText(find.byType(TextField).at(0), 'alice');
+      await tester.enterText(find.byType(TextField).at(1), 'secret');
+      await tester.tap(find.widgetWithText(GfButton, '登录账号'));
+      await tester.pump();
+
+      expect(await realStorage.read(), isNull, reason: '旧缓存仍未清完时不得持久化新会话');
+      expect(router.state.uri.path, '/login');
+      final GfButton submitButton = tester.widget<GfButton>(
+        find.widgetWithText(GfButton, '登录账号'),
+      );
+      expect(submitButton.loading, isTrue, reason: '缓存清理/会话提交期间按钮应禁用,防止重复提交');
+
+      gatedCache.allowClear.complete();
+      await tester.pumpAndSettle();
+      expect(await realStorage.read(), 'session-token');
+      expect(router.state.uri.path, '/');
     });
 
     testWidgets('会话失效后在途的会话列表响应不写回离线缓存', (tester) async {
@@ -2700,21 +2802,27 @@ void main() {
     });
 
     testWidgets('A 加载消息→401→B 登录→B 刷新失败:不可见 A 数据', (tester) async {
+      final realStorage = MemTokenStorage()..write('a-token');
+      final stagedStorage = MemTokenStorage();
       final client = GfApiClient(
         dio: Dio(),
-        tokenStorage: MemTokenStorage(),
+        tokenStorage: realStorage,
         baseUrl: 'http://fake.local',
       );
       final pageRepo = FailAfterFirstMessagesRepository(client);
-      final storage = MemTokenStorage()..write('a-token');
       final controller = InstantLoginController(
-        apiClient: client,
-        tokenStorage: storage,
+        apiClient: GfApiClient(
+          dio: Dio(),
+          tokenStorage: stagedStorage,
+          baseUrl: 'http://fake.local',
+        ),
+        tokenStorage: stagedStorage,
       );
       final container = await makeContainer(
         pageRepo: pageRepo,
         chatCache: RecordingCache(),
         topicCache: RecordingCache(),
+        tokenStorage: realStorage,
       );
       final router = GoRouter(
         initialLocation: '/',
@@ -2762,7 +2870,10 @@ void main() {
           ),
           GoRoute(
             path: '/login',
-            builder: (_, _) => LoginPage(authController: controller),
+            builder: (_, _) => LoginPage(
+              authController: controller,
+              authTokenStorage: stagedStorage,
+            ),
           ),
         ],
       );
@@ -2799,24 +2910,22 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
     });
 
-    testWidgets('TokenStorage.clear() 抛异常时登录仍被阻止(fail-closed)', (tester) async {
-      final topicCache = ThrowingCache();
-      final chatCache = ThrowingCache();
-      final storage = ThrowingClearTokenStorage();
+    testWidgets('真实安全存储写入失败时不进入 shell', (tester) async {
+      final stagedStorage = MemTokenStorage();
       final client = GfApiClient(
         dio: Dio(),
-        tokenStorage: storage,
+        tokenStorage: stagedStorage,
         baseUrl: 'http://fake.local',
       );
       final controller = InstantLoginController(
         apiClient: client,
-        tokenStorage: storage,
+        tokenStorage: stagedStorage,
       );
       final container = ProviderContainer(
         overrides: [
-          tokenStorageProvider.overrideWithValue(storage),
-          offlineTopicCacheProvider.overrideWithValue(topicCache),
-          offlineChatCacheProvider.overrideWithValue(chatCache),
+          tokenStorageProvider.overrideWithValue(ThrowingWriteTokenStorage()),
+          offlineTopicCacheProvider.overrideWithValue(RecordingCache()),
+          offlineChatCacheProvider.overrideWithValue(RecordingCache()),
         ],
       );
       addTearDown(container.dispose);
@@ -2825,7 +2934,10 @@ void main() {
         routes: [
           GoRoute(
             path: '/login',
-            builder: (_, _) => LoginPage(authController: controller),
+            builder: (_, _) => LoginPage(
+              authController: controller,
+              authTokenStorage: stagedStorage,
+            ),
           ),
           GoRoute(
             path: '/',
@@ -2834,100 +2946,111 @@ void main() {
           ),
         ],
       );
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MaterialApp.router(
-            routerConfig: router,
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            locale: const Locale('zh'),
-          ),
-        ),
-      );
+      await tester.pumpWidget(routerApp(container, router));
       await tester.pumpAndSettle();
       await tester.enterText(find.byType(TextField).at(0), 'alice');
       await tester.enterText(find.byType(TextField).at(1), 'secret');
       await tester.tap(find.widgetWithText(GfButton, '登录账号'));
       await tester.pumpAndSettle();
 
-      // clear() 抛异常:仍必须 fail-closed,不得带着新令牌进入应用。
-      expect(
-        router.state.uri.path,
-        '/login',
-        reason: 'TokenStorage.clear() 抛异常时不得放行登录',
-      );
-      expect(find.text('清除上一账号离线数据失败,请重试'), findsOneWidget);
+      expect(router.state.uri.path, '/login');
+      expect(find.text('安全保存新会话失败,请重试'), findsOneWidget);
+      expect(await stagedStorage.read(), isNull, reason: '提交失败后不得保留暂存令牌');
       await tester.tap(find.byTooltip('返回'));
       await tester.pumpAndSettle();
-      expect(
-        router.state.uri.path,
-        '/login',
-        reason: 'TokenStorage.clear() 抛异常时禁止返回旧 shell',
-      );
+      expect(router.state.uri.path, '/login', reason: '提交结果不确定时禁止返回旧 shell');
     });
 
-    testWidgets('跨重启门禁:标记存在时启动/导航均被强制留在登录页', (tester) async {
-      // 模拟上次会话缓存清理失败且令牌残留:持久化标记已置位,
-      // 且本次进入登录页的清理仍失败(ThrowingCache),标记保持。
-      SharedPreferences.setMockInitialValues(<String, Object>{
-        pendingCacheClearKey: true,
-      });
-      await initStartupGate();
-      addTearDown(() async {
-        SharedPreferences.setMockInitialValues(<String, Object>{});
-        await initStartupGate();
-      });
-
-      final storage = MemTokenStorage()..write(_jwtForUser(1));
+    testWidgets('无令牌时离线回退不渲染上一账号残留会话', (tester) async {
       final client = GfApiClient(
         dio: Dio(),
-        tokenStorage: storage,
+        tokenStorage: MemTokenStorage(),
         baseUrl: 'http://fake.local',
       );
-      final container = ProviderContainer(
-        overrides: [
-          tokenStorageProvider.overrideWithValue(storage),
-          pageRepositoryProvider.overrideWithValue(
-            CountingPageRepository(client),
+      final chatCache = SeededConversationCache(<ChatItemPayload>[
+        ChatItemPayload(
+          id: 0,
+          peerId: 99,
+          peerUsername: 'old-peer',
+          peerAvatar: '',
+          lastMsg: '私密消息',
+          lastMsgTime: '',
+          unreadCount: 0,
+          convId: 1,
+          peerUrl: '/u/99',
+        ),
+      ]);
+      // 无令牌:模拟上次 401 清库被进程中断后的重启状态。
+      final container = await makeContainer(
+        pageRepo: FailingPageRepository(client),
+        chatCache: chatCache,
+        tokenStorage: MemTokenStorage(),
+      );
+      await tester.pumpWidget(app(container, const MessagesPage()));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(GfErrorRetry),
+        findsOneWidget,
+        reason: '无令牌时网络失败应显示错误态而非离线缓存',
+      );
+      expect(find.text('old-peer'), findsNothing, reason: '无令牌时不得渲染上一账号残留会话');
+      expect(find.text('私密消息'), findsNothing);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 600));
+    });
+
+    testWidgets('启动无令牌时清空上一账号残留离线缓存', (tester) async {
+      final topicCache = RecordingCache();
+      final chatCache = RecordingCache();
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: MemTokenStorage(),
+        baseUrl: 'http://fake.local',
+      );
+      // 无令牌:模拟 401 后进程被杀、清库未完成的重启状态。
+      final container = await makeContainer(
+        pageRepo: CountingPageRepository(client),
+        topicCache: topicCache,
+        chatCache: chatCache,
+        tokenStorage: MemTokenStorage(),
+      );
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: <RouteBase>[
+          StatefulShellRoute.indexedStack(
+            builder:
+                (
+                  BuildContext context,
+                  GoRouterState state,
+                  StatefulNavigationShell navigationShell,
+                ) {
+                  return GfShell(navigationShell: navigationShell);
+                },
+            branches: <StatefulShellBranch>[
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(path: '/', builder: (_, _) => const HomePage()),
+                ],
+              ),
+            ],
           ),
-          topicRepositoryProvider.overrideWithValue(
-            PagingTopicRepository(client),
+          GoRoute(
+            path: '/login',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('login-page'))),
           ),
-          postRepositoryProvider.overrideWithValue(PostRepository(client)),
-          notificationRepositoryProvider.overrideWithValue(
-            FilteringNotificationRepository(client),
-          ),
-          authRepositoryProvider.overrideWithValue(
-            LogoutAuthRepository(client),
-          ),
-          userRepositoryProvider.overrideWithValue(
-            EmptySessionsUserRepository(client),
-          ),
-          // 清理失败:跨重启标记不会被登录页清除,门禁保持生效。
-          offlineTopicCacheProvider.overrideWithValue(ThrowingCache()),
-          offlineChatCacheProvider.overrideWithValue(ThrowingCache()),
         ],
       );
-      addTearDown(container.dispose);
-
-      // 重建 App:初始路径 / 被门禁重定向到登录页,残留令牌与旧缓存
-      // 无法进入 shell。
-      await tester.pumpWidget(routerApp(container, appRouter));
+      await tester.pumpWidget(routerApp(container, router));
       await tester.pumpAndSettle();
-      expect(appRouter.state.uri.path, '/login', reason: '门禁标记存在时启动必须落在登录页');
-      expect(find.byType(LoginPage), findsOneWidget);
-      expect(find.byType(HomePage), findsNothing, reason: '不得进入 shell');
 
-      // 即使显式导航到其它路径,仍被强制留在登录页。
-      appRouter.go('/messages');
-      await tester.pumpAndSettle();
       expect(
-        appRouter.state.uri.path,
-        '/login',
-        reason: '门禁标记存在时任何导航都被重定向到登录页',
+        topicCache.clears + chatCache.clears,
+        2,
+        reason: '启动无令牌时应清空上一账号残留离线缓存',
       );
-      expect(find.byType(HomePage), findsNothing);
 
       await tester.pumpWidget(const SizedBox.shrink());
     });
@@ -2939,16 +3062,21 @@ void main() {
         baseUrl: 'http://fake.local',
       );
       final pageRepo = CountingPageRepository(client);
+      final realStorage = MemTokenStorage()..write(_jwtForUser(1));
+      final stagedStorage = MemTokenStorage();
       // A 的令牌携带 UserId=1;currentUserProvider 走真实 JWT 解析(不 override)。
-      final storage = MemTokenStorage()..write(_jwtForUser(1));
       final controller = TokenWritingLoginController(
-        apiClient: client,
-        tokenStorage: storage,
-        userId: 2, // B 登录写入 UserId=2 的 JWT。
+        apiClient: GfApiClient(
+          dio: Dio(),
+          tokenStorage: stagedStorage,
+          baseUrl: 'http://fake.local',
+        ),
+        tokenStorage: stagedStorage,
+        userId: 2, // B 登录把 UserId=2 的 JWT 暂存到内存。
       );
       final container = ProviderContainer(
         overrides: [
-          tokenStorageProvider.overrideWithValue(storage),
+          tokenStorageProvider.overrideWithValue(realStorage),
           pageRepositoryProvider.overrideWithValue(pageRepo),
           topicRepositoryProvider.overrideWithValue(
             PagingTopicRepository(client),
@@ -3014,7 +3142,10 @@ void main() {
           ),
           GoRoute(
             path: '/login',
-            builder: (_, _) => LoginPage(authController: controller),
+            builder: (_, _) => LoginPage(
+              authController: controller,
+              authTokenStorage: stagedStorage,
+            ),
           ),
         ],
       );

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -23,7 +23,9 @@ import 'package:forum_app/src/pages/search/search_page.dart';
 import 'package:forum_app/src/pages/settings/settings_page.dart';
 import 'package:forum_app/src/pages/topic/topic_page.dart';
 import 'package:forum_app/src/providers.dart';
+import 'package:forum_app/src/router.dart';
 import 'package:forum_app/src/widgets/topic_list.dart';
+import 'package:forum_app/src/widgets/status_views.dart';
 import 'package:forum_app/src/widgets/skeletons.dart';
 
 import 'fixtures/page_fixtures.dart';
@@ -362,6 +364,23 @@ class CountingMessagesPageRepository extends PageRepository {
     }
     fetchCalls++;
     return parsePayload(messagesPayloadJson());
+  }
+}
+
+/// 首次 /messages 成功,之后失败(模拟 B 登录后刷新失败)。
+class FailAfterFirstMessagesRepository extends CountingPageRepository {
+  FailAfterFirstMessagesRepository(super.client);
+
+  int messagesCalls = 0;
+
+  @override
+  Future<PagePayload> fetch(String path) async {
+    if (path == '/messages') {
+      messagesCalls++;
+      if (messagesCalls > 1) throw StateError('network down');
+      return parsePayload(messagesPayloadJson());
+    }
+    return super.fetch(path);
   }
 }
 
@@ -2492,6 +2511,7 @@ void main() {
       );
       final container = ProviderContainer(
         overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
           offlineTopicCacheProvider.overrideWithValue(topicCache),
           offlineChatCacheProvider.overrideWithValue(chatCache),
         ],
@@ -2530,6 +2550,11 @@ void main() {
 
       expect(router.state.uri.path, '/login', reason: '上一账号缓存清理失败时不得放行登录');
       expect(find.text('清除上一账号离线数据失败,请重试'), findsOneWidget);
+      expect(await storage.read(), isNull, reason: '缓存清理失败应丢弃已持久化的新令牌');
+      // 返回按钮被拦截,无法回到 401 保留的旧 shell。
+      await tester.tap(find.byTooltip('返回'));
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/login', reason: '失败后禁止返回旧 shell');
     });
 
     testWidgets('缓存清理成功后登录放行并离开登录页', (tester) async {
@@ -2547,6 +2572,7 @@ void main() {
       );
       final container = ProviderContainer(
         overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
           offlineTopicCacheProvider.overrideWithValue(topicCache),
           offlineChatCacheProvider.overrideWithValue(chatCache),
         ],
@@ -2620,6 +2646,106 @@ void main() {
       );
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump(const Duration(milliseconds: 600));
+    });
+
+    testWidgets('A 加载消息→401→B 登录→B 刷新失败:不可见 A 数据', (tester) async {
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: MemTokenStorage(),
+        baseUrl: 'http://fake.local',
+      );
+      final pageRepo = FailAfterFirstMessagesRepository(client);
+      final storage = MemTokenStorage()..write('a-token');
+      final controller = InstantLoginController(
+        apiClient: client,
+        tokenStorage: storage,
+      );
+      final container = await makeContainer(
+        pageRepo: pageRepo,
+        chatCache: RecordingCache(),
+        topicCache: RecordingCache(),
+      );
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: <RouteBase>[
+          StatefulShellRoute.indexedStack(
+            builder:
+                (
+                  BuildContext context,
+                  GoRouterState state,
+                  StatefulNavigationShell navigationShell,
+                ) {
+                  return GfShell(navigationShell: navigationShell);
+                },
+            branches: <StatefulShellBranch>[
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(path: '/', builder: (_, _) => const HomePage()),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/search',
+                    builder: (_, _) => const SearchPage(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/messages',
+                    builder: (_, _) => const MessagesPage(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: <RouteBase>[
+                  GoRoute(
+                    path: '/profile',
+                    builder: (_, _) => const ProfilePage(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => LoginPage(authController: controller),
+          ),
+        ],
+      );
+      await tester.pumpWidget(routerApp(container, router));
+      await tester.pumpAndSettle();
+
+      // A 打开消息 tab,看到自己的会话(peerUsername 小写 bob)。
+      router.go('/messages');
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/messages');
+      expect(find.text('bob'), findsOneWidget, reason: 'A 的会话应可见');
+
+      // 401:替换导航栈到登录页,销毁保留 A 内存态的旧 shell。
+      container.read(unauthorizedEventsProvider.notifier).trigger();
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/login');
+      expect(router.canPop(), isFalse, reason: '401 应替换而非压栈登录页');
+      expect(find.text('bob'), findsNothing, reason: '旧 shell 已被销毁');
+
+      // B 登录(缓存清理成功)。
+      await tester.enterText(find.byType(TextField).at(0), 'bob');
+      await tester.enterText(find.byType(TextField).at(1), 'secret');
+      await tester.tap(find.widgetWithText(GfButton, '登录账号'));
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/', reason: 'B 登录后进入全新 shell');
+
+      // B 打开消息 tab:网络失败 → 错误态,无 A 数据。
+      router.go('/messages');
+      await tester.pumpAndSettle();
+      expect(router.state.uri.path, '/messages');
+      expect(find.text('bob'), findsNothing, reason: 'B 看不到 A 的会话');
+      expect(find.byType(GfErrorRetry), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox.shrink());
     });
   });
 }

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:ui_kit/ui_kit.dart';
 
 import 'package:core/core.dart';
+import 'package:auth/auth.dart';
 import 'package:forum_app/l10n/app_localizations.dart';
 import 'package:forum_app/src/current_user.dart';
 import 'package:forum_app/src/offline/drift_cache.dart';
@@ -119,6 +120,73 @@ class RecordingCache implements OfflineTopicCache, OfflineChatCache {
 
   @override
   Future<void> close() async {}
+}
+
+/// clear() 抛错的离线缓存替身(登录门禁失败路径)。
+class ThrowingCache implements OfflineTopicCache, OfflineChatCache {
+  @override
+  Future<void> put(int topicId, Map<String, dynamic> payload) async {}
+
+  @override
+  Future<PagePayload?> get(int topicId) async => null;
+
+  @override
+  Future<void> putConversations(List<ChatItemPayload> conversations) async {}
+
+  @override
+  Future<List<ChatItemPayload>> getConversations() async => const [];
+
+  @override
+  Future<void> putMessages(
+    int convId,
+    List<ChatMessagePayload> messages,
+  ) async {}
+
+  @override
+  Future<List<ChatMessagePayload>> getMessages(int convId) async => const [];
+
+  @override
+  Future<void> clear() async => throw StateError('sqlite locked');
+
+  @override
+  Future<void> close() async {}
+}
+
+/// 记录 putConversations 调用次数的会话缓存(在途写回断言)。
+class RecordingConversationCache extends NoopCache {
+  int putConversationCalls = 0;
+
+  @override
+  Future<void> putConversations(List<ChatItemPayload> conversations) async {
+    putConversationCalls++;
+  }
+}
+
+/// 登录即写入令牌并进入 authenticated 的 AuthController 替身(不触网)。
+class InstantLoginController extends AuthController {
+  // ignore: use_super_parameters — authRepository 依赖 apiClient,无法用 super 参数。
+  InstantLoginController({
+    required GfApiClient apiClient,
+    required TokenStorage tokenStorage,
+  }) : _storage = tokenStorage,
+       super(
+         authRepository: AuthRepository(apiClient),
+         apiClient: apiClient,
+         tokenStorage: tokenStorage,
+       );
+
+  final TokenStorage _storage;
+
+  @override
+  Future<void> login({
+    required String username,
+    required String password,
+    String? captchaId,
+    String? captchaCode,
+  }) async {
+    await _storage.write('session-token');
+    await init();
+  }
 }
 
 class RecordingChatRepository extends ChatRepository {
@@ -1019,9 +1087,7 @@ void main() {
         userRepositoryProvider.overrideWithValue(
           userRepo ?? EmptySessionsUserRepository(client),
         ),
-        offlineTopicCacheProvider.overrideWithValue(
-          topicCache ?? NoopCache(),
-        ),
+        offlineTopicCacheProvider.overrideWithValue(topicCache ?? NoopCache()),
         offlineChatCacheProvider.overrideWithValue(chatCache ?? NoopCache()),
       ],
     );
@@ -2404,6 +2470,156 @@ void main() {
         2,
         reason: '进入登录页应清空话题与私信离线缓存,换账号后不能读到上一账号数据',
       );
+      expect(
+        container.read(offlineCacheEpochProvider),
+        1,
+        reason: '进入登录页应使旧会话在途缓存写入失效',
+      );
+    });
+
+    testWidgets('缓存清理失败时登录被阻止并提示重试', (tester) async {
+      final topicCache = ThrowingCache();
+      final chatCache = ThrowingCache();
+      final storage = MemTokenStorage();
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: storage,
+        baseUrl: 'http://fake.local',
+      );
+      final controller = InstantLoginController(
+        apiClient: client,
+        tokenStorage: storage,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+      final router = GoRouter(
+        initialLocation: '/login',
+        routes: [
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => LoginPage(authController: controller),
+          ),
+          GoRoute(
+            path: '/',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('home-page'))),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).at(0), 'alice');
+      await tester.enterText(find.byType(TextField).at(1), 'secret');
+      await tester.tap(find.widgetWithText(GfButton, '登录账号'));
+      await tester.pumpAndSettle();
+
+      expect(router.state.uri.path, '/login', reason: '上一账号缓存清理失败时不得放行登录');
+      expect(find.text('清除上一账号离线数据失败,请重试'), findsOneWidget);
+    });
+
+    testWidgets('缓存清理成功后登录放行并离开登录页', (tester) async {
+      final topicCache = RecordingCache();
+      final chatCache = RecordingCache();
+      final storage = MemTokenStorage();
+      final client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: storage,
+        baseUrl: 'http://fake.local',
+      );
+      final controller = InstantLoginController(
+        apiClient: client,
+        tokenStorage: storage,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+      final router = GoRouter(
+        initialLocation: '/login',
+        routes: [
+          GoRoute(
+            path: '/login',
+            builder: (_, _) => LoginPage(authController: controller),
+          ),
+          GoRoute(
+            path: '/',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('home-page'))),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).at(0), 'alice');
+      await tester.enterText(find.byType(TextField).at(1), 'secret');
+      await tester.tap(find.widgetWithText(GfButton, '登录账号'));
+      await tester.pumpAndSettle();
+
+      expect(router.state.uri.path, '/', reason: '清理成功应放行登录');
+      expect(
+        topicCache.clears + chatCache.clears,
+        2,
+        reason: '登录页应清空话题与私信离线缓存',
+      );
+    });
+
+    testWidgets('会话失效后在途的会话列表响应不写回离线缓存', (tester) async {
+      final pageRepo = DelayedPageRepository(
+        GfApiClient(
+          dio: Dio(),
+          tokenStorage: MemTokenStorage(),
+          baseUrl: 'http://fake.local',
+        ),
+      );
+      final chatCache = RecordingConversationCache();
+      final container = await makeContainer(
+        pageRepo: pageRepo,
+        chatCache: chatCache,
+      );
+      await tester.pumpWidget(app(container, const MessagesPage()));
+      await tester.pump();
+
+      // 列表请求仍在途时触发 401 会话失效(缓存世代自增)。
+      container.read(offlineCacheEpochProvider.notifier).invalidate();
+      pageRepo.response.complete(parsePayload(messagesPayloadJson()));
+      // 只推进一帧处理响应 continuation,不推进 15s 轮询 timer。
+      await tester.pump();
+
+      expect(
+        chatCache.putConversationCalls,
+        0,
+        reason: '失效后的在途响应不得把上一账号数据写回离线缓存',
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 600));
     });
   });
 }

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -87,6 +87,40 @@ class RecordingChatCache extends NoopCache {
   }
 }
 
+/// 记录 clear 调用次数的离线缓存(登出/登录清缓存断言)。
+class RecordingCache implements OfflineTopicCache, OfflineChatCache {
+  int clears = 0;
+
+  @override
+  Future<void> put(int topicId, Map<String, dynamic> payload) async {}
+
+  @override
+  Future<PagePayload?> get(int topicId) async => null;
+
+  @override
+  Future<void> putConversation(ChatItemPayload conv) async {}
+
+  @override
+  Future<List<ChatItemPayload>> getConversations() async => const [];
+
+  @override
+  Future<void> putMessages(
+    int convId,
+    List<ChatMessagePayload> messages,
+  ) async {}
+
+  @override
+  Future<List<ChatMessagePayload>> getMessages(int convId) async => const [];
+
+  @override
+  Future<void> clear() async {
+    clears++;
+  }
+
+  @override
+  Future<void> close() async {}
+}
+
 class RecordingChatRepository extends ChatRepository {
   RecordingChatRepository(super.client);
 
@@ -949,6 +983,7 @@ void main() {
     LogoutAuthRepository? authRepo,
     ChatRepository? chatRepo,
     UserRepository? userRepo,
+    OfflineTopicCache? topicCache,
     OfflineChatCache? chatCache,
     int? currentUserId,
   }) async {
@@ -984,7 +1019,9 @@ void main() {
         userRepositoryProvider.overrideWithValue(
           userRepo ?? EmptySessionsUserRepository(client),
         ),
-        offlineTopicCacheProvider.overrideWithValue(NoopCache()),
+        offlineTopicCacheProvider.overrideWithValue(
+          topicCache ?? NoopCache(),
+        ),
         offlineChatCacheProvider.overrideWithValue(chatCache ?? NoopCache()),
       ],
     );
@@ -2002,6 +2039,8 @@ void main() {
         tokenStorage: storage,
         baseUrl: 'http://fake.local',
       );
+      final topicCache = RecordingCache();
+      final chatCache = RecordingCache();
       final container = ProviderContainer(
         overrides: [
           tokenStorageProvider.overrideWithValue(storage),
@@ -2013,8 +2052,8 @@ void main() {
             FilteringNotificationRepository(client),
           ),
           authRepositoryProvider.overrideWithValue(authRepo),
-          offlineTopicCacheProvider.overrideWithValue(NoopCache()),
-          offlineChatCacheProvider.overrideWithValue(NoopCache()),
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
         ],
       );
       addTearDown(container.dispose);
@@ -2062,6 +2101,11 @@ void main() {
 
       expect(authRepo.logoutCalls, 1, reason: '登出应调用 authRepository.logout');
       expect(await storage.read(), isNull, reason: '登出应清空本地 token');
+      expect(
+        topicCache.clears + chatCache.clears,
+        2,
+        reason: '登出应清空话题与私信离线缓存,防止跨账号数据泄漏',
+      );
       expect(router.state.uri.path, '/login', reason: '登出后应跳转登录页');
       expect(find.text('login-page'), findsOneWidget);
     });
@@ -2331,6 +2375,35 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.byType(GfProfileSkeleton), findsNothing);
       expect(find.text('Alice'), findsOneWidget);
+    });
+  });
+
+  group('离线缓存清理(登出/换账号数据泄漏)', () {
+    testWidgets('进入登录页即清空上一账号的离线缓存(换账号场景)', (tester) async {
+      final pageRepo = CountingPageRepository(
+        GfApiClient(
+          dio: Dio(),
+          tokenStorage: MemTokenStorage(),
+          baseUrl: 'http://fake.local',
+        ),
+      );
+      final topicCache = RecordingCache();
+      final chatCache = RecordingCache();
+      final container = await makeContainer(
+        pageRepo: pageRepo,
+        topicCache: topicCache,
+        chatCache: chatCache,
+      );
+
+      // 模拟上一账号遗留的缓存:非空缓存应被清空。
+      await tester.pumpWidget(app(container, const LoginPage()));
+      await tester.pumpAndSettle();
+
+      expect(
+        topicCache.clears + chatCache.clears,
+        2,
+        reason: '进入登录页应清空话题与私信离线缓存,换账号后不能读到上一账号数据',
+      );
     });
   });
 }

--- a/apps/mobile/packages/forum_app/test/providers_test.dart
+++ b/apps/mobile/packages/forum_app/test/providers_test.dart
@@ -163,6 +163,55 @@ void main() {
       expect(topicCache.clears, 1);
       expect(chatCache.clears, 1);
     });
+
+    test('会话边界后重建的 client 恢复续期与 401 处理', () async {
+      final storage = _GatedClearTokenStorage();
+      final topicCache = _MemOfflineCache();
+      final chatCache = _MemOfflineCache();
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+      await storage.write('old-token');
+
+      final stale = container.read(apiClientProvider);
+      // 会话边界(进入登录页/登出/401)使旧 client 捕获的世代失效。
+      container.read(offlineCacheEpochProvider.notifier).invalidate();
+      await stale.onTokenRenewed?.call('stale-renewal');
+      stale.onUnauthorized?.call();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        await storage.read(),
+        'old-token',
+        reason: '旧 client 在边界后必须忽略续期与 401',
+      );
+      expect(container.read(unauthorizedEventsProvider), 0);
+
+      // 登录提交成功后重建 provider(生产在 _finishAuthentication 中 invalidate)。
+      container.invalidate(apiClientProvider);
+      final fresh = container.read(apiClientProvider);
+      expect(fresh, isNot(same(stale)), reason: '登录后必须重建主 API client');
+
+      // 新 client 恢复滑动续期:New-Token 写回 tokenStorage。
+      await fresh.onTokenRenewed?.call('fresh-token');
+      expect(await storage.read(), 'fresh-token');
+
+      // 新 client 恢复 401 处理:清除 token/cache 并通知 UI 跳转登录页。
+      fresh.onUnauthorized?.call();
+      await storage.clearStarted.future;
+      storage.allowClear.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(await storage.read(), isNull);
+      expect(container.read(unauthorizedEventsProvider), 1);
+      expect(topicCache.clears, 1);
+      expect(chatCache.clears, 1);
+    });
   });
 }
 

--- a/apps/mobile/packages/forum_app/test/providers_test.dart
+++ b/apps/mobile/packages/forum_app/test/providers_test.dart
@@ -75,6 +75,11 @@ void main() {
 
       expect(await storage.read(), isNull);
       expect(container.read(unauthorizedEventsProvider), 1);
+      expect(
+        container.read(offlineCacheEpochProvider),
+        1,
+        reason: '401 应自增缓存世代,使旧会话在途写入失效',
+      );
       // 401 会话失效应清空离线缓存(防跨账号数据泄漏)。
       await Future<void>.delayed(Duration.zero);
       final topicCache = container.read(offlineTopicCacheProvider);

--- a/apps/mobile/packages/forum_app/test/providers_test.dart
+++ b/apps/mobile/packages/forum_app/test/providers_test.dart
@@ -3,6 +3,7 @@ import 'package:core/core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:forum_app/src/offline/drift_cache.dart';
 import 'package:forum_app/src/providers.dart';
 import 'package:forum_app/src/app_config.dart';
 
@@ -58,7 +59,11 @@ void main() {
 
     test('onUnauthorized 清空 tokenStorage 并触发 unauthorizedEvents', () async {
       final container = ProviderContainer(
-        overrides: [tokenStorageProvider.overrideWithValue(_MemTokenStorage())],
+        overrides: [
+          tokenStorageProvider.overrideWithValue(_MemTokenStorage()),
+          offlineTopicCacheProvider.overrideWithValue(_MemOfflineCache()),
+          offlineChatCacheProvider.overrideWithValue(_MemOfflineCache()),
+        ],
       );
       addTearDown(container.dispose);
       final storage = container.read(tokenStorageProvider);
@@ -70,6 +75,46 @@ void main() {
 
       expect(await storage.read(), isNull);
       expect(container.read(unauthorizedEventsProvider), 1);
+      // 401 会话失效应清空离线缓存(防跨账号数据泄漏)。
+      await Future<void>.delayed(Duration.zero);
+      final topicCache = container.read(offlineTopicCacheProvider);
+      final chatCache = container.read(offlineChatCacheProvider);
+      expect((topicCache as _MemOfflineCache).clears, 1);
+      expect((chatCache as _MemOfflineCache).clears, 1);
     });
   });
+}
+
+/// 内存离线缓存,记录 clear 调用。
+class _MemOfflineCache implements OfflineTopicCache, OfflineChatCache {
+  int clears = 0;
+
+  @override
+  Future<void> put(int topicId, Map<String, dynamic> payload) async {}
+
+  @override
+  Future<PagePayload?> get(int topicId) async => null;
+
+  @override
+  Future<void> putConversation(ChatItemPayload conv) async {}
+
+  @override
+  Future<List<ChatItemPayload>> getConversations() async => const [];
+
+  @override
+  Future<void> putMessages(
+    int convId,
+    List<ChatMessagePayload> messages,
+  ) async {}
+
+  @override
+  Future<List<ChatMessagePayload>> getMessages(int convId) async => const [];
+
+  @override
+  Future<void> clear() async {
+    clears++;
+  }
+
+  @override
+  Future<void> close() async {}
 }

--- a/apps/mobile/packages/forum_app/test/providers_test.dart
+++ b/apps/mobile/packages/forum_app/test/providers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:auth/auth.dart';
 import 'package:core/core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -19,6 +21,18 @@ class _MemTokenStorage implements TokenStorage {
 
   @override
   Future<void> clear() async => _token = null;
+}
+
+class _GatedClearTokenStorage extends _MemTokenStorage {
+  final clearStarted = Completer<void>();
+  final allowClear = Completer<void>();
+
+  @override
+  Future<void> clear() async {
+    if (!clearStarted.isCompleted) clearStarted.complete();
+    await allowClear.future;
+    await super.clear();
+  }
 }
 
 void main() {
@@ -46,6 +60,28 @@ void main() {
       expect(await storage.read(), 'fresh-token');
     });
 
+    test('会话边界后旧 client 的 New-Token 续期被丢弃', () async {
+      final storage = _MemTokenStorage();
+      final container = ProviderContainer(
+        overrides: [tokenStorageProvider.overrideWithValue(storage)],
+      );
+      addTearDown(container.dispose);
+      await storage.write('old-token');
+
+      final client = container.read(apiClientProvider);
+      // 会话边界(进入登录页/登出)使旧 client 捕获的世代失效。
+      container.read(offlineCacheEpochProvider.notifier).invalidate();
+      // 旧会话在途请求此时才带着 New-Token 返回,必须丢弃,否则会覆盖
+      // 新登录写入的令牌。
+      await client.onTokenRenewed?.call('stale-renewal');
+
+      expect(
+        await storage.read(),
+        'old-token',
+        reason: '过期 client 的续期不得覆盖当前会话令牌',
+      );
+    });
+
     test('apiBaseUrl 为空(未注入 dart-define)时回落到平台默认', () {
       final container = ProviderContainer(
         overrides: [tokenStorageProvider.overrideWithValue(_MemTokenStorage())],
@@ -57,35 +93,75 @@ void main() {
       expect(client.baseUrl, GfApiClient.defaultBaseUrl);
     });
 
-    test('onUnauthorized 清空 tokenStorage 并触发 unauthorizedEvents', () async {
+    test('onUnauthorized 完成 token/cache 清理后才触发事件', () async {
+      final storage = _GatedClearTokenStorage();
       final container = ProviderContainer(
         overrides: [
-          tokenStorageProvider.overrideWithValue(_MemTokenStorage()),
+          tokenStorageProvider.overrideWithValue(storage),
           offlineTopicCacheProvider.overrideWithValue(_MemOfflineCache()),
           offlineChatCacheProvider.overrideWithValue(_MemOfflineCache()),
         ],
       );
       addTearDown(container.dispose);
-      final storage = container.read(tokenStorageProvider);
       await storage.write('expired-token');
       expect(container.read(unauthorizedEventsProvider), 0);
 
       final client = container.read(apiClientProvider);
       client.onUnauthorized?.call();
+      await storage.clearStarted.future;
+
+      expect(await storage.read(), 'expired-token');
+      expect(
+        container.read(unauthorizedEventsProvider),
+        0,
+        reason: 'token clear 未完成前不得放行 UI 跳转并开始新登录',
+      );
+      expect(container.read(offlineCacheEpochProvider), 1);
+
+      storage.allowClear.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
 
       expect(await storage.read(), isNull);
       expect(container.read(unauthorizedEventsProvider), 1);
-      expect(
-        container.read(offlineCacheEpochProvider),
-        1,
-        reason: '401 应自增缓存世代,使旧会话在途写入失效',
-      );
-      // 401 会话失效应清空离线缓存(防跨账号数据泄漏)。
-      await Future<void>.delayed(Duration.zero);
       final topicCache = container.read(offlineTopicCacheProvider);
       final chatCache = container.read(offlineChatCacheProvider);
       expect((topicCache as _MemOfflineCache).clears, 1);
       expect((chatCache as _MemOfflineCache).clears, 1);
+    });
+
+    test('重复 401 只清理并通知一次', () async {
+      final storage = _GatedClearTokenStorage();
+      final topicCache = _MemOfflineCache();
+      final chatCache = _MemOfflineCache();
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+      await storage.write('expired-token');
+
+      final client = container.read(apiClientProvider);
+      client.onUnauthorized?.call();
+      await storage.clearStarted.future;
+      storage.allowClear.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(container.read(unauthorizedEventsProvider), 1);
+      expect(topicCache.clears, 1);
+      expect(chatCache.clears, 1);
+
+      // 同一旧 client 的第二个 401:世代已变化,必须被忽略。
+      client.onUnauthorized?.call();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(container.read(unauthorizedEventsProvider), 1);
+      expect(topicCache.clears, 1);
+      expect(chatCache.clears, 1);
     });
   });
 }

--- a/apps/mobile/packages/forum_app/test/providers_test.dart
+++ b/apps/mobile/packages/forum_app/test/providers_test.dart
@@ -96,7 +96,7 @@ class _MemOfflineCache implements OfflineTopicCache, OfflineChatCache {
   Future<PagePayload?> get(int topicId) async => null;
 
   @override
-  Future<void> putConversation(ChatItemPayload conv) async {}
+  Future<void> putConversations(List<ChatItemPayload> conversations) async {}
 
   @override
   Future<List<ChatItemPayload>> getConversations() async => const [];


### PR DESCRIPTION
Fixes #84

## 问题

移动端离线缓存(drift `yourtj_cache`)以明文保存私信消息、会话列表与已浏览话题,但登出、401 会话失效、换账号登录均不清空缓存:

- `_logout()` 只调 `tokenStorage.clear()`,从不调用离线缓存 `clear()`;
- `OfflineTopicCache.clear()` 存在但从未被调用,且 `OfflineChatCache` 接口**没有** `clear()`(私信缓存连清空入口都没有);
- 消息页/话题页在网络失败时回退读取缓存,同一设备换账号后可读到上一账号的私信/浏览记录。

## 修复

- `drift_cache.dart`:`OfflineChatCache` 接口补充 `clear()`(实现已存在)。
- `providers.dart`:新增 `clearOfflineCache` / `clearOfflineCacheQuietly`(失败静默)。
- 三处会话边界统一清空缓存:
  1. **登出** `settings_page.dart`:`_logout()` 清 token 后 `await clearOfflineCacheQuietly(...)`;
  2. **401 会话失效** `providers.dart`:`onUnauthorized` 中 `unawaited` 清理;
  3. **进入登录页(换账号兜底)** `login_page.dart`:`initState` 中 `unawaited` 清理 —— 即使登出路径被绕过,换账号登录前必经登录页,上一账号缓存必被清空。

## 验证

本地 Flutter 3.44.9(与 CI `flutter-version: 3.44.9` 一致):

- `flutter analyze`(forum_app):No issues found
- `flutter test`(forum_app 全量):86/86 通过,含新增回归用例:
  - 登出清空话题+私信缓存(`pages_behavior_test.dart` 设置登出组)
  - 进入登录页清空上一账号缓存(换账号场景,`pages_behavior_test.dart` 离线缓存清理组)
  - 401 会话失效清空缓存(`providers_test.dart`)

分支基于最新 `dev` rebase;`OfflineChatCache.putConversations` 批量接口改名(dev #73 引入)已适配。

## 说明

验收标准前两条(登出后无残留、换账号不可读)已满足;payload 加密存储属更大设计决策,建议单独立项。