### PR TITLE
fix(auth): OAuth 登录分支拒绝冻结账号（issue #130）

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -1,10 +1,10 @@
 package api
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/jwtopt"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/forum"
@@ -12,6 +12,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/oauthservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/sessionservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
+	"github.com/gin-gonic/gin"
 	"github.com/markbates/goth/gothic"
 )
 
@@ -60,6 +61,14 @@ func ProviderCallback(c *gin.Context) {
 		// 登录模式：处理OAuth登录
 		user, err := oauthservice.ProcessOAuthCallback(gothUser)
 		if err != nil {
+			// 冻结账号：service 层返回 ErrAccountFrozen，禁止通过 OAuth 重新获取会话，
+			// 这里渲染 403 冻结错误页，与 OIDC exchange 的冻结语义保持一致。
+			// 冻结拒绝是用户可预期触发的路径，用 Warn 记录，避免日志噪音。
+			if errors.Is(err, oauthservice.ErrAccountFrozen) {
+				slog.Warn("OAuth callback rejected frozen account", "error", err)
+				forum.RenderOAuthErrorPage(c, http.StatusForbidden, component.MessageOAuthAccountFrozen)
+				return
+			}
 			slog.Error("Process OAuth callback failed", "error", err)
 			forum.RenderInternalOAuthErrorPage(c, component.MessageOAuthProcessFailed)
 			return

--- a/apps/gooseforum/app/http/controllers/api/oauth_callback_test.go
+++ b/apps/gooseforum/app/http/controllers/api/oauth_callback_test.go
@@ -1,0 +1,177 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userOAuth"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userSessions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/oauthservice"
+	"github.com/gin-gonic/gin"
+	"github.com/markbates/goth"
+	"github.com/markbates/goth/gothic"
+)
+
+// setupOAuthCallbackTestDB 迁移 OAuth callback 路径涉及的 model。
+func setupOAuthCallbackTestDB(t *testing.T) {
+	t.Helper()
+	conn := db.Connect()
+	for _, model := range []any{
+		&users.EntityComplete{},
+		&userOAuth.Entity{},
+		&userSessions.Entity{},
+	} {
+		if err := conn.AutoMigrate(model); err != nil {
+			t.Fatalf("migrate %T: %v", model, err)
+		}
+	}
+}
+
+// stubGothUser 替换 gothic.CompleteUserAuth，模拟第三方 OAuth 回调返回指定用户。
+// 全局变量替换是 goth 的标准测试钩子，测试间必须串行（本包无 t.Parallel）。
+func stubGothUser(t *testing.T, user goth.User) {
+	t.Helper()
+	original := gothic.CompleteUserAuth
+	gothic.CompleteUserAuth = func(_ http.ResponseWriter, _ *http.Request) (goth.User, error) {
+		return user, nil
+	}
+	t.Cleanup(func() { gothic.CompleteUserAuth = original })
+}
+
+// oauthCallbackRequest 构造 GitHub callback 请求（页面模式，错误页返回 JSON）。
+func oauthCallbackRequest(t *testing.T) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Params = gin.Params{{Key: "provider", Value: oauthservice.ProviderGitHub}}
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/auth/github/callback", nil)
+	c.Request.Header.Set("X-Goose-Page", "true")
+	return recorder, c
+}
+
+func countSessions(t *testing.T, userID uint64) int64 {
+	t.Helper()
+	var count int64
+	if err := db.Connect().Model(&userSessions.Entity{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	return count
+}
+
+func hasAccessTokenCookie(recorder *httptest.ResponseRecorder) bool {
+	for _, cookie := range recorder.Result().Cookies() {
+		if cookie.Name == "access_token" && cookie.Value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestOAuthCallbackLoginRejectsFrozenUser 复现 issue #130：已绑定 GitHub 的冻结账号
+// 通过 OAuth callback 登录时，必须返回 403 + MessageOAuthAccountFrozen，
+// 不创建 session、不设置认证 Cookie、不重定向。
+func TestOAuthCallbackLoginRejectsFrozenUser(t *testing.T) {
+	setupOAuthCallbackTestDB(t)
+
+	user := &users.EntityComplete{
+		Username:    "oauthfrozen",
+		Email:       "oauthfrozen@example.com",
+		IsFrozen:    users.StatusFrozen,
+		IsActivated: users.ActivationSuccess,
+	}
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := userOAuth.Create(&userOAuth.Entity{
+		UserId:      user.Id,
+		Provider:    oauthservice.ProviderGitHub,
+		ProviderUid: "gh-uid-frozen",
+	}); err != nil {
+		t.Fatalf("create oauth binding: %v", err)
+	}
+
+	stubGothUser(t, goth.User{
+		Provider: oauthservice.ProviderGitHub,
+		UserID:   "gh-uid-frozen",
+		NickName: "oauthfrozen",
+		Email:    "oauthfrozen@example.com",
+	})
+
+	recorder, c := oauthCallbackRequest(t)
+	ProviderCallback(c)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (body: %s)", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Props struct {
+			MessageCode component.MessageCode `json:"messageCode"`
+		} `json:"props"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode error page: %v", err)
+	}
+	if payload.Props.MessageCode != component.MessageOAuthAccountFrozen {
+		t.Fatalf("messageCode = %q, want %q", payload.Props.MessageCode, component.MessageOAuthAccountFrozen)
+	}
+	if hasAccessTokenCookie(recorder) {
+		t.Fatal("frozen user must not receive an access_token cookie")
+	}
+	if count := countSessions(t, user.Id); count != 0 {
+		t.Fatalf("frozen user session rows = %d, want 0", count)
+	}
+	if loc := recorder.Header().Get("Location"); loc != "" {
+		t.Fatalf("unexpected redirect for frozen user: %q", loc)
+	}
+}
+
+// TestOAuthCallbackLoginSuccessIssuesSession 守卫正常路径：非冻结用户 OAuth 登录
+// 仍应创建 session 并设置认证 Cookie。
+func TestOAuthCallbackLoginSuccessIssuesSession(t *testing.T) {
+	setupOAuthCallbackTestDB(t)
+
+	user := &users.EntityComplete{
+		Username:    "oauthlogin",
+		Email:       "oauthlogin@example.com",
+		IsActivated: users.ActivationSuccess,
+	}
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := userOAuth.Create(&userOAuth.Entity{
+		UserId:      user.Id,
+		Provider:    oauthservice.ProviderGitHub,
+		ProviderUid: "gh-uid-login",
+	}); err != nil {
+		t.Fatalf("create oauth binding: %v", err)
+	}
+
+	stubGothUser(t, goth.User{
+		Provider: oauthservice.ProviderGitHub,
+		UserID:   "gh-uid-login",
+		NickName: "oauthlogin",
+		Email:    "oauthlogin@example.com",
+	})
+
+	recorder, c := oauthCallbackRequest(t)
+	ProviderCallback(c)
+
+	if recorder.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302 (body: %s)", recorder.Code, recorder.Body.String())
+	}
+	if loc := recorder.Header().Get("Location"); loc != "/" {
+		t.Fatalf("redirect location = %q, want /", loc)
+	}
+	if !hasAccessTokenCookie(recorder) {
+		t.Fatal("successful OAuth login must set access_token cookie")
+	}
+	if count := countSessions(t, user.Id); count != 1 {
+		t.Fatalf("session rows = %d, want 1", count)
+	}
+}

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -36,6 +36,10 @@ const (
 	ProviderTwitter  = "twitter"
 )
 
+// ErrAccountFrozen 表示账号被冻结，禁止通过 OAuth 重新获取论坛会话。
+// controller 依据该 sentinel error 渲染 403 冻结错误页（与 OIDC exchange 的冻结语义一致）。
+var ErrAccountFrozen = errors.New("账号已冻结，禁止 OAuth 登录")
+
 // InitOAuth configures available OAuth providers.
 func InitOAuth() {
 	gothic.Store = sessionstore.GetSession()
@@ -106,6 +110,10 @@ func ProcessOAuthCallback(gothUser goth.User) (*users.EntityComplete, error) {
 		user, err := users.Get(existingOAuth.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("获取用户信息失败: %w", err)
+		}
+		// 冻结账号禁止通过 OAuth（goth）重新获取论坛会话。
+		if user.IsFrozen == users.StatusFrozen {
+			return nil, ErrAccountFrozen
 		}
 		// 机器人（Agent）账号禁止通过 OAuth（goth）登录。
 		if user.IsBot() {


### PR DESCRIPTION
## 变更说明

修复 #130：冻结账号可通过 GitHub OAuth callback 重新获取论坛 JWT 会话（认证边界不一致）。

**根因**：`ProviderCallback` 登录分支无条件调用 `ProcessOAuthCallback` 并创建 session，未检查 `IsFrozen`；绑定分支、OIDC exchange（`oidcController.go`）、密码登录（`authController.go`）均有冻结检查，唯独 OAuth 登录缺失。

**改动**：
- **service 层**（`oauthservice/oauth.go`）：`ProcessOAuthCallback` 的已有绑定分支新增冻结检查，返回 sentinel error `ErrAccountFrozen`，禁止冻结账号通过 OAuth 重新获取论坛会话（置于 `IsBot()` 检查之前）。
- **controller 层**（`oauthController.go`）：登录分支用 `errors.Is` 识别冻结错误，渲染 `403 + oauth.account.frozen`（与 OIDC exchange 的冻结语义一致），不创建 session、不设置 Cookie；冻结拒绝是用户可预期触发的路径，以 `slog.Warn` 记录而非 `slog.Error`（采纳 synergy review 建议）。
- **测试**：新增 `oauth_callback_test.go`（2 用例）：
  - 冻结账号 OAuth 登录 → `403`、`MessageOAuthAccountFrozen`、无 `access_token` Cookie、零 session 行、无重定向；
  - 正常账号 → `302` 到 `/`、Cookie 设置、恰好 1 个 session 行。

## Rebase 说明（跟进 review #149 复审）

本 PR 已 rebase 到当前 `origin/dev`（`c0bb545`），并适配两项上游合并：
- **PR #128（module-path 迁移）**：import 路径已更新为 `github.com/YourTongji/YourTJ-Hub/apps/gooseforum/...`，并顺手修正 `oauthController.go` 因迁移遗留的 import 排序（`gofmt`）。
- **PR #150（OAuth token 移除）**：`userOAuth.Entity` 已无 `AccessToken` 等凭据列，回调路径不再刷新 provider token。回归测试已移除 `AccessToken` setup、`storedOAuthAccessToken` 及 token 刷新断言，仅保留 issue #130 的核心断言（冻结拒绝 + 正常会话签发）。

## 与 PR #146 的关系

本修复由 `synergy-agent[bot]` 的 PR #146 演进而来：采纳其验证过的冻结检查思路，并完善其 review 指出的两个问题——controller 层不引入 dead code `IsBot()`；冻结检查下沉到 service 层。建议关闭 PR #146，以本 PR 为准。

## 验证

- `git diff --check`：通过
- `cd apps/gooseforum && go vet ./...`：通过
- `go test ./...`：通过（全量绿，含新增 2 个回归测试）
- `go test -race ./app/http/controllers/api/ -run TestOAuthCallback`：通过
- `gofmt -l`：三个改动文件均干净

## 备注（非本次范围）

- 安全复查发现的 pre-existing MEDIUM：OIDC `CompleteLogin`（登录桥）只查 `IsBot()` 不查 `IsFrozen`，但冻结用户的授权码无法兑换成 session（OIDC exchange / token / userinfo 均拒绝冻结用户），无实际绕过，建议后续单独跟进。
- 冻结不撤销已有 session（`EditUser` 仅翻转 `IsFrozen`，不提升 `token_version`），冻结后仍持有效 JWT 的用户可读取会话内数据，属既有模型限制。

Closes #130