### PR TITLE
fix(test): OIDC 私钥权限测试在 Windows 上失败

### DIFF
--- a/apps/gooseforum/app/bundles/oidcprovider/oidcprovider_test.go
+++ b/apps/gooseforum/app/bundles/oidcprovider/oidcprovider_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -29,13 +30,15 @@ func TestLoadGeneratesAndPersistsKey(t *testing.T) {
 		t.Fatal("KeyID() = empty")
 	}
 
-	// 文件必须存在且权限为 0600
+	// 文件必须存在；POSIX 权限断言为 Unix 专属（Windows 无 mode 语义）
 	info, err := os.Stat(keyFile)
 	if err != nil {
 		t.Fatalf("key file not persisted: %v", err)
 	}
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Fatalf("key file perm = %o, want 600", perm)
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("key file perm = %o, want 600", perm)
+		}
 	}
 
 	// 再次加载必须得到同一把密钥（重启后 kid 不变）


### PR DESCRIPTION
## Summary
修复 #90。Windows 不提供 POSIX mode 语义，`os.Stat` 的 `Perm()` 对 `0600` 创建的文件返回 `0666`，导致 `TestLoadGeneratesAndPersistsKey` 在 Windows 上失败（`key file perm = 666, want 600`）。

## 变更内容
- `apps/gooseforum/app/bundles/oidcprovider/oidcprovider_test.go`：
  - 按 `runtime.GOOS` 在 Windows 上跳过 POSIX 专属的 0600 权限断言
  - 文件存在性检查保留（所有平台）
  - Linux/Unix 仍验证新生成的 OIDC RSA 私钥文件为 `0600`

## 安全性说明
- 生产代码 `persistKeyFile` 仍以 `0600` 写入私钥文件，**未做任何弱化**
- 仅测试断言按平台调整，不降低生产 Linux 上私钥权限的实现要求

## Verification
- `go vet ./app/bundles/oidcprovider/` ✅
- `go test ./app/bundles/oidcprovider/ -v -count=1` — 5/5 PASS ✅
- `GOOS=windows GOARCH=amd64 go vet ./app/bundles/oidcprovider/` — Windows 目标可编译 ✅
- `go test ./app/bundles/... -count=1` — 全部通过 ✅

Closes #90