### PR TITLE
fix(auth): TOTP 错误保留挑战可重试,仅 401 过期才退出

### DIFF
--- a/apps/mobile/packages/auth/lib/src/auth_controller.dart
+++ b/apps/mobile/packages/auth/lib/src/auth_controller.dart
@@ -124,12 +124,18 @@ class AuthController extends ChangeNotifier {
 
   /// TOTP 二次验证。
   ///
-  /// 错误语义(对齐后端 `totpController.go` 与 message_code.go):
+  /// 错误语义(对齐后端 `totpController.go`、`middleware/totpChallenge.go`
+  /// 与 message_code.go):
   /// - `totp.code.invalid` / `totp.rateLimited`:challenge 未消费,保留
   ///   [LoginPhase.needsTotp],用户可继续重试;
-  /// - HTTP 401 `auth.required`:challenge token 已过期/被消费,清理后回到
-  ///   [LoginPhase.failed],用户需重新走密码登录;
-  /// - 其他未知错误同样保留 needsTotp,避免一次抖动丢失有效 challenge。
+  /// - HTTP 401 `auth.required`:challenge token 已过期/被消费,回到
+  ///   [LoginPhase.failed] 并提示重新登录;
+  /// - HTTP 403 `auth.account.frozen`:账号已冻结,回到 [LoginPhase.failed]
+  ///   并展示冻结文案(契约:challenge 不消费,解冻后可重试);
+  /// - `auth.login.failed`(200,challenge 已消费后会话签发失败):终止性错误,
+  ///   回到 [LoginPhase.failed](重试无意义,下一次提交必然 401);
+  /// - 其他未知业务错误与网络抖动:防御性保留 needsTotp,避免一次抖动
+  ///   丢失有效 challenge。
   Future<void> submitTotp(String code) async {
     _busy = true;
     _error = '';
@@ -147,7 +153,21 @@ class AuthController extends ChangeNotifier {
       _phase = LoginPhase.failed;
       _error = 'Two-factor challenge expired, please sign in again';
     } on ApiException catch (e) {
-      // 保留 needsTotp 挑战,可重试;仅展示错误消息。
+      if (e.messageCode == 'auth.account.frozen') {
+        // 403 冻结:退出挑战并展示冻结文案,避免困在 TOTP 表单
+        // 误报"网络连接失败"(契约:解冻后重新走密码登录即可重试)。
+        _phase = LoginPhase.failed;
+        _error = 'Account is frozen';
+        return;
+      }
+      if (e.messageCode == 'auth.login.failed') {
+        // challenge 已被服务端消费后的会话签发失败:终止性错误,
+        // 保留挑战只会让用户看到"先失败、下一次又 401"的割裂体验。
+        _phase = LoginPhase.failed;
+        _error = 'Sign-in failed, please try again';
+        return;
+      }
+      // 其余未知业务错误:保留 needsTotp 挑战,可重试;仅展示错误消息。
       _error = _mapTotpError(e);
     } catch (e) {
       // 网络抖动等:保留挑战,可重试。
@@ -259,8 +279,10 @@ class AuthController extends ChangeNotifier {
     _pendingUsername = username;
   }
 
-  /// TOTP 错误消息映射。所有分支都保留 [LoginPhase.needsTotp],
-  /// 由调用方(login_page 的 `_submit`)决定是否清理挑战。
+  /// TOTP 错误消息映射。除 [submitTotp] 已显式处理的终止性错误
+  /// (`auth.account.frozen` / `auth.login.failed`)外,其余分支都保留
+  /// [LoginPhase.needsTotp],由调用方(login_page 的 `_submit`)决定
+  /// 是否清理挑战。
   String _mapTotpError(ApiException e) {
     switch (e.messageCode) {
       case 'totp.code.invalid':
@@ -268,8 +290,10 @@ class AuthController extends ChangeNotifier {
       case 'totp.rateLimited':
         return 'Too many attempts, please try again later';
       default:
-        // 未知业务错误:同样保留挑战,展示稳定 messageCode 供上层本地化。
-        return e.messageKey;
+        // 未知业务错误:与 _mapAuthError 一致的策略——认证页尚无
+        // server.* l10n 表,返回面向用户的操作级 fallback,不泄露
+        // messageKey(如 `server.auth.login.failed`)字面量。
+        return 'Two-factor verification failed, please try again';
     }
   }
 

--- a/apps/mobile/packages/auth/lib/src/auth_controller.dart
+++ b/apps/mobile/packages/auth/lib/src/auth_controller.dart
@@ -123,6 +123,13 @@ class AuthController extends ChangeNotifier {
   }
 
   /// TOTP 二次验证。
+  ///
+  /// 错误语义(对齐后端 `totpController.go` 与 message_code.go):
+  /// - `totp.code.invalid` / `totp.rateLimited`:challenge 未消费,保留
+  ///   [LoginPhase.needsTotp],用户可继续重试;
+  /// - HTTP 401 `auth.required`:challenge token 已过期/被消费,清理后回到
+  ///   [LoginPhase.failed],用户需重新走密码登录;
+  /// - 其他未知错误同样保留 needsTotp,避免一次抖动丢失有效 challenge。
   Future<void> submitTotp(String code) async {
     _busy = true;
     _error = '';
@@ -132,11 +139,18 @@ class AuthController extends ChangeNotifier {
       if (ok) {
         await _completeLogin(username: _pendingUsername);
       } else {
-        _phase = LoginPhase.failed;
+        // 契约上 totpVerify 只有 throw 与 true 两种结果;防御性保留挑战。
         _error = 'Invalid two-factor code';
       }
-    } catch (e) {
+    } on UnauthorizedException {
+      // 401:challenge 已过期或失效,必须重新开始密码登录。
       _phase = LoginPhase.failed;
+      _error = 'Two-factor challenge expired, please sign in again';
+    } on ApiException catch (e) {
+      // 保留 needsTotp 挑战,可重试;仅展示错误消息。
+      _error = _mapTotpError(e);
+    } catch (e) {
+      // 网络抖动等:保留挑战,可重试。
       _error = 'TOTP verification failed: $e';
     } finally {
       _busy = false;
@@ -243,6 +257,20 @@ class AuthController extends ChangeNotifier {
     }
     _phase = LoginPhase.authenticated;
     _pendingUsername = username;
+  }
+
+  /// TOTP 错误消息映射。所有分支都保留 [LoginPhase.needsTotp],
+  /// 由调用方(login_page 的 `_submit`)决定是否清理挑战。
+  String _mapTotpError(ApiException e) {
+    switch (e.messageCode) {
+      case 'totp.code.invalid':
+        return 'Invalid two-factor code, please try again';
+      case 'totp.rateLimited':
+        return 'Too many attempts, please try again later';
+      default:
+        // 未知业务错误:同样保留挑战,展示稳定 messageCode 供上层本地化。
+        return e.messageKey;
+    }
   }
 
   String _mapAuthError(ApiException e, {required String fallback}) {

--- a/apps/mobile/packages/auth/test/auth_controller_test.dart
+++ b/apps/mobile/packages/auth/test/auth_controller_test.dart
@@ -149,7 +149,56 @@ void main() {
       expect(controller.error, 'Too many attempts, please try again later');
     });
 
-    test('TOTP 未知业务错误保留 needsTotp 并透出 messageKey', () async {
+    test('TOTP 未知业务错误保留 needsTotp 并返回可读 fallback(不泄露 raw key)', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: const ApiException(
+          fallbackMessage: 'Request failed',
+          messageCode: 'some.unknown.code',
+        ),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      await controller.submitTotp('222222');
+
+      expect(controller.phase, LoginPhase.needsTotp);
+      // 与 _mapAuthError 策略一致:不泄露 `server.<code>` 字面量。
+      expect(
+        controller.error,
+        'Two-factor verification failed, please try again',
+      );
+      expect(controller.error, isNot(contains('server.')));
+      expect(controller.error, isNot(contains('some.unknown.code')));
+    });
+
+    test('TOTP 403 冻结账号进入 failed 并展示冻结文案(不再误报网络失败)', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        // #143 语义:403 携带 ResultStruct envelope,messageCode 保留。
+        totpVerifyError: const ApiFailureException(
+          fallbackMessage: 'Request failed with status 403',
+          messageCode: 'auth.account.frozen',
+          statusCode: 403,
+        ),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      expect(controller.phase, LoginPhase.needsTotp);
+
+      await controller.submitTotp('555555');
+
+      // 契约:challenge 不消费,解冻后可重试;但继续困在 TOTP 表单只会
+      // 误导用户,退出到 failed 允许重新走密码登录。
+      expect(controller.phase, LoginPhase.failed);
+      expect(controller.error, 'Account is frozen');
+      expect(controller.error, isNot(contains('Network connection failed')));
+    });
+
+    test('TOTP auth.login.failed(200,challenge 已消费)进入 failed 为终止性错误', () async {
       final storage = MemoryTokenStorage()..write('challenge-token');
       final controller = _buildController(
         storage: storage,
@@ -161,10 +210,50 @@ void main() {
       );
 
       await controller.login(username: 'alice', password: 'secret');
-      await controller.submitTotp('222222');
+      expect(controller.phase, LoginPhase.needsTotp);
+
+      await controller.submitTotp('666666');
+
+      // challenge 已被服务端消费,重试无意义,直接退出。
+      expect(controller.phase, LoginPhase.failed);
+      expect(controller.error, 'Sign-in failed, please try again');
+      expect(controller.error, isNot(contains('server.')));
+    });
+
+    test('TOTP 429 RateLimitException 保留 needsTotp 并展示限流文案', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: const RateLimitException(
+          fallbackMessage: 'Too many requests, please retry later',
+          messageCode: 'totp.rateLimited',
+          retryAfterSeconds: 30,
+        ),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      await controller.submitTotp('777777');
 
       expect(controller.phase, LoginPhase.needsTotp);
-      expect(controller.error, 'server.auth.login.failed');
+      expect(controller.error, 'Too many attempts, please try again later');
+    });
+
+    test('TOTP totpVerify 返回 false 防御性保留 needsTotp', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifySucceeds: false,
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      expect(controller.phase, LoginPhase.needsTotp);
+
+      await controller.submitTotp('888888');
+
+      expect(controller.phase, LoginPhase.needsTotp);
+      expect(controller.error, 'Invalid two-factor code');
     });
 
     test('TOTP 网络异常保留 needsTotp 可重试', () async {

--- a/apps/mobile/packages/auth/test/auth_controller_test.dart
+++ b/apps/mobile/packages/auth/test/auth_controller_test.dart
@@ -107,6 +107,101 @@ void main() {
       expect(controller.phase, LoginPhase.authenticated);
     });
 
+    test('TOTP invalid-code 保留 needsTotp 且可重试成功', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: const ApiException(
+          fallbackMessage: 'Request failed',
+          messageCode: 'totp.code.invalid',
+        ),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      expect(controller.phase, LoginPhase.needsTotp);
+
+      await controller.submitTotp('000000');
+      // 关键:phase 保持 needsTotp,输入框不消失,可重试。
+      expect(controller.phase, LoginPhase.needsTotp);
+      expect(controller.error, 'Invalid two-factor code, please try again');
+
+      // 第二次提交成功(模拟用户重试)。
+      await controller.submitTotp('123456');
+      expect(controller.phase, LoginPhase.authenticated);
+    });
+
+    test('TOTP rate-limited 保留 needsTotp 并展示限流文案', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: const ApiException(
+          fallbackMessage: 'Request failed',
+          messageCode: 'totp.rateLimited',
+        ),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      await controller.submitTotp('111111');
+
+      expect(controller.phase, LoginPhase.needsTotp);
+      expect(controller.error, 'Too many attempts, please try again later');
+    });
+
+    test('TOTP 未知业务错误保留 needsTotp 并透出 messageKey', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: const ApiException(
+          fallbackMessage: 'Request failed',
+          messageCode: 'auth.login.failed',
+        ),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      await controller.submitTotp('222222');
+
+      expect(controller.phase, LoginPhase.needsTotp);
+      expect(controller.error, 'server.auth.login.failed');
+    });
+
+    test('TOTP 网络异常保留 needsTotp 可重试', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: Exception('connection reset'),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      await controller.submitTotp('333333');
+
+      expect(controller.phase, LoginPhase.needsTotp);
+      expect(controller.error, contains('TOTP verification failed'));
+    });
+
+    test('TOTP 401 过期挑战进入 failed 并提示重新登录', () async {
+      final storage = MemoryTokenStorage()..write('challenge-token');
+      final controller = _buildController(
+        storage: storage,
+        twoFactorRequired: true,
+        totpVerifyError: const UnauthorizedException(),
+      );
+
+      await controller.login(username: 'alice', password: 'secret');
+      expect(controller.phase, LoginPhase.needsTotp);
+
+      await controller.submitTotp('444444');
+
+      expect(controller.phase, LoginPhase.failed);
+      expect(
+        controller.error,
+        'Two-factor challenge expired, please sign in again',
+      );
+    });
+
     test('401 登录失败进入 failed 并带错误消息', () async {
       final controller = _buildController(
         storage: MemoryTokenStorage(),
@@ -217,6 +312,8 @@ AuthController _buildController({
   String? loginMessageCode,
   bool registerCaptchaRequired = false,
   bool forgotCaptchaRequired = false,
+  Object? totpVerifyError,
+  bool totpVerifySucceeds = true,
 }) {
   final storageAdapter = storage;
   final client = GfApiClient(
@@ -231,6 +328,8 @@ AuthController _buildController({
     loginMessageCode: loginMessageCode,
     registerCaptchaRequired: registerCaptchaRequired,
     forgotCaptchaRequired: forgotCaptchaRequired,
+    totpVerifyError: totpVerifyError,
+    totpVerifySucceeds: totpVerifySucceeds,
   );
   return AuthController(
     authRepository: auth,
@@ -254,6 +353,8 @@ class FakeAuthRepository implements AuthRepository {
     this.loginMessageCode,
     this.registerCaptchaRequired = false,
     this.forgotCaptchaRequired = false,
+    this.totpVerifyError,
+    this.totpVerifySucceeds = true,
   });
 
   final bool twoFactorRequired;
@@ -262,6 +363,13 @@ class FakeAuthRepository implements AuthRepository {
   final String? loginMessageCode;
   final bool registerCaptchaRequired;
   final bool forgotCaptchaRequired;
+
+  /// totpVerify 注入的错误;非 null 时优先于 [totpVerifySucceeds]。
+  /// 抛错后自动清空,模拟"输错一次 → 重试成功"的真实链路。
+  Object? totpVerifyError;
+
+  /// totpVerify 是否成功返回;false 时返回 false(不抛错)。
+  final bool totpVerifySucceeds;
 
   @override
   Future<CaptchaPayload> getCaptcha() async {
@@ -304,8 +412,15 @@ class FakeAuthRepository implements AuthRepository {
   }
 
   @override
-  Future<bool> totpVerify({required String code, String? recoveryCode}) async =>
-      true;
+  Future<bool> totpVerify({required String code, String? recoveryCode}) async {
+    final error = totpVerifyError;
+    if (error != null) {
+      // 只失败一次:模拟"输错一次 → 重试成功"的真实链路。
+      totpVerifyError = null;
+      throw error;
+    }
+    return totpVerifySucceeds;
+  }
 
   @override
   Future<String> register({


### PR DESCRIPTION
## Summary
- 修复 TOTP 输错验证码后 phase 直接变 `failed`、输入框消失、无法在挑战 TTL 内重试的问题。
- 对齐后端 `totpController.go` / `message_code.go` 语义：`totp.code.invalid`、`totp.rateLimited` 及未知/网络错误均**保留 `needsTotp` 挑战**，仅展示错误消息，用户可继续重试；仅 HTTP 401（`auth.required`，challenge token 已过期/被消费）才退出到 `failed` 并提示重新登录。

## Root Cause
`apps/mobile/packages/auth/lib/src/auth_controller.dart:125-145` 的 `submitTotp` 对任何错误一律 `_phase = LoginPhase.failed`；而 `login_page.dart` 仅 `needsTotp` 阶段渲染 TOTP 表单，导致输错一次就丢失有效 challenge。

## Changes
- `auth_controller.dart`：`submitTotp` 按错误分类处理——`UnauthorizedException`（401 过期）→ `failed` 并提示重新登录；`ApiException`（invalid/rateLimited/未知）与网络异常 → 保留 `needsTotp` 可重试；新增 `_mapTotpError` 映射文案（未知错误透出稳定 `messageKey`）。
- 测试：invalid-code 保留挑战且重试成功、rate-limited 文案、未知错误 messageKey、网络异常保留挑战、401 过期退出。

## Verification
- `flutter analyze`（auth）：No issues found。
- `flutter test`：auth 22 passed（含 5 个新场景）、forum_app 90 passed。

Closes #140