### PR TITLE
fix(auth): 登录校验对不存在账号执行等量 PBKDF2，消除时间侧信道（CWE-208）

### DIFF
--- a/apps/gooseforum/app/bundles/algorithm/password.go
+++ b/apps/gooseforum/app/bundles/algorithm/password.go
@@ -32,6 +32,27 @@ func VerifyEncryptPassword(secretPassword, inputPassword string) error {
 	return VerifyPassword(passwordStore[0], passwordStore[1], inputPassword)
 }
 
+// IsWellFormedPasswordHash reports whether secretPassword is a hash:salt
+// value that VerifyEncryptPassword will fully process: exactly two segments,
+// both valid base64, decoding to the expected hash/salt lengths. Malformed
+// values fail fast inside VerifyEncryptPassword without running PBKDF2, so
+// callers that equalize verification timing must detect them up front.
+func IsWellFormedPasswordHash(secretPassword string) bool {
+	passwordStore := strings.Split(secretPassword, ":")
+	if len(passwordStore) != 2 {
+		return false
+	}
+	hash, err := base64.StdEncoding.DecodeString(passwordStore[0])
+	if err != nil || len(hash) != hashKeyLen {
+		return false
+	}
+	salt, err := base64.StdEncoding.DecodeString(passwordStore[1])
+	if err != nil || len(salt) != saltLength {
+		return false
+	}
+	return true
+}
+
 // EncryptPassword hashes password with a random salt.
 func EncryptPassword(password string) (string, string, error) {
 	salt := make([]byte, saltLength)

--- a/apps/gooseforum/app/bundles/algorithm/password_test.go
+++ b/apps/gooseforum/app/bundles/algorithm/password_test.go
@@ -28,6 +28,31 @@ func TestVerifyEncryptPasswordRejectsMalformedValue(t *testing.T) {
 	}
 }
 
+func TestIsWellFormedPasswordHash(t *testing.T) {
+	stored, err := MakePassword("correct horse battery staple")
+	if err != nil {
+		t.Fatalf("MakePassword failed: %v", err)
+	}
+	if !IsWellFormedPasswordHash(stored) {
+		t.Fatalf("MakePassword output %q should be well-formed", stored)
+	}
+	validHash, validSalt, _ := strings.Cut(stored, ":")
+	malformed := []string{
+		"",
+		"not-a-hash",
+		"%%%:" + validSalt,
+		validHash + ":%%%",
+		"a:b:c",
+		validHash + ":" + validSalt[:len(validSalt)-4],
+		validHash[:len(validHash)-4] + ":" + validSalt,
+	}
+	for _, value := range malformed {
+		if IsWellFormedPasswordHash(value) {
+			t.Fatalf("%q should not be well-formed", value)
+		}
+	}
+}
+
 func TestVerifyPasswordRejectsInvalidBase64(t *testing.T) {
 	if err := VerifyPassword("not base64", "also not base64", "password"); err == nil {
 		t.Fatalf("expected invalid hash error")

--- a/apps/gooseforum/app/models/forum/users/users_actor_test.go
+++ b/apps/gooseforum/app/models/forum/users/users_actor_test.go
@@ -16,6 +16,39 @@ func setupUserIsolationTestDB(t *testing.T) {
 	conn.Where("1 = 1").Delete(&EntityComplete{})
 }
 
+type verifySpyCall struct {
+	storedHash string
+	password   string
+}
+
+// installVerifySpy replaces the package-level verifyEncryptPassword seam with
+// a recording wrapper around the real implementation, so tests can assert
+// that every Verify path pays the equal-cost PBKDF2 against the intended
+// stored hash. The timing-equalization calls discard their results and are
+// otherwise unobservable, so without this seam deleting them would leave the
+// suite green while silently re-opening the CWE-208 timing side channel.
+func installVerifySpy(t *testing.T) *[]verifySpyCall {
+	t.Helper()
+	calls := &[]verifySpyCall{}
+	original := verifyEncryptPassword
+	verifyEncryptPassword = func(storedHash, password string) error {
+		*calls = append(*calls, verifySpyCall{storedHash: storedHash, password: password})
+		return original(storedHash, password)
+	}
+	t.Cleanup(func() { verifyEncryptPassword = original })
+	return calls
+}
+
+func assertSingleVerifyCall(t *testing.T, calls *[]verifySpyCall, wantHash string) {
+	t.Helper()
+	if len(*calls) != 1 {
+		t.Fatalf("verify calls = %d, want exactly 1", len(*calls))
+	}
+	if (*calls)[0].storedHash != wantHash {
+		t.Fatalf("verify stored hash = %q, want %q", (*calls)[0].storedHash, wantHash)
+	}
+}
+
 func TestVerifyRejectsBotAccount(t *testing.T) {
 	setupUserIsolationTestDB(t)
 	bot := MakeUser("bot-login-test", "correct-password-123", "")
@@ -23,11 +56,13 @@ func TestVerifyRejectsBotAccount(t *testing.T) {
 	if err := Create(bot); err != nil {
 		t.Fatalf("create bot: %v", err)
 	}
+	calls := installVerifySpy(t)
 	// Even with the right password the bot must never verify, and the error
 	// is the same generic credentials error used for wrong passwords.
 	if _, err := Verify("bot-login-test", "correct-password-123"); !errors.Is(err, ErrInvalidCredentials) {
 		t.Fatalf("bot login error = %v, want ErrInvalidCredentials", err)
 	}
+	assertSingleVerifyCall(t, calls, dummyHashForTiming)
 }
 
 func TestVerifyAcceptsHumanAccount(t *testing.T) {
@@ -37,6 +72,7 @@ func TestVerifyAcceptsHumanAccount(t *testing.T) {
 	if err := Create(human); err != nil {
 		t.Fatalf("create human: %v", err)
 	}
+	calls := installVerifySpy(t)
 	user, err := Verify("human-login-test", "correct-password-123")
 	if err != nil {
 		t.Fatalf("human login failed: %v", err)
@@ -44,6 +80,7 @@ func TestVerifyAcceptsHumanAccount(t *testing.T) {
 	if user.Id == 0 || user.Username != "human-login-test" {
 		t.Fatalf("human login returned wrong user: %#v", user)
 	}
+	assertSingleVerifyCall(t, calls, human.Password)
 }
 
 // Unknown accounts must fail with the same generic error as wrong passwords
@@ -57,14 +94,45 @@ func TestVerifyUnknownAccountMatchesCredentialFailures(t *testing.T) {
 		t.Fatalf("create human: %v", err)
 	}
 
-	if _, err := Verify("no-such-user", "whatever-password"); !errors.Is(err, ErrInvalidCredentials) {
-		t.Fatalf("unknown username error = %v, want ErrInvalidCredentials", err)
+	cases := []struct {
+		name     string
+		login    string
+		password string
+		wantHash string
+	}{
+		{"unknown username", "no-such-user", "whatever-password", dummyHashForTiming},
+		{"unknown email", "no-such-user@example.com", "whatever-password", dummyHashForTiming},
+		{"known username, wrong password", "human-login-enum-test", "wrong-password-456", human.Password},
+		{"known email, wrong password", "human-enum@example.com", "wrong-password-456", human.Password},
 	}
-	if _, err := Verify("no-such-user@example.com", "whatever-password"); !errors.Is(err, ErrInvalidCredentials) {
-		t.Fatalf("unknown email error = %v, want ErrInvalidCredentials", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := installVerifySpy(t)
+			if _, err := Verify(tc.login, tc.password); !errors.Is(err, ErrInvalidCredentials) {
+				t.Fatalf("%s error = %v, want ErrInvalidCredentials", tc.name, err)
+			}
+			assertSingleVerifyCall(t, calls, tc.wantHash)
+		})
 	}
-	if _, err := Verify("human-login-enum-test", "wrong-password-456"); !errors.Is(err, ErrInvalidCredentials) {
-		t.Fatalf("wrong password error = %v, want ErrInvalidCredentials", err)
+}
+
+// Accounts whose stored hash is empty or malformed (e.g. imported users
+// without a password) can never authenticate; they must still pay the
+// equal-cost PBKDF2 against the dummy hash, or a fast response would
+// deterministically reveal "username exists but has no usable password".
+func TestVerifyMalformedStoredHashUsesDummy(t *testing.T) {
+	setupUserIsolationTestDB(t)
+	for i, stored := range []string{"", "not-a-hash"} {
+		user := &EntityComplete{Username: "malformed-hash-user-" + string(rune('a'+i))}
+		user.Password = stored
+		if err := Create(user); err != nil {
+			t.Fatalf("create user with stored hash %q: %v", stored, err)
+		}
+		calls := installVerifySpy(t)
+		if _, err := Verify(user.Username, "whatever-password"); !errors.Is(err, ErrInvalidCredentials) {
+			t.Fatalf("stored hash %q error = %v, want ErrInvalidCredentials", stored, err)
+		}
+		assertSingleVerifyCall(t, calls, dummyHashForTiming)
 	}
 }
 

--- a/apps/gooseforum/app/models/forum/users/users_actor_test.go
+++ b/apps/gooseforum/app/models/forum/users/users_actor_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/leancodebox/GooseForum/app/bundles/algorithm"
 	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
 )
 
@@ -118,6 +119,21 @@ func TestVerifyUnknownAccountMatchesCredentialFailures(t *testing.T) {
 	}
 }
 
+// The dummy value must stay well-formed and run the full PBKDF2 cost:
+// VerifyEncryptPassword against it must reach the post-PBKDF2 comparison
+// and report "incorrect password", never a fail-fast parse error. If a
+// future hardening of VerifyPassword (e.g. hash/salt length checks) made
+// the dummy fail fast, the timing equalization would silently vanish while
+// the spy tests above stayed green.
+func TestDummyHashForTimingRunsFullCost(t *testing.T) {
+	if !algorithm.IsWellFormedPasswordHash(dummyHashForTiming) {
+		t.Fatal("dummyHashForTiming should satisfy IsWellFormedPasswordHash")
+	}
+	if err := algorithm.VerifyEncryptPassword(dummyHashForTiming, "whatever-password"); err == nil || err.Error() != "incorrect password" {
+		t.Fatalf("dummy verify error = %v, want post-PBKDF2 \"incorrect password\"", err)
+	}
+}
+
 // Accounts whose stored hash is empty or malformed (e.g. imported users
 // without a password) can never authenticate; they must still pay the
 // equal-cost PBKDF2 against the dummy hash, or a fast response would
@@ -134,6 +150,7 @@ func TestVerifyMalformedStoredHashUsesDummy(t *testing.T) {
 		validHash + ":%%%", // salt segment not base64
 		"a:b:c",            // more than two segments
 		validHash + ":" + validSalt[:len(validSalt)-4], // salt of wrong length
+		validHash[:len(validHash)-4] + ":" + validSalt, // hash of wrong length
 	}
 	for i, stored := range malformed {
 		user := &EntityComplete{Username: fmt.Sprintf("malformed-hash-user-%d", i)}
@@ -147,6 +164,18 @@ func TestVerifyMalformedStoredHashUsesDummy(t *testing.T) {
 		}
 		assertSingleVerifyCall(t, calls, dummyHashForTiming)
 	}
+
+	// Same handling via the email lookup route.
+	emailUser := &EntityComplete{Username: "malformed-hash-email-user", Email: "malformed-hash@example.com"}
+	emailUser.Password = ""
+	if err := Create(emailUser); err != nil {
+		t.Fatalf("create email-route user: %v", err)
+	}
+	calls := installVerifySpy(t)
+	if _, err := Verify("malformed-hash@example.com", "whatever-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("email-route malformed hash error = %v, want ErrInvalidCredentials", err)
+	}
+	assertSingleVerifyCall(t, calls, dummyHashForTiming)
 }
 
 func TestIsBotFlag(t *testing.T) {

--- a/apps/gooseforum/app/models/forum/users/users_actor_test.go
+++ b/apps/gooseforum/app/models/forum/users/users_actor_test.go
@@ -2,6 +2,8 @@ package users
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
@@ -120,10 +122,21 @@ func TestVerifyUnknownAccountMatchesCredentialFailures(t *testing.T) {
 // without a password) can never authenticate; they must still pay the
 // equal-cost PBKDF2 against the dummy hash, or a fast response would
 // deterministically reveal "username exists but has no usable password".
+// VerifyEncryptPassword fails fast on any malformed value, so the malformed
+// detection must reject every shape it would skip PBKDF2 for.
 func TestVerifyMalformedStoredHashUsesDummy(t *testing.T) {
 	setupUserIsolationTestDB(t)
-	for i, stored := range []string{"", "not-a-hash"} {
-		user := &EntityComplete{Username: "malformed-hash-user-" + string(rune('a'+i))}
+	validHash, validSalt, _ := strings.Cut(dummyHashForTiming, ":")
+	malformed := []string{
+		"",
+		"not-a-hash",
+		"%%%:" + validSalt, // hash segment not base64
+		validHash + ":%%%", // salt segment not base64
+		"a:b:c",            // more than two segments
+		validHash + ":" + validSalt[:len(validSalt)-4], // salt of wrong length
+	}
+	for i, stored := range malformed {
+		user := &EntityComplete{Username: fmt.Sprintf("malformed-hash-user-%d", i)}
 		user.Password = stored
 		if err := Create(user); err != nil {
 			t.Fatalf("create user with stored hash %q: %v", stored, err)

--- a/apps/gooseforum/app/models/forum/users/users_actor_test.go
+++ b/apps/gooseforum/app/models/forum/users/users_actor_test.go
@@ -46,6 +46,28 @@ func TestVerifyAcceptsHumanAccount(t *testing.T) {
 	}
 }
 
+// Unknown accounts must fail with the same generic error as wrong passwords
+// (and bot accounts), after an equal-cost PBKDF2 run, so neither the error
+// identity nor the response time can be used to enumerate registered
+// usernames/emails (CWE-208).
+func TestVerifyUnknownAccountMatchesCredentialFailures(t *testing.T) {
+	setupUserIsolationTestDB(t)
+	human := MakeUser("human-login-enum-test", "correct-password-123", "human-enum@example.com")
+	if err := Create(human); err != nil {
+		t.Fatalf("create human: %v", err)
+	}
+
+	if _, err := Verify("no-such-user", "whatever-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("unknown username error = %v, want ErrInvalidCredentials", err)
+	}
+	if _, err := Verify("no-such-user@example.com", "whatever-password"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("unknown email error = %v, want ErrInvalidCredentials", err)
+	}
+	if _, err := Verify("human-login-enum-test", "wrong-password-456"); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("wrong password error = %v, want ErrInvalidCredentials", err)
+	}
+}
+
 func TestIsBotFlag(t *testing.T) {
 	if (&EntityComplete{ActorType: ActorTypeBot}).IsBot() != true {
 		t.Fatal("ActorTypeBot should report IsBot")

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -56,9 +56,10 @@ func Verify(usernameOrEmail string, password string) (*EntityComplete, error) {
 	}
 	// 两类无法完成真实校验的账号同样先执行等量 PBKDF2 再返回统一错误：
 	// bot 账号不参与密码登录（也无可用密码）；存储哈希为空或畸形的账号
-	// （如数据导入未设密码）不可能校验通过。否则快速响应会确定性地区分
+	// （如数据导入未设密码）不可能校验通过，且 VerifyEncryptPassword 对
+	// 畸形值会跳过 PBKDF2 直接报错。否则快速响应会确定性地区分
 	// “账号不存在”与“账号已存在但无有效密码”，重开枚举侧信道。
-	if user.IsBot() || !strings.Contains(user.Password, ":") {
+	if user.IsBot() || !algorithm.IsWellFormedPasswordHash(user.Password) {
 		_ = verifyEncryptPassword(dummyHashForTiming, password)
 		return &EntityComplete{}, ErrInvalidCredentials
 	}

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -15,10 +15,17 @@ import (
 
 // dummyHashForTiming is a fixed PBKDF2-SHA256 hash:salt value used to
 // equalize password-verification timing when no usable credential row is
-// present (unknown username/email, or a bot account at the human login
-// endpoint). It runs the same 10000-iteration cost as real hashes so
-// username enumeration via response time is not possible.
-const dummyHashForTiming = "kQZbUFLHdF2p4QRUQ7kVsv6r0LqRFiYBoK9V0MaRTzc=:eW91cnRqLWJvdC10aW1pbmctc2FsdC0wMTIzNDU2Nzg5YWJjZGVm"
+// present (unknown username/email, bot account, or an empty/malformed
+// stored hash such as imported users without a password). It runs the same
+// 10000-iteration cost as real hashes so username enumeration via response
+// time is not possible.
+const dummyHashForTiming = "cvSnM8ciGWPMBCT/2aqq7QC6kxNmvCbn51nily0JhOc=:eW91cnRqLXRpbWluZy1kdW1teS1zYWx0LTAxMjM0NTY3ODk="
+
+// verifyEncryptPassword is the password verification entry point, held in a
+// package-level variable so tests can spy on which stored hash each Verify
+// path verifies against (the timing equalization calls return discarded
+// errors and are otherwise unobservable).
+var verifyEncryptPassword = algorithm.VerifyEncryptPassword
 
 // ErrInvalidCredentials is the single error returned for every failed
 // password verification (unknown user, bot account, or wrong password), so
@@ -42,19 +49,20 @@ func Verify(usernameOrEmail string, password string) (*EntityComplete, error) {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			// 账号不存在时也执行与真实校验等量的 PBKDF2，抹平响应时间差，
 			// 避免通过登录响应时间枚举已注册账号（CWE-208）。
-			_ = algorithm.VerifyEncryptPassword(dummyHashForTiming, password)
+			_ = verifyEncryptPassword(dummyHashForTiming, password)
 			return &EntityComplete{}, ErrInvalidCredentials
 		}
 		return &user, err
 	}
-	// 机器人（Agent）账号不参与密码登录。先执行与真实校验等量的 PBKDF2
-	// 以抹平响应时间，再返回与错误密码完全相同的错误，避免枚举 bot 账号，
-	// 也与“bot 邮箱为空、密码不可用”的约束一致。
-	if user.IsBot() {
-		_ = algorithm.VerifyEncryptPassword(dummyHashForTiming, password)
+	// 两类无法完成真实校验的账号同样先执行等量 PBKDF2 再返回统一错误：
+	// bot 账号不参与密码登录（也无可用密码）；存储哈希为空或畸形的账号
+	// （如数据导入未设密码）不可能校验通过。否则快速响应会确定性地区分
+	// “账号不存在”与“账号已存在但无有效密码”，重开枚举侧信道。
+	if user.IsBot() || !strings.Contains(user.Password, ":") {
+		_ = verifyEncryptPassword(dummyHashForTiming, password)
 		return &EntityComplete{}, ErrInvalidCredentials
 	}
-	err = algorithm.VerifyEncryptPassword(user.Password, password)
+	err = verifyEncryptPassword(user.Password, password)
 	if err != nil {
 		return &EntityComplete{}, ErrInvalidCredentials
 	}

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -19,7 +19,7 @@ import (
 // stored hash such as imported users without a password). It runs the same
 // 10000-iteration cost as real hashes so username enumeration via response
 // time is not possible.
-const dummyHashForTiming = "cvSnM8ciGWPMBCT/2aqq7QC6kxNmvCbn51nily0JhOc=:eW91cnRqLXRpbWluZy1kdW1teS1zYWx0LTAxMjM0NTY3ODk="
+const dummyHashForTiming = "BhHz/kgB9L+m25V1YC0SHSBS4njsDq8fyOaQvNTaX80=:eW91cnRqLXRpbWluZy1kdW1teS1zYWx0LTAxMjM0NTY="
 
 // verifyEncryptPassword is the password verification entry point, held in a
 // package-level variable so tests can spy on which stored hash each Verify

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -13,11 +13,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// dummyBotHashForTiming is a fixed PBKDF2-SHA256 hash:salt value used to
-// equalize password-verification timing when a bot account is presented at
-// the human login endpoint. It runs the same 10000-iteration cost as real
-// hashes so username enumeration via response time is not possible.
-const dummyBotHashForTiming = "kQZbUFLHdF2p4QRUQ7kVsv6r0LqRFiYBoK9V0MaRTzc=:eW91cnRqLWJvdC10aW1pbmctc2FsdC0wMTIzNDU2Nzg5YWJjZGVm"
+// dummyHashForTiming is a fixed PBKDF2-SHA256 hash:salt value used to
+// equalize password-verification timing when no usable credential row is
+// present (unknown username/email, or a bot account at the human login
+// endpoint). It runs the same 10000-iteration cost as real hashes so
+// username enumeration via response time is not possible.
+const dummyHashForTiming = "kQZbUFLHdF2p4QRUQ7kVsv6r0LqRFiYBoK9V0MaRTzc=:eW91cnRqLWJvdC10aW1pbmctc2FsdC0wMTIzNDU2Nzg5YWJjZGVm"
 
 // ErrInvalidCredentials is the single error returned for every failed
 // password verification (unknown user, bot account, or wrong password), so
@@ -38,13 +39,19 @@ func Verify(usernameOrEmail string, password string) (*EntityComplete, error) {
 		err = builder().Where("username = ?", usernameOrEmail).First(&user).Error
 	}
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// 账号不存在时也执行与真实校验等量的 PBKDF2，抹平响应时间差，
+			// 避免通过登录响应时间枚举已注册账号（CWE-208）。
+			_ = algorithm.VerifyEncryptPassword(dummyHashForTiming, password)
+			return &EntityComplete{}, ErrInvalidCredentials
+		}
 		return &user, err
 	}
 	// 机器人（Agent）账号不参与密码登录。先执行与真实校验等量的 PBKDF2
 	// 以抹平响应时间，再返回与错误密码完全相同的错误，避免枚举 bot 账号，
 	// 也与“bot 邮箱为空、密码不可用”的约束一致。
 	if user.IsBot() {
-		_ = algorithm.VerifyEncryptPassword(dummyBotHashForTiming, password)
+		_ = algorithm.VerifyEncryptPassword(dummyHashForTiming, password)
 		return &EntityComplete{}, ErrInvalidCredentials
 	}
 	err = algorithm.VerifyEncryptPassword(user.Password, password)

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers, Security reviewer
 >
-> Last verified: 2026-08-09
+> Last verified: 2026-08-11
 
 ## Identity model
 
@@ -129,7 +129,9 @@
 - Client secrets are configured server-side and never logged.
 - id_token / access token never persisted by clients; forum JWT goes into an HttpOnly cookie
   (Secure + SameSite=Lax when the site is served over HTTPS).
-- Enumeration resistance: login errors do not distinguish "user not found / wrong password".
+- Enumeration resistance: login errors do not distinguish "user not found / wrong password", and
+  unknown accounts run the same-cost PBKDF2 verification as real ones so response time does not
+  reveal whether a username/email is registered.
 - Session revocation is implemented as `jti` + `user_sessions` table (decision recorded in ADR note);
   TokenVersion remains as a global invalidation fallback.
 - TOTP secrets and recovery codes never leave the server in plaintext (secret encrypted at rest,


### PR DESCRIPTION
## 变更说明

修复 #109：`POST /api/login` 通过响应时间泄露账号是否注册。

**根因**：`users.Verify` 在用户名/邮箱查无记录时立即返回，不执行 PBKDF2；账号存在时则执行 10,000 次迭代 PBKDF2-SHA256 后再返回同一错误体。两条路径耗时分布完全不重叠（约 2.4 倍），可批量枚举注册账号。bot 账号路径此前已做等时处理，遗漏的是"账号不存在"路径。

**改动**：

- 查无记录（`gorm.ErrRecordNotFound`）时，先对固定 dummy hash 执行一次等量 PBKDF2，再返回与"密码错误"完全一致的 `ErrInvalidCredentials`；真实 DB 错误仍原样上抛，不掩盖可用性故障
- 原 `dummyBotHashForTiming` 常量更名为 `dummyHashForTiming`（语义覆盖未知账号与 bot 账号两种场景），注释同步更新
- 新增 `TestVerifyUnknownAccountMatchesCredentialFailures`：断言未知用户名、未知邮箱、错误密码三种失败返回同一错误（等时由同一代码路径构造保证，不做墙钟断言避免 CI 抖动）
- `docs/product/identity-and-access.md`：枚举防护条目补充时间维度说明

响应体与错误码无任何变化，`/api/login` 契约（`login-failure.json` fixture）不受影响。

## 验证

- `git diff --check`：通过
- `cd apps/gooseforum && go vet ./...`：通过
- `go test ./...`：通过（唯一失败为预存在的 Windows 环境用例 `oidcprovider.TestLoadGeneratesAndPersistsKey` 断言文件权限 0600，与本改动无关，Linux CI 为绿）
- 时序实测（30 次平均）：未知账号 1.35ms vs 已知账号错误密码 1.46ms，比值 0.92 处于噪声范围（修复前约 1/2.4）
- PG 迁移门禁不适用：无 model/migration 变更；前端未触碰

Closes #109