### PR TITLE
docs(contract): list course-review OpenAPI coverage

### DIFF
--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-09
+> Last verified: 2026-08-12
 
 ## Contract status
 
@@ -31,6 +31,14 @@ The contract capability is **Partial**. The controlled OpenAPI 3.1 entry point i
 - `GET /api/v1/agent/topics/{topicId}/posts` and `POST /api/v1/agent/topics/{topicId}/posts`;
 - `GET /api/v1/agent/search`.
 - `GET /api/forum/courses` and `GET /api/forum/courses/{courseId}` (course catalog read endpoints, `security: []`);
+- `GET /api/forum/courses/{courseId}/reviews`, `POST /api/forum/courses/{courseId}/reviews`,
+  `PATCH /api/forum/course-reviews/{reviewId}`, and `DELETE /api/forum/course-reviews/{reviewId}`;
+- `PUT /api/forum/course-reviews/{reviewId}/helpful`,
+  `DELETE /api/forum/course-reviews/{reviewId}/helpful`, and
+  `POST /api/forum/course-reviews/{reviewId}/report`;
+- `POST /api/forum/moderation/course-review-status`,
+  `POST /api/forum/moderation/course-review-reports`, and
+  `POST /api/forum/moderation/course-review-reveal`.
 
 Paths are split per domain under `packages/api-contract/paths/` (for example `auth.yaml`,
 `auth-sessions.yaml`, `forum-topics.yaml`); new coverage adds a new per-domain file instead of

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -31,11 +31,11 @@ The contract capability is **Partial**. The controlled OpenAPI 3.1 entry point i
 - `GET /api/v1/agent/topics/{topicId}/posts` and `POST /api/v1/agent/topics/{topicId}/posts`;
 - `GET /api/v1/agent/search`.
 - `GET /api/forum/courses` and `GET /api/forum/courses/{courseId}` (course catalog read endpoints, `security: []`);
-- `GET /api/forum/courses/{courseId}/reviews`, `POST /api/forum/courses/{courseId}/reviews`,
-  `PATCH /api/forum/course-reviews/{reviewId}`, and `DELETE /api/forum/course-reviews/{reviewId}`;
+- `GET /api/forum/courses/{courseId}/reviews` and `POST /api/forum/course-reviews`;
+- `PATCH /api/forum/course-reviews/{reviewId}` and `DELETE /api/forum/course-reviews/{reviewId}`;
 - `PUT /api/forum/course-reviews/{reviewId}/helpful`,
   `DELETE /api/forum/course-reviews/{reviewId}/helpful`, and
-  `POST /api/forum/course-reviews/{reviewId}/report`;
+  `POST /api/forum/course-reviews/{reviewId}/reports`;
 - `POST /api/forum/moderation/course-review-status`,
   `POST /api/forum/moderation/course-review-reports`, and
   `POST /api/forum/moderation/course-review-reveal`.


### PR DESCRIPTION
## Motivation

The contract-status inventory listed the course catalog read endpoints but omitted the ten course-review operations that are already covered by the controlled OpenAPI surface.

## Behavior change

Updates the current OpenAPI coverage inventory to include course-review list/create/update/delete, helpful/unhelpful, report, and the three moderation operations. The document verification date is updated to 2026-08-12.

## Verification

- `git diff --check` — passed
- Compared the documented operations with `packages/api-contract/paths/course-reviews.yaml` and `apps/gooseforum/app/http/routes/contract_course_review_test.go`.

## Contract / documentation impact

Documentation only. No API behavior, schema, generated client, fixture, or route-contract test changes.

## Known gaps

OpenAPI coverage remains `Partial`; this PR only corrects the inventory for operations already under contract.
