### PR TITLE
fix(contract): Agent 搜索/列表 schema 补齐实际响应字段（issue #141）

### DIFF
--- a/apps/gooseforum/app/http/routes/agent_contract_http_test.go
+++ b/apps/gooseforum/app/http/routes/agent_contract_http_test.go
@@ -161,8 +161,38 @@ func TestAgentContractPostWindowAndCreate(t *testing.T) {
 		}
 		var window struct {
 			Posts []struct {
-				PostNo uint64 `json:"postNo"`
+				ID                 uint64 `json:"id"`
+				TopicID            uint64 `json:"topicId"`
+				PostNo             uint64 `json:"postNo"`
+				Content            string `json:"content"`
+				RenderedContent    string `json:"renderedContent"`
+				ProcessStatus      int8   `json:"processStatus"`
+				IsHidden           bool   `json:"isHidden"`
+				IsAuthorDeleted    bool   `json:"isAuthorDeleted"`
+				IsModeratorRemoved bool   `json:"isModeratorRemoved"`
+				CanModerate        bool   `json:"canModerate"`
+				Author             struct {
+					ID        uint64 `json:"id"`
+					Username  string `json:"username"`
+					AvatarURL string `json:"avatarUrl"`
+				} `json:"author"`
+				CreatedAt    string `json:"createdAt"`
+				IsOwnPost    bool   `json:"isOwnPost"`
+				UpdatedAt    string `json:"updatedAt"`
+				LikeCount    uint64 `json:"likeCount"`
+				IsLiked      bool   `json:"isLiked"`
+				IsBookmarked bool   `json:"isBookmarked"`
 			} `json:"posts"`
+			ReplyTargets []struct {
+				ID uint64 `json:"id"`
+				Author struct {
+					ID uint64 `json:"id"`
+				} `json:"author"`
+				Unavailable bool `json:"unavailable"`
+			} `json:"replyTargets"`
+			HasBefore bool  `json:"hasBefore"`
+			HasAfter  bool  `json:"hasAfter"`
+			Total     int64 `json:"total"`
 			MaxPostNo uint64 `json:"maxPostNo"`
 		}
 		if err := json.Unmarshal(response.Result, &window); err != nil {
@@ -170,6 +200,18 @@ func TestAgentContractPostWindowAndCreate(t *testing.T) {
 		}
 		if len(window.Posts) != 1 || window.Posts[0].PostNo != 1 || window.MaxPostNo != 1 {
 			t.Fatalf("post window = %#v", window)
+		}
+		if window.Posts[0].ID == 0 || window.Posts[0].TopicID != topic.Id || window.Posts[0].Author.ID == 0 || window.Posts[0].Author.Username == "" {
+			t.Fatalf("post window post identity fields missing: %#v", window.Posts[0])
+		}
+		if window.Posts[0].RenderedContent == "" || window.Posts[0].CreatedAt == "" || window.Posts[0].UpdatedAt == "" {
+			t.Fatalf("post window rendered/time fields missing: %#v", window.Posts[0])
+		}
+		if window.Posts[0].IsAuthorDeleted || window.Posts[0].IsModeratorRemoved || window.Posts[0].IsHidden {
+			t.Fatalf("post window first post must not be hidden/removed: %#v", window.Posts[0])
+		}
+		if window.ReplyTargets == nil || window.HasBefore || window.HasAfter || window.Total != 1 {
+			t.Fatalf("post window pagination fields unexpected: %#v", window)
 		}
 	})
 
@@ -260,7 +302,22 @@ func TestAgentContractSearch(t *testing.T) {
 	}
 	var search struct {
 		Query             string   `json:"query"`
+		Scope             string   `json:"scope"`
 		Topics            []any    `json:"topics"`
+		Users             []any    `json:"users"`
+		Categories        []any    `json:"categories"`
+		Courses           []any    `json:"courses"`
+		Total             int64    `json:"total"`
+		UsersTotal        int64    `json:"usersTotal"`
+		CategoriesTotal   int64    `json:"categoriesTotal"`
+		CoursesTotal      int64    `json:"coursesTotal"`
+		TotalPages        int      `json:"totalPages"`
+		Pagination        struct {
+			Page     int    `json:"page"`
+			NextPage int    `json:"nextPage"`
+			HasNext  bool   `json:"hasNext"`
+			NextURL  string `json:"nextUrl"`
+		} `json:"pagination"`
 		SearchUnavailable bool     `json:"searchUnavailable"`
 		FailedScopes      []string `json:"failedScopes"`
 	}
@@ -270,7 +327,17 @@ func TestAgentContractSearch(t *testing.T) {
 	if search.Query != "campus" {
 		t.Fatalf("search query = %q, want campus", search.Query)
 	}
-	if search.Topics == nil {
-		t.Fatal("search topics must be a present array")
+	for name, value := range map[string][]any{
+		"topics":     search.Topics,
+		"users":      search.Users,
+		"categories": search.Categories,
+		"courses":    search.Courses,
+	} {
+		if value == nil {
+			t.Fatalf("search %s must be a present array", name)
+		}
+	}
+	if search.Pagination.Page != 1 {
+		t.Fatalf("search pagination = %#v, want page 1", search.Pagination)
 	}
 }

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -857,8 +857,8 @@ export interface components {
         /** @description Mirrors the forum PostWindow payload shape. */
         AgentPostListResponse: components["schemas"]["ApiSuccess"] & {
             result: {
-                posts: Record<string, never>[];
-                replyTargets: Record<string, never>[];
+                posts: components["schemas"]["PostPayload"][];
+                replyTargets: components["schemas"]["ReplyTargetPayload"][];
                 /** Format: uint64 */
                 anchorPostId?: number;
                 /** Format: uint64 */
@@ -889,22 +889,25 @@ export interface components {
         AgentCreatePostResponse: (components["schemas"]["ApiSuccess"] & {
             result: components["schemas"]["AgentCreatePostResult"];
         }) | components["schemas"]["ApiFailure"];
-        /** @description Mirrors the forum SearchJSON payload, including searchUnavailable and failedScopes. */
+        /** @description Mirrors the forum SearchJSON payload (including courses), including searchUnavailable and failedScopes. */
         AgentSearchResponse: components["schemas"]["ApiSuccess"] & {
             result: {
                 query: string;
                 scope: string;
-                topics: Record<string, never>[];
-                users: Record<string, never>[];
-                categories: Record<string, never>[];
+                topics: components["schemas"]["TopicPayload"][];
+                users: components["schemas"]["UserSearchPayload"][];
+                categories: components["schemas"]["CategorySearchPayload"][];
+                courses: components["schemas"]["CourseSearchPayload"][];
                 /** Format: int64 */
                 total: number;
                 /** Format: int64 */
                 usersTotal: number;
                 /** Format: int64 */
                 categoriesTotal: number;
+                /** Format: int64 */
+                coursesTotal: number;
                 totalPages: number;
-                pagination: Record<string, never>;
+                pagination: components["schemas"]["PaginationPayload"];
                 failedScopes?: string[];
                 searchUnavailable?: boolean;
             };
@@ -1155,6 +1158,129 @@ export interface components {
             expiresAt: number;
             /** @description True for the session that carries the current token. */
             isCurrent: boolean;
+        };
+        PostPayload: {
+            /** Format: uint64 */
+            id: number;
+            /** Format: uint64 */
+            topicId: number;
+            /** Format: uint64 */
+            postNo: number;
+            /** @description Raw post content; emptied for hidden or removed posts. */
+            content: string;
+            /** @description Rendered HTML; emptied for hidden or removed posts. */
+            renderedContent: string;
+            /**
+             * @description 0 normal, 1 blocked, 2 pending moderation.
+             * @enum {integer}
+             */
+            processStatus: 0 | 1 | 2;
+            isHidden: boolean;
+            isAuthorDeleted: boolean;
+            isModeratorRemoved: boolean;
+            canModerate: boolean;
+            author: components["schemas"]["TopicAuthorPayload"];
+            /** @description Post creation time in the server's `2006-01-02 15:04:05` format. */
+            createdAt: string;
+            /**
+             * Format: uint64
+             * @description Present only when the post replies to an in-window post.
+             */
+            replyToPostId?: number;
+            /** Format: uint64 */
+            replyToUserId?: number;
+            replyToUsername?: string;
+            isOwnPost: boolean;
+            /** @description Post update time in the server's `2006-01-02 15:04:05` format. */
+            updatedAt: string;
+            /** Format: uint64 */
+            likeCount: number;
+            isLiked: boolean;
+            isBookmarked: boolean;
+        };
+        ReplyTargetPayload: {
+            /** Format: uint64 */
+            id: number;
+            /**
+             * Format: uint64
+             * @description Present only when the target post is available.
+             */
+            postNo?: number;
+            /** @description The zero author payload when unavailable is true. */
+            author: components["schemas"]["TopicAuthorPayload"];
+            /** @description Present only when the target post is available and not author or moderator removed. */
+            renderedContent?: string;
+            isAuthorDeleted?: boolean;
+            isModeratorRemoved?: boolean;
+            /** @description True when the replied-to post is outside the window, purged, or pending moderation. */
+            unavailable?: boolean;
+        };
+        TopicCategoryPayload: {
+            /** Format: uint64 */
+            id: number;
+            name: string;
+            url: string;
+            color: string;
+        };
+        TopicPayload: {
+            /** Format: uint64 */
+            id: number;
+            title: string;
+            description: string;
+            /** @description Present only when the topic has a cover image. */
+            firstImageUrl?: string;
+            images?: string[];
+            url: string;
+            pinWeight: number;
+            /** @enum {integer} */
+            processStatus: 0 | 1 | 2;
+            author: components["schemas"]["TopicAuthorPayload"];
+            participants: components["schemas"]["TopicAuthorPayload"][];
+            categories: components["schemas"]["TopicCategoryPayload"][];
+            /** Format: uint64 */
+            replyCount: number;
+            /** Format: uint64 */
+            viewCount: number;
+            activityText: string;
+            lastUpdateTime: string;
+            /** @description Present only for authenticated viewers with unseen tracking. */
+            unseen?: boolean;
+        };
+        UserSearchPayload: {
+            /** Format: uint64 */
+            id: number;
+            username: string;
+            nickname: string;
+            avatarUrl: string;
+            bio: string;
+        };
+        CategorySearchPayload: {
+            /** Format: uint64 */
+            id: number;
+            name: string;
+            slug: string;
+            icon: string;
+            color: string;
+            desc: string;
+        };
+        CourseSearchPayload: {
+            /** Format: uint64 */
+            id: number;
+            primaryCode: string;
+            name: string;
+            department: string;
+            /** @description Credit multiplied by 10 to stay integral (2.5 credit -> 25). */
+            creditX10: number;
+            aliases: string[];
+            instructors: string[];
+            terms: string[];
+            campus: string[];
+        };
+        PaginationPayload: {
+            page: number;
+            nextPage: number;
+            hasNext: boolean;
+            nextUrl: string;
         };
         /** @description Report handler payload. Unlike TopicAuthorPayload the id may be 0 for open reports. */
         ReportHandlerPayload: {

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -545,11 +545,11 @@ AgentPostListResponse:
             posts:
               type: array
               items:
-                type: object
+                $ref: '#/PostPayload'
             replyTargets:
               type: array
               items:
-                type: object
+                $ref: '#/ReplyTargetPayload'
             anchorPostId:
               type: integer
               format: uint64
@@ -621,7 +621,7 @@ AgentSearchResponse:
       properties:
         result:
           type: object
-          required: [query, scope, topics, users, categories, total, usersTotal, categoriesTotal, totalPages, pagination]
+          required: [query, scope, topics, users, categories, courses, total, usersTotal, categoriesTotal, coursesTotal, totalPages, pagination]
           properties:
             query:
               type: string
@@ -630,15 +630,19 @@ AgentSearchResponse:
             topics:
               type: array
               items:
-                type: object
+                $ref: '#/TopicPayload'
             users:
               type: array
               items:
-                type: object
+                $ref: '#/UserSearchPayload'
             categories:
               type: array
               items:
-                type: object
+                $ref: '#/CategorySearchPayload'
+            courses:
+              type: array
+              items:
+                $ref: '#/CourseSearchPayload'
             total:
               type: integer
               format: int64
@@ -648,10 +652,13 @@ AgentSearchResponse:
             categoriesTotal:
               type: integer
               format: int64
+            coursesTotal:
+              type: integer
+              format: int64
             totalPages:
               type: integer
             pagination:
-              type: object
+              $ref: '#/PaginationPayload'
             failedScopes:
               type: array
               items:
@@ -659,7 +666,252 @@ AgentSearchResponse:
             searchUnavailable:
               type: boolean
           additionalProperties: false
-  description: Mirrors the forum SearchJSON payload, including searchUnavailable and failedScopes.
+  description: Mirrors the forum SearchJSON payload (including courses), including searchUnavailable and failedScopes.
+
+# Shared forum payloads reused by the Agent endpoints. Each mirrors the Go DTO
+# serialized by the corresponding forum controller so consumers can type-safely
+# access the real fields (post/topic/user/category/course) instead of an empty
+# record.
+PostPayload:
+  type: object
+  required: [id, topicId, postNo, content, renderedContent, processStatus, isHidden, isAuthorDeleted, isModeratorRemoved, canModerate, author, createdAt, isOwnPost, updatedAt, likeCount, isLiked, isBookmarked]
+  properties:
+    id:
+      type: integer
+      format: uint64
+      minimum: 1
+    topicId:
+      type: integer
+      format: uint64
+      minimum: 1
+    postNo:
+      type: integer
+      format: uint64
+      minimum: 1
+    content:
+      type: string
+      description: Raw post content; emptied for hidden or removed posts.
+    renderedContent:
+      type: string
+      description: Rendered HTML; emptied for hidden or removed posts.
+    processStatus:
+      type: integer
+      enum: [0, 1, 2]
+      description: 0 normal, 1 blocked, 2 pending moderation.
+    isHidden:
+      type: boolean
+    isAuthorDeleted:
+      type: boolean
+    isModeratorRemoved:
+      type: boolean
+    canModerate:
+      type: boolean
+    author:
+      $ref: '#/TopicAuthorPayload'
+    createdAt:
+      type: string
+      description: Post creation time in the server's `2006-01-02 15:04:05` format.
+    replyToPostId:
+      type: integer
+      format: uint64
+      minimum: 0
+      description: Present only when the post replies to an in-window post.
+    replyToUserId:
+      type: integer
+      format: uint64
+      minimum: 0
+    replyToUsername:
+      type: string
+    isOwnPost:
+      type: boolean
+    updatedAt:
+      type: string
+      description: Post update time in the server's `2006-01-02 15:04:05` format.
+    likeCount:
+      type: integer
+      format: uint64
+    isLiked:
+      type: boolean
+    isBookmarked:
+      type: boolean
+  additionalProperties: false
+
+ReplyTargetPayload:
+  type: object
+  required: [id, author]
+  properties:
+    id:
+      type: integer
+      format: uint64
+      minimum: 1
+    postNo:
+      type: integer
+      format: uint64
+      minimum: 1
+      description: Present only when the target post is available.
+    author:
+      $ref: '#/TopicAuthorPayload'
+      description: The zero author payload when unavailable is true.
+    renderedContent:
+      type: string
+      description: Present only when the target post is available and not author or moderator removed.
+    isAuthorDeleted:
+      type: boolean
+    isModeratorRemoved:
+      type: boolean
+    unavailable:
+      type: boolean
+      description: True when the replied-to post is outside the window, purged, or pending moderation.
+  additionalProperties: false
+
+TopicCategoryPayload:
+  type: object
+  required: [id, name, url, color]
+  properties:
+    id:
+      type: integer
+      format: uint64
+    name:
+      type: string
+    url:
+      type: string
+    color:
+      type: string
+  additionalProperties: false
+
+TopicPayload:
+  type: object
+  required: [id, title, description, url, pinWeight, processStatus, author, participants, categories, replyCount, viewCount, activityText, lastUpdateTime]
+  properties:
+    id:
+      type: integer
+      format: uint64
+    title:
+      type: string
+    description:
+      type: string
+    firstImageUrl:
+      type: string
+      description: Present only when the topic has a cover image.
+    images:
+      type: array
+      items:
+        type: string
+    url:
+      type: string
+    pinWeight:
+      type: integer
+    processStatus:
+      type: integer
+      enum: [0, 1, 2]
+    author:
+      $ref: '#/TopicAuthorPayload'
+    participants:
+      type: array
+      items:
+        $ref: '#/TopicAuthorPayload'
+    categories:
+      type: array
+      items:
+        $ref: '#/TopicCategoryPayload'
+    replyCount:
+      type: integer
+      format: uint64
+    viewCount:
+      type: integer
+      format: uint64
+    activityText:
+      type: string
+    lastUpdateTime:
+      type: string
+    unseen:
+      type: boolean
+      description: Present only for authenticated viewers with unseen tracking.
+  additionalProperties: false
+
+UserSearchPayload:
+  type: object
+  required: [id, username, nickname, avatarUrl, bio]
+  properties:
+    id:
+      type: integer
+      format: uint64
+    username:
+      type: string
+    nickname:
+      type: string
+    avatarUrl:
+      type: string
+    bio:
+      type: string
+  additionalProperties: false
+
+CategorySearchPayload:
+  type: object
+  required: [id, name, slug, icon, color, desc]
+  properties:
+    id:
+      type: integer
+      format: uint64
+    name:
+      type: string
+    slug:
+      type: string
+    icon:
+      type: string
+    color:
+      type: string
+    desc:
+      type: string
+  additionalProperties: false
+
+CourseSearchPayload:
+  type: object
+  required: [id, primaryCode, name, department, creditX10, aliases, instructors, terms, campus]
+  properties:
+    id:
+      type: integer
+      format: uint64
+    primaryCode:
+      type: string
+    name:
+      type: string
+    department:
+      type: string
+    creditX10:
+      type: integer
+      description: Credit multiplied by 10 to stay integral (2.5 credit -> 25).
+    aliases:
+      type: array
+      items:
+        type: string
+    instructors:
+      type: array
+      items:
+        type: string
+    terms:
+      type: array
+      items:
+        type: string
+    campus:
+      type: array
+      items:
+        type: string
+  additionalProperties: false
+
+PaginationPayload:
+  type: object
+  required: [page, nextPage, hasNext, nextUrl]
+  properties:
+    page:
+      type: integer
+    nextPage:
+      type: integer
+    hasNext:
+      type: boolean
+    nextUrl:
+      type: string
+  additionalProperties: false
 
 UserSession:
   type: object

--- a/packages/api-contract/fixtures/agent-post-list-success.json
+++ b/packages/api-contract/fixtures/agent-post-list-success.json
@@ -9,6 +9,8 @@
         "renderedContent": "<p>First post content</p>",
         "processStatus": 0,
         "isHidden": false,
+        "isAuthorDeleted": false,
+        "isModeratorRemoved": false,
         "canModerate": false,
         "author": {
           "id": 1001,
@@ -16,18 +18,33 @@
           "avatarUrl": "/static/img/avatar/1.png"
         },
         "createdAt": "2025-06-15 10:00:00",
+        "replyToPostId": 9099,
+        "replyToUserId": 1002,
+        "replyToUsername": "alumni",
         "isOwnPost": false,
         "updatedAt": "2025-06-15 10:00:00",
-        "likeCount": 0,
-        "isLiked": false,
+        "likeCount": 2,
+        "isLiked": true,
         "isBookmarked": false
       }
     ],
-    "replyTargets": [],
-    "hasBefore": false,
+    "replyTargets": [
+      {
+        "id": 9099,
+        "postNo": 1,
+        "author": {
+          "id": 1002,
+          "username": "alumni",
+          "avatarUrl": "/static/img/avatar/2.png"
+        },
+        "renderedContent": "<p>Out-of-window parent post</p>",
+        "unavailable": false
+      }
+    ],
+    "hasBefore": true,
     "hasAfter": false,
-    "total": 1,
-    "maxPostNo": 1
+    "total": 3,
+    "maxPostNo": 3
   },
   "code": 0
 }

--- a/packages/api-contract/fixtures/agent-search-success.json
+++ b/packages/api-contract/fixtures/agent-search-success.json
@@ -2,13 +2,77 @@
   "result": {
     "query": "campus",
     "scope": "all",
-    "topics": [],
-    "users": [],
-    "categories": [],
-    "total": 0,
-    "usersTotal": 0,
-    "categoriesTotal": 0,
-    "totalPages": 0,
+    "topics": [
+      {
+        "id": 9001,
+        "title": "Campus life discussion",
+        "description": "Everything about campus life.",
+        "url": "/p/9001",
+        "pinWeight": 0,
+        "processStatus": 0,
+        "author": {
+          "id": 1001,
+          "username": "campus-bot",
+          "avatarUrl": "/static/img/avatar/1.png"
+        },
+        "participants": [
+          {
+            "id": 1001,
+            "username": "campus-bot",
+            "avatarUrl": "/static/img/avatar/1.png"
+          }
+        ],
+        "categories": [
+          {
+            "id": 1,
+            "name": "校园生活",
+            "url": "/campus-life",
+            "color": "#10b981"
+          }
+        ],
+        "replyCount": 12,
+        "viewCount": 345,
+        "activityText": "2025-06-15 10:00:00",
+        "lastUpdateTime": "2025-06-15 10:00:00"
+      }
+    ],
+    "users": [
+      {
+        "id": 1001,
+        "username": "campus-bot",
+        "nickname": "校园机器人",
+        "avatarUrl": "/static/img/avatar/1.png",
+        "bio": "YourTJ Hub campus bot"
+      }
+    ],
+    "categories": [
+      {
+        "id": 1,
+        "name": "校园生活",
+        "slug": "campus-life",
+        "icon": "🎓",
+        "color": "#10b981",
+        "desc": "Campus life discussions"
+      }
+    ],
+    "courses": [
+      {
+        "id": 2001,
+        "primaryCode": "TONGJI100",
+        "name": "Introduction to Tongji",
+        "department": "教务处",
+        "creditX10": 20,
+        "aliases": ["同济导论"],
+        "instructors": ["张老师"],
+        "terms": ["2025-2026-1"],
+        "campus": ["四平路"]
+      }
+    ],
+    "total": 1,
+    "usersTotal": 1,
+    "categoriesTotal": 1,
+    "coursesTotal": 1,
+    "totalPages": 1,
     "pagination": {
       "page": 1,
       "nextPage": 0,

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -7,7 +7,8 @@
     "lint": "redocly lint openapi.yaml",
     "bundle": "redocly bundle openapi.yaml --output .tmp/openapi.bundle.yaml",
     "generate:ts": "openapi-typescript openapi.yaml -o ../../apps/gooseforum/resource/packages/client/src/gen/openapi.ts",
-    "check": "pnpm run lint && pnpm run bundle && pnpm run generate:ts"
+    "check:gen": "node scripts/check-ts-gen.mjs",
+    "check": "pnpm run lint && pnpm run bundle && pnpm run generate:ts && pnpm run check:gen"
   },
   "devDependencies": {
     "@redocly/cli": "2.45.0",

--- a/packages/api-contract/scripts/check-ts-gen.mjs
+++ b/packages/api-contract/scripts/check-ts-gen.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Regression guard for issue #141: the generated Agent list/search TypeScript
+// types must reference the concrete payload schemas instead of empty records.
+// Run after `pnpm run generate:ts`.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const output = join(root, "apps", "gooseforum", "resource", "packages", "client", "src", "gen", "openapi.ts");
+
+const source = readFileSync(output, "utf8");
+
+// Each previously-empty Agent item/pagination must now be a named schema ref.
+const requiredRefs = [
+  'components["schemas"]["PostPayload"]',
+  'components["schemas"]["ReplyTargetPayload"]',
+  'components["schemas"]["TopicPayload"]',
+  'components["schemas"]["UserSearchPayload"]',
+  'components["schemas"]["CategorySearchPayload"]',
+  'components["schemas"]["CourseSearchPayload"]',
+  'components["schemas"]["PaginationPayload"]',
+];
+
+// Exact generated lines that appeared when the Agent list/search schemas were
+// empty objects. Any one remaining means the empty-record regression is back.
+const forbiddenLines = [
+  "posts: Record<string, never>[];",
+  "replyTargets: Record<string, never>[];",
+  "topics: Record<string, never>[];",
+  "users: Record<string, never>[];",
+  "categories: Record<string, never>[];",
+  "pagination: Record<string, never>;",
+];
+
+const missing = requiredRefs.filter((ref) => !source.includes(ref));
+if (missing.length > 0) {
+  console.error(
+    `[check-ts-gen] generated types are missing expected schema refs:\n${missing.map((ref) => `  - ${ref}`).join("\n")}\n` +
+      `Run \`pnpm run generate:ts\` after editing packages/api-contract, then commit the regenerated openapi.ts.`
+  );
+  process.exit(1);
+}
+
+const leftover = forbiddenLines.filter((line) => source.includes(line));
+if (leftover.length > 0) {
+  console.error(
+    `[check-ts-gen] Agent list/search types still contain empty records:\n${leftover.map((line) => `  - ${line}`).join("\n")}\n` +
+      `Fix packages/api-contract/components/schemas.yaml so the Agent responses reference concrete payload schemas, then regenerate.`
+  );
+  process.exit(1);
+}
+
+console.log("[check-ts-gen] OK: Agent list/search types reference concrete payload schemas.");


### PR DESCRIPTION
## 变更说明

修复 #141：Agent 搜索与列表的 OpenAPI schema 使用空 object，生成出的 TS 类型为 `Record<string, never>[]`，consumer 无法类型安全访问 post/topic 等实际字段。

**根因**：`packages/api-contract/components/schemas.yaml` 中 `AgentPostListResponse.posts/replyTargets` 与 `AgentSearchResponse.topics/users/categories/pagination` 均以 `type: object`（无 properties）占位；服务端实际返回的是 `forum.PostWindow` / `forum.SearchJSON` 的完整 payload。

**改动**：

- **schemas.yaml**：新增 8 个共享 payload schema，逐字段对齐 Go DTO（`app/http/controllers/forum/payload.go`）——`PostPayload`、`ReplyTargetPayload`、`TopicPayload`、`TopicCategoryPayload`、`UserSearchPayload`、`CategorySearchPayload`、`CourseSearchPayload`、`PaginationPayload`；`AgentPostListResponse` 与 `AgentSearchResponse` 的 items/pagination 改为引用具体 schema。
- **补全响应字段**：`AgentSearchResponse` 新增此前缺失的 `courses` / `coursesTotal`（`SearchJSON` 实际始终返回，scope=all 时含课程结果）。
- **回归守卫**：新增 `packages/api-contract/scripts/check-ts-gen.mjs` 并接入 `pnpm run check`（`check:gen`），断言生成的 Agent 列表/搜索类型引用具体 schema、不再出现空 `Record`，防止问题复发。
- **fixtures**：补全 `agent-post-list-success.json`（补 `isAuthorDeleted`/`isModeratorRemoved`/replyTarget 示例等实际字段）与 `agent-search-success.json`（填充 topics/users/categories/courses/pagination 完整示例）。
- **契约测试**：强化 `agent_contract_http_test.go` 的 post-window 与 search 用例，解码并断言文档化字段与运行时一致。

**类型变化**：`openapi.ts` 中 `AgentPostListResponse.posts` 从 `Record<string, never>[]` 变为 `components["schemas"]["PostPayload"][]`，`AgentSearchResponse.topics/users/categories/courses/pagination` 同理；均为"空类型 → 具体类型"的增强，无字段删除，前端无 consumer 使用这些类型（供外部/移动端 Agent 用），无破坏性。

## 验证

- `cd packages/api-contract && pnpm run check`：通过（lint 2 个 warning 为既有 loginPublicKey/logout，与本次无关；bundle + generate:ts + check:gen 全绿）
- `go test ./app/http/routes/`（含强化的 Agent 契约测试）：通过
- `go test ./app/http/controllers/forum/`：通过
- `go vet ./app/http/routes/`：通过
- 对抗性核验：8 个新增 schema + 响应接线与 Go DTO 逐字段比对，9/9 零偏差
- `git diff --check`：通过

## 备注

- `wornBadge`（作者可选徽章）仍是既有未类型化的 `[object, null]`，与本次空 Record 问题无关，属后续可跟进项。

Closes #141