### PR TITLE
fix(mobile): 解析全部非 2xx 业务错误并保留 messageCode

### DIFF
--- a/apps/mobile/packages/auth/lib/src/oidc_controller.dart
+++ b/apps/mobile/packages/auth/lib/src/oidc_controller.dart
@@ -95,6 +95,12 @@ class OidcController extends ChangeNotifier {
       _authenticated = true;
       notifyListeners();
       return true;
+    } on ApiException catch (e) {
+      // 后端已应答的业务失败(HTTP 2xx envelope 或 4xx/5xx ApiFailure):
+      // 展示稳定的 messageCode 便于上层本地化,不再吞成笼统的"OIDC login failed"。
+      _error = e.messageKey;
+      notifyListeners();
+      return false;
     } catch (e) {
       _error = 'OIDC login failed: $e';
       notifyListeners();

--- a/apps/mobile/packages/auth/test/oidc_controller_test.dart
+++ b/apps/mobile/packages/auth/test/oidc_controller_test.dart
@@ -233,6 +233,36 @@ void main() {
     expect(await storage.read(), isNull);
   });
 
+  test('exchange 收到 403 冻结 ApiFailure → 保留稳定 messageCode', () async {
+    final storage = MemoryTokenStorage();
+    final appAuth = FakeAppAuth(
+      response: const AuthorizationResponse(
+        authorizationCode: 'auth-code-frozen',
+        codeVerifier: 'pkce-verifier-frozen',
+      ),
+    );
+    final auth = FakeAuthRepository()
+      ..exchangeError = const ApiFailureException(
+        fallbackMessage: 'Request failed with status 403',
+        messageCode: 'oauth.account.frozen',
+        params: {'action': 'login'},
+        statusCode: 403,
+      );
+    final controller = buildController(
+      storage: storage,
+      appAuth: appAuth,
+      auth: auth,
+    );
+
+    final ok = await controller.login();
+
+    expect(ok, isFalse);
+    expect(controller.isAuthenticated, isFalse);
+    // 暴露稳定 messageCode 供上层本地化,而不是笼统的 "OIDC login failed"。
+    expect(controller.error, 'server.oauth.account.frozen');
+    expect(await storage.read(), isNull);
+  });
+
   test('exchange 返回空 token → 登录失败', () async {
     final storage = MemoryTokenStorage();
     final appAuth = FakeAppAuth(

--- a/apps/mobile/packages/core/lib/src/api/api_error.dart
+++ b/apps/mobile/packages/core/lib/src/api/api_error.dart
@@ -1,7 +1,10 @@
 /// API 错误类型。
 ///
-/// 后端错误协议:HTTP 200 + `{code != 0, messageCode, params}` 表示业务失败;
-/// HTTP 429 限流(带 Retry-After);HTTP 401 未授权;其它为网络/传输错误。
+/// 后端错误协议:HTTP 2xx + `{code != 0, messageCode, params}` 表示业务失败;
+/// 中间件/控制器直接以 HTTP 4xx/5xx 返回同一 `ResultStruct` envelope
+/// (`{code: 1, messageCode, params, result: null}`,见
+/// `component.FailDataCode`);HTTP 429 限流(带 Retry-After);HTTP 401 未授权;
+/// 只有真正的传输层故障(DNS、连接拒绝、超时等)才是 [NetworkException]。
 library;
 
 /// 业务失败(code != 0)或传输层错误(messageCode 为空)。
@@ -59,7 +62,30 @@ class UnauthorizedException extends ApiException {
   }) : super(statusCode: 401);
 }
 
-/// 网络层失败(DNS、连接拒绝、超时等)。
+/// HTTP 4xx/5xx 且响应体可解析为 `ResultStruct` envelope 的服务端错误
+/// (如 OIDC 400/403、冻结 `permission.userFrozen`、500)。区别于
+/// [NetworkException]:这是**后端已应答**的业务失败,messageCode 稳定。
+class ApiFailureException extends ApiException {
+  const ApiFailureException({
+    required super.fallbackMessage,
+    super.messageCode,
+    super.params,
+    super.statusCode,
+  });
+
+  @override
+  String toString() {
+    final code = messageCode == null ? '' : ' ($messageCode)';
+    return 'ApiFailureException: $fallbackMessage$code';
+  }
+}
+
+/// 网络层失败(DNS、连接拒绝、超时等),后端未产生业务响应。
 class NetworkException extends ApiException {
-  const NetworkException({required super.fallbackMessage, super.statusCode});
+  const NetworkException({
+    required super.fallbackMessage,
+    super.statusCode,
+    super.messageCode,
+    super.params,
+  });
 }

--- a/apps/mobile/packages/core/lib/src/api/gf_api_client.dart
+++ b/apps/mobile/packages/core/lib/src/api/gf_api_client.dart
@@ -13,6 +13,9 @@ typedef TokenRenewedCallback = FutureOr<void> Function(String newToken);
 ///
 /// 统一处理:Bearer 令牌注入、New-Token 头滑动续期、401 会话失效、
 /// 429 限流(Retry-After)、`{code, messageCode, params, result}` 错误协议。
+/// 后端所有失败(HTTP 2xx 业务失败或 HTTP 4xx/5xx 的 `ResultStruct` envelope)
+/// 都解析为带 messageCode 的 [ApiException];只有真正的传输层故障
+/// (DNS、连接拒绝、超时)才是 [NetworkException]。
 class GfApiClient {
   GfApiClient({
     required this.dio,
@@ -112,9 +115,22 @@ class GfApiClient {
           retryAfterSeconds: _retryAfter(e.response),
         );
       }
+      if (status != null) {
+        // 后端已应答的 4xx/5xx:解析 ResultStruct envelope,保留
+        // status/messageCode/params,不再伪装成 NetworkException。
+        // 无 body 或非 envelope 时退化为无 messageCode 的 ApiFailureException,
+        // 仍是"服务端错误"而非网络故障。
+        final envelope = _tryParseEnvelope(e.response?.data);
+        throw ApiFailureException(
+          fallbackMessage: 'Request failed with status $status',
+          messageCode: envelope?.messageCode,
+          params: envelope?.params,
+          statusCode: status,
+        );
+      }
+      // 无 HTTP 状态码:传输层故障(DNS、连接拒绝、超时等)。
       throw NetworkException(
         fallbackMessage: 'Network connection failed, please check your network',
-        statusCode: status,
       );
     }
   }

--- a/apps/mobile/packages/core/test/api_client_test.dart
+++ b/apps/mobile/packages/core/test/api_client_test.dart
@@ -226,6 +226,165 @@ void main() {
       );
     });
 
+    test('DioException 无 status 时 NetworkException 不携带 statusCode', () async {
+      setupClient();
+      dio.httpClientAdapter = MockAdapter((request) async {
+        throw DioException(
+          requestOptions: request,
+          type: DioExceptionType.connectionError,
+        );
+      });
+
+      await expectLater(
+        client.get<bool>('/api/ping'),
+        throwsA(
+          isA<NetworkException>().having(
+            (e) => e.statusCode,
+            'statusCode',
+            isNull,
+          ),
+        ),
+      );
+    });
+
+    test(
+      '400 envelope 抛 ApiFailureException 并保留 messageCode/params/status',
+      () async {
+        setupClient();
+        final adapter = MockAdapter((request) async {
+          return ResponseData(400, {
+            'code': 1,
+            'messageCode': 'common.request.invalidFormat',
+            'params': {'field': 'code'},
+          });
+        });
+        dio.httpClientAdapter = adapter;
+
+        await expectLater(
+          client.post<bool>('/api/auth/oidc/exchange', body: {}),
+          throwsA(
+            isA<ApiFailureException>()
+                .having((e) => e.statusCode, 'statusCode', 400)
+                .having(
+                  (e) => e.messageCode,
+                  'messageCode',
+                  'common.request.invalidFormat',
+                )
+                .having(
+                  (e) => e.messageKey,
+                  'messageKey',
+                  'server.common.request.invalidFormat',
+                )
+                .having((e) => e.params?['field'], 'params', 'code'),
+          ),
+        );
+      },
+    );
+
+    test('403 冻结 envelope 抛 ApiFailureException 并保留 messageCode', () async {
+      setupClient();
+      dio.httpClientAdapter = MockAdapter((request) async {
+        return ResponseData(403, {
+          'code': 1,
+          'messageCode': 'oauth.account.frozen',
+          'params': {'action': 'login'},
+        });
+      });
+
+      await expectLater(
+        client.post<bool>('/api/auth/oidc/exchange', body: {}),
+        throwsA(
+          isA<ApiFailureException>()
+              .having((e) => e.statusCode, 'statusCode', 403)
+              .having(
+                (e) => e.messageCode,
+                'messageCode',
+                'oauth.account.frozen',
+              )
+              .having((e) => e.params?['action'], 'params', 'login'),
+        ),
+      );
+    });
+
+    test('404 envelope 抛 ApiFailureException 并保留 messageCode', () async {
+      setupClient();
+      dio.httpClientAdapter = MockAdapter((request) async {
+        return ResponseData(404, {'code': 1, 'messageCode': 'route.notFound'});
+      });
+
+      await expectLater(
+        client.get<bool>('/api/forum/does-not-exist'),
+        throwsA(
+          isA<ApiFailureException>()
+              .having((e) => e.statusCode, 'statusCode', 404)
+              .having((e) => e.messageCode, 'messageCode', 'route.notFound'),
+        ),
+      );
+    });
+
+    test('500 envelope 抛 ApiFailureException 并保留 messageCode', () async {
+      setupClient();
+      dio.httpClientAdapter = MockAdapter((request) async {
+        return ResponseData(500, {
+          'code': 1,
+          'messageCode': 'oauth.token.failed',
+        });
+      });
+
+      await expectLater(
+        client.post<bool>('/api/auth/oidc/exchange', body: {}),
+        throwsA(
+          isA<ApiFailureException>()
+              .having((e) => e.statusCode, 'statusCode', 500)
+              .having(
+                (e) => e.messageCode,
+                'messageCode',
+                'oauth.token.failed',
+              ),
+        ),
+      );
+    });
+
+    test(
+      '4xx 无 envelope body 时降级为无 messageCode 的 ApiFailureException',
+      () async {
+        setupClient();
+        dio.httpClientAdapter = MockAdapter((request) async {
+          return ResponseData(403, {'error': 'forbidden'});
+        });
+
+        await expectLater(
+          client.get<bool>('/api/ping'),
+          throwsA(
+            isA<ApiFailureException>()
+                .having((e) => e.statusCode, 'statusCode', 403)
+                .having((e) => e.messageCode, 'messageCode', isNull)
+                .having(
+                  (e) => e.fallbackMessage,
+                  'fallbackMessage',
+                  'Request failed with status 403',
+                ),
+          ),
+        );
+      },
+    );
+
+    test('5xx 空 body 时降级为无 messageCode 的 ApiFailureException', () async {
+      setupClient();
+      dio.httpClientAdapter = MockAdapter((request) async {
+        return ResponseData(502, <String, dynamic>{});
+      });
+
+      await expectLater(
+        client.get<bool>('/api/ping'),
+        throwsA(
+          isA<ApiFailureException>()
+              .having((e) => e.statusCode, 'statusCode', 502)
+              .having((e) => e.messageCode, 'messageCode', isNull),
+        ),
+      );
+    });
+
     test('成功响应经 parser 解析 result', () async {
       setupClient();
       final adapter = MockAdapter((request) async {


### PR DESCRIPTION
## Summary
- 移动端 `GfApiClient` 此前仅处理 401/429，其余 4xx/5xx 一律伪装成 `NetworkException`，丢失后端 `ResultStruct` envelope 的 `messageCode`（如 OIDC 400/403 冻结 `oauth.account.frozen`、500）。
- 统一解析所有非 2xx 的 `ApiFailure` envelope：新增 `ApiFailureException`（保留 `statusCode`/`messageCode`/`params`），仅无 HTTP 状态码的真实传输层故障（DNS、连接拒绝、超时）映射为 `NetworkException`。
- `OidcController` 对后端业务失败展示稳定的 `messageKey`（`server.<messageCode>`），不再吞成笼统的 "OIDC login failed"。

## Root Cause
`apps/mobile/packages/core/lib/src/api/gf_api_client.dart:95-119` 的 `_request` 只在 `DioException` 中处理 401/429，其余状态码一律抛 `NetworkException`；而契约（`packages/api-contract/paths/auth.yaml` OIDC 400/401/403/500，`components/schemas.yaml#/ApiFailure`）与后端实现（`component.FailDataCode`、`oidcController.go`）表明 4xx/5xx 均返回同一 envelope。

## Changes
- `core/lib/src/api/api_error.dart`：新增 `ApiFailureException`；`NetworkException` 不再伪造 statusCode 语义。
- `core/lib/src/api/gf_api_client.dart`：非 2xx 带 status 时解析 envelope 抛 `ApiFailureException`；无 status 才抛 `NetworkException`。
- `auth/lib/src/oidc_controller.dart`：`ApiException` 展示 `messageKey`。
- 测试：400/403/404/500 envelope 映射、messageCode/params/status 保留、非 envelope 与空 body fallback、`NetworkException` 无 status、OIDC 冻结 messageCode 透传。

## Verification
- `flutter analyze`：core / auth 均 No issues found。
- `flutter test`：core 58 passed、auth 18 passed、forum_app 90 passed。

Closes #143