### PR TITLE
fix(deps): 升级 pgx/v5 至 v5.9.2，修复三个 CVE（issue #107）

### DIFF
--- a/apps/gooseforum/go.mod
+++ b/apps/gooseforum/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/apps/gooseforum/go.sum
+++ b/apps/gooseforum/go.sum
@@ -132,8 +132,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
-github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=


### PR DESCRIPTION
## Summary
- 修复 `github.com/jackc/pgx/v5 v5.6.0`（间接依赖）的三个公开 CVE
- 升级至 **v5.9.2**（同时覆盖全部 3 个 CVE 的最小版本）

## CVE 与升级对照
| CVE | GHSA | 类型 | 修复版本 | 升级后状态 |
|---|---|---|---|---|
| CVE-2026-33815 | GHSA-xgrm-4fwx-7qm8 | 内存安全（CVSS 9.8） | v5.9.0 | ✅ v5.9.2 已覆盖 |
| CVE-2026-33816 | GHSA-9jj7-4m8r-rfcm | 内存安全（CVSS 9.8） | v5.9.0 | ✅ v5.9.2 已覆盖 |
| CVE-2026-41889 | GHSA-j88v-2chj-qfwx | SQL 注入，simple 查询协议（CVSS 9.8） | v5.9.2 | ✅ v5.9.2 已覆盖 |

## 变更内容
- `apps/gooseforum/go.mod`：`github.com/jackc/pgx/v5 v5.6.0 // indirect` → `v5.9.2 // indirect`（唯一变更行）
- `apps/gooseforum/go.sum`：对应两条哈希更新
- `go mod tidy` + `go mod verify` 通过

## 兼容性说明
- pgx/v5 为间接依赖，经 `gorm.io/driver/postgres v1.6.0` 引入；全仓库无直接 `import` pgx 的 Go 文件，**无 API 兼容性变更**
- `go mod graph` 确认依赖链：`gorm.io/driver/postgres@v1.6.0 → github.com/jackc/pgx/v5`
- 应用经 GORM 默认走 prepared statements（扩展协议），CVE-2026-41889 的 simple 协议触发面低，但内存安全类 CVE 仍构成供应链风险，予以修复

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` — 93 个包全部通过 ✅
- `go mod verify` — all modules verified ✅

Closes #107