### PR TITLE
fix(auth): 消除 register / forgot-password 账号枚举信号（issue #124）

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -99,13 +99,14 @@ func Register(c *gin.Context) {
 		return
 	}
 
-	if users.ExistUsername(r.Username) {
-		c.JSON(200, component.FailDataCode(component.MessageAuthUsernameExists, nil))
-		return
-	}
-
-	if users.ExistEmail(r.Email) {
-		c.JSON(200, component.FailDataCode(component.MessageAuthEmailExists, nil))
+	// 账号枚举防护（CWE-208）：用户名/邮箱已占用时返回与其他注册失败一致的
+	// auth.register.failed 错误体，不再区分 auth.username.exists / auth.email.exists。
+	// 否则一次请求即可确定性枚举邮箱注册状态（PII 级身份关联信息）。
+	// 两次存在性查询无条件执行，查询次数不随账号状态变化，消除查询次数侧信道。
+	usernameExists := users.ExistUsername(r.Username)
+	emailExists := users.ExistEmail(r.Email)
+	if usernameExists || emailExists {
+		c.JSON(200, component.FailDataCode(component.MessageAuthRegisterFailed, nil))
 		return
 	}
 

--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -100,9 +100,11 @@ func Register(c *gin.Context) {
 	}
 
 	// 账号枚举防护（CWE-208）：用户名/邮箱已占用时返回与其他注册失败一致的
-	// auth.register.failed 错误体，不再区分 auth.username.exists / auth.email.exists。
-	// 否则一次请求即可确定性枚举邮箱注册状态（PII 级身份关联信息）。
+	// auth.register.failed 错误体，不再区分 auth.username.exists / auth.email.exists，
+	// 消除"具体哪个字段被占用"的子 oracle（邮箱注册状态属 PII 级身份关联信息）。
 	// 两次存在性查询无条件执行，查询次数不随账号状态变化，消除查询次数侧信道。
+	// 注意：注册协议本身（新建账号并自动登录成功 vs 失败）仍固有地区分邮箱是否
+	// 已注册；彻底消除该残余信号需改为异步邮箱验证流程，属产品决策（issue #124 验收项 1）。
 	usernameExists := users.ExistUsername(r.Username)
 	emailExists := users.ExistEmail(r.Email)
 	if usernameExists || emailExists {

--- a/apps/gooseforum/app/http/controllers/api/userController.go
+++ b/apps/gooseforum/app/http/controllers/api/userController.go
@@ -572,15 +572,16 @@ func ForgotPassword(req component.BetterRequest[ForgotPasswordReq]) component.Re
 
 	userEntity, err := users.GetByEmail(req.Params.Email)
 	if err != nil || userEntity.IsBot() {
-		// 为了安全考虑，即使邮箱不存在（或命中机器人账号）也返回成功消息
-		return component.SuccessResponseCode("操作成功：如果该邮箱已注册，您将收到密码重置邮件", component.MessageAuthResetMailQueued, nil)
+		// 为了安全考虑，即使邮箱不存在（或命中机器人账号）也返回统一成功消息；
+		// 先执行等量 dummy 工作（HMAC 签名 + 同步 noop 入队）抹平响应时间差。
+		return forgotPasswordSilentSuccess(req.Params.Email)
 	}
 
 	// 冷静期：邮箱变更后 24 小时内，新邮箱不能用于密码重置。
 	// 静默返回成功（与邮箱未注册完全一致，无枚举差异），但绝不入队重置邮件，
-	// 防止会话 token 被接管后立刻用新邮箱重置密码。
+	// 防止会话 token 被接管后立刻用新邮箱重置密码。同样先执行等量 dummy 工作对齐耗时。
 	if userEntity.EmailChangedAt != nil && time.Since(*userEntity.EmailChangedAt) < emailChangeCooldown {
-		return component.SuccessResponseCode("操作成功：如果该邮箱已注册，您将收到密码重置邮件", component.MessageAuthResetMailQueued, nil)
+		return forgotPasswordSilentSuccess(req.Params.Email)
 	}
 	token, err := tokenservice.GeneratePasswordResetToken(userEntity.Id, userEntity.Email, userEntity.TokenVersion)
 	if err != nil {
@@ -599,6 +600,28 @@ func ForgotPassword(req component.BetterRequest[ForgotPasswordReq]) component.Re
 		return component.FailResponseCode(component.MessageAuthResetMailSendFailed, nil)
 	}
 
+	return component.SuccessResponseCode("操作成功：如果该邮箱已注册，您将收到密码重置邮件", component.MessageAuthResetMailQueued, nil)
+}
+
+// forgotPasswordSilentSuccess 在"未知邮箱/机器人账号/邮箱变更冷静期"路径返回与
+// 已注册路径一致的响应：先执行等量 dummy 工作（一次 HMAC 令牌签名 + 一次同步
+// task_queue 写入 email.noop 任务，由邮件 worker 静默消费、不发邮件），抹平响应
+// 时间差，避免通过响应时间枚举邮箱注册状态（CWE-208，与 #109/#119 的等时化
+// 模式一致）。dummy 工作失败时返回与已注册路径相同的失败码（令牌生成失败 →
+// auth.passwordReset.tokenCreateFailed、队列写入失败 → auth.passwordReset.mailSendFailed），
+// 使两条路径在任何状态下响应逐字节一致，不残留系统级故障窗口内的枚举信号。
+func forgotPasswordSilentSuccess(email string) component.Response {
+	if _, err := tokenservice.GeneratePasswordResetToken(0, email, 0); err != nil {
+		slog.Error("forgot-password 等时化令牌生成失败", "email", email, "error", err)
+		return component.FailResponseCode(component.MessageAuthResetTokenCreateFailed, nil)
+	}
+	if err := mailservice.AddToQueue(mailservice.EmailTask{
+		To:   email,
+		Type: "noop",
+	}); err != nil {
+		slog.Error("forgot-password 等时化队列写入失败", "email", email, "error", err)
+		return component.FailResponseCode(component.MessageAuthResetMailSendFailed, nil)
+	}
 	return component.SuccessResponseCode("操作成功：如果该邮箱已注册，您将收到密码重置邮件", component.MessageAuthResetMailQueued, nil)
 }
 

--- a/apps/gooseforum/app/http/controllers/api/userController.go
+++ b/apps/gooseforum/app/http/controllers/api/userController.go
@@ -603,20 +603,21 @@ func ForgotPassword(req component.BetterRequest[ForgotPasswordReq]) component.Re
 	return component.SuccessResponseCode("操作成功：如果该邮箱已注册，您将收到密码重置邮件", component.MessageAuthResetMailQueued, nil)
 }
 
-// dummyTimingUsername 是 forgot-password 等时化 noop 任务中与真实用户名同量的
-// 固定占位值（用户名上限 32 字符），使 dummy 任务的序列化与 DB 写入负载与
-// 已注册路径的 reset_password 任务一致（review #129 P2）。
+// dummyTimingUsername 是 forgot-password 等时化 noop 任务中接近真实用户名长度的
+// 固定占位值（用户名上限 32 字符），使 dummy 任务的序列化负载接近已注册路径的
+// reset_password 任务（review #129 P2；不承诺字节级一致）。
 const dummyTimingUsername = "timing-dummy-username-0123456789"
 
 // forgotPasswordSilentSuccess 在"未知邮箱/机器人账号/邮箱变更冷静期"路径返回与
-// 已注册路径一致的响应：先执行等量 dummy 工作（一次 HMAC 令牌签名 + 一次同步
-// task_queue 写入 email.noop 任务，由邮件 worker 静默消费、不发邮件），抹平响应
-// 时间差，避免通过响应时间枚举邮箱注册状态（CWE-208，与 #109/#119 的等时化
-// 模式一致）。noop 任务携带与真实 reset_password 任务同量的负载（复用刚生成的
-// dummy token 填充 Token、Username 用固定占位），确保序列化与 DB 写入负载一致。
-// dummy 工作失败时返回与已注册路径相同的失败码（令牌生成失败 →
+// 已注册路径一致的响应：先执行与已注册路径同类的工作（一次 HMAC 令牌签名 +
+// 一次同步 task_queue 写入 email.noop 任务，由邮件 worker 静默消费、不发邮件），
+// 抬高攻击者通过响应时间区分邮箱注册状态的测量成本（CWE-208，与 #109/#119 的
+// 等时化思路一致）。dummy 工作失败时返回与已注册路径相同的失败码（令牌生成失败 →
 // auth.passwordReset.tokenCreateFailed、队列写入失败 → auth.passwordReset.mailSendFailed），
 // 使两条路径在任何状态下响应逐字节一致，不残留系统级故障窗口内的枚举信号。
+// 注意：dummy 任务不声称与真实 reset_password 任务字节级负载或时序精确等价——
+// 真实 JWT 长度随 userId/tokenVersion、Locale 随用户设置变化，Type 也因 worker 识别
+// 而异；本函数只保证同类操作 + 相同的失败语义，不承诺精确的时序/负载等价。
 func forgotPasswordSilentSuccess(email string) component.Response {
 	dummyToken, err := tokenservice.GeneratePasswordResetToken(0, email, 0)
 	if err != nil {

--- a/apps/gooseforum/app/http/controllers/api/userController.go
+++ b/apps/gooseforum/app/http/controllers/api/userController.go
@@ -603,21 +603,31 @@ func ForgotPassword(req component.BetterRequest[ForgotPasswordReq]) component.Re
 	return component.SuccessResponseCode("操作成功：如果该邮箱已注册，您将收到密码重置邮件", component.MessageAuthResetMailQueued, nil)
 }
 
+// dummyTimingUsername 是 forgot-password 等时化 noop 任务中与真实用户名同量的
+// 固定占位值（用户名上限 32 字符），使 dummy 任务的序列化与 DB 写入负载与
+// 已注册路径的 reset_password 任务一致（review #129 P2）。
+const dummyTimingUsername = "timing-dummy-username-0123456789"
+
 // forgotPasswordSilentSuccess 在"未知邮箱/机器人账号/邮箱变更冷静期"路径返回与
 // 已注册路径一致的响应：先执行等量 dummy 工作（一次 HMAC 令牌签名 + 一次同步
 // task_queue 写入 email.noop 任务，由邮件 worker 静默消费、不发邮件），抹平响应
 // 时间差，避免通过响应时间枚举邮箱注册状态（CWE-208，与 #109/#119 的等时化
-// 模式一致）。dummy 工作失败时返回与已注册路径相同的失败码（令牌生成失败 →
+// 模式一致）。noop 任务携带与真实 reset_password 任务同量的负载（复用刚生成的
+// dummy token 填充 Token、Username 用固定占位），确保序列化与 DB 写入负载一致。
+// dummy 工作失败时返回与已注册路径相同的失败码（令牌生成失败 →
 // auth.passwordReset.tokenCreateFailed、队列写入失败 → auth.passwordReset.mailSendFailed），
 // 使两条路径在任何状态下响应逐字节一致，不残留系统级故障窗口内的枚举信号。
 func forgotPasswordSilentSuccess(email string) component.Response {
-	if _, err := tokenservice.GeneratePasswordResetToken(0, email, 0); err != nil {
+	dummyToken, err := tokenservice.GeneratePasswordResetToken(0, email, 0)
+	if err != nil {
 		slog.Error("forgot-password 等时化令牌生成失败", "email", email, "error", err)
 		return component.FailResponseCode(component.MessageAuthResetTokenCreateFailed, nil)
 	}
 	if err := mailservice.AddToQueue(mailservice.EmailTask{
-		To:   email,
-		Type: "noop",
+		To:       email,
+		Username: dummyTimingUsername,
+		Token:    dummyToken,
+		Type:     "noop",
 	}); err != nil {
 		slog.Error("forgot-password 等时化队列写入失败", "email", email, "error", err)
 		return component.FailResponseCode(component.MessageAuthResetMailSendFailed, nil)

--- a/apps/gooseforum/app/http/routes/account_enumeration_test.go
+++ b/apps/gooseforum/app/http/routes/account_enumeration_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/leancodebox/GooseForum/app/http/controllers/api"
 	"github.com/leancodebox/GooseForum/app/http/controllers/component"
+	"github.com/leancodebox/GooseForum/app/service/mailservice"
 )
 
 // postRegister 通过 gin.CreateTestContext 直调 api.Register，返回 recorder 与
@@ -111,6 +113,26 @@ func TestForgotPasswordUnknownEmailEnqueuesNoopOnly(t *testing.T) {
 	}
 	if count := countEmailTaskByType(t, "reset_password"); count != 0 {
 		t.Fatalf("unknown-email forgot-password must not enqueue reset mail (count = %d)", count)
+	}
+
+	// 等量负载断言（review #129 P2）：noop 任务必须携带与真实 reset_password 任务同量的
+	// 载荷（非空 Token 签名、非空 Username 占位），保证 JSON 序列化与 DB 写入负载一致。
+	var noopTask *mailservice.EmailTask
+	tasks := getEmailTasks(t)
+	for i := range tasks {
+		if tasks[i].Type == "noop" {
+			noopTask = &tasks[i]
+			break
+		}
+	}
+	if noopTask == nil {
+		t.Fatal("no noop task found in queue")
+	}
+	if strings.TrimSpace(noopTask.Token) == "" {
+		t.Fatal("noop task must carry an equal-size dummy reset token (P2)")
+	}
+	if len(noopTask.Username) < 6 {
+		t.Fatalf("noop task Username placeholder too short: %q", noopTask.Username)
 	}
 }
 

--- a/apps/gooseforum/app/http/routes/account_enumeration_test.go
+++ b/apps/gooseforum/app/http/routes/account_enumeration_test.go
@@ -1,0 +1,177 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/leancodebox/GooseForum/app/http/controllers/api"
+	"github.com/leancodebox/GooseForum/app/http/controllers/component"
+)
+
+// postRegister 通过 gin.CreateTestContext 直调 api.Register，返回 recorder 与
+// 解出的响应体，与 honeypot 测试的调用方式一致。
+func postRegister(t *testing.T, body string) (*httptest.ResponseRecorder, component.ResultStruct) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/register", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	api.Register(c)
+
+	var res component.ResultStruct
+	if err := json.Unmarshal(recorder.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode register response %q: %v", recorder.Body.String(), err)
+	}
+	return recorder, res
+}
+
+// TestRegisterOccupiedUsernameReturnsGenericError 验证注册用户名被占用时返回与其他
+// 注册失败一致的通用错误体 auth.register.failed，而非之前的 auth.username.exists。
+// 否则攻击者可一次请求确定性枚举用户名占用状态。
+func TestRegisterOccupiedUsernameReturnsGenericError(t *testing.T) {
+	setupEmailChangeTestDB(t)
+	disableForgotPasswordCaptcha(t)
+	createEmailChangeUser(t, 9201, "occupieduser", "correct-password-123")
+
+	_, res := postRegister(t, `{"email":"brandnew@example.com","userName":"occupieduser","passWord":"password123"}`)
+	if res.Code != component.FAIL {
+		t.Fatalf("code = %d, want FAIL", res.Code)
+	}
+	if res.MessageCode != component.MessageAuthRegisterFailed {
+		t.Fatalf("messageCode = %q, want %q", res.MessageCode, component.MessageAuthRegisterFailed)
+	}
+}
+
+// TestRegisterOccupiedEmailReturnsGenericError 验证注册邮箱被占用时返回通用错误体
+// auth.register.failed，而非之前的 auth.email.exists。否则攻击者可一次请求确定性
+// 枚举邮箱注册状态（PII 级身份关联信息）。
+func TestRegisterOccupiedEmailReturnsGenericError(t *testing.T) {
+	setupEmailChangeTestDB(t)
+	disableForgotPasswordCaptcha(t)
+	createEmailChangeUser(t, 9202, "freshuser2", "correct-password-123")
+
+	_, res := postRegister(t, `{"email":"freshuser2@example.com","userName":"brandnewuser1","passWord":"password123"}`)
+	if res.Code != component.FAIL {
+		t.Fatalf("code = %d, want FAIL", res.Code)
+	}
+	if res.MessageCode != component.MessageAuthRegisterFailed {
+		t.Fatalf("messageCode = %q, want %q", res.MessageCode, component.MessageAuthRegisterFailed)
+	}
+}
+
+// TestRegisterEnumerationResponsesIdentical 是核心枚举断言：用户名占用与邮箱占用两种
+// 请求的响应体必须逐字节完全一致，且都解出 auth.register.failed。修复前两者返回
+// 不同 messageCode，攻击者可据此区分到底哪个字段被占用。
+func TestRegisterEnumerationResponsesIdentical(t *testing.T) {
+	setupEmailChangeTestDB(t)
+	disableForgotPasswordCaptcha(t)
+	createEmailChangeUser(t, 9201, "occupieduser", "correct-password-123")
+	createEmailChangeUser(t, 9202, "freshuser2", "correct-password-123")
+
+	recUsername, resUsername := postRegister(t, `{"email":"brandnew@example.com","userName":"occupieduser","passWord":"password123"}`)
+	recEmail, resEmail := postRegister(t, `{"email":"freshuser2@example.com","userName":"brandnewuser1","passWord":"password123"}`)
+
+	if !bytes.Equal(recUsername.Body.Bytes(), recEmail.Body.Bytes()) {
+		t.Fatalf("register enumeration responses differ:\nusername-occupied: %s\nemail-occupied:     %s",
+			recUsername.Body.String(), recEmail.Body.String())
+	}
+	if resUsername.MessageCode != component.MessageAuthRegisterFailed {
+		t.Fatalf("username-occupied messageCode = %q, want %q", resUsername.MessageCode, component.MessageAuthRegisterFailed)
+	}
+	if resEmail.MessageCode != component.MessageAuthRegisterFailed {
+		t.Fatalf("email-occupied messageCode = %q, want %q", resEmail.MessageCode, component.MessageAuthRegisterFailed)
+	}
+}
+
+// TestForgotPasswordUnknownEmailEnqueuesNoopOnly 验证未知邮箱路径执行等量 dummy 工作：
+// 只入队一条 email.noop 任务（由邮件 worker 静默消费、不发邮件），绝不入队重置邮件，
+// 返回与其他路径一致的 auth.passwordReset.mailQueued 成功响应。
+func TestForgotPasswordUnknownEmailEnqueuesNoopOnly(t *testing.T) {
+	setupEmailChangeTestDB(t)
+	disableForgotPasswordCaptcha(t)
+
+	res := api.ForgotPassword(component.BetterRequest[api.ForgotPasswordReq]{
+		Params: api.ForgotPasswordReq{Email: "nobody@example.com"},
+	})
+	if res.Code != http.StatusOK || res.Data.Code != component.SUCCESS {
+		t.Fatalf("response = %#v, want silent success", res)
+	}
+	if res.Data.MessageCode != component.MessageAuthResetMailQueued {
+		t.Fatalf("messageCode = %q, want %q", res.Data.MessageCode, component.MessageAuthResetMailQueued)
+	}
+	if count := countEmailTaskByType(t, "noop"); count != 1 {
+		t.Fatalf("unknown-email forgot-password should enqueue exactly 1 noop task (count = %d)", count)
+	}
+	if count := countEmailTaskByType(t, "reset_password"); count != 0 {
+		t.Fatalf("unknown-email forgot-password must not enqueue reset mail (count = %d)", count)
+	}
+}
+
+// TestForgotPasswordKnownEmailResponseMatchesUnknown 验证已注册邮箱与未知邮箱的响应体
+// 逐字节一致（静默成功），同时已注册邮箱确实入队 1 条重置邮件、未知探针入队 1 条 noop，
+// 响应不泄露邮箱注册状态。
+func TestForgotPasswordKnownEmailResponseMatchesUnknown(t *testing.T) {
+	setupEmailChangeTestDB(t)
+	disableForgotPasswordCaptcha(t)
+	createEmailChangeUser(t, 9203, "knownuser", "correct-password-123")
+
+	resUnknown := api.ForgotPassword(component.BetterRequest[api.ForgotPasswordReq]{
+		Params: api.ForgotPasswordReq{Email: "nobody@example.com"},
+	})
+	resKnown := api.ForgotPassword(component.BetterRequest[api.ForgotPasswordReq]{
+		Params: api.ForgotPasswordReq{Email: "knownuser@example.com"},
+	})
+
+	unknownBody, err := json.Marshal(resUnknown.Data)
+	if err != nil {
+		t.Fatalf("marshal unknown response: %v", err)
+	}
+	knownBody, err := json.Marshal(resKnown.Data)
+	if err != nil {
+		t.Fatalf("marshal known response: %v", err)
+	}
+	if !bytes.Equal(unknownBody, knownBody) {
+		t.Fatalf("forgot-password responses differ between known/unknown email:\nunknown: %s\nknown:   %s", unknownBody, knownBody)
+	}
+	if resKnown.Data.Code != component.SUCCESS || resKnown.Data.MessageCode != component.MessageAuthResetMailQueued {
+		t.Fatalf("known-email response = %#v, want success + %q", resKnown.Data, component.MessageAuthResetMailQueued)
+	}
+	if count := countEmailTaskByType(t, "reset_password"); count != 1 {
+		t.Fatalf("known-email forgot-password should enqueue exactly 1 reset mail (count = %d)", count)
+	}
+	if count := countEmailTaskByType(t, "noop"); count != 1 {
+		t.Fatalf("known-email forgot-password should enqueue exactly 1 noop for the unknown probe (count = %d)", count)
+	}
+}
+
+// TestForgotPasswordCooldownEnqueuesNoopNotReset 验证邮箱变更冷静期内 forgot-password
+// 静默返回成功但绝不入队重置邮件（只执行等量 noop dummy 工作），防止会话 token 被接管
+// 后立刻用新邮箱重置密码，且不产生枚举差异。
+func TestForgotPasswordCooldownEnqueuesNoopNotReset(t *testing.T) {
+	setupEmailChangeTestDB(t)
+	disableForgotPasswordCaptcha(t)
+	createEmailChangeUserWithChangedAt(t, 9204, "cooldown-enum", "correct-password-123", "cooldown-enum@example.com", time.Now())
+
+	res := api.ForgotPassword(component.BetterRequest[api.ForgotPasswordReq]{
+		Params: api.ForgotPasswordReq{Email: "cooldown-enum@example.com"},
+	})
+	if res.Code != http.StatusOK || res.Data.Code != component.SUCCESS {
+		t.Fatalf("response = %#v, want silent success", res)
+	}
+	if res.Data.MessageCode != component.MessageAuthResetMailQueued {
+		t.Fatalf("messageCode = %q, want %q", res.Data.MessageCode, component.MessageAuthResetMailQueued)
+	}
+	if count := countEmailTaskByType(t, "noop"); count != 1 {
+		t.Fatalf("cooldown forgot-password should enqueue exactly 1 noop task (count = %d)", count)
+	}
+	if count := countEmailTaskByType(t, "reset_password"); count != 0 {
+		t.Fatalf("cooldown forgot-password must not enqueue reset mail (count = %d)", count)
+	}
+}

--- a/apps/gooseforum/app/http/routes/account_enumeration_test.go
+++ b/apps/gooseforum/app/http/routes/account_enumeration_test.go
@@ -115,8 +115,8 @@ func TestForgotPasswordUnknownEmailEnqueuesNoopOnly(t *testing.T) {
 		t.Fatalf("unknown-email forgot-password must not enqueue reset mail (count = %d)", count)
 	}
 
-	// 等量负载断言（review #129 P2）：noop 任务必须携带与真实 reset_password 任务同量的
-	// 载荷（非空 Token 签名、非空 Username 占位），保证 JSON 序列化与 DB 写入负载一致。
+	// 同类操作断言（review #129 P2）：noop 任务应携带非空 Token 签名与非空 Username 占位，
+	// 与真实 reset_password 任务执行同类的 HMAC 签名 + 入队操作；不承诺字节级负载一致。
 	var noopTask *mailservice.EmailTask
 	tasks := getEmailTasks(t)
 	for i := range tasks {

--- a/apps/gooseforum/app/models/forum/taskQueue/taskQueue_rep.go
+++ b/apps/gooseforum/app/models/forum/taskQueue/taskQueue_rep.go
@@ -11,6 +11,12 @@ func Create(entity *Entity) error {
 	return builder().Create(entity).Error
 }
 
+// Delete 删除任务行。仅用于 noop 等时化 dummy 任务（账号枚举防护 #124）消费后
+// 清理，避免 task_queue 无界增长；真实邮件任务仍保留为 Success 以留存审计痕迹。
+func Delete(id uint64) error {
+	return builder().Where("id = ?", id).Delete(&Entity{}).Error
+}
+
 // CreateTx 在业务事务内入队（transaction-bound outbox）：
 // 任务行与业务写入同事务提交，崩溃前不提交 ⇒ 不产生任务；提交后 ⇒ worker 可消费。
 func CreateTx(tx *gorm.DB, entity *Entity) error {

--- a/apps/gooseforum/app/service/mailservice/queue.go
+++ b/apps/gooseforum/app/service/mailservice/queue.go
@@ -129,6 +129,16 @@ func processPendingEmailTasks(stopCh <-chan struct{}) bool {
 				continue
 			}
 
+			// noop 是 forgot-password 等时化 dummy 任务（#124）：静默消费并删除行，
+			// 不保留 Success 状态、不发送邮件、不打"邮件发送成功"日志，避免未认证
+			// 请求通过未知邮箱路径让 task_queue 无界增长。
+			if emailTask.Type == "noop" {
+				if delErr := taskQueue.Delete(task.Id); delErr != nil {
+					slog.Error("删除 noop 任务失败", "id", task.Id, "error", delErr)
+				}
+				continue
+			}
+
 			err := processEmailTask(emailTask)
 			if err != nil {
 				slog.Error("处理邮件任务失败",
@@ -182,6 +192,9 @@ func processEmailTask(task EmailTask) error {
 		return SendPasswordResetEmail(task.To, task.Username, task.Token, task.Locale)
 	case "email_changed":
 		return SendEmailChangedEmail(task.To, task.Username, task.NewEmail, task.Locale)
+	case "noop":
+		// 等时化 dummy 任务：静默消费，不发送任何邮件（账号枚举防护 #124）。
+		return nil
 	default:
 		return fmt.Errorf("未知的邮件类型: %s", task.Type)
 	}

--- a/apps/gooseforum/app/service/mailservice/queue_noop_test.go
+++ b/apps/gooseforum/app/service/mailservice/queue_noop_test.go
@@ -1,0 +1,56 @@
+package mailservice
+
+import (
+	"testing"
+
+	db "github.com/leancodebox/GooseForum/app/bundles/connect/dbconnect"
+	"github.com/leancodebox/GooseForum/app/models/forum/taskQueue"
+)
+
+// TestProcessEmailTaskNoopSilentlySucceeds 验证 noop 类型任务被静默消费：
+// 等时化 dummy 任务（账号枚举防护 #124）直接成功返回，不发送任何邮件。
+func TestProcessEmailTaskNoopSilentlySucceeds(t *testing.T) {
+	err := processEmailTask(EmailTask{To: "nobody@example.com", Type: "noop"})
+	if err != nil {
+		t.Fatalf("processEmailTask(noop) 应返回 nil，实际返回错误: %v", err)
+	}
+}
+
+// TestProcessEmailTaskUnknownTypeReturnsError 验证未知类型仍返回错误，
+// 确保 noop 只静默消费 dummy 任务，不会误吞真实邮件类型。
+func TestProcessEmailTaskUnknownTypeReturnsError(t *testing.T) {
+	err := processEmailTask(EmailTask{To: "nobody@example.com", Type: "bogus"})
+	if err == nil {
+		t.Fatal("processEmailTask(bogus) 应返回错误，实际返回 nil")
+	}
+}
+
+// TestPendingNoopTaskDeletedAfterConsumption 验证邮件 worker 消费 noop 任务后
+// 直接删除行（不保留 Success 状态、不打"发送成功"日志），避免未认证请求通过
+// 未知邮箱路径让 task_queue 无界增长（账号枚举防护 #124 的副作用收敛）。
+func TestPendingNoopTaskDeletedAfterConsumption(t *testing.T) {
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&taskQueue.Entity{}); err != nil {
+		t.Fatalf("migrate task_queue: %v", err)
+	}
+	conn.Unscoped().Where("1 = 1").Delete(&taskQueue.Entity{})
+	t.Cleanup(func() {
+		conn.Unscoped().Where("1 = 1").Delete(&taskQueue.Entity{})
+	})
+
+	if err := AddToQueue(EmailTask{To: "nobody@example.com", Type: "noop"}); err != nil {
+		t.Fatalf("enqueue noop: %v", err)
+	}
+
+	if !processPendingEmailTasks(make(chan struct{})) {
+		t.Fatal("processPendingEmailTasks 应处理完所有任务并返回 true")
+	}
+
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Count(&count).Error; err != nil {
+		t.Fatalf("count task_queue: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("noop 任务应被删除而非保留为 Success，task_queue 剩余 %d 行", count)
+	}
+}

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -153,10 +153,10 @@
   failure) still inherently distinguishes an already-registered email from a fresh one; removing
   that residual signal would require an async email-verification flow (product decision, issue #124
   acceptance item 1). Forgot-password answers unknown emails, bots, and the 24-hour email-change
-  cooldown with the same success message after equal dummy work (one HMAC token signing plus a
-  synchronous `email.noop` task carrying an equal-size token, silently consumed and dropped by the
-  mail worker so it never accumulates), so response time does not reveal whether an email is
-  registered (issue #124).
+  cooldown with the same success message after the same class of work as the registered path (one
+  HMAC token signing plus a synchronous `email.noop` task, silently consumed and dropped by the
+  mail worker so it never accumulates), so probing an email's registration status via response
+  time is not reliable (issue #124).
 - Session revocation is implemented as `jti` + `user_sessions` table (decision recorded in ADR note);
   TokenVersion remains as a global invalidation fallback.
 - TOTP secrets and recovery codes never leave the server in plaintext (secret encrypted at rest,

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -146,13 +146,17 @@
   template default `server.url = "http://localhost"` is left untouched — issue #113).
 - Enumeration resistance: login errors do not distinguish "user not found / wrong password", and
   unknown accounts run the same-cost PBKDF2 verification as real ones so response time does not
-  reveal whether a username/email is registered. Registration returns the generic
-  `auth.register.failed` body for username/email-taken (never `auth.username.exists` /
-  `auth.email.exists`) and always runs both existence queries, so neither the error body nor the
-  query count varies with account state. Forgot-password answers unknown emails, bots, and the
-  24-hour email-change cooldown with the same success message after equal dummy work (one HMAC
-  token signing plus a synchronous `email.noop` task, silently consumed and dropped by the mail worker so it never accumulates), so response time
-  does not reveal whether an email is registered (issue #124).
+  reveal whether a username/email is registered. Registration collapses username/email-taken into
+  the same generic `auth.register.failed` body as other failures (never `auth.username.exists` /
+  `auth.email.exists`) and always runs both existence queries, so the error body no longer reveals
+  which field is taken. The registration protocol itself (immediate account creation + session vs.
+  failure) still inherently distinguishes an already-registered email from a fresh one; removing
+  that residual signal would require an async email-verification flow (product decision, issue #124
+  acceptance item 1). Forgot-password answers unknown emails, bots, and the 24-hour email-change
+  cooldown with the same success message after equal dummy work (one HMAC token signing plus a
+  synchronous `email.noop` task carrying an equal-size token, silently consumed and dropped by the
+  mail worker so it never accumulates), so response time does not reveal whether an email is
+  registered (issue #124).
 - Session revocation is implemented as `jti` + `user_sessions` table (decision recorded in ADR note);
   TokenVersion remains as a global invalidation fallback.
 - TOTP secrets and recovery codes never leave the server in plaintext (secret encrypted at rest,

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -146,7 +146,13 @@
   template default `server.url = "http://localhost"` is left untouched — issue #113).
 - Enumeration resistance: login errors do not distinguish "user not found / wrong password", and
   unknown accounts run the same-cost PBKDF2 verification as real ones so response time does not
-  reveal whether a username/email is registered.
+  reveal whether a username/email is registered. Registration returns the generic
+  `auth.register.failed` body for username/email-taken (never `auth.username.exists` /
+  `auth.email.exists`) and always runs both existence queries, so neither the error body nor the
+  query count varies with account state. Forgot-password answers unknown emails, bots, and the
+  24-hour email-change cooldown with the same success message after equal dummy work (one HMAC
+  token signing plus a synchronous `email.noop` task, silently consumed and dropped by the mail worker so it never accumulates), so response time
+  does not reveal whether an email is registered (issue #124).
 - Session revocation is implemented as `jti` + `user_sessions` table (decision recorded in ADR note);
   TokenVersion remains as a global invalidation fallback.
 - TOTP secrets and recovery codes never leave the server in plaintext (secret encrypted at rest,


### PR DESCRIPTION
## 变更说明

修复 #124：`POST /api/register` 与 `POST /api/forgot-password` 泄露账号注册状态（CWE-208 同类，与 #109 同主题、不同攻击面）。

**根因**：
- `register`（确定性 body oracle）：用户名/邮箱已占用时返回 `auth.username.exists` / `auth.email.exists`，与其他注册失败（`auth.register.failed`）响应体不同，一次请求即可确定性枚举邮箱注册状态（PII 级身份关联信息）。
- `forgot-password`（时序 oracle）：未知邮箱路径仅一次 SELECT 即返回；已注册邮箱额外执行 HMAC 令牌签名 + 同步 `task_queue` INSERT，存在约 0.2–1ms 可测时序差。

**改动**：

- **register**：用户名/邮箱已占用时统一返回与其他注册失败完全一致的 `auth.register.failed` 错误体，不再区分具体字段（消除"具体哪个字段被占用"的子 oracle）；两次存在性查询无条件执行（查询次数不随账号状态变化，消除查询次数侧信道）。**残余信号说明（review P1，已解决）**：注册协议本身（立即创建并自动登录成功 vs 失败）仍固有地区分邮箱是否已注册，本 PR 不声称消除该协议级信号；彻底消除需改异步邮箱验证流程，属产品决策（issue #124 验收项 1）。
- **forgot-password**：未知邮箱/机器人账号/邮箱变更冷静期路径经 `forgotPasswordSilentSuccess` 执行与已注册路径同类的工作——一次 HMAC 令牌签名 + 一次同步 `email.noop` 任务入队，抬高攻击者通过响应时间区分邮箱注册状态的测量成本；dummy 工作失败时返回与真实路径一致的失败码（`auth.passwordReset.tokenCreateFailed` / `auth.passwordReset.mailSendFailed`），不残留故障窗口枚举信号。noop 任务携带 dummy token 与等长 Username 占位作为纵深；不承诺与真实任务字节级负载或时序精确等价（review P2，见下）。
- **mailservice**：worker 对 `noop` 任务静默消费并删除行，不保留 Success 状态、不发邮件、不打"发送成功"日志，避免 task_queue 无界增长；`taskQueue` 新增 `Delete`。
- **测试**：新增 `account_enumeration_test.go`（7 用例：已占用用户名/邮箱返回逐字节相同且为通用错误码；未知邮箱恰好入队 1 条 noop 且携带非空 token/username；已注册邮箱响应体与未知邮箱逐字节一致且仍入队重置邮件；冷静期入队 noop 而非重置邮件）与 `queue_noop_test.go`（3 用例：noop 静默成功、未知类型报错、worker 消费后删除行）。
- **docs**：`docs/product/identity-and-access.md` 枚举防护条目扩展到 register/forgot-password，如实标注 register 协议级残余信号与 forgot-password 的同类工作语义。

## Review 跟进（oierxjn）

- **P1（register 主 oracle）**：已解决。采纳收敛声明路径：消除字段级子 oracle + 查询次数侧信道，代码注释/文档/PR 描述如实标注"立即创建并自动登录成功 vs 失败"的协议级残余信号，并指向产品决策点（异步邮箱验证流程，issue #124 验收项 1）。
- **P2（noop 负载不等量）**：已处理。dummy token 现写入 noop 任务 `Token` 字段、`Username` 用接近真实长度的固定占位作为纵深；按复审意见，dummy 任务的 `Locale`/`Type`/JWT 长度与真实 `reset_password` 任务存在固有差异（真实 JWT 随 `userId`/`tokenVersion`、Locale 随用户设置变化，Type 因 worker 识别而异），无法承诺字节级负载或时序等价——代码注释、`identity-and-access.md` 与本描述已收敛为"执行同类 HMAC 签名 + 入队操作"（commit `ad2fcd5`）。

响应体与错误码无契约破坏：`register` 不再返回 `auth.username.exists`/`auth.email.exists`（移动端 Dart 对这两个码的 UX 映射退化为通用 fallback，无编译/契约影响，可另行产品决策）；`forgot-password` 响应体不变。

## 验证

- `git diff --check`：通过
- `cd apps/gooseforum && go vet ./...`：通过
- `go test ./...`：通过（全量绿，含新增 10 个回归测试）
- gofmt：改动文件干净
- CI：ci-backend / ci-backend-pg / ci-contract / ci-frontend 均成功

## 备注（非本次范围）

- register 的 `email` 列是普通索引非 unique（既有竞态问题，建议单独 issue）
- 移动端 register 具体错误提示（用户名/邮箱被占用）现退化为通用"注册失败"，如需保留可加 `auth.register.failed` 折中文案
- register 协议级枚举信号（成功 vs 失败）的彻底消除需异步验证流程，属产品决策

Closes #124