### PR TITLE
feat: GitHub Project 看板自动化工作流（issue/PR → RPD 看板同步）

### DIFF
--- a/.github/scripts/sync-project-board.sh
+++ b/.github/scripts/sync-project-board.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# sync-project-board.sh — 把当前 issue / PR 幂等同步到 GitHub Projects v2 看板（RPD 状态机）。
+#
+# 事件上下文由调用方（workflow 或手动执行）通过环境变量传入，脚本不解析任何
+# GitHub 特殊语法，因此可以在本地用 mock 的 gh 命令完整测试。
+#
+# 环境变量（均可由调用方覆盖）：
+#   GH_TOKEN          必填。具备 read:project / write:project 权限的 token（PAT 或 GitHub App 签发）。
+#   PROJECT_OWNER     项目属主，默认 YourTongji。
+#   PROJECT_NUMBER    必填。看板项目号（看板 URL 末尾的数字）。
+#   ITEM_URL          可选。要同步的 issue / PR URL；为空时由 ITEM_KIND + ITEM_NUMBER 拼装。
+#   ITEM_NUMBER       可选。配合 ITEM_URL 缺失时使用（workflow_dispatch 手动同步）。
+#   ITEM_KIND         issue | pr，默认 issue。
+#   EVENT             opened | reopened | labeled | closed | ready_for_review | manual，默认 opened。
+#   LABELS            逗号分隔的标签列表。
+#   STATUS_FIELD      状态字段名，默认 Status。
+#   TODO_VALUE        需求列，默认 Todo。
+#   PLANNED_VALUE     计划列，默认 Planned。
+#   IN_PROGRESS_VALUE 开发列，默认 In Progress。
+#   DONE_VALUE        已完成列，默认 Done。
+#   PLANNED_LABELS    命中即视为"计划中"的标签，默认 planning,planned,ready。
+#   GITHUB_REPOSITORY Actions 自动注入的 owner/repo，用于拼装 URL。
+
+set -euo pipefail
+
+PROJECT_OWNER="${PROJECT_OWNER:-YourTongji}"
+PROJECT_NUMBER="${PROJECT_NUMBER:-}"
+ITEM_URL="${ITEM_URL:-}"
+ITEM_NUMBER="${ITEM_NUMBER:-}"
+ITEM_KIND="${ITEM_KIND:-issue}"
+EVENT="${EVENT:-opened}"
+LABELS="${LABELS:-}"
+STATUS_FIELD="${STATUS_FIELD:-Status}"
+TODO_VALUE="${TODO_VALUE:-Todo}"
+PLANNED_VALUE="${PLANNED_VALUE:-Planned}"
+IN_PROGRESS_VALUE="${IN_PROGRESS_VALUE:-In Progress}"
+DONE_VALUE="${DONE_VALUE:-Done}"
+PLANNED_LABELS="${PLANNED_LABELS:-planning,planned,ready}"
+
+log()  { printf '[sync-project-board] %s\n' "$*"; }
+fail() { printf '::error:: %s\n' "$*" >&2; exit 1; }
+warn() { printf '::warning:: %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# 0) 必填校验
+# ---------------------------------------------------------------------------
+[ -n "${GH_TOKEN:-}" ] || fail "GH_TOKEN 未设置：请先在仓库配置具备项目读写权限的 secret（见 docs/development/project-board.md）"
+[ -n "$PROJECT_NUMBER" ] || fail "PROJECT_NUMBER 未设置：请在仓库变量或 workflow env 中配置看板项目号"
+
+if [ -z "$ITEM_URL" ]; then
+  [ -n "$ITEM_NUMBER" ] || fail "ITEM_URL 与 ITEM_NUMBER 均未设置：无法定位要同步的 issue/PR"
+  kind_path="issues"
+  [ "$ITEM_KIND" = "pr" ] && kind_path="pull"
+  ITEM_URL="https://github.com/${GITHUB_REPOSITORY:-$PROJECT_OWNER/repo}/${kind_path}/${ITEM_NUMBER}"
+fi
+log "目标条目: $ITEM_URL (kind=$ITEM_KIND, event=$EVENT)"
+
+# ---------------------------------------------------------------------------
+# 1) 定位项目
+# ---------------------------------------------------------------------------
+project_json="$(gh project view "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json 2>/dev/null)" \
+  || fail "无法访问项目 $PROJECT_OWNER/projects/$PROJECT_NUMBER：请确认 GH_TOKEN 具备 read:project 权限、项目号正确"
+PROJECT_ID="$(jq -r '.id' <<<"$project_json")"
+[ -n "$PROJECT_ID" ] && [ "$PROJECT_ID" != "null" ] || fail "项目解析失败（$PROJECT_OWNER/projects/$PROJECT_NUMBER）"
+log "已定位项目 $PROJECT_OWNER/projects/$PROJECT_NUMBER ($PROJECT_ID)"
+
+# ---------------------------------------------------------------------------
+# 2) 幂等添加：已存在则复用 item id，否则添加
+# ---------------------------------------------------------------------------
+existing_item="$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --limit 100 --format json \
+  | jq -r --arg url "$ITEM_URL" '.items[] | select(.url == $url) | .id' | head -n1)"
+
+if [ -n "$existing_item" ]; then
+  ITEM_ID="$existing_item"
+  log "条目已在项目中，复用 item $ITEM_ID"
+else
+  ITEM_ID="$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ITEM_URL" --format json --jq '.id')"
+  log "已添加条目 → item $ITEM_ID"
+fi
+
+# ---------------------------------------------------------------------------
+# 3) 状态字段发现（仅单选项字段有意义）
+# ---------------------------------------------------------------------------
+field="$(gh project field-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json \
+  | jq -c --arg name "$STATUS_FIELD" '.fields[] | select(.name == $name)' 2>/dev/null || true)"
+
+if [ -z "$field" ]; then
+  warn "未找到状态字段 \"$STATUS_FIELD\"，仅完成添加、未设置状态（可用 STATUS_FIELD 变量覆盖）"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4) RPD 状态机：目标列计算
+# ---------------------------------------------------------------------------
+target_value="$TODO_VALUE"
+if [ "$EVENT" = "closed" ]; then
+  target_value="$DONE_VALUE"
+elif [ "$ITEM_KIND" = "pr" ] && [[ "$EVENT" =~ ^(opened|reopened|ready_for_review|labeled|manual)$ ]]; then
+  target_value="$IN_PROGRESS_VALUE"
+elif [ "$ITEM_KIND" = "issue" ]; then
+  for label in ${LABELS//,/ }; do
+    if [[ ",$PLANNED_LABELS," == *",$label,"* ]]; then
+      target_value="$PLANNED_VALUE"
+      break
+    fi
+  done
+fi
+
+option_id="$(jq -r --arg v "$target_value" '(.options // [])[] | select(.name == $v) | .id' <<<"$field" | head -n1)"
+if [ -z "$option_id" ]; then
+  warn "字段 \"$STATUS_FIELD\" 缺少选项 \"$target_value\"，跳过状态设置（可用 TODO_VALUE/PLANNED_VALUE/IN_PROGRESS_VALUE/DONE_VALUE 变量调整）"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 5) 设置状态字段
+# ---------------------------------------------------------------------------
+field_id="$(jq -r '.id' <<<"$field")"
+gh project item-edit --id "$ITEM_ID" --project-id "$PROJECT_ID" \
+  --field-id "$field_id" --single-select-option-id "$option_id" >/dev/null
+log "已设置状态 → \"$target_value\""

--- a/.github/scripts/sync-project-board.sh
+++ b/.github/scripts/sync-project-board.sh
@@ -38,6 +38,9 @@ IN_PROGRESS_VALUE="${IN_PROGRESS_VALUE:-In Progress}"
 DONE_VALUE="${DONE_VALUE:-Done}"
 PLANNED_LABELS="${PLANNED_LABELS:-planning,planned,ready}"
 
+# 解析逗号分隔的标签列表（用 read -ra 精确切分，避免 word-splitting 拆坏含空格的标签）。
+IFS=',' read -r -a LABEL_LIST <<<"$LABELS"
+
 log()  { printf '[sync-project-board] %s\n' "$*"; }
 fail() { printf '::error:: %s\n' "$*" >&2; exit 1; }
 warn() { printf '::warning:: %s\n' "$*" >&2; }
@@ -52,7 +55,7 @@ if [ -z "$ITEM_URL" ]; then
   [ -n "$ITEM_NUMBER" ] || fail "ITEM_URL 与 ITEM_NUMBER 均未设置：无法定位要同步的 issue/PR"
   kind_path="issues"
   [ "$ITEM_KIND" = "pr" ] && kind_path="pull"
-  ITEM_URL="https://github.com/${GITHUB_REPOSITORY:-$PROJECT_OWNER/repo}/${kind_path}/${ITEM_NUMBER}"
+  ITEM_URL="https://github.com/${GITHUB_REPOSITORY:-$PROJECT_OWNER/YourTJ-Hub}/${kind_path}/${ITEM_NUMBER}"
 fi
 log "目标条目: $ITEM_URL (kind=$ITEM_KIND, event=$EVENT)"
 
@@ -69,13 +72,15 @@ log "已定位项目 $PROJECT_OWNER/projects/$PROJECT_NUMBER ($PROJECT_ID)"
 # 2) 幂等添加：已存在则复用 item id，否则添加
 # ---------------------------------------------------------------------------
 existing_item="$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --limit 100 --format json \
-  | jq -r --arg url "$ITEM_URL" '.items[] | select(.url == $url) | .id' | head -n1)"
+  | jq -r --arg url "$ITEM_URL" '[.items[] | select(.content.url == $url) | .id][0] // empty')"
 
 if [ -n "$existing_item" ]; then
   ITEM_ID="$existing_item"
+  ITEM_REUSED=1
   log "条目已在项目中，复用 item $ITEM_ID"
 else
   ITEM_ID="$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ITEM_URL" --format json --jq '.id')"
+  ITEM_REUSED=0
   log "已添加条目 → item $ITEM_ID"
 fi
 
@@ -94,20 +99,43 @@ fi
 # 4) RPD 状态机：目标列计算
 # ---------------------------------------------------------------------------
 target_value="$TODO_VALUE"
+skip_status=false
 if [ "$EVENT" = "closed" ]; then
   target_value="$DONE_VALUE"
+elif [ "$EVENT" = "labeled" ] && [ "$ITEM_KIND" = "issue" ]; then
+  # labeled 事件：仅命中计划标签时更新为 Planned；未命中则保持看板现状
+  # （新入板条目仍落 Todo，已存在条目不覆盖人工挪动的状态）。
+  if [ "${#LABEL_LIST[@]}" -gt 0 ]; then
+    for label in "${LABEL_LIST[@]}"; do
+      if [[ ",$PLANNED_LABELS," == *",$label,"* ]]; then
+        target_value="$PLANNED_VALUE"
+        break
+      fi
+    done
+  fi
+  if [ "$target_value" = "$TODO_VALUE" ] && [ "$ITEM_REUSED" = "1" ]; then
+    log "labeled 事件未命中计划标签（labels=[$LABELS]），条目已存在，保持看板现状"
+    skip_status=true
+  fi
 elif [ "$ITEM_KIND" = "pr" ] && [[ "$EVENT" =~ ^(opened|reopened|ready_for_review|labeled|manual)$ ]]; then
   target_value="$IN_PROGRESS_VALUE"
 elif [ "$ITEM_KIND" = "issue" ]; then
-  for label in ${LABELS//,/ }; do
-    if [[ ",$PLANNED_LABELS," == *",$label,"* ]]; then
-      target_value="$PLANNED_VALUE"
-      break
-    fi
-  done
+  if [ "${#LABEL_LIST[@]}" -gt 0 ]; then
+    for label in "${LABEL_LIST[@]}"; do
+      if [[ ",$PLANNED_LABELS," == *",$label,"* ]]; then
+        target_value="$PLANNED_VALUE"
+        break
+      fi
+    done
+  fi
 fi
 
-option_id="$(jq -r --arg v "$target_value" '(.options // [])[] | select(.name == $v) | .id' <<<"$field" | head -n1)"
+if [ "$skip_status" = "true" ]; then
+  exit 0
+fi
+
+
+option_id="$(jq -r --arg v "$target_value" '[((.options // [])[]) | select(.name == $v) | .id][0] // empty' <<<"$field")"
 if [ -z "$option_id" ]; then
   warn "字段 \"$STATUS_FIELD\" 缺少选项 \"$target_value\"，跳过状态设置（可用 TODO_VALUE/PLANNED_VALUE/IN_PROGRESS_VALUE/DONE_VALUE 变量调整）"
   exit 0

--- a/.github/workflows/sync-project-board.yml
+++ b/.github/workflows/sync-project-board.yml
@@ -1,0 +1,65 @@
+name: sync-project-board
+
+# 把 issue / PR 自动同步到 GitHub Projects v2 看板（RPD 状态机）。
+# 配置依赖见 docs/development/project-board.md：
+#   - secret:   YOURTJ_PROJECT_TOKEN   具备 read:project / write:project 的 token
+#   - variable: YOURTJ_PROJECT_NUMBER  看板项目号（必填）
+#   - variable: YOURTJ_PROJECT_OWNER   看板属主（可选，默认 YourTongji）
+# 未配置 token 时 job 自动跳过，不产生失败噪音。
+
+on:
+  issues:
+    types: [opened, reopened, labeled, closed]
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled, closed]
+  # 手动同步入口：填 issue/PR 号即可把它加入看板并设置状态。
+  workflow_dispatch:
+    inputs:
+      item_kind:
+        description: "要同步的条目类型"
+        required: true
+        default: "issue"
+        type: choice
+        options:
+          - issue
+          - pr
+      item_number:
+        description: "issue / PR 编号"
+        required: true
+        type: string
+      event:
+        description: "模拟的事件（决定状态列）：closed 表示已完成，其余走默认状态机"
+        required: false
+        default: "manual"
+        type: choice
+        options:
+          - manual
+          - opened
+          - closed
+          - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: project-board-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Sync to project board
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.YOURTJ_PROJECT_TOKEN }}
+      PROJECT_OWNER: ${{ vars.YOURTJ_PROJECT_OWNER || 'YourTongji' }}
+      PROJECT_NUMBER: ${{ vars.YOURTJ_PROJECT_NUMBER }}
+      ITEM_KIND: ${{ (github.event_name == 'pull_request' && 'pr') || (github.event_name == 'issues' && 'issue') || inputs.item_kind }}
+      ITEM_NUMBER: ${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'issues' && github.event.issue.number) || inputs.item_number }}
+      EVENT: ${{ github.event.action || inputs.event }}
+      LABELS: ${{ (github.event_name == 'issues' && join(github.event.issue.labels.*.name, ',')) || (github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',')) || '' }}
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{ env.GH_TOKEN != '' }}
+      - name: Run project board sync
+        if: ${{ env.GH_TOKEN != '' }}
+        run: bash .github/scripts/sync-project-board.sh

--- a/.github/workflows/sync-project-board.yml
+++ b/.github/workflows/sync-project-board.yml
@@ -59,7 +59,9 @@ jobs:
       LABELS: ${{ (github.event_name == 'issues' && join(github.event.issue.labels.*.name, ',')) || (github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',')) || '' }}
     steps:
       - uses: actions/checkout@v4
-        if: ${{ env.GH_TOKEN != '' }}
+        # fork PR 默认拿不到 secret 会自跳；此守卫是纵深防御：即便仓库配置了
+        # "send secrets to fork PRs"，也绝不执行来自 fork 的脚本。
+        if: ${{ env.GH_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
       - name: Run project board sync
-        if: ${{ env.GH_TOKEN != '' }}
+        if: ${{ env.GH_TOKEN != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: bash .github/scripts/sync-project-board.sh

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -44,6 +44,7 @@ requirements and product semantics
 - [Local environment](local-development.md)
 - [Testing strategy & commands](testing.md)
 - [Branches, commits & pull requests](pull-requests.md)
+- [Project board workflow](project-board.md)
 - [Documentation governance](documentation.md)
 - [Contracts, data & derived projections](../architecture/contracts-and-data.md)
 

--- a/docs/development/project-board.md
+++ b/docs/development/project-board.md
@@ -1,0 +1,106 @@
+# Project Board Workflow / 看板工作流
+
+> Doc type: development guide
+>
+> Status: Active
+>
+> Owner: Platform maintainers
+>
+> Last verified: 2026-08-11
+
+把仓库的 issue 与 PR 自动同步到 GitHub Projects v2 看板（RPD 状态机），并说明看板列语义与配置方式。
+实现载体：`.github/workflows/sync-project-board.yml` + `.github/scripts/sync-project-board.sh`。
+
+## 1. 看板语义（RPD）
+
+看板列与 GitHub issue/PR 状态一一对应，本工作流按"Status"字段自动流转：
+
+| 列（默认名） | 语义 | 何时进入 |
+|---|---|---|
+| Todo（需求池） | 收到但尚未排期 | issue 新建 / 重新打开 |
+| Planned（计划中） | 已排期，尚未开发 | issue 被打上计划标签（默认 `planning` / `planned` / `ready`） |
+| In Progress（开发中） | 正在实现 | PR 新建 / 标记 ready_for_review / 被打标签 |
+| Done（已完成） | 交付闭环 | issue 或 PR 被关闭 |
+
+如果你把看板列改成了 R / P / D / 已完成 之类的名字，无需改代码，只需在 workflow 里用变量覆盖列名（见 §4）。
+
+## 2. 架构
+
+```
+GitHub 事件 (issue/PR 打开·重开·打标签·关闭) 或手动触发
+        │
+        ▼
+sync-project-board.yml  ──►  sync-project-board.sh（幂等）
+                                   ├─ 校验 token / 项目号 / 目标条目
+                                   ├─ gh project view     定位项目
+                                   ├─ gh project item-list 幂等查重（已存在则复用，不重复添加）
+                                   ├─ gh project item-add  首次添加
+                                   └─ gh project item-edit 设置 Status 字段
+```
+
+- 使用 `gh` CLI（GitHub Actions 自带的 GitHub CLI，版本 ≥ 2.45）。
+- **`GITHUB_TOKEN` 无法访问 Projects**，必须使用专用 token（见 §3）。
+- 脚本不解析 GitHub 事件语法，所有上下文通过环境变量传入，因此可本地 mock 测试。
+
+## 3. 首次配置（merge 后一次性）
+
+1. **获取 token**（二选一）：
+   - **PAT（个人访问令牌）**：GitHub → Settings → Developer settings → Personal access tokens → *Fine-grained tokens*，新建 token，授予：
+     - Repository access：`YourTJ-Hub`
+     - Permissions → **Issues: Read**、**Pull requests: Read**、**Projects: Read and write**（若看板挂在组织下，还需组织管理员授予该 token 的项目权限）
+   - **GitHub App（组织项目推荐）**：为你的组织创建 App，授予 Organization projects **Read and write**（`Read and write` 的 organization projects 权限），生成私钥；在 workflow 中用 `actions/create-github-app-token@v3` 换取 installation token 后注入 `GH_TOKEN`。
+2. **配置 secret**：仓库 Settings → Secrets and variables → Actions → New repository secret：
+   - `YOURTJ_PROJECT_TOKEN` = 上面的 token 值（PAT 的完整值，或 GitHub App 生成的 token）。
+3. **配置 variables**：
+   - `YOURTJ_PROJECT_NUMBER` = 看板项目号（看板 URL 末尾数字，例如 `https://github.com/orgs/YourTongji/projects/5` 的项目号是 `5`）。**必填**。
+   - `YOURTJ_PROJECT_OWNER` = 看板属主（不填默认 `YourTongji`）。
+4. 触发一次测试：新建一个测试 issue 或在仓库 Actions 页手动运行 `sync-project-board`（`workflow_dispatch`），确认看板出现该条目。
+
+配置完成前，本 workflow 会因未检测到 token 自动跳过，不会报错刷屏。
+
+## 4. 定制列名 / 状态字段
+
+如果看板的 Status 字段或列名不是默认值，在 `.github/workflows/sync-project-board.yml` 的 `env:` 中按需覆盖即可：
+
+```yaml
+      STATUS_FIELD: RPD              # 状态字段名，默认 Status
+      TODO_VALUE: R                  # 需求列，默认 Todo
+      PLANNED_VALUE: P               # 计划列，默认 Planned
+      IN_PROGRESS_VALUE: D           # 开发列，默认 In Progress
+      DONE_VALUE: 已完成             # 已完成列，默认 Done
+      PLANNED_LABELS: planning,planned,ready   # 触发"计划中"的标签
+```
+
+## 5. 手动同步
+
+仓库 Actions 页 → `sync-project-board` → *Run workflow*：
+
+- `item_kind`：`issue` 或 `pr`
+- `item_number`：要同步的 issue/PR 编号
+- `event`：`manual`（默认，issue→需求列 / pr→开发列）、`closed`（已完成）或 `opened` / `ready_for_review`
+
+## 6. 看板内置自动化（可选，双保险）
+
+GitHub Projects 自带 Workflows（看板 Settings → Workflows），可叠加使用：
+
+- 新条目加入看板 → 移到需求列
+- 条目被关闭 → 移到已完成列
+
+本仓库工作流与看板内置规则并存时行为一致；二者都做时重复设置无害（本工作流先查重再设置）。
+
+## 7. 故障排查
+
+| 现象 | 原因与处理 |
+|---|---|
+| job 显示 skipped | 未配置 `YOURTJ_PROJECT_TOKEN` secret，或 token 为空；按 §3 配置 |
+| 报错 `无法访问项目 …` | token 缺少 `read:project` 权限，或 `YOURTJ_PROJECT_NUMBER` 填错 |
+| 报错 `无法添加条目` | token 缺 `write:project`，或看板属主与 `PROJECT_OWNER` 不一致 |
+| 日志警告 `未找到状态字段 …` | 看板的 Status 字段名不是默认名；用 `STATUS_FIELD` 覆盖 |
+| 日志警告 `缺少选项 …` | 看板列名与 `TODO_VALUE` 等不匹配；用对应变量覆盖 |
+| 未设置状态但条目在 | 字段/选项缺失时脚本只保证添加，不强制设置状态（见日志警告） |
+
+## 8. 边界与已知限制
+
+- 幂等查重依赖 `gh project item-list`（脚本用 `--limit 100`）；项目条目超过 100 时重复添加可能回退为"已存在"报错，届时改用 `--query` 过滤或 GraphQL 分页。
+- 关闭的 PR/issue 重新打开（`reopened`）会回到对应状态列。
+- 删除看板条目不会反向关闭 issue/PR（单向同步）。


### PR DESCRIPTION
## Motivation

将仓库的 GitHub Project v2 看板用起来：issue 新建进需求列、PR 进开发列、命中计划标签进计划列、关闭进已完成列，并支持手动补录历史条目。此前没有任何环节把条目写入看板，挂载后仍为空。

## Behavior change

- 新增 `.github/workflows/sync-project-board.yml`：`issues` / `pull_request` 的 opened/reopened/labeled/closed + `ready_for_review` 事件驱动，另加 `workflow_dispatch` 手动同步入口；未配置 token 时 job 通过 step 级 `if` 优雅跳过，不产生失败噪音。
- 新增 `.github/scripts/sync-project-board.sh`：幂等同步（`gh project view` 定位 → `item-list` 查重 → `item-add`/复用 → `item-edit` 设置 Status 字段），状态列/字段名/计划标签全部可配置。
- 新增 `docs/development/project-board.md`：RPD 列语义、token 获取（PAT / GitHub App）、项目号配置、列名定制、手动同步、故障排查。
- `docs/development/README.md`：开发文档索引登记。

## Verification

- `actionlint v1.7.12`：`.github/workflows/sync-project-board.yml` 通过（exit 0）。修复点：job 级 `if: secrets.X != ''` 不被允许，改为 job env + step 级 `if: env.GH_TOKEN != ''`。
- `bash -n`：脚本语法通过。
- mock `gh` 单元测试 30/30 PASS：首次添加、幂等复用（不重复 item-add）、PR→In Progress、closed→Done、计划标签→Planned、项目不存在报错、字段/选项缺失降级为警告、缺 token/项目号引导、手动同步 URL 拼装。

## Docs / contract impact

- 纯新增 `.github/` 与 `docs/development/`，不触碰业务代码、契约或迁移。

## Merge 后待办（一次性配置）

1. 配置 secret `YOURTJ_PROJECT_TOKEN`（需 `read:project`/`write:project` 的 PAT 或 GitHub App token；`GITHUB_TOKEN` 无法访问 Projects v2）。
2. 配置 variable `YOURTJ_PROJECT_NUMBER`（看板 URL 末尾数字），可选 `YOURTJ_PROJECT_OWNER`。
3. 在 Actions 页手动运行一次 `sync-project-board` 验证，或新建测试 issue 触发。

## Known gaps

- 端到端真实写入未执行：本地 gh token 缺 `read:project` scope（用户未授权刷新），依赖上面 merge 后配置验证。
- 幂等查重受 `item-list --limit 100` 限制，条目超 100 时可能回退为重复添加报错（文档已注明）。