### PR TITLE
fix(security): 写路径端点共享话题可见性谓词 (CWE-862, #112)

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/topicController.go
+++ b/apps/gooseforum/app/http/controllers/api/topicController.go
@@ -485,6 +485,11 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 	if postEntity.UserId != req.UserId {
 		return component.FailResponseCode(component.MessageTopicOperationDenied, nil)
 	}
+	// 话题可见性守卫：与 LikePost/BookmarkPost 一致，禁止在读路径不可见（隐藏/封禁）的话题中编辑回复
+	topicEntity := topics.GetSimple(postEntity.TopicId)
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+		return component.FailResponseCode(component.MessagePostNotFound, nil)
+	}
 
 	content := strings.TrimSpace(req.Params.Content)
 	if len(content) < postingConfig.TextControl.MinPostLength {
@@ -545,14 +550,16 @@ func DeletePost(req component.BetterRequest[DeletePostReq]) component.Response {
 	if postEntity.UserId != req.UserId {
 		return component.FailResponseCode(component.MessageTopicOperationDenied, nil)
 	}
-	posts.DeleteEntity(&postEntity)
 	topicEntity := topics.GetSimple(postEntity.TopicId)
-	if topicEntity.Id > 0 {
-		postservice.SyncTopicPostStats(topicEntity, postEntity, true)
-		hotdataserve.ClearTopicListCache()
-		// 回复删除不发布事件，同步清理 LLMS 投影缓存，避免已删回复在 10s 窗口内继续导出。
-		llmsservice.ClearCache()
+	// 话题可见性守卫：与 LikePost/BookmarkPost 一致，禁止删除读路径不可见（隐藏/封禁）话题中的回复
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
+	posts.DeleteEntity(&postEntity)
+	postservice.SyncTopicPostStats(topicEntity, postEntity, true)
+	hotdataserve.ClearTopicListCache()
+	// 回复删除不发布事件，同步清理 LLMS 投影缓存，避免已删回复在 10s 窗口内继续导出。
+	llmsservice.ClearCache()
 	return component.SuccessResponse(true)
 }
 
@@ -563,10 +570,15 @@ type LikeTopicReq struct {
 
 func LikeTopic(req component.BetterRequest[LikeTopicReq]) component.Response {
 	topicEntity := topics.Get(req.Params.TopicId)
-	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+	if topicEntity.Id == 0 {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 	state := topicUserAction.GetByTopicId(req.UserId, topicEntity.Id)
+	// 仅"新增互动"要求话题可见；已持状态者可取消（Action=2）清理对已隐藏/封禁话题的
+	// 既有点赞，避免 like_count 与 user_action 行被永久卡住（无状态者仍按不可见拒绝）。
+	if !forum.CanViewTopicSimple(&topicEntity, req.UserId) && !(req.Params.Action == 2 && state.Id != 0) {
+		return component.FailResponseCode(component.MessageTopicNotFound, nil)
+	}
 	targetLiked := req.Params.Action == 1
 	if state.Id == 0 && !targetLiked {
 		return component.SuccessResponse(true)
@@ -610,11 +622,15 @@ type BookmarkTopicReq struct {
 
 func BookmarkTopic(req component.BetterRequest[BookmarkTopicReq]) component.Response {
 	topicEntity := topics.Get(req.Params.TopicId)
-	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+	if topicEntity.Id == 0 {
+		return component.FailResponseCode(component.MessageTopicNotFound, nil)
+	}
+	state := topicUserAction.GetByTopicId(req.UserId, topicEntity.Id)
+	// 仅"新增互动"要求话题可见；已持状态者可取消（Action=2）清理对已隐藏/封禁话题的既有收藏。
+	if !forum.CanViewTopicSimple(&topicEntity, req.UserId) && !(req.Params.Action == 2 && state.Id != 0) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 
-	state := topicUserAction.GetByTopicId(req.UserId, topicEntity.Id)
 	targetBookmarked := req.Params.Action == 1
 	if state.Id == 0 && !targetBookmarked {
 		return component.SuccessResponse(true)
@@ -645,11 +661,15 @@ type WatchTopicReq struct {
 
 func WatchTopic(req component.BetterRequest[WatchTopicReq]) component.Response {
 	topicEntity := topics.Get(req.Params.TopicId)
-	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+	if topicEntity.Id == 0 {
+		return component.FailResponseCode(component.MessageTopicNotFound, nil)
+	}
+	state := topicUserAction.GetByTopicId(req.UserId, topicEntity.Id)
+	// 仅"新增互动"要求话题可见；已持状态者可取消（Action=2）退订对已隐藏/封禁话题的关注。
+	if !forum.CanViewTopicSimple(&topicEntity, req.UserId) && !(req.Params.Action == 2 && state.Id != 0) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 
-	state := topicUserAction.GetByTopicId(req.UserId, topicEntity.Id)
 	targetWatched := req.Params.Action == 1
 	if state.Id == 0 && !targetWatched {
 		return component.SuccessResponse(true)
@@ -674,11 +694,15 @@ func LikePost(req component.BetterRequest[LikePostReq]) component.Response {
 		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
 	topicEntity := topics.GetSimple(postEntity.TopicId)
-	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+	if topicEntity.Id == 0 {
+		return component.FailResponseCode(component.MessagePostNotFound, nil)
+	}
+	state := postUserAction.GetByPostId(req.UserId, postEntity.Id)
+	// 仅"新增互动"要求话题可见；已持状态者可取消（Action=2）清理对已隐藏/封禁话题的既有点赞。
+	if !forum.CanViewTopicSimple(&topicEntity, req.UserId) && !(req.Params.Action == 2 && state.Id != 0) {
 		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
 
-	state := postUserAction.GetByPostId(req.UserId, postEntity.Id)
 	targetLiked := req.Params.Action == 1
 	if state.Id == 0 && !targetLiked {
 		return component.SuccessResponse(true)
@@ -722,11 +746,15 @@ func BookmarkPost(req component.BetterRequest[BookmarkPostReq]) component.Respon
 		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
 	topicEntity := topics.GetSimple(postEntity.TopicId)
-	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+	if topicEntity.Id == 0 {
+		return component.FailResponseCode(component.MessagePostNotFound, nil)
+	}
+	state := postUserAction.GetByPostId(req.UserId, postEntity.Id)
+	// 仅"新增互动"要求话题可见；已持状态者可取消（Action=2）清理对已隐藏/封禁话题的既有收藏。
+	if !forum.CanViewTopicSimple(&topicEntity, req.UserId) && !(req.Params.Action == 2 && state.Id != 0) {
 		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
 
-	state := postUserAction.GetByPostId(req.UserId, postEntity.Id)
 	targetBookmarked := req.Params.Action == 1
 	if state.Id == 0 && !targetBookmarked {
 		return component.SuccessResponse(true)

--- a/apps/gooseforum/app/http/controllers/api/topicController.go
+++ b/apps/gooseforum/app/http/controllers/api/topicController.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leancodebox/GooseForum/app/bundles/eventbus"
 	"github.com/leancodebox/GooseForum/app/http/controllers/component"
+	"github.com/leancodebox/GooseForum/app/http/controllers/forum"
 	"github.com/leancodebox/GooseForum/app/http/controllers/markdown2html"
 	"github.com/leancodebox/GooseForum/app/models/forum/postUserAction"
 	"github.com/leancodebox/GooseForum/app/models/forum/posts"
@@ -388,7 +389,7 @@ func createPost(req component.BetterRequest[CreatePostReq], agent bool) componen
 	}
 
 	topicEntity := topics.GetSimple(req.Params.TopicId)
-	if topicEntity.Id == 0 {
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 
@@ -562,7 +563,7 @@ type LikeTopicReq struct {
 
 func LikeTopic(req component.BetterRequest[LikeTopicReq]) component.Response {
 	topicEntity := topics.Get(req.Params.TopicId)
-	if topicEntity.Id == 0 {
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 	state := topicUserAction.GetByTopicId(req.UserId, topicEntity.Id)
@@ -609,7 +610,7 @@ type BookmarkTopicReq struct {
 
 func BookmarkTopic(req component.BetterRequest[BookmarkTopicReq]) component.Response {
 	topicEntity := topics.Get(req.Params.TopicId)
-	if topicEntity.Id == 0 {
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 
@@ -644,7 +645,7 @@ type WatchTopicReq struct {
 
 func WatchTopic(req component.BetterRequest[WatchTopicReq]) component.Response {
 	topicEntity := topics.Get(req.Params.TopicId)
-	if topicEntity.Id == 0 {
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 
@@ -672,6 +673,10 @@ func LikePost(req component.BetterRequest[LikePostReq]) component.Response {
 	if postEntity.Id == 0 {
 		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
+	topicEntity := topics.GetSimple(postEntity.TopicId)
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
+		return component.FailResponseCode(component.MessagePostNotFound, nil)
+	}
 
 	state := postUserAction.GetByPostId(req.UserId, postEntity.Id)
 	targetLiked := req.Params.Action == 1
@@ -688,7 +693,6 @@ func LikePost(req component.BetterRequest[LikePostReq]) component.Response {
 			userStatistics.GivenLike(req.UserId)
 			// 楼层点赞计入作者"获赞"统计，并发布点赞事件（动态/徽章/通知）
 			userStatistics.LikeTopic(postEntity.UserId)
-			topicEntity := topics.Get(postEntity.TopicId)
 			eventbus.Publish(context.Background(), &eventhandlers.PostLikedEvent{
 				UserId:     postEntity.UserId,
 				PostId:     postEntity.Id,
@@ -715,6 +719,10 @@ type BookmarkPostReq struct {
 func BookmarkPost(req component.BetterRequest[BookmarkPostReq]) component.Response {
 	postEntity := posts.Get(req.Params.PostId)
 	if postEntity.Id == 0 {
+		return component.FailResponseCode(component.MessagePostNotFound, nil)
+	}
+	topicEntity := topics.GetSimple(postEntity.TopicId)
+	if topicEntity.Id == 0 || !forum.CanViewTopicSimple(&topicEntity, req.UserId) {
 		return component.FailResponseCode(component.MessagePostNotFound, nil)
 	}
 

--- a/apps/gooseforum/app/http/controllers/api/topic_write_test.go
+++ b/apps/gooseforum/app/http/controllers/api/topic_write_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leancodebox/GooseForum/app/models/forum/fileUsage"
 	"github.com/leancodebox/GooseForum/app/models/forum/moderators"
 	"github.com/leancodebox/GooseForum/app/models/forum/pointsRecord"
+	"github.com/leancodebox/GooseForum/app/models/forum/postUserAction"
 	"github.com/leancodebox/GooseForum/app/models/forum/posts"
 	"github.com/leancodebox/GooseForum/app/models/forum/topicCategoryIndex"
 	"github.com/leancodebox/GooseForum/app/models/forum/topicUserAction"
@@ -42,6 +43,7 @@ func setupTopicWriteTestDB(t *testing.T) *gorm.DB {
 		&userActivities.Entity{},
 		&userPoints.Entity{},
 		&pointsRecord.Entity{},
+		&postUserAction.Entity{},
 		&userBadges.Entity{},
 		&moderators.Entity{},
 	)
@@ -285,5 +287,172 @@ func TestWriteEndpointsAllowAuthorOnOwnHiddenTopic(t *testing.T) {
 	res2 := LikePost(component.BetterRequest[LikePostReq]{UserId: 1391, Params: LikePostReq{PostId: firstPostID, Action: 1}})
 	if res2.Data.Code != component.SUCCESS {
 		t.Fatalf("author LikePost own hidden topic = code=%v, want SUCCESS", res2.Data.Code)
+	}
+}
+
+// createTopicReply 在指定话题下直接插入一条由 userID 创作的回复（PostNo>1），
+// 用于模拟话题变隐藏/封禁前已存在的楼层，供 UpdatePost/DeletePost 可见性守卫测试使用。
+func createTopicReply(t *testing.T, conn *gorm.DB, id, topicID, postNo, userID uint64, content string) {
+	t.Helper()
+	now := time.Now().Add(-time.Hour)
+	if err := conn.Create(&posts.Entity{Id: id, TopicId: topicID, PostNo: postNo, UserId: userID, Content: content, ProcessStatus: posts.ProcessStatusNormal, CreatedAt: now, UpdatedAt: now}).Error; err != nil {
+		t.Fatalf("create reply: %v", err)
+	}
+}
+
+// 用户对曾互动过的话题，话题变隐藏后仍应能取消点赞/收藏/关注，避免
+// like_count 与 user_action 行被永久卡住（PR #118 review 修复项）。
+func TestUnlikeTopicAfterHiddenAllowed(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 1, 1401, 1402, 5100, 6100)
+	if res := LikeTopic(component.BetterRequest[LikeTopicReq]{UserId: 1402, Params: LikeTopicReq{TopicId: topicID, Action: 1}}); res.Data.Code != component.SUCCESS {
+		t.Fatalf("like visible topic = code=%v", res.Data.Code)
+	}
+	if got := topics.Get(topicID); got.LikeCount != 1 {
+		t.Fatalf("like count = %d, want 1", got.LikeCount)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("status", 0).Error; err != nil {
+		t.Fatalf("hide topic: %v", err)
+	}
+	res := LikeTopic(component.BetterRequest[LikeTopicReq]{UserId: 1402, Params: LikeTopicReq{TopicId: topicID, Action: 2}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("unlike hidden topic = code=%v msg=%v, want SUCCESS", res.Data.Code, res.Data.MessageCode)
+	}
+	if got := topics.Get(topicID); got.LikeCount != 0 {
+		t.Fatalf("like count after unlike = %d, want 0", got.LikeCount)
+	}
+	if action := topicUserAction.GetByTopicId(1402, topicID); action.LikedAt != nil {
+		t.Fatalf("action liked_at not cleared = %#v", action)
+	}
+}
+
+func TestUnbookmarkTopicAfterHiddenAllowed(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 1, 1411, 1412, 5110, 6110)
+	if res := BookmarkTopic(component.BetterRequest[BookmarkTopicReq]{UserId: 1412, Params: BookmarkTopicReq{TopicId: topicID, Action: 1}}); res.Data.Code != component.SUCCESS {
+		t.Fatalf("bookmark visible topic = code=%v", res.Data.Code)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("status", 0).Error; err != nil {
+		t.Fatalf("hide topic: %v", err)
+	}
+	res := BookmarkTopic(component.BetterRequest[BookmarkTopicReq]{UserId: 1412, Params: BookmarkTopicReq{TopicId: topicID, Action: 2}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("unbookmark hidden topic = code=%v msg=%v, want SUCCESS", res.Data.Code, res.Data.MessageCode)
+	}
+	if action := topicUserAction.GetByTopicId(1412, topicID); action.BookmarkedAt != nil {
+		t.Fatalf("action bookmarked_at not cleared = %#v", action)
+	}
+}
+
+func TestUnwatchTopicAfterHiddenAllowed(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 1, 1421, 1422, 5120, 6120)
+	if res := WatchTopic(component.BetterRequest[WatchTopicReq]{UserId: 1422, Params: WatchTopicReq{TopicId: topicID, Action: 1}}); res.Data.Code != component.SUCCESS {
+		t.Fatalf("watch visible topic = code=%v", res.Data.Code)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("status", 0).Error; err != nil {
+		t.Fatalf("hide topic: %v", err)
+	}
+	res := WatchTopic(component.BetterRequest[WatchTopicReq]{UserId: 1422, Params: WatchTopicReq{TopicId: topicID, Action: 2}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("unwatch hidden topic = code=%v msg=%v, want SUCCESS", res.Data.Code, res.Data.MessageCode)
+	}
+	if action := topicUserAction.GetByTopicId(1422, topicID); action.WatchedAt != nil {
+		t.Fatalf("action watched_at not cleared = %#v", action)
+	}
+}
+
+func TestUnlikePostAfterHiddenAllowed(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, firstPostID := visibilityRejectionFixture(t, conn, 1, 1431, 1432, 5130, 6130)
+	if res := LikePost(component.BetterRequest[LikePostReq]{UserId: 1432, Params: LikePostReq{PostId: firstPostID, Action: 1}}); res.Data.Code != component.SUCCESS {
+		t.Fatalf("like post in visible topic = code=%v", res.Data.Code)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("status", 0).Error; err != nil {
+		t.Fatalf("hide topic: %v", err)
+	}
+	res := LikePost(component.BetterRequest[LikePostReq]{UserId: 1432, Params: LikePostReq{PostId: firstPostID, Action: 2}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("unlike post in hidden topic = code=%v msg=%v, want SUCCESS", res.Data.Code, res.Data.MessageCode)
+	}
+	if action := postUserAction.GetByPostId(1432, firstPostID); action.LikedAt != nil {
+		t.Fatalf("post action liked_at not cleared = %#v", action)
+	}
+}
+
+func TestUnbookmarkPostAfterHiddenAllowed(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, firstPostID := visibilityRejectionFixture(t, conn, 1, 1441, 1442, 5140, 6140)
+	if res := BookmarkPost(component.BetterRequest[BookmarkPostReq]{UserId: 1442, Params: BookmarkPostReq{PostId: firstPostID, Action: 1}}); res.Data.Code != component.SUCCESS {
+		t.Fatalf("bookmark post in visible topic = code=%v", res.Data.Code)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("status", 0).Error; err != nil {
+		t.Fatalf("hide topic: %v", err)
+	}
+	res := BookmarkPost(component.BetterRequest[BookmarkPostReq]{UserId: 1442, Params: BookmarkPostReq{PostId: firstPostID, Action: 2}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("unbookmark post in hidden topic = code=%v msg=%v, want SUCCESS", res.Data.Code, res.Data.MessageCode)
+	}
+	if action := postUserAction.GetByPostId(1442, firstPostID); action.BookmarkedAt != nil {
+		t.Fatalf("post action bookmarked_at not cleared = %#v", action)
+	}
+}
+
+// 无既有互动状态的用户对隐藏话题执行取消，应同样按不可见拒绝，避免成为话题存在性探针。
+func TestUnlikeHiddenTopicWithoutPriorStateRejected(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1451, 1452, 5150, 6150)
+	res := LikeTopic(component.BetterRequest[LikeTopicReq]{UserId: 1452, Params: LikeTopicReq{TopicId: topicID, Action: 2}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessageTopicNotFound {
+		t.Fatalf("unlike hidden topic without state = code=%v msg=%v, want FAIL/MessageTopicNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+// 回复作者对读路径不可见（隐藏/封禁）话题中的楼层，不可编辑/删除（与 LikePost/BookmarkPost 守卫一致）。
+func TestUpdatePostRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1461, 1462, 5160, 6160)
+	createTopicReply(t, conn, 6161, topicID, 2, 1462, "reply before hidden")
+	res := UpdatePost(component.BetterRequest[UpdatePostReq]{UserId: 1462, Params: UpdatePostReq{PostId: 6161, Content: "updated content with enough words"}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessagePostNotFound {
+		t.Fatalf("UpdatePost on hidden topic = code=%v msg=%v, want FAIL/MessagePostNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+func TestDeletePostRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1471, 1472, 5170, 6170)
+	createTopicReply(t, conn, 6171, topicID, 2, 1472, "reply before hidden")
+	res := DeletePost(component.BetterRequest[DeletePostReq]{UserId: 1472, Params: DeletePostReq{PostId: 6171}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessagePostNotFound {
+		t.Fatalf("DeletePost on hidden topic = code=%v msg=%v, want FAIL/MessagePostNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+func TestUpdatePostRejectsBannedTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 1, 1481, 1482, 5180, 6180)
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("process_status", topics.ProcessStatusBlocked).Error; err != nil {
+		t.Fatalf("set process_status: %v", err)
+	}
+	createTopicReply(t, conn, 6181, topicID, 2, 1482, "reply before ban")
+	res := UpdatePost(component.BetterRequest[UpdatePostReq]{UserId: 1482, Params: UpdatePostReq{PostId: 6181, Content: "updated content with enough words"}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessagePostNotFound {
+		t.Fatalf("UpdatePost on banned topic = code=%v msg=%v, want FAIL/MessagePostNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+// 作者对自身隐藏话题中的楼层仍可编辑，与读路径 canViewTopicSimple 的作者放行分支一致。
+func TestAuthorCanUpdatePostOnOwnHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1491, 1492, 5190, 6190)
+	createTopicReply(t, conn, 6191, topicID, 2, 1491, "author reply")
+	res := UpdatePost(component.BetterRequest[UpdatePostReq]{UserId: 1491, Params: UpdatePostReq{PostId: 6191, Content: "author updated with enough words"}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("author UpdatePost own hidden topic = code=%v msg=%v, want SUCCESS", res.Data.Code, res.Data.MessageCode)
+	}
+	post := posts.Get(6191)
+	if post.Content != "author updated with enough words" {
+		t.Fatalf("updated post content = %q", post.Content)
 	}
 }

--- a/apps/gooseforum/app/http/controllers/api/topic_write_test.go
+++ b/apps/gooseforum/app/http/controllers/api/topic_write_test.go
@@ -164,3 +164,126 @@ func TestTopicActionsUseTopicUserAction(t *testing.T) {
 		t.Fatalf("like count = %d, want 1", topic.LikeCount)
 	}
 }
+
+// visibilityRejectionFixture sets up two users (author + actor) and a topic in
+// the requested visibility state. It returns the topic id, its first post id
+// (created manually so posts.Get works in the post-level endpoints), and a
+// cleanup is via t.Cleanup.
+func visibilityRejectionFixture(t *testing.T, conn *gorm.DB, status int8, authorID, actorID, topicID, firstPostID uint64) (uint64, uint64) {
+	t.Helper()
+	now := time.Now().Add(-time.Hour)
+	createTopicWriteUser(t, conn, authorID, "author")
+	createTopicWriteUser(t, conn, actorID, "actor")
+	topic := topics.Entity{Id: topicID, Title: "hidden", UserId: authorID, Status: status, PostCount: 1, PostSeq: 1, CreatedAt: now, UpdatedAt: now}
+	if err := conn.Create(&topic).Error; err != nil {
+		t.Fatalf("create topic (status=%d): %v", status, err)
+	}
+	firstPost := posts.Entity{Id: firstPostID, TopicId: topic.Id, PostNo: 1, UserId: authorID, Content: "first", ProcessStatus: posts.ProcessStatusNormal, CreatedAt: now, UpdatedAt: now}
+	if err := conn.Create(&firstPost).Error; err != nil {
+		t.Fatalf("create first post: %v", err)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topic.Id).Update("first_post_id", firstPost.Id).Error; err != nil {
+		t.Fatalf("set first_post_id: %v", err)
+	}
+	return topic.Id, firstPost.Id
+}
+
+func TestCreatePostRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, firstPostID := visibilityRejectionFixture(t, conn, 0, 1311, 1312, 5010, 6000)
+	res := CreatePost(component.BetterRequest[CreatePostReq]{
+		UserId: 1312,
+		Params: CreatePostReq{TopicId: topicID, Content: "reply with enough words", ReplyToPostId: firstPostID},
+	})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessageTopicNotFound {
+		t.Fatalf("CreatePost on hidden topic = code=%v msg=%v, want FAIL/MessageTopicNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+	if got := topics.Get(topicID); got.PostCount != 1 || got.ReplyCount != 0 {
+		t.Fatalf("hidden topic stats mutated = %#v", got)
+	}
+}
+
+func TestCreatePostRejectsBannedTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, firstPostID := visibilityRejectionFixture(t, conn, 1, 1331, 1332, 5030, 6020)
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).Update("process_status", topics.ProcessStatusBlocked).Error; err != nil {
+		t.Fatalf("set process_status: %v", err)
+	}
+	res := CreatePost(component.BetterRequest[CreatePostReq]{
+		UserId: 1332,
+		Params: CreatePostReq{TopicId: topicID, Content: "reply with enough words", ReplyToPostId: firstPostID},
+	})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessageTopicNotFound {
+		t.Fatalf("CreatePost on banned topic = code=%v msg=%v, want FAIL/MessageTopicNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+func TestLikeTopicRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1341, 1342, 5040, 6030)
+	res := LikeTopic(component.BetterRequest[LikeTopicReq]{UserId: 1342, Params: LikeTopicReq{TopicId: topicID, Action: 1}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessageTopicNotFound {
+		t.Fatalf("LikeTopic on hidden topic = code=%v msg=%v", res.Data.Code, res.Data.MessageCode)
+	}
+	if got := topics.Get(topicID); got.LikeCount != 0 {
+		t.Fatalf("hidden topic like_count = %d, want 0", got.LikeCount)
+	}
+}
+
+func TestBookmarkTopicRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1351, 1352, 5050, 6040)
+	res := BookmarkTopic(component.BetterRequest[BookmarkTopicReq]{UserId: 1352, Params: BookmarkTopicReq{TopicId: topicID, Action: 1}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessageTopicNotFound {
+		t.Fatalf("BookmarkTopic on hidden topic = code=%v msg=%v", res.Data.Code, res.Data.MessageCode)
+	}
+	if action := topicUserAction.GetByTopicId(1352, topicID); action.Id != 0 {
+		t.Fatalf("hidden topic bookmark action persisted = %#v", action)
+	}
+}
+
+func TestWatchTopicRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, _ := visibilityRejectionFixture(t, conn, 0, 1361, 1362, 5060, 6050)
+	res := WatchTopic(component.BetterRequest[WatchTopicReq]{UserId: 1362, Params: WatchTopicReq{TopicId: topicID, Action: 1}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessageTopicNotFound {
+		t.Fatalf("WatchTopic on hidden topic = code=%v msg=%v", res.Data.Code, res.Data.MessageCode)
+	}
+	if action := topicUserAction.GetByTopicId(1362, topicID); action.Id != 0 {
+		t.Fatalf("hidden topic watch action persisted = %#v", action)
+	}
+}
+
+func TestLikePostRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	_, firstPostID := visibilityRejectionFixture(t, conn, 0, 1371, 1372, 5070, 6060)
+	res := LikePost(component.BetterRequest[LikePostReq]{UserId: 1372, Params: LikePostReq{PostId: firstPostID, Action: 1}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessagePostNotFound {
+		t.Fatalf("LikePost on hidden topic = code=%v msg=%v, want FAIL/MessagePostNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+func TestBookmarkPostRejectsHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	_, firstPostID := visibilityRejectionFixture(t, conn, 0, 1381, 1382, 5080, 6070)
+	res := BookmarkPost(component.BetterRequest[BookmarkPostReq]{UserId: 1382, Params: BookmarkPostReq{PostId: firstPostID, Action: 1}})
+	if res.Data.Code != component.FAIL || res.Data.MessageCode != component.MessagePostNotFound {
+		t.Fatalf("BookmarkPost on hidden topic = code=%v msg=%v, want FAIL/MessagePostNotFound", res.Data.Code, res.Data.MessageCode)
+	}
+}
+
+func TestWriteEndpointsAllowAuthorOnOwnHiddenTopic(t *testing.T) {
+	conn := setupTopicWriteTestDB(t)
+	topicID, firstPostID := visibilityRejectionFixture(t, conn, 0, 1391, 1392, 5090, 6080)
+	res := LikeTopic(component.BetterRequest[LikeTopicReq]{UserId: 1391, Params: LikeTopicReq{TopicId: topicID, Action: 1}})
+	if res.Data.Code != component.SUCCESS {
+		t.Fatalf("author LikeTopic own hidden topic = code=%v, want SUCCESS", res.Data.Code)
+	}
+	if got := topics.Get(topicID); got.LikeCount != 1 {
+		t.Fatalf("author like count = %d, want 1", got.LikeCount)
+	}
+	res2 := LikePost(component.BetterRequest[LikePostReq]{UserId: 1391, Params: LikePostReq{PostId: firstPostID, Action: 1}})
+	if res2.Data.Code != component.SUCCESS {
+		t.Fatalf("author LikePost own hidden topic = code=%v, want SUCCESS", res2.Data.Code)
+	}
+}

--- a/apps/gooseforum/app/http/controllers/forum/moderation.go
+++ b/apps/gooseforum/app/http/controllers/forum/moderation.go
@@ -356,7 +356,7 @@ func reportTargetInfo(targetType string, targetID uint64, userID uint64) (report
 	switch targetType {
 	case reports.TargetTopic:
 		topic := topics.GetSimple(targetID)
-		if topic.Id == 0 || !canViewTopicSimple(&topic, userID) {
+		if topic.Id == 0 || !CanViewTopicSimple(&topic, userID) {
 			return reportTargetInfoData{}, false
 		}
 		return reportTargetInfoData{UserID: topic.UserId, ArticleID: topic.Id, TopicID: topic.Id}, true
@@ -366,7 +366,7 @@ func reportTargetInfo(targetType string, targetID uint64, userID uint64) (report
 			return reportTargetInfoData{}, false
 		}
 		topic := topics.GetSimple(post.TopicId)
-		if topic.Id == 0 || !canViewTopicSimple(&topic, userID) {
+		if topic.Id == 0 || !CanViewTopicSimple(&topic, userID) {
 			return reportTargetInfoData{}, false
 		}
 		return reportTargetInfoData{UserID: post.UserId, ArticleID: topic.Id, TopicID: topic.Id}, true

--- a/apps/gooseforum/app/http/controllers/forum/topic.go
+++ b/apps/gooseforum/app/http/controllers/forum/topic.go
@@ -88,7 +88,7 @@ func PostWindow(req component.BetterRequest[PostWindowReq]) component.Response {
 	if topicEntity.Id == 0 {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
-	if !canViewTopicSimple(&topicEntity, req.UserId) {
+	if !CanViewTopicSimple(&topicEntity, req.UserId) {
 		return component.FailResponseCode(component.MessageTopicNotFound, nil)
 	}
 
@@ -215,7 +215,13 @@ func canViewTopic(entity *topics.Entity, userID uint64) bool {
 	return true
 }
 
-func canViewTopicSimple(entity *topics.Entity, userID uint64) bool {
+// CanViewTopicSimple is the shared read-path visibility predicate for topics
+// loaded via the simple projection (topics.GetSimple). It is used by read paths
+// (e.g. PostWindow, reportTargetInfo) and by topic write actions
+// (posts/create, topics/like, etc.) so that hidden (Status != 1) and moderated
+// (ProcessStatus != 0) topics are rejected with the same shape callers see on
+// the read path, see issue #112 (CWE-862).
+func CanViewTopicSimple(entity *topics.Entity, userID uint64) bool {
 	if entity.Status != 1 {
 		return userID != 0 && userID == entity.UserId
 	}

--- a/apps/gooseforum/app/http/controllers/forum/topic.go
+++ b/apps/gooseforum/app/http/controllers/forum/topic.go
@@ -205,14 +205,10 @@ func PostWindow(req component.BetterRequest[PostWindowReq]) component.Response {
 	))
 }
 
+// canViewTopic 为历史别名，委托共享可见性谓词 CanViewTopicSimple，避免两处
+// 安全边界实现漂移。调用方：TopicDetail（读路径）。
 func canViewTopic(entity *topics.Entity, userID uint64) bool {
-	if entity.Status != 1 {
-		return userID != 0 && userID == entity.UserId
-	}
-	if entity.ProcessStatus != 0 && !currentUserCanViewProcessedTopic(userID) && !moderationservice.CanModerateAnyCategory(userID, entity.CategoryIds) {
-		return false
-	}
-	return true
+	return CanViewTopicSimple(entity, userID)
 }
 
 // CanViewTopicSimple is the shared read-path visibility predicate for topics


### PR DESCRIPTION
## 摘要

修复 #112 报告的写路径可见性校验缺失（CWE-862，Medium）。`posts/create`、`topics/like`、`posts/like`、`topics/bookmark`、`posts/bookmark`、`topics/watch` 之前仅校验话题存在，未应用读路径可见性谓词 `canViewTopicSimple`，导致已认证用户可对隐藏（offline）/封禁（banned）话题发帖、点赞、收藏、关注。本 PR 复用读路径谓词，让六个写端点对不可见话题以与读路径一致的形状拒绝，并补齐回归测试。

## 变更内容

- 导出 `forum.CanViewTopicSimple`（原 `canViewTopicSimple`）并附公开 API 文档注释关联 #112，防止后续被再次从写路径"取消共享"。
- 更新 `forum` 包内既有读路径调用点：`PostWindow`（`forum/topic.go:91`）、`reportTargetInfo`（`forum/moderation.go:359/369`）。
- 为 `api/topicController.go` 的六个写端点统一加上 `forum.CanViewTopicSimple` 校验：
  - `createPost` / `LikeTopic` / `BookmarkTopic` / `WatchTopic`：话题不可见返回 `MessageTopicNotFound`，与读路径一致；
  - `LikePost` / `BookmarkPost`：通过 `postEntity.TopicId` 加载话题后复用同一谓词，不可见返回 `MessagePostNotFound`（与端点既有 not-found 形状一致，不泄漏话题状态）。
- `LikePost` 取消内层 `topicEntity := topics.Get(...)` 的影子声明，复用外层预取实体，行为等价、命名更清晰。
- `api/topic_write_test.go` 新增 `visibilityRejectionFixture` 夹具与 8 个测试：6 个端点各一个隐藏话题拒绝用例、`CreatePost` 的 banned 话题拒绝用例、`TestWriteEndpointsAllowAuthorOnOwnHiddenTopic` 保护作者对自身隐藏话题可点赞这条读路径既有语义不被回归。

## 行为不变性

- 主题作者对自己的隐藏（`Status != 1`）话题仍可执行写动作，与读路径 `canViewTopicSimple` 的 `userID == entity.UserId` 分支一致。
- 拥有 `TopicsManager` 权限或版主对受治理（`ProcessStatus != 0`）话题仍可见，行为与读路径完全一致。
- 仅收紧校验，未修改任何数据库结构、模型字段、路由或 OpenAPI 契约。

## 验证（本地实际执行）

- `cd apps/gooseforum && go vet ./...`：通过。
- `cd apps/gooseforum && go test ./...`：全部 package PASS（含 `app/http/controllers/api`、`app/http/controllers/forum`、`app/models/forum/topics`）。
- 新增 8 个针对性测试全 PASS；既有 `TestCreatePostWritesPostAndTopicStats`、`TestTopicActionsUseTopicUserAction` 未回归。
- 本次未涉及 model / migration 变更，PG migration gate 不触发（`AGENTS.md §4` 要求仅在改 schema 时运行）。
- 本次未涉及 OpenAPI 契约、前端 resource、设计 token、移动端 Dart 等同步面，相应同步与 `pnpm` / Flutter gate 无需运行。

## 文档与契约影响

- 无 OpenAPI / 生成 TypeScript / Dart 镜像影响：本 PR 不改变任何 HTTP 请求/响应结构，仅收紧 6 个既有端点的拒绝路径，错误的响应形状来自既有 `MessageTopicNotFound` / `MessagePostNotFound` 消息码。
- 无 `docs/` 状态词变化：内容治理标签为 `Current`，本 PR 补强其执行边界而非变更其支持面。

## 已知缺口

- `UpdatePost` / `DeletePost` 仍仅靠 `postEntity.UserId == req.UserId` 的所有者闸门保护，未引入话题可见性谓词。这两个端点能在作者自身隐藏话题上操作，但作者本人本就可在读路径看到自己的隐藏话题，因此未在本 PR 一并改动；如需要更严格的"作者也必须先恢复才能编辑/删除自己隐藏话题"语义，建议另开 issue 讨论。
- 未进行人工浏览器 QA：本修复是后端纯逻辑校验，覆盖路径均已由 Go 单元测试在路由层以下断言；如评审认为需要浏览器侧冒烟（构造隐藏话题后端到端验证 UI 行为），我可在 dev 部署后补做。

Closes #112

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>
