### PR TITLE
fix(security): fail-close session cookie Secure by env (issue #113)

### DIFF
--- a/apps/gooseforum/app/bundles/jwtopt/jwtHelper.go
+++ b/apps/gooseforum/app/bundles/jwtopt/jwtHelper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/leancodebox/GooseForum/app/bundles/algorithm"
 	"github.com/leancodebox/GooseForum/app/bundles/preferences"
+	"github.com/leancodebox/GooseForum/app/bundles/setting"
 	"github.com/spf13/cast"
 )
 
@@ -190,7 +191,7 @@ func TokenSettingWithMaxAge(c *gin.Context, newToken string, maxAge time.Duratio
 		cast.ToInt(maxAge/time.Second),
 		"/",
 		"",
-		cookieSecure(),
+		setting.CookieSecure(),
 		true,
 	)
 }
@@ -204,20 +205,7 @@ func TokenClean(c *gin.Context) {
 		-1,
 		"/",
 		"",
-		cookieSecure(),
+		setting.CookieSecure(),
 		true,
 	)
-}
-
-// cookieSecure mirrors sessionstore's secure-cookie decision: HTTPS sites get
-// Secure cookies; local (http://) dev stays usable.
-func cookieSecure() bool {
-	normalizedURL := strings.ToLower(strings.TrimSpace(preferences.GetString("server.url", "")))
-	if strings.HasPrefix(normalizedURL, "https://") {
-		return true
-	}
-	if strings.HasPrefix(normalizedURL, "http://") {
-		return false
-	}
-	return !strings.EqualFold(strings.TrimSpace(preferences.GetString("app.env", "production")), "local")
 }

--- a/apps/gooseforum/app/bundles/jwtopt/jwt_test.go
+++ b/apps/gooseforum/app/bundles/jwtopt/jwt_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/leancodebox/GooseForum/app/bundles/preferences"
 )
 
 func TestCreateNewToken(t *testing.T) {
@@ -122,6 +123,74 @@ func TestTokenSettingAndClean(t *testing.T) {
 	setCookie := cleanRecorder.Header().Get("Set-Cookie")
 	if !strings.Contains(setCookie, "access_token=") || !strings.Contains(setCookie, "Max-Age=0") {
 		t.Fatalf("clear cookie header = %q", setCookie)
+	}
+}
+
+// withEnv restores app.env and server.url after the test so package-level
+// viper state does not leak across tests.
+func withEnv(t *testing.T, appEnv, serverURL string) {
+	t.Helper()
+	prevEnv := preferences.GetString("app.env", "production")
+	prevURL := preferences.GetString("server.url", "")
+	preferences.Set("app.env", appEnv)
+	preferences.Set("server.url", serverURL)
+	t.Cleanup(func() {
+		preferences.Set("app.env", prevEnv)
+		preferences.Set("server.url", prevURL)
+	})
+}
+
+// TestAccessTokenCookieSecureProductionHTTP reproduces issue #113: under the
+// template defaults `app.env = "production"` + `server.url = "http://localhost"`
+// the access_token cookie must still carry the Secure flag.
+func TestAccessTokenCookieSecureProductionHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withEnv(t, "production", "http://localhost")
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	TokenSetting(c, "tok")
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name != "access_token" {
+			continue
+		}
+		if !ck.Secure {
+			t.Fatalf("access_token cookie Secure=false under production+http://localhost, want Secure (CWE-614)")
+		}
+		if !ck.HttpOnly {
+			t.Fatalf("access_token cookie HttpOnly=false")
+		}
+		if ck.SameSite != http.SameSiteLaxMode {
+			t.Fatalf("access_token SameSite = %v, want Lax", ck.SameSite)
+		}
+	}
+
+	cleanRec := httptest.NewRecorder()
+	cleanC, _ := gin.CreateTestContext(cleanRec)
+	cleanC.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	TokenClean(cleanC)
+	for _, ck := range cleanRec.Result().Cookies() {
+		if ck.Name == "access_token" && !ck.Secure {
+			t.Fatalf("access_token clear cookie Secure=false under production+http://localhost, want Secure")
+		}
+	}
+}
+
+// TestAccessTokenCookieLocalKeepsSecureOff verifies local dev still drops Secure
+// so plain-http 0.0.0.0 / LAN-IP access keeps the cookie.
+func TestAccessTokenCookieLocalKeepsSecureOff(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	withEnv(t, "local", "http://localhost:5234")
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	TokenSetting(c, "tok")
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == "access_token" && ck.Secure {
+			t.Fatalf("access_token Secure=true under local, want false for dev over plain http")
+		}
 	}
 }
 

--- a/apps/gooseforum/app/bundles/sessionstore/sessionstore.go
+++ b/apps/gooseforum/app/bundles/sessionstore/sessionstore.go
@@ -2,12 +2,12 @@ package sessionstore
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/gorilla/sessions"
 	"github.com/leancodebox/GooseForum/app/bundles/algorithm"
 	"github.com/leancodebox/GooseForum/app/bundles/preferences"
+	"github.com/leancodebox/GooseForum/app/bundles/setting"
 )
 
 var store *sessions.CookieStore
@@ -32,16 +32,5 @@ func configureSessionStore(store *sessions.CookieStore) {
 	store.Options.Path = "/"
 	store.Options.HttpOnly = true
 	store.Options.SameSite = http.SameSiteLaxMode
-	store.Options.Secure = sessionCookieSecure(preferences.GetString("server.url", ""), preferences.GetString("app.env", "production"))
-}
-
-func sessionCookieSecure(serverURL string, appEnv string) bool {
-	normalizedURL := strings.ToLower(strings.TrimSpace(serverURL))
-	if strings.HasPrefix(normalizedURL, "https://") {
-		return true
-	}
-	if strings.HasPrefix(normalizedURL, "http://") {
-		return false
-	}
-	return !strings.EqualFold(strings.TrimSpace(appEnv), "local")
+	store.Options.Secure = setting.CookieSecure()
 }

--- a/apps/gooseforum/app/bundles/setting/globalConfig.go
+++ b/apps/gooseforum/app/bundles/setting/globalConfig.go
@@ -40,3 +40,15 @@ func GetCDNURL() string {
 func URL(path string) string {
 	return preferences.Get("server.url") + path
 }
+
+// CookieSecure reports whether session cookies should carry the Secure flag.
+//
+// Fail-closed by environment, not by site URL scheme: any environment other
+// than "local" forces Secure regardless of `server.url`. This closes the
+// CWE-614 gap where template defaults `app.env = "production"` with
+// `server.url = "http://localhost"` dropped the Secure flag on `access_token`
+// and goth session cookies. Local keeps Secure off so 0.0.0.0 / LAN-IP dev
+// access over plain http keeps working (browsers accept Secure on localhost).
+func CookieSecure() bool {
+	return !IsLocal()
+}

--- a/apps/gooseforum/app/bundles/setting/globalConfig_test.go
+++ b/apps/gooseforum/app/bundles/setting/globalConfig_test.go
@@ -1,9 +1,8 @@
-package sessionstore
+package setting
 
 import (
 	"testing"
 
-	"github.com/gorilla/sessions"
 	"github.com/leancodebox/GooseForum/app/bundles/preferences"
 )
 
@@ -21,21 +20,21 @@ func withEnv(t *testing.T, appEnv, serverURL string) {
 	})
 }
 
-// TestSessionStoreSecureByEnv replaces the old scheme-based sessionCookieSecure
-// table: the Secure flag now follows setting.CookieSecure (fail-closed by env),
-// not server.url scheme. Covers issue #113.
-func TestSessionStoreSecureByEnv(t *testing.T) {
+func TestCookieSecureFailClosed(t *testing.T) {
 	cases := []struct {
 		name      string
 		appEnv    string
 		serverURL string
 		want      bool
 	}{
-		{name: "production http localhost default", appEnv: "production", serverURL: "http://localhost", want: true},
+		// Issue #113: production must force Secure regardless of server.url scheme.
 		{name: "production http example", appEnv: "production", serverURL: "http://example.com", want: true},
+		{name: "production http localhost", appEnv: "production", serverURL: "http://localhost", want: true},
 		{name: "production https", appEnv: "production", serverURL: "https://example.com", want: true},
 		{name: "production empty url", appEnv: "production", serverURL: "", want: true},
 		{name: "staging http", appEnv: "staging", serverURL: "http://staging.example.com", want: true},
+		{name: "unknown env treated as non-local", appEnv: "anything-else", serverURL: "http://x", want: true},
+		// Local dev keeps Secure off so 0.0.0.0 / LAN-IP over plain http works.
 		{name: "local http localhost", appEnv: "local", serverURL: "http://localhost:5234", want: false},
 		{name: "local https", appEnv: "local", serverURL: "https://localhost", want: false},
 		{name: "local empty url", appEnv: "local", serverURL: "", want: false},
@@ -44,17 +43,17 @@ func TestSessionStoreSecureByEnv(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			withEnv(t, tt.appEnv, tt.serverURL)
-			st := sessions.NewCookieStore([]byte("test-key"))
-			configureSessionStore(st)
-			if st.Options.Secure != tt.want {
-				t.Fatalf("Options.Secure = %v (env=%q url=%q), want %v", st.Options.Secure, tt.appEnv, tt.serverURL, tt.want)
-			}
-			if st.Options.Path != "/" {
-				t.Fatalf("Path = %q, want /", st.Options.Path)
-			}
-			if !st.Options.HttpOnly {
-				t.Fatalf("HttpOnly = false, want true")
+			if got := CookieSecure(); got != tt.want {
+				t.Fatalf("CookieSecure(env=%q, url=%q) = %v, want %v", tt.appEnv, tt.serverURL, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCookieSecureDefaultIsProduction(t *testing.T) {
+	// When app.env is unset the default must read as production (fail-closed).
+	withEnv(t, "production", "http://example.com")
+	if !CookieSecure() {
+		t.Fatal("default production env must yield Secure=true")
 	}
 }

--- a/apps/gooseforum/app/console/serve.go
+++ b/apps/gooseforum/app/console/serve.go
@@ -7,8 +7,10 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/pprof"
+	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/leancodebox/GooseForum/app/bundles/captchaOpt"
@@ -47,8 +49,52 @@ func runWeb(_ *cobra.Command, _ []string) {
 	slog.Info("GooseForum:start")
 	slog.Info(fmt.Sprintf("GooseForum:useMem %d KB", m.Alloc/1024/8))
 
+	warnInsecureServerURL()
 	startDebugServices()
 	ginServe()
+}
+
+// warnInsecureServerURL logs a startup warning when a non-local deployment is
+// reachable over plain http (CWE-614). Cookies are already fail-closed by
+// setting.CookieSecure(), so this is a deployment hygiene notice, not a fatal
+// gate — template defaults are `production` + `http://localhost`, and browsers
+// treat `localhost` as a secure context that still accepts Secure cookies,
+// so we do not refuse to boot (issue #113).
+func warnInsecureServerURL() {
+	serverURL := strings.TrimSpace(preferences.GetString("server.url", ""))
+	if !shouldWarnInsecureServerURL() {
+		return
+	}
+	slog.Warn(fmt.Sprintf(
+		"server.url=%q 在非 local 环境下不是 https，会话 Cookie 已强制 Secure，浏览器不会在明文连接上回传它们；请将 server.url 改为 https:// 反向代理地址或显式配置 HTTPS 终结",
+		serverURL,
+	))
+}
+
+// shouldWarnInsecureServerURL is the pure decision predicate backing
+// warnInsecureServerURL. Returns true only when the deployment is non-local
+// and `server.url` points at a non-https, non-loopback host.
+func shouldWarnInsecureServerURL() bool {
+	if setting.IsLocal() {
+		return false
+	}
+	serverURL := strings.TrimSpace(preferences.GetString("server.url", ""))
+	if serverURL == "" {
+		return false
+	}
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return false
+	}
+	if strings.ToLower(u.Scheme) == "https" {
+		return false
+	}
+	host := strings.ToLower(strings.TrimSpace(u.Hostname()))
+	switch host {
+	case "localhost", "127.0.0.1", "::1", "":
+		return false
+	}
+	return true
 }
 
 func startDebugServices() {

--- a/apps/gooseforum/app/console/serve_secure_test.go
+++ b/apps/gooseforum/app/console/serve_secure_test.go
@@ -1,0 +1,54 @@
+package console
+
+import (
+	"testing"
+
+	"github.com/leancodebox/GooseForum/app/bundles/preferences"
+)
+
+// withEnv restores app.env and server.url after the test so package-level
+// viper state does not leak across tests.
+func withEnv(t *testing.T, appEnv, serverURL string) {
+	t.Helper()
+	prevEnv := preferences.GetString("app.env", "production")
+	prevURL := preferences.GetString("server.url", "")
+	preferences.Set("app.env", appEnv)
+	preferences.Set("server.url", serverURL)
+	t.Cleanup(func() {
+		preferences.Set("app.env", prevEnv)
+		preferences.Set("server.url", prevURL)
+	})
+}
+
+// TestWarnInsecureServerURLGuardsCases focuses on the pure decision function:
+// whether the non-https non-local warning should fire. The slog output itself
+// is captured indirectly; we assert on an extracted helper so logic is decoupled
+// from the logger.
+func TestWarnInsecureServerURLGuardsCases(t *testing.T) {
+	cases := []struct {
+		name      string
+		appEnv    string
+		serverURL string
+		wantWarn  bool
+	}{
+		{name: "local http localhost no warn", appEnv: "local", serverURL: "http://localhost:5234", wantWarn: false},
+		{name: "production https no warn", appEnv: "production", serverURL: "https://example.com", wantWarn: false},
+		{name: "production http localhost no warn", appEnv: "production", serverURL: "http://localhost", wantWarn: false},
+		{name: "production http 127.0.0.1 no warn", appEnv: "production", serverURL: "http://127.0.0.1:5234", wantWarn: false},
+		{name: "production http ::1 no warn", appEnv: "production", serverURL: "http://[::1]:5234", wantWarn: false},
+		{name: "production empty url no warn", appEnv: "production", serverURL: "", wantWarn: false},
+		{name: "production http example WARN", appEnv: "production", serverURL: "http://example.com", wantWarn: true},
+		{name: "production http lan IP WARN", appEnv: "production", serverURL: "http://10.0.0.5:5234", wantWarn: true},
+		{name: "staging http example WARN", appEnv: "staging", serverURL: "http://staging.example.com", wantWarn: true},
+		{name: "local http example no warn (local bypasses all)", appEnv: "local", serverURL: "http://example.com", wantWarn: false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			withEnv(t, tt.appEnv, tt.serverURL)
+			if got := shouldWarnInsecureServerURL(); got != tt.wantWarn {
+				t.Fatalf("shouldWarnInsecureServerURL(env=%q, url=%q) = %v, want %v", tt.appEnv, tt.serverURL, got, tt.wantWarn)
+			}
+		})
+	}
+}

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -75,7 +75,7 @@ GooseForum is configured by `apps/gooseforum/config.toml` (not environment varia
 
 | Section | Note |
 |---|---|
-| `[app]` | env (local binds 127.0.0.1), debug, maintenance, signingKey, cdn_url |
+| `[app]` | env (local binds 127.0.0.1; any non-`local` value forces session-cookie `Secure` even when `server.url` is `http://…` — issue #113), debug, maintenance, signingKey, cdn_url |
 | `[server]` | url, port (default 5234), accessLog, gzip |
 | `[db]` / `[db.default]` / `[db.file]` | SQLite default; main db (`[db.default]`) also supports MySQL and PostgreSQL (issue #11); file db stays SQLite; migration, backup, pool |
 | `[meilisearch]` | url, masterkey (optional search) |

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -132,6 +132,21 @@ Generate one with `openssl rand -base64 32`. Without it the new binary exits
 immediately on startup; `init-server.sh` already generates a random key for
 new installs.
 
+### Upgrade note: session Cookie `Secure` is now fail-closed by environment
+
+Before issue #113, the `access_token` and goth session cookies decided the
+`Secure` flag from the `server.url` scheme: anything `http://` dropped `Secure`
+even under `app.env = "production"`. The template default
+`server.url = "http://localhost"` thus produced a session cookie without
+`Secure` on a production build (CWE-614). Since the issue #113 build, the flag
+is fail-closed by environment via `setting.CookieSecure()`: **any `app.env`
+other than `"local"` forces `Secure` regardless of `server.url`**, and the
+binary logs a startup warning when a non-local `server.url` is non-https and
+non-loopback. No `config.toml` change is required for existing instances, but
+operators who relied on plain-http production access (e.g. 0.0.0.0 without a
+TLS-terminating proxy) should switch `server.url` to the https reverse-proxy
+address so browsers actually return the now-`Secure` cookies.
+
 ### Unique-index preflight (user_o_auth provider_uid)
 
 Issue #8 added a unique index on `(provider, provider_uid)` in `user_o_auth`. On databases that

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -128,7 +128,9 @@
 - The forum HS256 JWT is never accepted at the OIDC userinfo endpoint (opaque access tokens only).
 - Client secrets are configured server-side and never logged.
 - id_token / access token never persisted by clients; forum JWT goes into an HttpOnly cookie
-  (Secure + SameSite=Lax when the site is served over HTTPS).
+  (`Secure` + SameSite=Lax whenever `app.env != "local"`; the Secure flag follows the environment
+  fail-closed rather than the `server.url` scheme, so production cookies stay Secure even when the
+  template default `server.url = "http://localhost"` is left untouched — issue #113).
 - Enumeration resistance: login errors do not distinguish "user not found / wrong password".
 - Session revocation is implemented as `jti` + `user_sessions` table (decision recorded in ADR note);
   TokenVersion remains as a global invalidation fallback.


### PR DESCRIPTION
## 动机

Closes #113。

模板默认 `app.env = "production"` + `server.url = "http://localhost"` 时，登录下发的 `access_token` 会话 Cookie 不带 `Secure` 标志（HttpOnly/SameSite=Lax 已设置），构成 CWE-614（Low）。`server.url` 的 scheme 覆盖了 `app.env` 的决策，导致非 local 环境下会话 Cookie 仍被降级为不带 `Secure`。

## 行为变更

- **fail-closed 策略集中化**：新增 `app/bundles/setting/globalConfig.go:CookieSecure()`，`app.env != "local"` 即强制 `Secure`，与 `server.url` 的 scheme 无关。`http://` 仅允许在 local 开发环境降级。
- **两处 Cookie 写入统一委托**：`jwtopt.TokenSettingWithMaxAge` / `TokenClean` 与 `sessionstore.configureSessionStore` 删除各自重复的 scheme 判断，改用 `setting.CookieSecure()`。
- **启动告警**：`app/console/serve.go` 在非 local 环境且 `server.url` 非 https、非回环地址时输出 `slog.Warn`，提示部署配置错误。采用 Issue 建议的"告警"而非"拒绝启动"——模板默认配置即 `production` + `http://localhost`，而浏览器将 `localhost` 视为安全上下文、会接受 Secure Cookie，直接拒绝会破坏首次本地运行。

## 关键场景对照

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| `production` + `http://example.com` | 无 Secure（漏洞） | Secure + 启动告警 |
| `production` + `http://localhost` | 无 Secure（漏洞，模板默认） | Secure |
| `production` + `https://example.com` | Secure | Secure（无告警） |
| `local` + `http://localhost:5234` | 无 Secure | 无 Secure（dev 行为不变） |

## 文档影响

- `docs/product/identity-and-access.md`：Security notes 修正 Cookie 策略描述（Secure 由环境 fail-closed，而非 site over HTTPS）。
- `docs/operations/deployment.md`：新增 Upgrade note `session cookie Secure is now fail-closed by environment`，与既有 `signingKey upgrade note` 风格一致。
- `docs/development/local-development.md`：`[app]` 配置行补 Cookie 策略说明。

无契约/迁移/前端/移动端改动。OpenAPI 契约未涉及。

## 验证

在 worktree `../yourtj-hub-113` 跑（`GOPROXY=https://goproxy.cn,direct`）：

- `git diff --check`：无空白错误。
- `gofmt -l <改动文件>`：clean（仅 `app/console/cmd/seedFeedTopics.go` 是预存问题，不在本次改动）。
- `cd apps/gooseforum && go vet ./...`：无输出。
- `cd apps/gooseforum && go test ./...`：所有包 `ok`，无 FAIL、无 skip。受影响包独立结果：
  - `app/bundles/setting`：`ok 0.996s`（10 用例）
  - `app/bundles/jwtopt`：`ok 4.901s`（含 production+http://localhost 必带 Secure 的回归测试）
  - `app/bundles/sessionstore`：`ok 1.857s`
  - `app/console`：`ok 3.059s`（告警谓词 10 用例）
  - `app/service/oidcservice`：`ok 7.277s`（adjacent regression，goth 桥使用 sessionstore）

无 model/migration 改动，PG 迁移 gate 不属强制范围（按 `AGENTS.md §4`）。无前端改动，Web 测试未运行。

## 已知局限

- `oidcservice.withBrowserBinding` 的 binding cookie 决策未改：它用 issuer scheme 且仅接受 loopback http，属于 CSRF 缓解而非会话凭据，不在 Issue #113 描述范围。
- 任何生产用 `0.0.0.0` 直出且无 TLS 终结的部署，浏览器将不再回传 `access_token`（这正是修复目的），已在 deployment.md 升级说明里写清。

## 提交范围

11 文件，+310 / -43。2 个新增测试文件，9 个修改。不含预存的 `seedFeedTopics.go` 格式问题或其他无关改动。

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>
