### PR TITLE
fix: harden session revocation

### DIFF
--- a/apps/gooseforum/app/bundles/localcache/cache.go
+++ b/apps/gooseforum/app/bundles/localcache/cache.go
@@ -1,8 +1,10 @@
 package localcache
 
 import (
+	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -11,20 +13,43 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+// errCacheInvalidated is returned when a value was invalidated while its load
+// was in flight and the bounded retry could not settle.
+var errCacheInvalidated = errors.New("localcache: value invalidated during load")
+
 // Cache is a small in-process cache facade backed by ttlcache.
+//
+// Invalidation is epoch-based so that a value loaded concurrently with an
+// invalidation is never served afterwards: every mutation that can make
+// in-flight loads stale (Set, Delete, Clear, UpdateIfPresent) bumps the cache
+// epoch, and every entry records the epoch it was produced under. A read
+// accepts an entry only when its epoch matches the current one, so a stale
+// write that lands after a Delete is treated as a miss and reloaded instead
+// of being served. Security-relevant caches (e.g. the user-info snapshot used
+// for TokenVersion checks) rely on this under concurrent "revoke all
+// sessions" style invalidations.
 type Cache[V any] struct {
 	MaxEntries uint64
 
 	once  sync.Once
-	cache *ttlcache.Cache[string, V]
+	cache *ttlcache.Cache[string, cachedEntry[V]]
 	group singleflight.Group
+	epoch atomic.Uint64
+}
+
+// cachedEntry couples a value with the cache epoch it was produced under.
+// Entries whose epoch no longer matches the current one are stale and must
+// not be served.
+type cachedEntry[V any] struct {
+	value V
+	epoch uint64
 }
 
 func (c *Cache[V]) init() {
 	c.once.Do(func() {
-		c.cache = ttlcache.New[string, V](
-			ttlcache.WithCapacity[string, V](c.maxEntries()),
-			ttlcache.WithDisableTouchOnHit[string, V](),
+		c.cache = ttlcache.New[string, cachedEntry[V]](
+			ttlcache.WithCapacity[string, cachedEntry[V]](c.maxEntries()),
+			ttlcache.WithDisableTouchOnHit[string, cachedEntry[V]](),
 		)
 		go c.cache.Start()
 		closer.RegisterPriority(closer.PriorityCache, func() error {
@@ -59,41 +84,69 @@ func (c *Cache[V]) GetOrLoadE(
 	timeout time.Duration,
 ) (V, error) {
 	c.init()
-	if item := c.cache.Get(key); item != nil {
-		slog.Debug("localcache: hit", "key", key)
-		return item.Value(), nil
-	}
-	slog.Debug("localcache: miss", "key", key)
-
-	result, err, _ := c.group.Do(key, func() (any, error) {
-		if item := c.cache.Get(key); item != nil {
-			slog.Debug("localcache: hit after singleflight wait", "key", key)
-			return item.Value(), nil
+	for attempt := 0; attempt < 2; attempt++ {
+		if value, ok := c.getValid(key); ok {
+			slog.Debug("localcache: hit", "key", key)
+			return value, nil
 		}
-		newVal, err := getData()
+		slog.Debug("localcache: miss", "key", key)
+
+		_, err, _ := c.group.Do(key, func() (any, error) {
+			if value, ok := c.getValid(key); ok {
+				slog.Debug("localcache: hit after singleflight wait", "key", key)
+				return value, nil
+			}
+			epoch := c.epoch.Load()
+			newVal, err := getData()
+			if err != nil {
+				slog.Debug("localcache: loader error", "key", key, "err", err)
+				return *new(V), err
+			}
+			c.cache.Set(key, cachedEntry[V]{value: newVal, epoch: epoch}, timeout)
+			slog.Debug("localcache: stored", "key", key, "ttl", timeout)
+			return newVal, nil
+		})
 		if err != nil {
-			slog.Debug("localcache: loader error", "key", key, "err", err)
+			slog.Debug("localcache: load failed", "key", key, "err", err)
 			return *new(V), err
 		}
-		c.cache.Set(key, newVal, timeout)
-		slog.Debug("localcache: stored", "key", key, "ttl", timeout)
-		return newVal, nil
-	})
-	if err != nil {
-		slog.Debug("localcache: load failed", "key", key, "err", err)
-		return *new(V), err
+
+		// singleflight shared the leader's result with waiters; it may have
+		// been produced under a stale epoch, so re-validate before serving.
+		if value, ok := c.getValid(key); ok {
+			return value, nil
+		}
+		slog.Debug("localcache: discarding stale in-flight load", "key", key)
 	}
-	return result.(V), nil
+	return *new(V), errCacheInvalidated
+}
+
+// getValid returns the cached value for key when it was produced under the
+// current cache epoch, dropping the entry otherwise.
+func (c *Cache[V]) getValid(key string) (V, bool) {
+	item := c.cache.Get(key)
+	if item == nil {
+		return *new(V), false
+	}
+	entry := item.Value()
+	if entry.epoch != c.epoch.Load() {
+		slog.Debug("localcache: dropping stale entry", "key", key)
+		c.cache.Delete(key)
+		return *new(V), false
+	}
+	return entry.value, true
 }
 
 func (c *Cache[V]) Clear() {
 	c.init()
 	c.cache.DeleteAll()
+	c.epoch.Add(1)
 }
 
 func (c *Cache[V]) Set(key string, value V, timeout time.Duration) {
 	c.init()
-	c.cache.Set(key, value, timeout)
+	c.epoch.Add(1)
+	c.cache.Set(key, cachedEntry[V]{value: value, epoch: c.epoch.Load()}, timeout)
 	slog.Debug("localcache: set", "key", key, "ttl", timeout)
 }
 
@@ -103,7 +156,8 @@ func (c *Cache[V]) UpdateIfPresent(key string, update func(V) V, timeout time.Du
 	if item == nil {
 		return false
 	}
-	c.cache.Set(key, update(item.Value()), timeout)
+	c.epoch.Add(1)
+	c.cache.Set(key, cachedEntry[V]{value: update(item.Value().value), epoch: c.epoch.Load()}, timeout)
 	slog.Debug("localcache: updated", "key", key, "ttl", timeout)
 	return true
 }
@@ -111,5 +165,6 @@ func (c *Cache[V]) UpdateIfPresent(key string, update func(V) V, timeout time.Du
 func (c *Cache[V]) Delete(key string) {
 	c.init()
 	c.cache.Delete(key)
+	c.epoch.Add(1)
 	slog.Debug("localcache: deleted", "key", key)
 }

--- a/apps/gooseforum/app/bundles/localcache/cache_test.go
+++ b/apps/gooseforum/app/bundles/localcache/cache_test.go
@@ -163,3 +163,92 @@ func stopTestCache[V any](c *Cache[V]) {
 		c.cache.Stop()
 	}
 }
+
+// TestCache_DeleteDiscardsInFlightLoad pins the epoch-based invalidation
+// guarantee: a load that started before Delete must not write its (stale)
+// result back into the cache. The next read observes the fresh value.
+func TestCache_DeleteDiscardsInFlightLoad(t *testing.T) {
+	c := Cache[string]{}
+	defer stopTestCache(&c)
+
+	firstLoadStarted := make(chan struct{})
+	releaseFirstLoad := make(chan struct{})
+	loadDone := make(chan struct{})
+	loads := 0
+
+	go func() {
+		defer close(loadDone)
+		_, _ = c.GetOrLoadE("key", func() (string, error) {
+			loads++
+			if loads == 1 {
+				close(firstLoadStarted)
+				<-releaseFirstLoad
+				return "stale", nil
+			}
+			return "fresh", nil
+		}, time.Minute)
+	}()
+
+	<-firstLoadStarted
+	c.Delete("key")
+	close(releaseFirstLoad)
+	<-loadDone
+
+	if loads != 2 {
+		t.Fatalf("loads = %d, want 2 (stale load must be retried)", loads)
+	}
+
+	got, err := c.GetOrLoadE("key", func() (string, error) {
+		return "fresh", nil
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("GetOrLoadE() error = %v", err)
+	}
+	if got != "fresh" {
+		t.Fatalf("cached value = %q, want fresh (stale in-flight load must be discarded)", got)
+	}
+}
+
+// TestCache_ClearDiscardsInFlightLoad is the Clear counterpart of the Delete
+// test, covering the same epoch guarantee for whole-cache invalidation.
+func TestCache_ClearDiscardsInFlightLoad(t *testing.T) {
+	c := Cache[string]{}
+	defer stopTestCache(&c)
+
+	firstLoadStarted := make(chan struct{})
+	releaseFirstLoad := make(chan struct{})
+	loadDone := make(chan struct{})
+	loads := 0
+
+	go func() {
+		defer close(loadDone)
+		_, _ = c.GetOrLoadE("key", func() (string, error) {
+			loads++
+			if loads == 1 {
+				close(firstLoadStarted)
+				<-releaseFirstLoad
+				return "stale", nil
+			}
+			return "fresh", nil
+		}, time.Minute)
+	}()
+
+	<-firstLoadStarted
+	c.Clear()
+	close(releaseFirstLoad)
+	<-loadDone
+
+	if loads != 2 {
+		t.Fatalf("loads = %d, want 2 (stale load must be retried)", loads)
+	}
+
+	got, err := c.GetOrLoadE("key", func() (string, error) {
+		return "fresh", nil
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("GetOrLoadE() error = %v", err)
+	}
+	if got != "fresh" {
+		t.Fatalf("cached value = %q, want fresh", got)
+	}
+}

--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -31,6 +31,7 @@ func Logout(c *gin.Context) {
 	if claims, _, err := jwt.VerifyTokenWithFreshClaims(token); err == nil && claims.Jti != "" {
 		if err := sessionservice.RevokeByJti(claims.UserId, claims.Jti); err != nil {
 			slog.Error("Logout revoke session failed", "userId", claims.UserId, "jti", claims.Jti, "error", err)
+			jwt.TokenClean(c)
 			c.JSON(http.StatusOK, component.FailDataCode(component.MessageSessionRevokeFailed, nil))
 			return
 		}

--- a/apps/gooseforum/app/http/controllers/api/logout_test.go
+++ b/apps/gooseforum/app/http/controllers/api/logout_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -78,6 +79,48 @@ func TestLogoutRevokesSession(t *testing.T) {
 	}
 	if sessionservice.GetValidByJti(jti) != nil {
 		t.Fatal("session row still valid after logout")
+	}
+}
+
+func TestLogoutClearsCookieWhenSessionRevocationFails(t *testing.T) {
+	setupLogoutTestDB(t)
+	if !db.IsSqlite() {
+		t.Skip("requires SQLite trigger support")
+	}
+
+	user, err := userservice.CreateUser("logoutfailure", "password", "logoutfailure@example.com", false)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	token, jti, err := jwt.CreateSessionToken(user.Id, user.TokenVersion)
+	if err != nil {
+		t.Fatalf("CreateSessionToken() error = %v", err)
+	}
+	if err := sessionservice.Create(user.Id, jti, "test-agent", "127.0.0.1"); err != nil {
+		t.Fatalf("sessionservice.Create() error = %v", err)
+	}
+	conn := db.Connect()
+	if err := conn.Exec("CREATE TRIGGER logout_revoke_failure BEFORE DELETE ON user_sessions BEGIN SELECT RAISE(ABORT, 'forced session revoke failure'); END;").Error; err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Exec("DROP TRIGGER IF EXISTS logout_revoke_failure").Error; err != nil {
+			t.Errorf("drop failure trigger: %v", err)
+		}
+	})
+
+	c, recorder := newLogoutContext(token)
+	Logout(c)
+
+	var res component.ResultStruct
+	if err := json.Unmarshal(recorder.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if res.Code != component.FAIL {
+		t.Fatalf("response code = %v, want FAIL", res.Code)
+	}
+	if cookie := recorder.Header().Get("Set-Cookie"); !strings.Contains(cookie, "access_token=") {
+		t.Fatalf("logout failure did not clear access_token cookie: %q", cookie)
 	}
 }
 

--- a/apps/gooseforum/app/http/controllers/api/sessionController.go
+++ b/apps/gooseforum/app/http/controllers/api/sessionController.go
@@ -3,7 +3,6 @@ package api
 import (
 	"github.com/leancodebox/GooseForum/app/http/controllers/component"
 	"github.com/leancodebox/GooseForum/app/models/forum/userSessions"
-	"github.com/leancodebox/GooseForum/app/models/forum/users"
 	"github.com/leancodebox/GooseForum/app/service/sessionservice"
 )
 
@@ -79,9 +78,8 @@ func RevokeSession(req component.BetterRequest[RevokeSessionReq]) component.Resp
 // RevokeAllSessions 吊销该用户全部会话（含当前），并自增 TokenVersion 双保险
 func RevokeAllSessions(req component.BetterRequest[component.Null]) component.Response {
 	userID := req.UserId
-	if err := sessionservice.RevokeAll(userID); err != nil {
+	if err := sessionservice.RevokeAllAndInvalidate(userID); err != nil {
 		return component.FailResponseCode(component.MessageSessionRevokeFailed, nil)
 	}
-	users.IncrementTokenVersion(userID)
 	return component.SuccessResponseCode("已退出所有设备", component.MessageSessionRevokeAllSuccess, nil)
 }

--- a/apps/gooseforum/app/http/routes/contract_sessions_test.go
+++ b/apps/gooseforum/app/http/routes/contract_sessions_test.go
@@ -8,11 +8,14 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/leancodebox/GooseForum/app/http/controllers/api"
 	"github.com/leancodebox/GooseForum/app/http/middleware"
+	"github.com/leancodebox/GooseForum/app/models/forum/userSessions"
 	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/service/sessionservice"
 	"gorm.io/gorm"
 )
 
@@ -200,6 +203,47 @@ func TestListSessionsHTTPContract(t *testing.T) {
 		}
 		if currentCount != 1 {
 			t.Fatalf("isCurrent count = %d, want exactly 1", currentCount)
+		}
+	})
+
+	t.Run("excludes expired rows and never exposes unparseable addresses", func(t *testing.T) {
+		conn, router := setupSessionContractTest(t)
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		if err := sessionservice.Create(user.Id, "contract-malformed-ip", "contract-test", "not-an-ip"); err != nil {
+			t.Fatalf("create malformed-ip session: %v", err)
+		}
+		if err := sessionservice.Create(user.Id, "contract-expired-session", "contract-test", "203.0.113.9"); err != nil {
+			t.Fatalf("create expired session: %v", err)
+		}
+		if err := userSessions.UpdateExpiresAtByJti("contract-expired-session", time.Now().Add(-time.Hour)); err != nil {
+			t.Fatalf("expire session: %v", err)
+		}
+
+		recorder := serveSessionJSON(router, http.MethodGet, "/api/user/sessions", "", token)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("list sessions status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		items := decodeSessionList(t, decodeContractEnvelope(t, recorder).Result)
+		if len(items) != 2 {
+			t.Fatalf("session count = %d, want 2 live rows", len(items))
+		}
+		for _, item := range items {
+			if item.ID == 0 {
+				t.Fatal("session id = 0, want positive")
+			}
+			if item.IPMasked == "not-an-ip" {
+				t.Fatal("session list exposed an unparseable raw IP")
+			}
+		}
+		var malformedIPFound bool
+		for _, item := range items {
+			if item.IPMasked == "" {
+				malformedIPFound = true
+			}
+		}
+		if !malformedIPFound {
+			t.Fatal("session list did not include the malformed-IP session as an empty mask")
 		}
 	})
 

--- a/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
+++ b/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
@@ -43,11 +43,6 @@ func DeleteExpired() error {
 	return builder().Where(fieldExpiresAt+" < ?", time.Now()).Delete(&Entity{}).Error
 }
 
-// DeleteAllByUserID 删除用户全部会话
-func DeleteAllByUserID(userID uint64) error {
-	return DeleteAllByUserIDWithDB(builder(), userID)
-}
-
 // DeleteAllByUserIDWithDB deletes every session of the user through the supplied database handle.
 func DeleteAllByUserIDWithDB(conn *gorm.DB, userID uint64) error {
 	return conn.Where(fieldUserId, userID).Delete(&Entity{}).Error

--- a/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
+++ b/apps/gooseforum/app/models/forum/userSessions/userSessions_rep.go
@@ -2,6 +2,8 @@ package userSessions
 
 import (
 	"time"
+
+	"gorm.io/gorm"
 )
 
 // Create 创建会话记录
@@ -32,7 +34,7 @@ func DeleteByID(userID uint64, id uint64) error {
 // ListByUserID 获取用户全部会话，按创建时间倒序
 func ListByUserID(userID uint64) ([]Entity, error) {
 	var entities []Entity
-	err := builder().Where(fieldUserId, userID).Order(fieldCreatedAt + " desc").Find(&entities).Error
+	err := builder().Where(fieldUserId, userID).Where(fieldExpiresAt+" > ?", time.Now()).Order(fieldCreatedAt + " desc").Find(&entities).Error
 	return entities, err
 }
 
@@ -43,7 +45,12 @@ func DeleteExpired() error {
 
 // DeleteAllByUserID 删除用户全部会话
 func DeleteAllByUserID(userID uint64) error {
-	return builder().Where(fieldUserId, userID).Delete(&Entity{}).Error
+	return DeleteAllByUserIDWithDB(builder(), userID)
+}
+
+// DeleteAllByUserIDWithDB deletes every session of the user through the supplied database handle.
+func DeleteAllByUserIDWithDB(conn *gorm.DB, userID uint64) error {
+	return conn.Where(fieldUserId, userID).Delete(&Entity{}).Error
 }
 
 // UpdateExpiresAtByJti 更新会话过期时间（续签时保持同一会话）

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -10,6 +10,7 @@ import (
 	"github.com/leancodebox/GooseForum/app/bundles/pageutil"
 	"github.com/leancodebox/GooseForum/app/bundles/queryopt"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 )
 
 // dummyBotHashForTiming is a fixed PBKDF2-SHA256 hash:salt value used to
@@ -179,5 +180,18 @@ func IncrementPrestige(addNumber int64, userId uint64) int64 {
 // IncrementTokenVersion bumps the user's token version, invalidating every
 // previously issued access token (used by "revoke all devices").
 func IncrementTokenVersion(userId uint64) {
-	builder().Exec("UPDATE users SET token_version = token_version + 1 where id = ?", userId)
+	_ = IncrementTokenVersionWithDB(builder(), userId)
+}
+
+// IncrementTokenVersionWithDB increments token_version through the supplied database handle.
+// A missing user is an error so callers can roll back any coupled changes.
+func IncrementTokenVersionWithDB(conn *gorm.DB, userId uint64) error {
+	result := conn.Exec("UPDATE users SET token_version = token_version + 1 where id = ?", userId)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -177,13 +177,6 @@ func IncrementPrestige(addNumber int64, userId uint64) int64 {
 	return result.RowsAffected
 }
 
-// IncrementTokenVersion bumps the user's token version, invalidating every
-// previously issued access token (used by "revoke all devices"). Callers that
-// need error propagation or transactional composition should use IncrementTokenVersionWithDB.
-func IncrementTokenVersion(userId uint64) {
-	_ = IncrementTokenVersionWithDB(builder(), userId)
-}
-
 // IncrementTokenVersionWithDB increments token_version through the supplied database handle.
 // A missing user is an error so callers can roll back any coupled changes.
 func IncrementTokenVersionWithDB(conn *gorm.DB, userId uint64) error {

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -178,7 +178,8 @@ func IncrementPrestige(addNumber int64, userId uint64) int64 {
 }
 
 // IncrementTokenVersion bumps the user's token version, invalidating every
-// previously issued access token (used by "revoke all devices").
+// previously issued access token (used by "revoke all devices"). Callers that
+// need error propagation or transactional composition should use IncrementTokenVersionWithDB.
 func IncrementTokenVersion(userId uint64) {
 	_ = IncrementTokenVersionWithDB(builder(), userId)
 }

--- a/apps/gooseforum/app/service/authsessionservice/authsessionservice_test.go
+++ b/apps/gooseforum/app/service/authsessionservice/authsessionservice_test.go
@@ -1,0 +1,94 @@
+package authsessionservice
+
+import (
+	"testing"
+
+	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
+	"github.com/leancodebox/GooseForum/app/bundles/jwtopt"
+	"github.com/leancodebox/GooseForum/app/models/forum/userSessions"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/service/sessionservice"
+)
+
+func setupAuthSessionTestDB(t *testing.T) {
+	t.Helper()
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&users.EntityComplete{}, &userSessions.Entity{}); err != nil {
+		t.Fatalf("migrate auth session test tables: %v", err)
+	}
+	conn.Where("1 = 1").Delete(&userSessions.Entity{})
+	conn.Where("1 = 1").Delete(&users.EntityComplete{})
+}
+
+// TestValidateTokenAfterRevokeAll pins the end-to-end token-version chain that
+// the auth middleware relies on: after RevokeAllAndInvalidate, an old token
+// must be rejected (session row gone + TokenVersion bumped) and a freshly
+// issued token must be accepted even though the user-info cache may have
+// served a stale TokenVersion between the commit and the invalidation.
+func TestValidateTokenAfterRevokeAll(t *testing.T) {
+	setupAuthSessionTestDB(t)
+
+	user := users.MakeUser("auth-validate-revoke", "password", "auth-validate-revoke@example.com")
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	token, jti, err := jwtopt.CreateSessionToken(user.Id, user.TokenVersion)
+	if err != nil {
+		t.Fatalf("CreateSessionToken: %v", err)
+	}
+	if err := sessionservice.Create(user.Id, jti, "test-agent", "127.0.0.1"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if _, _, _, ok := ValidateToken(token); !ok {
+		t.Fatal("ValidateToken must accept a live session token")
+	}
+
+	if err := sessionservice.RevokeAllAndInvalidate(user.Id); err != nil {
+		t.Fatalf("RevokeAllAndInvalidate: %v", err)
+	}
+	if _, _, _, ok := ValidateToken(token); ok {
+		t.Fatal("ValidateToken must reject a token after revoke-all")
+	}
+
+	reloaded, err := users.Get(user.Id)
+	if err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	newToken, newJti, err := jwtopt.CreateSessionToken(user.Id, reloaded.TokenVersion)
+	if err != nil {
+		t.Fatalf("CreateSessionToken after revoke-all: %v", err)
+	}
+	if err := sessionservice.Create(user.Id, newJti, "test-agent", "127.0.0.1"); err != nil {
+		t.Fatalf("recreate session: %v", err)
+	}
+	if _, _, _, ok := ValidateToken(newToken); !ok {
+		t.Fatal("ValidateToken must accept a freshly issued token after revoke-all (cache must not serve the stale TokenVersion)")
+	}
+}
+
+// TestValidateTokenRejectsBot mirrors the middleware contract that bot
+// accounts can never authenticate through the session-token path.
+func TestValidateTokenRejectsBot(t *testing.T) {
+	setupAuthSessionTestDB(t)
+
+	bot := users.EntityComplete{
+		Username:    "auth-validate-bot",
+		ActorType:   users.ActorTypeBot,
+		IsActivated: users.ActivationSuccess,
+	}
+	if err := db.Connect().Create(&bot).Error; err != nil {
+		t.Fatalf("create bot: %v", err)
+	}
+	token, jti, err := jwtopt.CreateSessionToken(bot.Id, bot.TokenVersion)
+	if err != nil {
+		t.Fatalf("CreateSessionToken: %v", err)
+	}
+	if err := sessionservice.Create(bot.Id, jti, "test-agent", "127.0.0.1"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if _, _, _, ok := ValidateToken(token); ok {
+		t.Fatal("ValidateToken must reject bot accounts")
+	}
+}

--- a/apps/gooseforum/app/service/oidcservice/provider_test.go
+++ b/apps/gooseforum/app/service/oidcservice/provider_test.go
@@ -606,7 +606,7 @@ func TestUserinfoRespectsTokenVersionAndFrozen(t *testing.T) {
 	}
 
 	// 改密/吊销全部设备 → TokenVersion 递增 → userinfo 拒绝
-	users.IncrementTokenVersion(user.Id)
+	users.IncrementTokenVersionWithDB(db.Connect(), user.Id)
 	if code := userinfo(); code == http.StatusOK {
 		t.Fatalf("userinfo must reject token after TokenVersion bump")
 	}

--- a/apps/gooseforum/app/service/sessionservice/sessionservice.go
+++ b/apps/gooseforum/app/service/sessionservice/sessionservice.go
@@ -6,8 +6,12 @@ import (
 	"strings"
 	"time"
 
+	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
 	"github.com/leancodebox/GooseForum/app/bundles/preferences"
 	"github.com/leancodebox/GooseForum/app/models/forum/userSessions"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/service/userservice"
+	"gorm.io/gorm"
 )
 
 // sessionLifetime mirrors jwtopt.validTime so session records stay in sync
@@ -70,6 +74,22 @@ func RevokeAll(userID uint64) error {
 	return userSessions.DeleteAllByUserID(userID)
 }
 
+// RevokeAllAndInvalidate atomically deletes every session and invalidates every
+// previously issued token for the user. The user-info cache is cleared only
+// after the database transaction commits.
+func RevokeAllAndInvalidate(userID uint64) error {
+	if err := db.Connect().Transaction(func(tx *gorm.DB) error {
+		if err := userSessions.DeleteAllByUserIDWithDB(tx, userID); err != nil {
+			return err
+		}
+		return users.IncrementTokenVersionWithDB(tx, userID)
+	}); err != nil {
+		return err
+	}
+	userservice.InvalidateUserInfoCache(userID)
+	return nil
+}
+
 // CleanupExpired removes expired session rows (cheap housekeeping on issue).
 func CleanupExpired() {
 	_ = userSessions.DeleteExpired()
@@ -90,7 +110,7 @@ func MaskIP(ip string) string {
 		}
 	}
 	if parsed == nil {
-		return ip
+		return ""
 	}
 	if v4 := parsed.To4(); v4 != nil {
 		return fmt.Sprintf("%d.%d.%d.*", v4[0], v4[1], v4[2])

--- a/apps/gooseforum/app/service/sessionservice/sessionservice.go
+++ b/apps/gooseforum/app/service/sessionservice/sessionservice.go
@@ -69,14 +69,14 @@ func RevokeByID(userID uint64, id uint64) error {
 	return userSessions.DeleteByID(userID, id)
 }
 
-// RevokeAll deletes every session of the user.
-func RevokeAll(userID uint64) error {
-	return userSessions.DeleteAllByUserID(userID)
-}
-
 // RevokeAllAndInvalidate atomically deletes every session and invalidates every
 // previously issued token for the user. The user-info cache is cleared only
 // after the database transaction commits.
+//
+// The transaction runs on the process-wide db.Connect() handle: concurrent
+// callers on the same user serialize on the DB, and the cache invalidation
+// after commit is race-free with respect to in-flight cache loads thanks to
+// the epoch-based localcache invalidation.
 func RevokeAllAndInvalidate(userID uint64) error {
 	if err := db.Connect().Transaction(func(tx *gorm.DB) error {
 		if err := userSessions.DeleteAllByUserIDWithDB(tx, userID); err != nil {

--- a/apps/gooseforum/app/service/sessionservice/sessionservice_test.go
+++ b/apps/gooseforum/app/service/sessionservice/sessionservice_test.go
@@ -42,20 +42,32 @@ func TestCreateAndGetValidByJti(t *testing.T) {
 	}
 }
 
+// TestRevokeByIDAndRevokeAll exercises single-session and all-session
+// revocation. RevokeAllAndInvalidate additionally bumps token_version and
+// clears the user-info cache; the transaction path is covered by the
+// rollback test below.
 func TestRevokeByIDAndRevokeAll(t *testing.T) {
 	setupTestDB(t)
 
-	_ = Create(100, "jti-1", "ua", "1.1.1.1")
-	_ = Create(100, "jti-2", "ua", "2.2.2.2")
-	_ = Create(200, "jti-3", "ua", "3.3.3.3")
+	user := users.MakeUser("session-revoke-both", "password", "session-revoke-both@example.com")
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	other := users.MakeUser("session-revoke-other", "password", "session-revoke-other@example.com")
+	if err := users.Create(other); err != nil {
+		t.Fatalf("create other user: %v", err)
+	}
+	_ = Create(user.Id, "jti-1", "ua", "1.1.1.1")
+	_ = Create(user.Id, "jti-2", "ua", "2.2.2.2")
+	_ = Create(other.Id, "jti-3", "ua", "3.3.3.3")
 
-	list, err := List(100)
+	list, err := List(user.Id)
 	if err != nil || len(list) != 2 {
 		t.Fatalf("list = %d sessions, err = %v", len(list), err)
 	}
 
-	// Revoke one session of user 100.
-	if err := RevokeByID(100, list[0].Id); err != nil {
+	// Revoke one session of the first user.
+	if err := RevokeByID(user.Id, list[0].Id); err != nil {
 		t.Fatal(err)
 	}
 	if GetValidByJti(list[0].Jti) != nil {
@@ -66,8 +78,8 @@ func TestRevokeByIDAndRevokeAll(t *testing.T) {
 		t.Fatal("other user session should remain")
 	}
 
-	// Revoke all for user 100.
-	if err := RevokeAll(100); err != nil {
+	// Revoke all for the first user.
+	if err := RevokeAllAndInvalidate(user.Id); err != nil {
 		t.Fatal(err)
 	}
 	if GetValidByJti("jti-2") != nil {
@@ -97,6 +109,10 @@ func TestListExcludesExpiredSessions(t *testing.T) {
 	}
 }
 
+// The two trigger-based tests below create and drop SQLite triggers on the
+// shared :memory: test database. They must not run in parallel with any other
+// test in this package, because a trigger applies to every statement on the
+// shared connection.
 func TestRevokeAllAndInvalidateInvalidatesCacheAfterCommit(t *testing.T) {
 	setupTestDB(t)
 

--- a/apps/gooseforum/app/service/sessionservice/sessionservice_test.go
+++ b/apps/gooseforum/app/service/sessionservice/sessionservice_test.go
@@ -6,15 +6,18 @@ import (
 
 	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
 	"github.com/leancodebox/GooseForum/app/models/forum/userSessions"
+	"github.com/leancodebox/GooseForum/app/models/forum/users"
+	"github.com/leancodebox/GooseForum/app/service/userservice"
 )
 
 func setupTestDB(t *testing.T) {
 	t.Helper()
 	conn := db.Connect()
-	if err := conn.AutoMigrate(&userSessions.Entity{}); err != nil {
-		t.Fatalf("migrate user_sessions: %v", err)
+	if err := conn.AutoMigrate(&users.EntityComplete{}, &userSessions.Entity{}); err != nil {
+		t.Fatalf("migrate session test tables: %v", err)
 	}
 	conn.Where("1 = 1").Delete(&userSessions.Entity{})
+	conn.Where("1 = 1").Delete(&users.EntityComplete{})
 }
 
 func TestCreateAndGetValidByJti(t *testing.T) {
@@ -72,6 +75,91 @@ func TestRevokeByIDAndRevokeAll(t *testing.T) {
 	}
 }
 
+func TestListExcludesExpiredSessions(t *testing.T) {
+	setupTestDB(t)
+
+	if err := Create(100, "jti-live", "ua", "1.1.1.1"); err != nil {
+		t.Fatalf("create live session: %v", err)
+	}
+	if err := Create(100, "jti-expired-list", "ua", "2.2.2.2"); err != nil {
+		t.Fatalf("create expired session: %v", err)
+	}
+	if err := userSessions.UpdateExpiresAtByJti("jti-expired-list", time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("expire session: %v", err)
+	}
+
+	entities, err := List(100)
+	if err != nil {
+		t.Fatalf("list sessions: %v", err)
+	}
+	if len(entities) != 1 || entities[0].Jti != "jti-live" {
+		t.Fatalf("List() = %+v, want only the live session", entities)
+	}
+}
+
+func TestRevokeAllAndInvalidateInvalidatesCacheAfterCommit(t *testing.T) {
+	setupTestDB(t)
+
+	user := users.MakeUser("session-revoke-all", "password", "session-revoke-all@example.com")
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := Create(user.Id, "jti-revoke-all", "ua", "1.1.1.1"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	if cached, ok := userservice.GetUserInfo(user.Id); !ok || cached.TokenVersion != user.TokenVersion {
+		t.Fatalf("warm user-info cache = %+v, ok = %t", cached, ok)
+	}
+
+	if err := RevokeAllAndInvalidate(user.Id); err != nil {
+		t.Fatalf("revoke all: %v", err)
+	}
+	if GetValidByJti("jti-revoke-all") != nil {
+		t.Fatal("revoke-all should delete every session")
+	}
+	if cached, ok := userservice.GetUserInfo(user.Id); !ok || cached.TokenVersion != user.TokenVersion+1 {
+		t.Fatalf("cached token version = %d, ok = %t, want %d after commit", cached.TokenVersion, ok, user.TokenVersion+1)
+	}
+}
+
+func TestRevokeAllAndInvalidateRollsBackWhenTokenVersionUpdateFails(t *testing.T) {
+	setupTestDB(t)
+	if !db.IsSqlite() {
+		t.Skip("requires SQLite trigger support")
+	}
+
+	user := users.MakeUser("session-revoke-all-rollback", "password", "session-revoke-all-rollback@example.com")
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := Create(user.Id, "jti-revoke-all-rollback", "ua", "1.1.1.1"); err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	conn := db.Connect()
+	if err := conn.Exec("CREATE TRIGGER session_revoke_all_rollback BEFORE UPDATE OF token_version ON users BEGIN SELECT RAISE(ABORT, 'forced token version failure'); END;").Error; err != nil {
+		t.Fatalf("create failure trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Exec("DROP TRIGGER IF EXISTS session_revoke_all_rollback").Error; err != nil {
+			t.Errorf("drop failure trigger: %v", err)
+		}
+	})
+
+	if err := RevokeAllAndInvalidate(user.Id); err == nil {
+		t.Fatal("revoke all succeeded, want token-version failure")
+	}
+	if GetValidByJti("jti-revoke-all-rollback") == nil {
+		t.Fatal("session delete committed even though token-version update failed")
+	}
+	reloaded, err := users.Get(user.Id)
+	if err != nil {
+		t.Fatalf("reload user: %v", err)
+	}
+	if reloaded.TokenVersion != user.TokenVersion {
+		t.Fatalf("token version = %d, want %d after rollback", reloaded.TokenVersion, user.TokenVersion)
+	}
+}
+
 func TestTouchExpiry(t *testing.T) {
 	setupTestDB(t)
 
@@ -108,6 +196,7 @@ func TestMaskIP(t *testing.T) {
 		"203.0.113.7":    "203.0.113.*",
 		"203.0.113.7:80": "203.0.113.*",
 		"2001:db8::1":    "2001:db8:0:0:*",
+		"not-an-ip":      "",
 		"":               "",
 	}
 	for in, want := range cases {

--- a/apps/gooseforum/app/service/userservice/user_cache.go
+++ b/apps/gooseforum/app/service/userservice/user_cache.go
@@ -151,6 +151,14 @@ func GetUserPublicProfile(userID uint64) (UserPublicProfile, bool) {
 	return profile, true
 }
 
+// InvalidateUserInfoCache removes the cached account snapshot for one user.
+func InvalidateUserInfoCache(userID uint64) {
+	if userID == 0 {
+		return
+	}
+	userInfoCache.Delete(userInfoKey(userID))
+}
+
 func InvalidateUserPublicProfileCache(userID uint64) {
 	if userID == 0 {
 		return

--- a/apps/gooseforum/app/service/userservice/user_cache.go
+++ b/apps/gooseforum/app/service/userservice/user_cache.go
@@ -81,6 +81,9 @@ var (
 	userPublicProfileCache = localcache.Cache[UserPublicProfile]{MaxEntries: cacheconfig.Current().UserPublicProfile}
 )
 
+// GetUserInfo returns the cached account snapshot for one user, loading it on
+// demand. Invalidation (see InvalidateUserInfoCache) also drops any in-flight
+// load, so a stale row is never written back into the cache.
 func GetUserInfo(userID uint64) (UserInfo, bool) {
 	if userID == 0 {
 		return UserInfo{}, false

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -549,7 +549,7 @@ export interface components {
         UserSession: {
             /** Format: uint64 */
             id: number;
-            /** @description Privacy-masked client IP (the last IPv4 octet or the IPv6 interface ID is hidden); unparseable stored values are currently echoed as-is (tracked in issue */
+            /** @description Privacy-masked client IP (the last IPv4 octet or the IPv6 interface ID is hidden); unparseable stored values are returned as an empty string. */
             ipMasked: string;
             /** @description Truncated raw user agent; clients render a parsed device label. */
             userAgent: string;

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -58,9 +58,8 @@ export interface paths {
          * @description Session is optional. When the request carries a valid session token (cookie or Bearer), the
          *     server revokes that session record, so the token immediately stops authenticating. An absent,
          *     unverifiable, or already-revoked token is treated as already logged out, which makes this
-         *     operation idempotent. The `access_token` cookie is cleared on the success and
-         *     already-logged-out paths; the rare `session.revoke.failed` business failure (HTTP 200 with
-         *     `code: 1`) currently returns before the cookie is cleared (tracked in issue #79).
+         *     operation idempotent. The `access_token` cookie is cleared on every path, including the rare
+         *     `session.revoke.failed` business failure (HTTP 200 with `code: 1`).
          */
         post: operations["logout"];
         delete?: never;
@@ -133,12 +132,11 @@ export interface paths {
         };
         /**
          * List the authenticated user's sessions
-         * @description Returns all stored session rows of the caller, newest first, marking the session that carries
-         *     the current token; expired rows may appear until housekeeping removes them (tracked in issue
-         *     #79). Parseable addresses in `ipMasked` are privacy-masked (the last IPv4 octet or the IPv6
-         *     interface ID is hidden); unparseable stored values are currently echoed as-is (tracked in
-         *     issue #79). Frozen accounts are intentionally not rejected here so they can still inspect and
-         *     revoke their sessions.
+         * @description Returns only non-expired session rows of the caller, newest first, marking the session that
+         *     carries the current token. `ipMasked` never exposes the stored raw address: parseable values
+         *     hide the last IPv4 octet or the IPv6 interface ID, while unparseable values are returned as an
+         *     empty string. Frozen accounts are intentionally not rejected here so they can still inspect
+         *     and revoke their sessions.
          */
         get: operations["listSessions"];
         put?: never;
@@ -186,11 +184,12 @@ export interface paths {
         put?: never;
         /**
          * Revoke every session of the authenticated user
-         * @description Deletes all session records of the caller, including the one carrying the current token, and
-         *     increments the account's token version as a second layer of invalidation; the increment is
-         *     currently best-effort (not transactional with the deletion, tracked in issue #79). Every
-         *     existing token of the account gets 401 on its next request; the client must log in again
-         *     afterwards. Frozen accounts are not rejected here either.
+         * @description Atomically deletes all session records of the caller, including the one carrying the current
+         *     token, and increments the account's token version as a second layer of invalidation. If either
+         *     database operation fails, neither change is committed and the endpoint returns
+         *     `session.revoke.failed`. Every existing token of the account gets 401 on its next request
+         *     after a successful revocation; the client must log in again afterwards. Frozen accounts are
+         *     not rejected here either.
          */
         post: operations["revokeAllSessions"];
         delete?: never;
@@ -646,7 +645,7 @@ export interface operations {
             /** @description Logout completed (or the caller was already logged out), or a revocation failure. */
             200: {
                 headers: {
-                    /** @description Expires the HTTP-only `access_token` session cookie on the success and already-logged-out paths. */
+                    /** @description Expires the HTTP-only `access_token` session cookie on every logout response. */
                     "Set-Cookie"?: string;
                     [name: string]: unknown;
                 };

--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -76,6 +76,7 @@ export default {
     themePreview: 'Theme preview',
     admin: 'Admin',
     logout: 'Log out',
+    logoutFailed: 'Logout failed: the session could not be revoked. Your login may still be active on this device.',
     login: 'Log in',
     register: 'Sign up',
     resources: 'Resources',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -76,6 +76,7 @@ export default {
     themePreview: 'Anteprima tema',
     admin: 'Amministrazione',
     logout: 'Esci',
+    logoutFailed: 'Disconnessione non riuscita: la sessione non può essere revocata. Potresti essere ancora connesso su questo dispositivo.',
     login: 'Accedi',
     register: 'Registrati',
     resources: 'Risorse',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -76,6 +76,7 @@ export default {
     themePreview: 'テーマプレビュー',
     admin: '管理画面',
     logout: 'ログアウト',
+    logoutFailed: 'ログアウトに失敗しました：セッションを取り消せませんでした。この端末ではログイン状態が続いている可能性があります。',
     login: 'ログイン',
     register: '登録',
     resources: 'リソース',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -76,6 +76,7 @@ export default {
     themePreview: '主题预览',
     admin: '管理后台',
     logout: '退出登录',
+    logoutFailed: '退出登录失败：会话未能撤销，本设备的登录状态可能仍然有效。',
     login: '登录',
     register: '注册',
     resources: '资源',

--- a/apps/gooseforum/resource/src/site/components/AppShell.vue
+++ b/apps/gooseforum/resource/src/site/components/AppShell.vue
@@ -25,6 +25,7 @@ import {
 import { useI18n } from 'vue-i18n'
 import GlobalFlash from './GlobalFlash.vue'
 import { setLocale, supportedLocales, type Locale } from '@/runtime/i18n'
+import { queueFlashMessage } from '@/runtime/flash-message'
 import { useSiteTheme } from '@/runtime/site-theme'
 import { useNavigationState } from '@/runtime/navigation-state'
 import { useUnreadStatus } from '@/runtime/unread-status'
@@ -201,7 +202,15 @@ function closeDrawer() {
 }
 
 async function logout() {
-  await fetch('/api/logout', { method: 'POST' })
+  const res = await fetch('/api/logout', { method: 'POST' })
+  if (res.ok) {
+    const data = await res.json().catch(() => null)
+    if (data && typeof data.code === 'number' && data.code !== 0) {
+      // 服务端撤销失败（session.revoke.failed）：cookie 已清除但会话行可能仍在，
+      // 跨刷新提示用户登录态可能依然有效。
+      queueFlashMessage(t('shell.logoutFailed'), 'error')
+    }
+  }
   window.location.reload()
 }
 

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -524,7 +524,7 @@ UserSession:
       minimum: 1
     ipMasked:
       type: string
-      description: Privacy-masked client IP (the last IPv4 octet or the IPv6 interface ID is hidden); unparseable stored values are currently echoed as-is (tracked in issue #79).
+      description: Privacy-masked client IP (the last IPv4 octet or the IPv6 interface ID is hidden); unparseable stored values are returned as an empty string.
     userAgent:
       type: string
       description: Truncated raw user agent; clients render a parsed device label.

--- a/packages/api-contract/paths/auth-sessions.yaml
+++ b/packages/api-contract/paths/auth-sessions.yaml
@@ -8,15 +8,14 @@ logout:
       Session is optional. When the request carries a valid session token (cookie or Bearer), the
       server revokes that session record, so the token immediately stops authenticating. An absent,
       unverifiable, or already-revoked token is treated as already logged out, which makes this
-      operation idempotent. The `access_token` cookie is cleared on the success and
-      already-logged-out paths; the rare `session.revoke.failed` business failure (HTTP 200 with
-      `code: 1`) currently returns before the cookie is cleared (tracked in issue #79).
+      operation idempotent. The `access_token` cookie is cleared on every path, including the rare
+      `session.revoke.failed` business failure (HTTP 200 with `code: 1`).
     responses:
       '200':
         description: Logout completed (or the caller was already logged out), or a revocation failure.
         headers:
           Set-Cookie:
-            description: Expires the HTTP-only `access_token` session cookie on the success and already-logged-out paths.
+            description: Expires the HTTP-only `access_token` session cookie on every logout response.
             schema:
               type: string
         content:
@@ -36,12 +35,11 @@ listSessions:
       - bearerAuth: []
       - accessTokenCookie: []
     description: |
-      Returns all stored session rows of the caller, newest first, marking the session that carries
-      the current token; expired rows may appear until housekeeping removes them (tracked in issue
-      #79). Parseable addresses in `ipMasked` are privacy-masked (the last IPv4 octet or the IPv6
-      interface ID is hidden); unparseable stored values are currently echoed as-is (tracked in
-      issue #79). Frozen accounts are intentionally not rejected here so they can still inspect and
-      revoke their sessions.
+      Returns only non-expired session rows of the caller, newest first, marking the session that
+      carries the current token. `ipMasked` never exposes the stored raw address: parseable values
+      hide the last IPv4 octet or the IPv6 interface ID, while unparseable values are returned as an
+      empty string. Frozen accounts are intentionally not rejected here so they can still inspect
+      and revoke their sessions.
     responses:
       '200':
         description: Session list, or a legacy business failure envelope (`session.list.failed`).
@@ -120,11 +118,12 @@ revokeAllSessions:
       - bearerAuth: []
       - accessTokenCookie: []
     description: |
-      Deletes all session records of the caller, including the one carrying the current token, and
-      increments the account's token version as a second layer of invalidation; the increment is
-      currently best-effort (not transactional with the deletion, tracked in issue #79). Every
-      existing token of the account gets 401 on its next request; the client must log in again
-      afterwards. Frozen accounts are not rejected here either.
+      Atomically deletes all session records of the caller, including the one carrying the current
+      token, and increments the account's token version as a second layer of invalidation. If either
+      database operation fails, neither change is committed and the endpoint returns
+      `session.revoke.failed`. Every existing token of the account gets 401 on its next request
+      after a successful revocation; the client must log in again afterwards. Frozen accounts are
+      not rejected here either.
     responses:
       '200':
         description: All sessions revoked, or a legacy business failure envelope (`session.revoke.failed`).


### PR DESCRIPTION
## 摘要

修复 #79 发现的四个会话管理实现缝隙，并将 OpenAPI、生成的 Web TypeScript 类型和路由级契约测试同步回强保证语义。

## 变更内容

- `POST /api/logout`：会话撤销失败仍清除 `access_token` cookie，失败响应仍保持 `session.revoke.failed`。
- `GET /api/user/sessions`：在 repository 查询层仅返回未过期 session；不可解析的历史/脏 IP 返回空 `ipMasked`，不再原样泄漏。
- `POST /api/user/sessions/revoke-all`：在同一数据库事务中删除全部 session 并递增 `token_version`；更新报错或影响行数不是 1 时整体回滚，不再返回成功。
- 事务提交后立即失效 user-info cache，确保依赖 `TokenVersion` 的校验不会继续读取旧缓存。
- 新增 logout 失败清 cookie、过期会话过滤、IP 脱敏回退、revoke-all 回滚与提交后缓存失效的服务/路由回归测试。

## 验证（本地实际执行）

- `git diff --check`：通过。
- `go test ./app/service/sessionservice ./app/http/controllers/api`：通过。
- `go test ./app/http/routes`：通过。
- `go vet ./...`：通过。
- `pnpm run check`（OpenAPI lint / bundle / TypeScript generation）：通过；保留已有的 always-200 路由 2 条 lint warning。
- 前端 `pnpm typecheck`、`pnpm test`（14 files / 101 tests）、`pnpm build`：通过。
- 单二进制 `go build`：通过。
- `go test ./...`：本次相关 package 均通过，但全量命令因 Windows 上既有的 `app/bundles/oidcprovider.TestLoadGeneratesAndPersistsKey` 文件权限断言失败（实际 `666`，期望 `600`）而失败；未在本 PR 修改该环境无关问题。

## 已知验证限制

- 本机未安装 `make`，无法执行 `make build`；已分别完成前端生产构建和后端单二进制构建。
- 本机未安装 Docker，无法启动 PostgreSQL 运行仓库的 PG migration gate；本 PR 不改变 schema 或 migration。

Closes #79

Relates to #56, #58