### PR TITLE
fix(deps): 升级 nanoid 与 postcss，修复前端构建链 CVE（issue #108）

### DIFF
--- a/apps/gooseforum/resource/pnpm-lock.yaml
+++ b/apps/gooseforum/resource/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid: ^3.3.17
+  postcss: ^8.5.23
+
 importers:
 
   .:
@@ -1527,8 +1531,8 @@ packages:
   murmurhash-js@1.0.0:
     resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1605,12 +1609,8 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   potpack@1.0.2:
@@ -2773,7 +2773,7 @@ snapshots:
       '@vue/shared': 3.5.34
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.14
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.34':
@@ -3388,7 +3388,7 @@ snapshots:
 
   murmurhash-js@1.0.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   node-forge@1.4.0: {}
 
@@ -3447,15 +3447,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.14:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.16:
-    dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3693,7 +3687,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/apps/gooseforum/resource/pnpm-workspace.yaml
+++ b/apps/gooseforum/resource/pnpm-workspace.yaml
@@ -6,3 +6,8 @@ allowBuilds:
   core-js: true
   maplibre-gl: true
   vue-demi: true
+overrides:
+  # CVE-2026-67213 / CVE-2026-67214: nanoid customAlphabet/customRandom size=0 infinite loop DoS
+  nanoid: ^3.3.17
+  # CVE-2026-69153: postcss source map file disclosure during builds
+  postcss: ^8.5.23


### PR DESCRIPTION
## Summary
- 修复前端构建链依赖 CVE：`nanoid` 无限循环 DoS + `postcss` source map 泄露（issue #108）
- 在 `apps/gooseforum/resource/pnpm-workspace.yaml` 增加 `overrides`，重新生成 `pnpm-lock.yaml`

## 依赖变化
| 依赖 | 升级前 | 升级后 | CVE | 说明 |
|---|---|---|---|---|
| `nanoid` | 3.3.12 | 3.3.18 | CVE-2026-67213 / CVE-2026-67214 | `customAlphabet`/`customRandom` size=0 无限循环 DoS（GHSA-28wg-ghj8-5hjv / GHSA-2v37-7h3g-55p8） |
| `postcss` | 8.5.14 / 8.5.16 | 8.5.26 | CVE-2026-69153 | source map 文件泄露（GHSA-r28c-9q8g-f849，`<=8.5.17` 受影响；8.5.26 同时覆盖 GHSA-fxqj-rqcc-2cmp 补丁不完全问题） |

## 实现说明
- pnpm 11 不再读取 `package.json` 中的 `pnpm` 字段，因此 overrides 放在 `pnpm-workspace.yaml`（而非 issue 建议的 `package.json` `pnpm.overrides`），经实测验证。
- override 使用 `^3.3.17` / `^8.5.23` 而非裸 `>=`，避免把 `nanoid` 误拉到 6.x 造成破坏性升级（`@vue/compiler-sfc`、`vite` 等消费者的依赖树要求保持 3.x 主版本线）。
- 锁文件 diff 仅 32 行，无其他包漂移。

## Verification
- `pnpm install` ✅
- `pnpm typecheck` ✅
- `pnpm test` — 14 files / 101 tests passed ✅
- `pnpm build` — built in ~1.2s（仅有既存 chunk-size / rolldown pure-annotation 警告，与本次改动无关）✅

Closes #108