### PR TITLE
fix(topic): keep comment popup visible for guests

### DIFF
--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -403,6 +403,7 @@ export default {
     publishReply: 'Post reply',
     loginToReply: 'Log in to reply to this topic.',
     loginRequiredToComment: 'Only logged-in users can comment',
+    loginRequiredToCommentHint: 'Log in to join the discussion and interact with other members.',
     loginToComment: 'Log in',
     fullEditor: 'Full editor',
     overview: 'Topic overview',

--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -401,7 +401,6 @@ export default {
     resizeComposer: 'Resize reply panel',
     markdownSoon: 'Markdown support is coming later',
     publishReply: 'Post reply',
-    loginToReply: 'Log in to reply to this topic.',
     loginRequiredToComment: 'Only logged-in users can comment',
     loginRequiredToCommentHint: 'Log in to join the discussion and interact with other members.',
     loginToComment: 'Log in',

--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -402,6 +402,8 @@ export default {
     markdownSoon: 'Markdown support is coming later',
     publishReply: 'Post reply',
     loginToReply: 'Log in to reply to this topic.',
+    loginRequiredToComment: 'Only logged-in users can comment',
+    loginToComment: 'Log in',
     fullEditor: 'Full editor',
     overview: 'Topic overview',
     createdAt: 'Created',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -402,6 +402,8 @@ export default {
     markdownSoon: 'Il supporto Markdown arriverà più avanti',
     publishReply: 'Pubblica risposta',
     loginToReply: 'Accedi per rispondere a questo argomento.',
+    loginRequiredToComment: 'Solo gli utenti autenticati possono commentare',
+    loginToComment: 'Accedi',
     fullEditor: 'Editor completo',
     overview: 'Panoramica argomento',
     createdAt: 'Creato',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -403,6 +403,7 @@ export default {
     publishReply: 'Pubblica risposta',
     loginToReply: 'Accedi per rispondere a questo argomento.',
     loginRequiredToComment: 'Solo gli utenti autenticati possono commentare',
+    loginRequiredToCommentHint: 'Accedi per partecipare alla discussione e interagire con gli altri membri.',
     loginToComment: 'Accedi',
     fullEditor: 'Editor completo',
     overview: 'Panoramica argomento',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -401,7 +401,6 @@ export default {
     resizeComposer: 'Regola l’altezza del pannello',
     markdownSoon: 'Il supporto Markdown arriverà più avanti',
     publishReply: 'Pubblica risposta',
-    loginToReply: 'Accedi per rispondere a questo argomento.',
     loginRequiredToComment: 'Solo gli utenti autenticati possono commentare',
     loginRequiredToCommentHint: 'Accedi per partecipare alla discussione e interagire con gli altri membri.',
     loginToComment: 'Accedi',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -402,6 +402,8 @@ export default {
     markdownSoon: 'Markdown 対応は後日追加予定です',
     publishReply: '返信を投稿',
     loginToReply: 'ログインするとこのトピックに返信できます。',
+    loginRequiredToComment: 'ログインユーザーのみコメントできます',
+    loginToComment: 'ログイン',
     fullEditor: 'フルエディター',
     overview: 'トピック概要',
     createdAt: '作成',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -401,7 +401,6 @@ export default {
     resizeComposer: '返信パネルの高さを調整',
     markdownSoon: 'Markdown 対応は後日追加予定です',
     publishReply: '返信を投稿',
-    loginToReply: 'ログインするとこのトピックに返信できます。',
     loginRequiredToComment: 'ログインユーザーのみコメントできます',
     loginRequiredToCommentHint: 'ログインするとディスカッションに参加し、他のユーザーと交流できます。',
     loginToComment: 'ログイン',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -403,6 +403,7 @@ export default {
     publishReply: '返信を投稿',
     loginToReply: 'ログインするとこのトピックに返信できます。',
     loginRequiredToComment: 'ログインユーザーのみコメントできます',
+    loginRequiredToCommentHint: 'ログインするとディスカッションに参加し、他のユーザーと交流できます。',
     loginToComment: 'ログイン',
     fullEditor: 'フルエディター',
     overview: 'トピック概要',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -401,7 +401,6 @@ export default {
     resizeComposer: '调整回复面板高度',
     markdownSoon: 'Markdown 支持稍后补齐',
     publishReply: '发布回复',
-    loginToReply: '登录后可以回复这个话题。',
     loginRequiredToComment: '仅登录用户可评论',
     loginRequiredToCommentHint: '登录后即可参与讨论，与其他用户交流。',
     loginToComment: '去登录',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -402,6 +402,8 @@ export default {
     markdownSoon: 'Markdown 支持稍后补齐',
     publishReply: '发布回复',
     loginToReply: '登录后可以回复这个话题。',
+    loginRequiredToComment: '仅登录用户可评论',
+    loginToComment: '去登录',
     fullEditor: '完整编辑',
     overview: '话题概览',
     createdAt: '创建于',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -403,6 +403,7 @@ export default {
     publishReply: '发布回复',
     loginToReply: '登录后可以回复这个话题。',
     loginRequiredToComment: '仅登录用户可评论',
+    loginRequiredToCommentHint: '登录后即可参与讨论，与其他用户交流。',
     loginToComment: '去登录',
     fullEditor: '完整编辑',
     overview: '话题概览',

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -221,7 +221,6 @@ function submit() {
           <div
             v-if="open"
             role="dialog"
-            aria-modal="true"
             aria-labelledby="post-composer-title"
             class="gf-floating-surface pointer-events-auto relative flex max-h-[calc(100dvh-1rem)] w-[min(42rem,calc(100vw-1.5rem))] flex-col overflow-hidden p-3"
             :style="{
@@ -320,7 +319,6 @@ function submit() {
             </template>
             <div
               v-else
-              role="status"
               class="flex min-h-40 flex-1 flex-col items-center justify-center gap-5 px-6 py-8 text-center"
               :class="{ 'guest-lock-settled': lockSettled }"
             >

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue'
-import { Check, Loader2, Lock, Send, X } from '@lucide/vue'
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import { Check, Loader2, LockKeyhole, LockKeyholeOpen, Send, X } from '@lucide/vue'
 import { uploadImage } from '@/runtime/api'
 import { processImageFile, validateImageFile } from '@/runtime/image'
 import VditorOfficial from '@/site/components/VditorOfficial.vue'
@@ -106,19 +106,46 @@ const submitText = computed(() => {
   return editing.value ? t('common.save') : t('topic.publishReply')
 })
 
+// 访客登录门的登录链接引用：打开面板时把键盘焦点移过去（访客态没有编辑器可聚焦）
+const loginLinkRef = ref<HTMLAnchorElement | null>(null)
+// 访客门进场叙事：先呈现"开锁"，短暂停留后切换为"闭锁"——登录后才能解锁评论
+const lockSettled = ref(false)
+let lockSettleTimer: ReturnType<typeof setTimeout> | undefined
+
 watch(
   () => props.open,
   async (open) => {
     if (!open) return
     // 面板关闭会卸载内层 Vditor；再次打开时清失败态，重新走 loading → ready/error
     editorInitFailed.value = false
+    if (!props.authenticated) {
+      lockSettled.value = false
+      clearTimeout(lockSettleTimer)
+      lockSettleTimer = setTimeout(() => {
+        lockSettled.value = true
+      }, 650)
+    }
     await nextTick()
     window.requestAnimationFrame(() => {
-      if (!editorInitFailed.value) editor.value?.focus()
+      if (props.authenticated) {
+        if (!editorInitFailed.value) editor.value?.focus()
+      } else {
+        loginLinkRef.value?.focus()
+      }
     })
   },
   { immediate: true },
 )
+
+onBeforeUnmount(() => {
+  clearTimeout(lockSettleTimer)
+})
+
+// 登录后回跳当前话题页，与 TopicPage.openLogin() 的 next 约定一致（服务端白名单校验 / 前缀，拒绝 // 与 \）
+const loginHref = computed(() => {
+  const currentPath = typeof window === 'undefined' ? '' : window.location.pathname + window.location.search
+  return currentPath ? `/login?next=${encodeURIComponent(currentPath)}` : '/login'
+})
 
 function closeComposer() {
   if (composerBusy.value) return
@@ -218,7 +245,7 @@ function submit() {
               <div class="min-w-0">
                 <div class="text-sm font-semibold text-base-content">{{ composerTitle }}</div>
               </div>
-              <button type="button" class="rounded-md p-1 text-base-content/55 transition hover:bg-base-300 hover:text-base-content/75 disabled:cursor-not-allowed disabled:opacity-60" :disabled="composerBusy" @click="closeComposer">
+              <button type="button" class="rounded-md p-1 text-base-content/55 transition hover:bg-base-300 hover:text-base-content/75 disabled:cursor-not-allowed disabled:opacity-60" :disabled="composerBusy" :aria-label="t('common.close')" @click="closeComposer">
                 <X class="h-4 w-4" />
               </button>
             </div>
@@ -288,10 +315,25 @@ function submit() {
               </button>
             </div>
             </template>
-            <div v-else class="grid min-h-40 flex-1 place-items-center px-6 py-10 text-center">
-              <Lock class="h-8 w-8 text-base-content/35" />
-              <p class="mt-3 text-sm font-semibold text-base-content/70">{{ t('topic.loginRequiredToComment') }}</p>
-              <a href="/login" class="gf-button gf-button-md gf-button-primary mt-4">{{ t('topic.loginToComment') }}</a>
+            <div
+              v-else
+              class="flex min-h-40 flex-1 flex-col items-center justify-center gap-5 px-6 py-8 text-center"
+              :class="{ 'guest-lock-settled': lockSettled }"
+            >
+              <!-- 开锁 → 闭锁 进场叙事：访客看到"需要登录才能解锁评论" -->
+              <div class="relative h-14 w-14 shrink-0 overflow-hidden rounded-full bg-info/10 text-primary">
+                <LockKeyholeOpen aria-hidden="true" class="guest-lock-icon guest-lock-open absolute inset-0 m-auto h-7 w-7" />
+                <LockKeyhole aria-hidden="true" class="guest-lock-icon guest-lock-closed absolute inset-0 m-auto h-7 w-7" />
+              </div>
+              <div class="space-y-1.5">
+                <p class="text-sm font-semibold text-base-content">{{ t('topic.loginRequiredToComment') }}</p>
+                <p class="text-xs text-base-content/55">{{ t('topic.loginRequiredToCommentHint') }}</p>
+              </div>
+              <a
+                ref="loginLinkRef"
+                :href="loginHref"
+                class="gf-button gf-button-md gf-button-primary"
+              >{{ t('topic.loginToComment') }}</a>
             </div>
           </div>
         </Transition>
@@ -332,5 +374,58 @@ function submit() {
 
 .composer-resize-handle.is-active {
   background: color-mix(in oklch, var(--gf-color-primary) 6%, transparent);
+}
+
+/*
+ * 访客登录门：开锁 → 闭锁 进场叙事（design-taste：trust-first 语言，VARIANCE 4 / MOTION 5）。
+ * 面板打开先呈现"开锁"，650ms 后 cross-fade 到"闭锁"，隐喻"登录后才能解锁评论"。
+ * 遵循 better-ui：opacity / scale / blur 驱动（0.25→1、0→1、4px→0），一次性、之后静止；
+ * prefers-reduced-motion 下直接显示闭锁态。
+ */
+.guest-lock-icon {
+  transition:
+    opacity 0.45s cubic-bezier(0.2, 0, 0, 1),
+    transform 0.45s cubic-bezier(0.2, 0, 0, 1),
+    filter 0.45s cubic-bezier(0.2, 0, 0, 1);
+}
+
+.guest-lock-open {
+  opacity: 1;
+  transform: scale(1);
+  filter: blur(0);
+}
+
+.guest-lock-closed {
+  opacity: 0;
+  transform: scale(0.25);
+  filter: blur(4px);
+}
+
+.guest-lock-settled .guest-lock-open {
+  opacity: 0;
+  transform: scale(0.25);
+  filter: blur(4px);
+}
+
+.guest-lock-settled .guest-lock-closed {
+  opacity: 1;
+  transform: scale(1);
+  filter: blur(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .guest-lock-icon {
+    transition: none;
+  }
+
+  .guest-lock-open {
+    opacity: 0;
+    transform: scale(1);
+    filter: none;
+  }
+
+  .guest-lock-closed {
+    opacity: 1;
+  }
 }
 </style>

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -141,10 +141,10 @@ onBeforeUnmount(() => {
   clearTimeout(lockSettleTimer)
 })
 
-// 登录后回跳当前话题页，与 TopicPage.openLogin() 的 next 约定一致（服务端白名单校验 / 前缀，拒绝 // 与 \）
+// 登录后回跳当前话题页；服务端只读取 ?redirect=，并用站内相对路径白名单校验。
 const loginHref = computed(() => {
-  const currentPath = typeof window === 'undefined' ? '' : window.location.pathname + window.location.search
-  return currentPath ? `/login?next=${encodeURIComponent(currentPath)}` : '/login'
+  const currentPath = typeof window === 'undefined' ? '' : window.location.pathname + window.location.search + window.location.hash
+  return currentPath ? `/login?redirect=${encodeURIComponent(currentPath)}` : '/login'
 })
 
 function closeComposer() {
@@ -220,6 +220,9 @@ function submit() {
         <Transition name="composer-rise" appear>
           <div
             v-if="open"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="post-composer-title"
             class="gf-floating-surface pointer-events-auto relative flex max-h-[calc(100dvh-1rem)] w-[min(42rem,calc(100vw-1.5rem))] flex-col overflow-hidden p-3"
             :style="{
               height: isMobileComposer() ? undefined : `${composerHeight}px`,
@@ -243,7 +246,7 @@ function submit() {
 
             <div class="mb-2 flex items-center justify-between gap-3">
               <div class="min-w-0">
-                <div class="text-sm font-semibold text-base-content">{{ composerTitle }}</div>
+                <div id="post-composer-title" class="text-sm font-semibold text-base-content">{{ composerTitle }}</div>
               </div>
               <button type="button" class="rounded-md p-1 text-base-content/55 transition hover:bg-base-300 hover:text-base-content/75 disabled:cursor-not-allowed disabled:opacity-60" :disabled="composerBusy" :aria-label="t('common.close')" @click="closeComposer">
                 <X class="h-4 w-4" />
@@ -317,6 +320,7 @@ function submit() {
             </template>
             <div
               v-else
+              role="status"
               class="flex min-h-40 flex-1 flex-col items-center justify-center gap-5 px-6 py-8 text-center"
               :class="{ 'guest-lock-settled': lockSettled }"
             >

--- a/apps/gooseforum/resource/src/site/components/PostComposer.vue
+++ b/apps/gooseforum/resource/src/site/components/PostComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
-import { Check, Loader2, Send, X } from '@lucide/vue'
+import { Check, Loader2, Lock, Send, X } from '@lucide/vue'
 import { uploadImage } from '@/runtime/api'
 import { processImageFile, validateImageFile } from '@/runtime/image'
 import VditorOfficial from '@/site/components/VditorOfficial.vue'
@@ -192,7 +192,7 @@ function submit() {
         <!-- appear：覆盖首次打开时组件刚挂载、Transition 与其子元素同帧出现的场景 -->
         <Transition name="composer-rise" appear>
           <div
-            v-if="open && authenticated"
+            v-if="open"
             class="gf-floating-surface pointer-events-auto relative flex max-h-[calc(100dvh-1rem)] w-[min(42rem,calc(100vw-1.5rem))] flex-col overflow-hidden p-3"
             :style="{
               height: isMobileComposer() ? undefined : `${composerHeight}px`,
@@ -222,6 +222,7 @@ function submit() {
                 <X class="h-4 w-4" />
               </button>
             </div>
+            <template v-if="authenticated">
             <div v-if="target && !editing" class="mb-2 flex min-w-0 items-center justify-between gap-3 rounded-md border border-primary/20 bg-info/10 px-3 py-2">
               <div class="min-w-0 text-sm font-medium text-base-content/75">
                 {{ t('topic.replyTo', { user: `@${target.author.username}` }) }}
@@ -285,6 +286,12 @@ function submit() {
                 <Send v-else class="h-4 w-4" />
                 {{ submitText }}
               </button>
+            </div>
+            </template>
+            <div v-else class="grid min-h-40 flex-1 place-items-center px-6 py-10 text-center">
+              <Lock class="h-8 w-8 text-base-content/35" />
+              <p class="mt-3 text-sm font-semibold text-base-content/70">{{ t('topic.loginRequiredToComment') }}</p>
+              <a href="/login" class="gf-button gf-button-md gf-button-primary mt-4">{{ t('topic.loginToComment') }}</a>
             </div>
           </div>
         </Transition>

--- a/apps/gooseforum/resource/src/site/components/TopicFloatingControls.vue
+++ b/apps/gooseforum/resource/src/site/components/TopicFloatingControls.vue
@@ -44,7 +44,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const showFloatingControls = computed(() => props.hasRail || props.authenticated)
+const showFloatingControls = computed(() => true)
 
 function toggleMobileRail() {
   emit('update:mobileRailOpen', !props.mobileRailOpen)
@@ -124,7 +124,7 @@ function closeMobileRail() {
                 </button>
               </template>
               <button
-                v-if="authenticated && canPost"
+                v-if="authenticated ? canPost : true"
                 type="button"
                 class="inline-flex h-9 items-center gap-1.5 rounded-full px-3 text-sm font-semibold text-base-content/75 transition hover:bg-info/10 hover:text-primary"
                 :title="t('topic.joinDiscussion')"

--- a/apps/gooseforum/resource/src/site/components/TopicFloatingControls.vue
+++ b/apps/gooseforum/resource/src/site/components/TopicFloatingControls.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import type { Component } from 'vue'
 import { Loader2, MessageSquare, X } from '@lucide/vue'
 import { formatNumber } from '@/runtime/format'
@@ -44,8 +43,6 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
-const showFloatingControls = computed(() => true)
-
 function toggleMobileRail() {
   emit('update:mobileRailOpen', !props.mobileRailOpen)
 }
@@ -56,7 +53,7 @@ function closeMobileRail() {
 </script>
 
 <template>
-  <Teleport v-if="showFloatingControls" to="body">
+  <Teleport to="body">
     <div
       v-if="mobileRailOpen"
       class="pointer-events-auto fixed inset-0 z-[89] xl:hidden"
@@ -124,7 +121,7 @@ function closeMobileRail() {
                 </button>
               </template>
               <button
-                v-if="authenticated ? canPost : true"
+                v-if="!authenticated || canPost"
                 type="button"
                 class="inline-flex h-9 items-center gap-1.5 rounded-full px-3 text-sm font-semibold text-base-content/75 transition hover:bg-info/10 hover:text-primary"
                 :title="t('topic.joinDiscussion')"

--- a/apps/gooseforum/resource/src/site/pages/TopicPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/TopicPage.vue
@@ -1412,7 +1412,7 @@ async function updateTopicModerationFromDetail() {
 }
 
 function openLogin() {
-  window.location.href = `/login?next=${encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}`
+  window.location.href = `/login?redirect=${encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}`
 }
 
 function requestReport(target: { targetType: 'topic' | 'post'; targetId: number; title: string; excerpt: string }) {
@@ -1675,7 +1675,7 @@ async function removePost(postId: number) {
                       <span class="sr-only">{{ deletingPostId === group.root.id ? t('topic.deleting') : t('topic.delete') }}</span>
                     </button>
                     <button
-                      v-if="(page.props.permissions.canPost || !page.layout.viewer.isAuthenticated) && !group.root.isHidden"
+                      v-if="(!page.layout.viewer.isAuthenticated || page.props.permissions.canPost) && !group.root.isHidden"
                       type="button"
                       class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-icon-muted transition hover:bg-info/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 sm:h-8 sm:w-8"
                       :title="t('topic.reply')"
@@ -1866,7 +1866,7 @@ async function removePost(postId: number) {
                     </div>
                     <div class="mt-2 flex items-center gap-1">
                       <button
-                        v-if="(page.props.permissions.canPost || !page.layout.viewer.isAuthenticated) && !reply.isHidden"
+                        v-if="(!page.layout.viewer.isAuthenticated || page.props.permissions.canPost) && !reply.isHidden"
                         type="button"
                         class="inline-flex h-7 items-center gap-1 rounded px-1.5 text-xs font-semibold text-base-content/55 transition hover:bg-info/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                         :title="t('topic.reply')"

--- a/apps/gooseforum/resource/src/site/pages/TopicPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/TopicPage.vue
@@ -1675,7 +1675,7 @@ async function removePost(postId: number) {
                       <span class="sr-only">{{ deletingPostId === group.root.id ? t('topic.deleting') : t('topic.delete') }}</span>
                     </button>
                     <button
-                      v-if="page.props.permissions.canPost && !group.root.isHidden"
+                      v-if="(page.props.permissions.canPost || !page.layout.viewer.isAuthenticated) && !group.root.isHidden"
                       type="button"
                       class="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-icon-muted transition hover:bg-info/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 sm:h-8 sm:w-8"
                       :title="t('topic.reply')"
@@ -1866,7 +1866,7 @@ async function removePost(postId: number) {
                     </div>
                     <div class="mt-2 flex items-center gap-1">
                       <button
-                        v-if="page.props.permissions.canPost && !reply.isHidden"
+                        v-if="(page.props.permissions.canPost || !page.layout.viewer.isAuthenticated) && !reply.isHidden"
                         type="button"
                         class="inline-flex h-7 items-center gap-1 rounded px-1.5 text-xs font-semibold text-base-content/55 transition hover:bg-info/10 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                         :title="t('topic.reply')"


### PR DESCRIPTION
## 问题

未登录用户进入帖子详情后找不到评论区/回复入口，点击回复时浮层被直接隐藏。

## 修复

- 未登录用户也能打开回复浮层。
- 浮层保留标题和关闭按钮，编辑器区域替换为锁图标 + “仅登录用户可评论” + 去登录按钮。
- 帖子内和底部悬浮的回复入口对未登录用户可见。
- 补充 zh/en/ja/it 文案。

## 验证

- `pnpm typecheck`：通过
- `pnpm build`：通过
- `vitest`：84/84 通过

Closes #97