### PR TITLE
fix(deploy): 备份/同步脚本支持 URL 与 key=value 两种 PG DSN，解析失败先于 stop

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -86,7 +86,10 @@ jobs:
       - name: Deploy scripts (bash syntax + DSN parser tests)
         if: steps.filter.outputs.deploy_scripts == 'true'
         run: |
-          bash -n deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh
+          # bash -n 只语法检查第一个文件参数, 多文件写法会静默跳过其余文件, 必须逐个检查
+          for f in deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh; do
+            bash -n "$f"
+          done
           bash deploy/scripts/pgdsn_test.sh
 
   # 全部主库模型必须在 PostgreSQL 上可迁移。回归背景: issue #8 曾因模型里

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -59,6 +59,9 @@ jobs:
               - 'apps/gooseforum/go.mod'
               - 'apps/gooseforum/go.sum'
               - '.github/workflows/ci-backend.yml'
+            deploy_scripts:
+              - 'deploy/scripts/**'
+              - '.github/workflows/ci-backend.yml'
 
       - uses: actions/setup-go@v5
         if: steps.filter.outputs.backend == 'true'
@@ -76,6 +79,14 @@ jobs:
         if: steps.filter.outputs.backend == 'true'
         working-directory: apps/gooseforum
         run: go build .
+
+      # deploy 运维脚本测试(issue #134): DSN 解析支持 URL/key=value 两种格式,
+      # 非法 DSN 在调用侧于任何 DB 操作前报错; 仅脚本变更时运行。
+      - name: Deploy scripts (bash syntax + DSN parser tests)
+        if: steps.filter.outputs.deploy_scripts == 'true'
+        run: |
+          bash -n deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh
+          bash deploy/scripts/pgdsn_test.sh
 
   # 全部主库模型必须在 PostgreSQL 上可迁移。回归背景: issue #8 曾因模型里
   # 硬编码 MySQL 类型(bigint unsigned/datetime/tinyint)导致 PG 建表失败、

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -13,6 +13,7 @@ on:
       - "apps/gooseforum/resource/templates/**"
       - "apps/gooseforum/testdata/markdown-compat/**"
       - "packages/api-contract/**"
+      - "deploy/scripts/**"
       - ".github/workflows/ci-backend.yml"
   # PR 无条件触发, 保证 required status check 稳定存在(不会被 paths 跳过卡死)
   pull_request:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -48,10 +48,7 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: |
-            deploy/scripts/deploy.sh
-            deploy/scripts/sync-db-from-main.sh
-            deploy/scripts/pgdsn.sh
+          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh"
           target: "/tmp"
           strip_components: 2
       - name: Deploy to dev (sync db from main + build image + restart + smoke)

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,14 +41,17 @@ jobs:
           source: "bin/yourtj-hub"
           target: "/tmp"
           strip_components: 1
-      - name: Upload deploy script to dev host
+      - name: Upload deploy scripts to dev host
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh"
+          source: |
+            deploy/scripts/deploy.sh
+            deploy/scripts/sync-db-from-main.sh
+            deploy/scripts/pgdsn.sh
           target: "/tmp"
           strip_components: 2
       - name: Deploy to dev (sync db from main + build image + restart + smoke)
@@ -60,8 +63,12 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
-            # 0. 同步仓库最新 deploy.sh 到服务器(install 保证可执行位)
+            # 0. 同步仓库最新脚本到服务器(install 保证可执行位)。
+            #    sync-db-from-main.sh source pgdsn.sh, 必须一并下发, 否则
+            #    set -e 下 source 失败阻断部署(review W2)。
             install -m 0755 /tmp/deploy.sh /opt/yourtj/scripts/deploy.sh
+            install -m 0755 /tmp/sync-db-from-main.sh /opt/yourtj/scripts/sync-db-from-main.sh
+            install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
             # 1. 同步 main 数据库一致性快照(dev 用 main 真实数据预演迁移)
             /opt/yourtj/scripts/sync-db-from-main.sh
             # 2. 构建镜像 + 部署 + 健康检查(失败自动回滚), dev 对外端口 5235

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -33,14 +33,17 @@ jobs:
           source: "bin/yourtj-hub"
           target: "/tmp"
           strip_components: 1
-      - name: Upload deploy script to prod host
+      - name: Upload deploy scripts to prod host
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.VM_HOST }}
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh"
+          source: |
+            deploy/scripts/deploy.sh
+            deploy/scripts/backup-db.sh
+            deploy/scripts/pgdsn.sh
           target: "/tmp"
           strip_components: 2
       - name: Deploy to main (backup db + build image + restart + smoke + rollback)
@@ -52,8 +55,12 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
-            # 0. 同步仓库最新 deploy.sh 到服务器(install 保证可执行位)
+            # 0. 同步仓库最新脚本到服务器(install 保证可执行位)。
+            #    backup-db.sh source pgdsn.sh, 必须一并下发, 否则 set -e 下
+            #    source 失败阻断部署(review W2)。
             install -m 0755 /tmp/deploy.sh /opt/yourtj/scripts/deploy.sh
+            install -m 0755 /tmp/backup-db.sh /opt/yourtj/scripts/backup-db.sh
+            install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
             # 1. 部署前一致性备份(保留最近 7 份)
             /opt/yourtj/scripts/backup-db.sh main
             # 2. 构建镜像 + 部署 + 健康检查(失败自动回滚), main 对外端口 5234

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -40,10 +40,7 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: |
-            deploy/scripts/deploy.sh
-            deploy/scripts/backup-db.sh
-            deploy/scripts/pgdsn.sh
+          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh"
           target: "/tmp"
           strip_components: 2
       - name: Deploy to main (backup db + build image + restart + smoke + rollback)

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -42,11 +42,9 @@ pg_dbname() {
 }
 
 if [ "$(db_mode)" = "postgres" ]; then
-  PG_DB="$(pg_dbname)"
-  if [ -z "$PG_DB" ]; then
-    echo "backup-db: cannot parse dbname from $ROOT/$INSTANCE/config.toml" >&2
-    exit 1
-  fi
+  # 解析失败时 pg_dbname 已输出错误并返回非零(set -e 下即终止),
+  # 与 sync-db-from-main.sh 的 pg_dbname || exit 1 语义一致。
+  PG_DB="$(pg_dbname)" || exit 1
   TMP="/tmp/backup-${PG_DB}-$$.sql"
   if docker exec yourtj-postgres pg_dump -U yourtj -d "$PG_DB" > "$TMP"; then
     mv -f "$TMP" "$BACKUP_DIR/pg-${PG_DB}-${TS}.sql"

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -32,11 +32,10 @@ db_mode() {
 # 从 config.toml 提取 [db.default] url 值, 经 pg_dsn_dbname 解析数据库名。
 # URL 与 key=value 两种格式均支持; 解析失败输出错误并返回非零(调用方须在
 # 任何 DB 操作之前检查, 避免"先操作再报错"留下中间状态)。
+# 注: pg_toml_url 同时负责剥离 TOML 行尾内联注释(review W1)。
 pg_dbname() {
   local cfg="$ROOT/$INSTANCE/config.toml" url
-  # 只匹配 [db.default] 区块内的 url 行, 避免误取 [db.file]/[meilisearch] 的 url
-  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS)
-  url="$(sed -n '/^\[db\.default\]/,/^\[/p' "$cfg" | grep -E '^[[:space:]]*url[[:space:]]*=' | head -n1 | sed -E 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*//' | tr -d '"')"
+  url="$(pg_toml_url "$cfg")"
   [ -n "$url" ] || { echo "backup-db: $cfg 未配置 [db.default].url" >&2; return 1; }
   pg_dsn_dbname "$url"
 }

--- a/deploy/scripts/backup-db.sh
+++ b/deploy/scripts/backup-db.sh
@@ -11,6 +11,11 @@ DB_DIR="$ROOT/$INSTANCE/storage/database"
 BACKUP_DIR="$ROOT/snapshots/$INSTANCE"
 TS="$(date +%Y%m%d_%H%M%S)"
 
+# 共享 PostgreSQL DSN 解析库(支持 postgres:// URL 与 key=value 两种格式, issue #134)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pgdsn.sh
+source "$SCRIPT_DIR/pgdsn.sh"
+
 mkdir -p "$BACKUP_DIR"
 
 # 检测主库模式: 读 config.toml [db.default] connection
@@ -24,8 +29,16 @@ db_mode() {
   fi
 }
 
+# 从 config.toml 提取 [db.default] url 值, 经 pg_dsn_dbname 解析数据库名。
+# URL 与 key=value 两种格式均支持; 解析失败输出错误并返回非零(调用方须在
+# 任何 DB 操作之前检查, 避免"先操作再报错"留下中间状态)。
 pg_dbname() {
-  grep -E '^\s*url\s*=' "$ROOT/$INSTANCE/config.toml" | grep -oE 'dbname=[^ ]+' | cut -d= -f2 || true
+  local cfg="$ROOT/$INSTANCE/config.toml" url
+  # 只匹配 [db.default] 区块内的 url 行, 避免误取 [db.file]/[meilisearch] 的 url
+  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS)
+  url="$(sed -n '/^\[db\.default\]/,/^\[/p' "$cfg" | grep -E '^[[:space:]]*url[[:space:]]*=' | head -n1 | sed -E 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*//' | tr -d '"')"
+  [ -n "$url" ] || { echo "backup-db: $cfg 未配置 [db.default].url" >&2; return 1; }
+  pg_dsn_dbname "$url"
 }
 
 if [ "$(db_mode)" = "postgres" ]; then
@@ -44,7 +57,7 @@ if [ "$(db_mode)" = "postgres" ]; then
     exit 1
   fi
   # 清理旧 PG 备份(每库保留 KEEP 份)
-  ls -1t "$BACKUP_DIR"/pg-${PG_DB}-*.sql 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
+  ls -1t "$BACKUP_DIR"/pg-"${PG_DB}"-*.sql 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
   echo "backup-db: $INSTANCE pg backups done (keep $KEEP)"
   exit 0
 fi
@@ -68,6 +81,6 @@ backup_one "$DB_DIR/file.db" "file"
 
 # 清理旧备份(任一标签), 每个标签保留 KEEP 份
 for label in sqlite file; do
-  ls -1t "$BACKUP_DIR"/${label}-*.db 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
+  ls -1t "$BACKUP_DIR"/"${label}"-*.db 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
 done
 echo "backup-db: $INSTANCE backups done (keep $KEEP per label)"

--- a/deploy/scripts/pgdsn.sh
+++ b/deploy/scripts/pgdsn.sh
@@ -101,7 +101,8 @@ pg_uri_split() {
   # host[:port] — IPv6 字面量 [::1] 或 [::1]:5432 按括号整体识别(review INFO),
   # 避免 host 被错误切分为 "["
   if [[ "$hostport" == \[*\]* ]]; then
-    printf -v "${var}_host" '%s' "${hostport%%]*}"
+    # %%]* 最长后缀匹配会连闭合 ] 一起吞掉, 需补回(否则 host 变成 "[::1")
+    printf -v "${var}_host" '%s' "${hostport%%]*}]"
     if [[ "${hostport##*]}" == ":"* ]]; then
       printf -v "${var}_port" '%s' "${hostport##*]:}"
     else
@@ -193,7 +194,7 @@ pg_dsn_dbname() {
   # (dbname="my forum") 拼接引号内全部 token(review LOW3)。
   if [[ "$dsn" == *"dbname="* ]]; then
     local -a toks=()
-    local tok val i=0
+    local tok i=0
     key=""
     set -f
     # read -a 按 IFS(默认含空格)切分; set -f 防 glob 展开

--- a/deploy/scripts/pgdsn.sh
+++ b/deploy/scripts/pgdsn.sh
@@ -76,6 +76,22 @@ pg_uri_split() {
   fi
 }
 
+# pg_toml_url <cfg> — 从 config.toml 的 [db.default] 区块提取 url 值。
+# 按 TOML 语义剥离行尾内联注释(review W1): 只取双引号字符串内部,
+# 引号之后的内容(含 "  # 注释")全部丢弃; 引号值内合法 #(如密码含 #)
+# 不受影响。旧 grep 实现([^ ]+)对行尾注释免疫, 新 URL 支持的
+# tr -d '"' 会把注释并入 DSN 导致 dbname 带脏值, 此函数修复该回归。
+# 输出 url; 未配置或非双引号值(如单引号 TOML 字面量)时输出空/原样。
+pg_toml_url() {
+  local cfg="$1"
+  # 只匹配 [db.default] 区块内的 url 行, 避免误取 [db.file]/[meilisearch] 的 url
+  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS); \1 捕获双引号内全部内容
+  sed -n '/^\[db\.default\]/,/^\[/p' "$cfg" \
+    | grep -E '^[[:space:]]*url[[:space:]]*=' \
+    | head -n1 \
+    | sed -E 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*"([^"]*)".*$/\1/'
+}
+
 # pg_dsn_dbname <dsn> — 输出 DSN 中的数据库名。
 # 支持 key=value(key 可带引号)与 postgres:// URL 两种格式。
 # 解析失败输出错误到 stderr 并返回 1(错误信息经 pg_dsn_normalize 脱敏,

--- a/deploy/scripts/pgdsn.sh
+++ b/deploy/scripts/pgdsn.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# pgdsn.sh — 共享 PostgreSQL DSN 解析库(source 后使用)。
+# 同时支持 libpq key=value 与 postgres:// URL 两种 DSN 格式, 供
+# backup-db.sh / sync-db-from-main.sh 等运维脚本提取数据库名。
+#
+# 用法:
+#   source pgdsn.sh
+#   pg_dsn_dbname <dsn>        # 输出 dbname; 解析失败返回 1 并输出错误到 stderr
+#   pg_dsn_normalize <dsn>     # 输出归一化 DSN(用于回显/日志, 脱敏密码)
+#
+# 设计约束(issue #134):
+#   - 解析失败必须返回非零, 调用方必须在任何 DB/stop 操作之前检查,
+#     避免"先停服务再报错"导致服务停留在停止状态。
+#   - 不依赖 psql/外部工具, 纯 bash 实现, 便于在无 PG 客户端的主机上测试。
+
+# pg_uri_split <uri> <var> — 从 postgres:// URL 提取组件。
+# 支持: postgres://user:pass@host:port/db?sslmode=disable&param=v
+#       postgresql://user@host/db
+# 输出到 <var>_user/_password/_host/_port/_db/_params(空为未提供)。
+pg_uri_split() {
+  local uri="$1" var="$2" rest userinfo hostport pathquery dbpart
+  # 去掉 scheme 前缀
+  rest="${uri#*://}"
+  # 分离 userinfo(最后一个 @ 之前)与 host 部分
+  if [[ "$rest" == *"@"* ]]; then
+    userinfo="${rest%%@*}"
+    rest="${rest#*@}"
+  else
+    userinfo=""
+  fi
+  # userinfo: user[:password]
+  if [ -n "$userinfo" ]; then
+    if [[ "$userinfo" == *":"* ]]; then
+      eval "${var}_user='${userinfo%%:*}'"
+      eval "${var}_password='${userinfo#*:}'"
+    else
+      eval "${var}_user='$userinfo'"
+      eval "${var}_password=''"
+    fi
+  else
+    eval "${var}_user=''"
+    eval "${var}_password=''"
+  fi
+  # host[:port] 与 path 的边界是第一个 /
+  hostport="${rest%%/*}"
+  pathquery="${rest#*/}"
+  # 若路径不存在(rest 无 /), pathquery 会等于 rest, 需修正
+  if [ "$pathquery" = "$rest" ]; then
+    pathquery=""
+  fi
+  # pathquery: db[?params]
+  if [[ "$pathquery" == *"?"* ]]; then
+    dbpart="${pathquery%%\?*}"
+    eval "${var}_db='$dbpart'"
+    eval "${var}_params='${pathquery#*\?}'"
+  else
+    eval "${var}_db='$pathquery'"
+    eval "${var}_params=''"
+  fi
+  # host[:port]
+  if [[ "$hostport" == *":"* ]]; then
+    eval "${var}_host='${hostport%%:*}'"
+    eval "${var}_port='${hostport#*:}'"
+  else
+    eval "${var}_host='$hostport'"
+    eval "${var}_port=''"
+  fi
+}
+
+# pg_dsn_dbname <dsn> — 输出 DSN 中的数据库名。
+# 支持 key=value(key 可带引号)与 postgres:// URL 两种格式。
+# 解析失败输出错误到 stderr 并返回 1。
+pg_dsn_dbname() {
+  local dsn="$1" key uri db
+  [ -n "$dsn" ] || { echo "pg_dsn_dbname: empty DSN" >&2; return 1; }
+  # URL 格式: postgres:// 或 postgresql://
+  if [[ "$dsn" == postgres://* || "$dsn" == postgresql://* ]]; then
+    pg_uri_split "$dsn" uri
+    [ -n "$uri_db" ] || { echo "pg_dsn_dbname: URL DSN 缺少数据库名: $dsn" >&2; return 1; }
+    [ -n "$uri_host" ] || { echo "pg_dsn_dbname: URL DSN 缺少主机名: $dsn" >&2; return 1; }
+    # URL 中的 dbname 参数优先于路径段(libpq 行为: 后者覆盖前者)
+    if [ -n "$uri_params" ]; then
+      local IFS='&' p
+      for p in $uri_params; do
+        case "$p" in
+          dbname=*) db="${p#dbname=}";;
+        esac
+      done
+    fi
+    echo "${db:-$uri_db}"
+    return 0
+  fi
+  # key=value 格式: 取 dbname= 的值(支持引号包裹)
+  if [[ "$dsn" == *"dbname="* ]]; then
+    key="${dsn#*dbname=}"
+    key="${key%%[[:space:]]*}"
+    # 去掉包裹引号(单/双)
+    if [[ "$key" == \"*\" || "$key" == \'*\' ]]; then
+      key="${key:1:${#key}-2}"
+    fi
+    [ -n "$key" ] || { echo "pg_dsn_dbname: dbname 为空: $dsn" >&2; return 1; }
+    echo "$key"
+    return 0
+  fi
+  echo "pg_dsn_dbname: 无法解析 DSN(需为 postgres:// URL 或含 dbname= 的 key=value 格式): $dsn" >&2
+  return 1
+}
+
+# pg_dsn_normalize <dsn> — 输出归一化 DSN 用于日志/回显:
+#   - URL 格式: 脱敏密码(保留 user@host/db)
+#   - key=value 格式: 脱敏 password 值
+pg_dsn_normalize() {
+  local dsn="$1" uri result
+  if [[ "$dsn" == postgres://* || "$dsn" == postgresql://* ]]; then
+    pg_uri_split "$dsn" uri
+    # shellcheck disable=SC2154  # uri_* 由 pg_uri_split 的 eval 赋值
+    result="postgres://${uri_user}"
+    if [ -n "$uri_password" ]; then
+      result="${result}:***"
+    fi
+    if [ -n "$uri_port" ]; then
+      result="${result}@${uri_host}:${uri_port}"
+    else
+      result="${result}@${uri_host}"
+    fi
+    if [ -n "$uri_db" ]; then
+      result="${result}/${uri_db}"
+    fi
+    echo "$result"
+    return 0
+  fi
+  # key=value: 脱敏 password
+  result=""
+  local IFS=' ' tok
+  for tok in $dsn; do
+    case "$tok" in
+      password=*) result="$result password=***";;
+      *) result="$result $tok";;
+    esac
+  done
+  echo "${result# }"
+}

--- a/deploy/scripts/pgdsn.sh
+++ b/deploy/scripts/pgdsn.sh
@@ -12,34 +12,37 @@
 #   - 解析失败必须返回非零, 调用方必须在任何 DB/stop 操作之前检查,
 #     避免"先停服务再报错"导致服务停留在停止状态。
 #   - 不依赖 psql/外部工具, 纯 bash 实现, 便于在无 PG 客户端的主机上测试。
+#   - 不使用 eval 拼接 DSN 内容(review P1 命令注入): 赋值一律走 printf -v。
 
 # pg_uri_split <uri> <var> — 从 postgres:// URL 提取组件。
 # 支持: postgres://user:pass@host:port/db?sslmode=disable&param=v
 #       postgresql://user@host/db
 # 输出到 <var>_user/_password/_host/_port/_db/_params(空为未提供)。
+# 密码中可能含任意字符(含 ' " @ / 等), 全部按字面量处理, 不做任何 shell 求值。
 pg_uri_split() {
   local uri="$1" var="$2" rest userinfo hostport pathquery dbpart
-  # 去掉 scheme 前缀
+  # 去掉 scheme 前缀(大小写不敏感, RFC 3986)
   rest="${uri#*://}"
-  # 分离 userinfo(最后一个 @ 之前)与 host 部分
+  # 分离 userinfo 与 host 部分: 按最后一个 @ 切分(libpq 语义,
+  # 密码中的裸 @ 不会破坏 host 解析)
   if [[ "$rest" == *"@"* ]]; then
-    userinfo="${rest%%@*}"
-    rest="${rest#*@}"
+    userinfo="${rest%@*}"
+    rest="${rest##*@}"
   else
     userinfo=""
   fi
   # userinfo: user[:password]
   if [ -n "$userinfo" ]; then
     if [[ "$userinfo" == *":"* ]]; then
-      eval "${var}_user='${userinfo%%:*}'"
-      eval "${var}_password='${userinfo#*:}'"
+      printf -v "${var}_user" '%s' "${userinfo%%:*}"
+      printf -v "${var}_password" '%s' "${userinfo#*:}"
     else
-      eval "${var}_user='$userinfo'"
-      eval "${var}_password=''"
+      printf -v "${var}_user" '%s' "$userinfo"
+      printf -v "${var}_password" '%s' ""
     fi
   else
-    eval "${var}_user=''"
-    eval "${var}_password=''"
+    printf -v "${var}_user" '%s' ""
+    printf -v "${var}_password" '%s' ""
   fi
   # host[:port] 与 path 的边界是第一个 /
   hostport="${rest%%/*}"
@@ -49,60 +52,86 @@ pg_uri_split() {
     pathquery=""
   fi
   # pathquery: db[?params]
-  if [[ "$pathquery" == *"?"* ]]; then
+  # 无路径但有 query 参数(postgres://u@h?dbname=dbq): query 挂在 hostport
+  # 末尾, db 段为空, ? 之后全部归 params
+  if [ -z "$pathquery" ] && [[ "$hostport" == *"?"* ]]; then
+    printf -v "${var}_db" '%s' ""
+    printf -v "${var}_params" '%s' "${hostport#*\?}"
+    hostport="${hostport%%\?*}"
+  elif [[ "$pathquery" == *"?"* ]]; then
     dbpart="${pathquery%%\?*}"
-    eval "${var}_db='$dbpart'"
-    eval "${var}_params='${pathquery#*\?}'"
+    printf -v "${var}_db" '%s' "$dbpart"
+    printf -v "${var}_params" '%s' "${pathquery#*\?}"
   else
-    eval "${var}_db='$pathquery'"
-    eval "${var}_params=''"
+    printf -v "${var}_db" '%s' "$pathquery"
+    printf -v "${var}_params" '%s' ""
   fi
   # host[:port]
   if [[ "$hostport" == *":"* ]]; then
-    eval "${var}_host='${hostport%%:*}'"
-    eval "${var}_port='${hostport#*:}'"
+    printf -v "${var}_host" '%s' "${hostport%%:*}"
+    printf -v "${var}_port" '%s' "${hostport#*:}"
   else
-    eval "${var}_host='$hostport'"
-    eval "${var}_port=''"
+    printf -v "${var}_host" '%s' "$hostport"
+    printf -v "${var}_port" '%s' ""
   fi
 }
 
 # pg_dsn_dbname <dsn> — 输出 DSN 中的数据库名。
 # 支持 key=value(key 可带引号)与 postgres:// URL 两种格式。
-# 解析失败输出错误到 stderr 并返回 1。
+# 解析失败输出错误到 stderr 并返回 1(错误信息经 pg_dsn_normalize 脱敏,
+# 避免明文密码进入 CI/部署日志)。
 pg_dsn_dbname() {
   local dsn="$1" key uri db
   [ -n "$dsn" ] || { echo "pg_dsn_dbname: empty DSN" >&2; return 1; }
-  # URL 格式: postgres:// 或 postgresql://
-  if [[ "$dsn" == postgres://* || "$dsn" == postgresql://* ]]; then
+  # URL 格式: postgres:// 或 postgresql:// (scheme 大小写不敏感, RFC 3986)
+  # 注: 用 [pP][oO]... 模式匹配而非 ${dsn,,}(bash 4+ 特性, macOS 默认 bash 3.2 不支持)
+  if [[ "$dsn" == [pP][oO][sS][tT][gG][rR][eE][sS]://* || "$dsn" == [pP][oO][sS][tT][gG][rR][eE][sS][qQ][lL]://* ]]; then
     pg_uri_split "$dsn" uri
-    [ -n "$uri_db" ] || { echo "pg_dsn_dbname: URL DSN 缺少数据库名: $dsn" >&2; return 1; }
-    [ -n "$uri_host" ] || { echo "pg_dsn_dbname: URL DSN 缺少主机名: $dsn" >&2; return 1; }
+    if [ -z "$uri_db" ] && [ -z "$uri_params" ]; then
+      echo "pg_dsn_dbname: URL DSN 缺少数据库名: $(pg_dsn_normalize "$dsn")" >&2
+      return 1
+    fi
+    [ -n "$uri_host" ] || { echo "pg_dsn_dbname: URL DSN 缺少主机名: $(pg_dsn_normalize "$dsn")" >&2; return 1; }
     # URL 中的 dbname 参数优先于路径段(libpq 行为: 后者覆盖前者)
     if [ -n "$uri_params" ]; then
       local IFS='&' p
+      # set -f: 参数值含 * 等通配符时不触发路径展开
+      set -f
       for p in $uri_params; do
         case "$p" in
           dbname=*) db="${p#dbname=}";;
         esac
       done
+      set +f
     fi
     echo "${db:-$uri_db}"
     return 0
   fi
-  # key=value 格式: 取 dbname= 的值(支持引号包裹)
+  # key=value 格式: 按空格 token 化逐项解析, 取最后一个 dbname token
+  # (libpq 语义: 后者覆盖前者)。按 token 解析可避免密码/其他值中
+  # 含 "dbname=" 子串时被第一个匹配误判。
   if [[ "$dsn" == *"dbname="* ]]; then
-    key="${dsn#*dbname=}"
-    key="${key%%[[:space:]]*}"
-    # 去掉包裹引号(单/双)
-    if [[ "$key" == \"*\" || "$key" == \'*\' ]]; then
-      key="${key:1:${#key}-2}"
-    fi
-    [ -n "$key" ] || { echo "pg_dsn_dbname: dbname 为空: $dsn" >&2; return 1; }
+    local IFS=' ' tok val
+    key=""
+    set -f
+    for tok in $dsn; do
+      case "$tok" in
+        dbname=*)
+          val="${tok#dbname=}"
+          # 去掉包裹引号(单/双; 引号值含空格时截断到引号前, libpq 无引号语义)
+          if [[ "$val" == \"*\" || "$val" == \'*\' ]]; then
+            val="${val:1:${#val}-2}"
+          fi
+          key="$val"
+          ;;
+      esac
+    done
+    set +f
+    [ -n "$key" ] || { echo "pg_dsn_dbname: dbname 为空: $(pg_dsn_normalize "$dsn")" >&2; return 1; }
     echo "$key"
     return 0
   fi
-  echo "pg_dsn_dbname: 无法解析 DSN(需为 postgres:// URL 或含 dbname= 的 key=value 格式): $dsn" >&2
+  echo "pg_dsn_dbname: 无法解析 DSN(需为 postgres:// URL 或含 dbname= 的 key=value 格式): $(pg_dsn_normalize "$dsn")" >&2
   return 1
 }
 
@@ -111,9 +140,9 @@ pg_dsn_dbname() {
 #   - key=value 格式: 脱敏 password 值
 pg_dsn_normalize() {
   local dsn="$1" uri result
-  if [[ "$dsn" == postgres://* || "$dsn" == postgresql://* ]]; then
+  if [[ "$dsn" == [pP][oO][sS][tT][gG][rR][eE][sS]://* || "$dsn" == [pP][oO][sS][tT][gG][rR][eE][sS][qQ][lL]://* ]]; then
     pg_uri_split "$dsn" uri
-    # shellcheck disable=SC2154  # uri_* 由 pg_uri_split 的 eval 赋值
+    # shellcheck disable=SC2154  # uri_* 由 pg_uri_split 的 printf -v 动态赋值
     result="postgres://${uri_user}"
     if [ -n "$uri_password" ]; then
       result="${result}:***"
@@ -132,11 +161,13 @@ pg_dsn_normalize() {
   # key=value: 脱敏 password
   result=""
   local IFS=' ' tok
+  set -f
   for tok in $dsn; do
     case "$tok" in
       password=*) result="$result password=***";;
       *) result="$result $tok";;
     esac
   done
+  set +f
   echo "${result# }"
 }

--- a/deploy/scripts/pgdsn.sh
+++ b/deploy/scripts/pgdsn.sh
@@ -14,6 +14,28 @@
 #   - 不依赖 psql/外部工具, 纯 bash 实现, 便于在无 PG 客户端的主机上测试。
 #   - 不使用 eval 拼接 DSN 内容(review P1 命令注入): 赋值一律走 printf -v。
 
+# pg_percent_decode <s> — 将 URL percent-encoding(%XX)解码为字符。
+# libpq 对 dbname 路径段做 percent-decode, 解析库保持一致(review LOW1),
+# 避免 pg_dump -d "my%20db" 连错库。
+pg_percent_decode() {
+  local s="$1" out="" ch hex
+  while [ -n "$s" ]; do
+    case "$s" in
+      %[0-9a-fA-F][0-9a-fA-F]*)
+        hex="${s:1:2}"
+        printf -v ch "\\x$hex"
+        out="$out$ch"
+        s="${s:3}"
+        ;;
+      *)
+        out="$out${s:0:1}"
+        s="${s:1}"
+        ;;
+    esac
+  done
+  printf '%s' "$out"
+}
+
 # pg_uri_split <uri> <var> — 从 postgres:// URL 提取组件。
 # 支持: postgres://user:pass@host:port/db?sslmode=disable&param=v
 #       postgresql://user@host/db
@@ -66,8 +88,16 @@ pg_uri_split() {
     printf -v "${var}_db" '%s' "$pathquery"
     printf -v "${var}_params" '%s' ""
   fi
-  # host[:port]
-  if [[ "$hostport" == *":"* ]]; then
+  # host[:port] — IPv6 字面量 [::1] 或 [::1]:5432 按括号整体识别(review INFO),
+  # 避免 host 被错误切分为 "["
+  if [[ "$hostport" == \[*\]* ]]; then
+    printf -v "${var}_host" '%s' "${hostport%%]*}"
+    if [[ "${hostport##*]}" == ":"* ]]; then
+      printf -v "${var}_port" '%s' "${hostport##*]:}"
+    else
+      printf -v "${var}_port" '%s' ""
+    fi
+  elif [[ "$hostport" == *":"* ]]; then
     printf -v "${var}_host" '%s' "${hostport%%:*}"
     printf -v "${var}_port" '%s' "${hostport#*:}"
   else
@@ -108,41 +138,69 @@ pg_dsn_dbname() {
       return 1
     fi
     [ -n "$uri_host" ] || { echo "pg_dsn_dbname: URL DSN 缺少主机名: $(pg_dsn_normalize "$dsn")" >&2; return 1; }
-    # URL 中的 dbname 参数优先于路径段(libpq 行为: 后者覆盖前者)
+    # URL 中的 dbname 参数优先于路径段(libpq 行为: 后者覆盖前者)。
+    # query 中显式出现 dbname=(即使值为空)即覆盖路径段, 空值报错,
+    # 不静默回退(review LOW2)。用 has_query_dbname 哨兵区分
+    # "显式空 dbname"与"query 未提供 dbname"(后者回退路径段)。
+    db=""
+    has_query_dbname=""
     if [ -n "$uri_params" ]; then
       local IFS='&' p
       # set -f: 参数值含 * 等通配符时不触发路径展开
       set -f
       for p in $uri_params; do
         case "$p" in
-          dbname=*) db="${p#dbname=}";;
+          dbname=*) has_query_dbname=1; db="${p#dbname=}";;
         esac
       done
       set +f
     fi
-    echo "${db:-$uri_db}"
+    if [ -n "$has_query_dbname" ] && [ -z "$db" ]; then
+      echo "pg_dsn_dbname: URL DSN 数据库名为空: $(pg_dsn_normalize "$dsn")" >&2
+      return 1
+    fi
+    [ -n "$db" ] || db="$uri_db"
+    if [ -z "$db" ]; then
+      echo "pg_dsn_dbname: URL DSN 数据库名为空: $(pg_dsn_normalize "$dsn")" >&2
+      return 1
+    fi
+    # libpq 对 dbname 做 percent-decode(review LOW1), 避免 pg_dump -d 连错库
+    echo "$(pg_percent_decode "$db")"
     return 0
   fi
   # key=value 格式: 按空格 token 化逐项解析, 取最后一个 dbname token
   # (libpq 语义: 后者覆盖前者)。按 token 解析可避免密码/其他值中
-  # 含 "dbname=" 子串时被第一个匹配误判。
+  # 含 "dbname=" 子串时被第一个匹配误判。引号值含空格时
+  # (dbname="my forum") 拼接引号内全部 token(review LOW3)。
   if [[ "$dsn" == *"dbname="* ]]; then
-    local IFS=' ' tok val
+    local -a toks=()
+    local tok val i=0
     key=""
     set -f
-    for tok in $dsn; do
+    # read -a 按 IFS(默认含空格)切分; set -f 防 glob 展开
+    read -r -a toks <<< "$dsn"
+    set +f
+    while [ "$i" -lt "${#toks[@]}" ]; do
+      tok="${toks[$i]}"
       case "$tok" in
         dbname=*)
-          val="${tok#dbname=}"
-          # 去掉包裹引号(单/双; 引号值含空格时截断到引号前, libpq 无引号语义)
-          if [[ "$val" == \"*\" || "$val" == \'*\' ]]; then
-            val="${val:1:${#val}-2}"
+          key="${tok#dbname=}"
+          # 引号未闭合 → 拼接后续 token 直至闭合引号
+          while [[ "$key" == \"* && "$key" != *\" || "$key" == \'* && "$key" != *\' ]]; do
+            i=$((i + 1))
+            [ "$i" -lt "${#toks[@]}" ] || break
+            key="$key ${toks[$i]}"
+          done
+          # 去掉包裹引号(单/双)
+          if [[ "$key" == \"*\" ]]; then
+            key="${key:1:${#key}-2}"
+          elif [[ "$key" == \'*\' ]]; then
+            key="${key:1:${#key}-2}"
           fi
-          key="$val"
           ;;
       esac
+      i=$((i + 1))
     done
-    set +f
     [ -n "$key" ] || { echo "pg_dsn_dbname: dbname 为空: $(pg_dsn_normalize "$dsn")" >&2; return 1; }
     echo "$key"
     return 0

--- a/deploy/scripts/pgdsn.sh
+++ b/deploy/scripts/pgdsn.sh
@@ -42,16 +42,29 @@ pg_percent_decode() {
 # 输出到 <var>_user/_password/_host/_port/_db/_params(空为未提供)。
 # 密码中可能含任意字符(含 ' " @ / 等), 全部按字面量处理, 不做任何 shell 求值。
 pg_uri_split() {
-  local uri="$1" var="$2" rest userinfo hostport pathquery dbpart
+  local uri="$1" var="$2" rest authority userinfo hostport pathquery dbpart
   # 去掉 scheme 前缀(大小写不敏感, RFC 3986)
   rest="${uri#*://}"
-  # 分离 userinfo 与 host 部分: 按最后一个 @ 切分(libpq 语义,
-  # 密码中的裸 @ 不会破坏 host 解析)
-  if [[ "$rest" == *"@"* ]]; then
-    userinfo="${rest%@*}"
-    rest="${rest##*@}"
+  # 分离 authority 与 path/query: 边界是首个 / 或 ?(libpq 语义,
+  # review S4: @ 只允许出现在 authority 内, path/query 中的裸 @
+  # 属于 dbname/参数值, 不能被当作 userinfo 分隔符)
+  authority="$rest"
+  case "$rest" in
+    *\?*) authority="${rest%%\?*}" ;;
+  esac
+  case "$authority" in
+    */*) authority="${authority%%/*}" ;;
+  esac
+  # 剩余部分: path?query(可能为空)
+  pathquery="${rest#"$authority"}"
+  # 分离 userinfo 与 host 部分: 在 authority 内按最后一个 @ 切分
+  # (libpq 语义, 密码中的裸 @ 不会破坏 host 解析)
+  if [[ "$authority" == *"@"* ]]; then
+    userinfo="${authority%@*}"
+    hostport="${authority##*@}"
   else
     userinfo=""
+    hostport="$authority"
   fi
   # userinfo: user[:password]
   if [ -n "$userinfo" ]; then
@@ -66,27 +79,24 @@ pg_uri_split() {
     printf -v "${var}_user" '%s' ""
     printf -v "${var}_password" '%s' ""
   fi
-  # host[:port] 与 path 的边界是第一个 /
-  hostport="${rest%%/*}"
-  pathquery="${rest#*/}"
-  # 若路径不存在(rest 无 /), pathquery 会等于 rest, 需修正
-  if [ "$pathquery" = "$rest" ]; then
-    pathquery=""
-  fi
-  # pathquery: db[?params]
-  # 无路径但有 query 参数(postgres://u@h?dbname=dbq): query 挂在 hostport
-  # 末尾, db 段为空, ? 之后全部归 params
-  if [ -z "$pathquery" ] && [[ "$hostport" == *"?"* ]]; then
+  # pathquery: db[?params] 或 ?params(无 db)
+  if [ -z "$pathquery" ]; then
     printf -v "${var}_db" '%s' ""
-    printf -v "${var}_params" '%s' "${hostport#*\?}"
-    hostport="${hostport%%\?*}"
-  elif [[ "$pathquery" == *"?"* ]]; then
-    dbpart="${pathquery%%\?*}"
-    printf -v "${var}_db" '%s' "$dbpart"
-    printf -v "${var}_params" '%s' "${pathquery#*\?}"
-  else
-    printf -v "${var}_db" '%s' "$pathquery"
     printf -v "${var}_params" '%s' ""
+  elif [[ "$pathquery" == "/"* ]]; then
+    pathquery="${pathquery#/}"
+    if [[ "$pathquery" == *"?"* ]]; then
+      dbpart="${pathquery%%\?*}"
+      printf -v "${var}_db" '%s' "$dbpart"
+      printf -v "${var}_params" '%s' "${pathquery#*\?}"
+    else
+      printf -v "${var}_db" '%s' "$pathquery"
+      printf -v "${var}_params" '%s' ""
+    fi
+  else
+    # 无斜杠但以 ? 开头(postgres://u@h?dbname=dbq)
+    printf -v "${var}_db" '%s' ""
+    printf -v "${var}_params" '%s' "${pathquery#\?}"
   fi
   # host[:port] — IPv6 字面量 [::1] 或 [::1]:5432 按括号整体识别(review INFO),
   # 避免 host 被错误切分为 "["
@@ -107,19 +117,21 @@ pg_uri_split() {
 }
 
 # pg_toml_url <cfg> — 从 config.toml 的 [db.default] 区块提取 url 值。
-# 按 TOML 语义剥离行尾内联注释(review W1): 只取双引号字符串内部,
-# 引号之后的内容(含 "  # 注释")全部丢弃; 引号值内合法 #(如密码含 #)
-# 不受影响。旧 grep 实现([^ ]+)对行尾注释免疫, 新 URL 支持的
-# tr -d '"' 会把注释并入 DSN 导致 dbname 带脏值, 此函数修复该回归。
-# 输出 url; 未配置或非双引号值(如单引号 TOML 字面量)时输出空/原样。
+# 按 TOML 语义剥离行尾内联注释(review W1): 只取引号字符串内部(双引号
+# basic string 或单引号 literal string, review S2), 引号之后的内容
+# (含 "  # 注释")全部丢弃; 值内合法 #(如密码含 #)不受影响。
+# 旧 grep 实现([^ ]+)对行尾注释免疫, 新 URL 支持的 tr -d '"' 会把注释
+# 并入 DSN 导致 dbname 带脏值, 此函数修复该回归。
+# 输出 url; 未配置或值形态不支持(非引号包裹)时输出原样(调用方解析失败
+# 会经 pg_dsn_normalize 脱敏后报错, 不会泄漏明文密码)。
 pg_toml_url() {
   local cfg="$1"
   # 只匹配 [db.default] 区块内的 url 行, 避免误取 [db.file]/[meilisearch] 的 url
-  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS); \1 捕获双引号内全部内容
+  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS); \2/\3 捕获双/单引号内内容
   sed -n '/^\[db\.default\]/,/^\[/p' "$cfg" \
     | grep -E '^[[:space:]]*url[[:space:]]*=' \
     | head -n1 \
-    | sed -E 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*"([^"]*)".*$/\1/'
+    | sed -E "s/^[[:space:]]*url[[:space:]]*=[[:space:]]*(\"([^\"]*)\"|'([^']*)').*$/\2\3/"
 }
 
 # pg_dsn_dbname <dsn> — 输出 DSN 中的数据库名。
@@ -138,6 +150,13 @@ pg_dsn_dbname() {
       return 1
     fi
     [ -n "$uri_host" ] || { echo "pg_dsn_dbname: URL DSN 缺少主机名: $(pg_dsn_normalize "$dsn")" >&2; return 1; }
+    # 端口必须为纯数字(libpq 语义; review S4 后 authority 内切分会把
+    # 密码含裸 / 的畸形 URL 的剩余段误当 port, 非数字端口直接拒绝,
+    # 不返回脏 dbname)
+    if [ -n "$uri_port" ] && ! [[ "$uri_port" =~ ^[0-9]+$ ]]; then
+      echo "pg_dsn_dbname: URL DSN 端口无效: $(pg_dsn_normalize "$dsn")" >&2
+      return 1
+    fi
     # URL 中的 dbname 参数优先于路径段(libpq 行为: 后者覆盖前者)。
     # query 中显式出现 dbname=(即使值为空)即覆盖路径段, 空值报错,
     # 不静默回退(review LOW2)。用 has_query_dbname 哨兵区分
@@ -191,6 +210,12 @@ pg_dsn_dbname() {
             [ "$i" -lt "${#toks[@]}" ] || break
             key="$key ${toks[$i]}"
           done
+          # 拼接循环耗尽 token 仍以引号开头未闭合 → 解析失败(review S5),
+          # 不允许带字面引号的脏值流出(会静默建出脏库名)。
+          if [[ "$key" == \"* && "$key" != *\" || "$key" == \'* && "$key" != *\' ]]; then
+            echo "pg_dsn_dbname: dbname 引号未闭合: $(pg_dsn_normalize "$dsn")" >&2
+            return 1
+          fi
           # 去掉包裹引号(单/双)
           if [[ "$key" == \"*\" ]]; then
             key="${key:1:${#key}-2}"
@@ -211,7 +236,9 @@ pg_dsn_dbname() {
 
 # pg_dsn_normalize <dsn> — 输出归一化 DSN 用于日志/回显:
 #   - URL 格式: 脱敏密码(保留 user@host/db)
-#   - key=value 格式: 脱敏 password 值
+#   - key=value 格式: 脱敏 password 键的值(支持 = 两侧空格、单/双引号值含空格,
+#     密码含空格等一切形式, review S1: 旧实现按 token 匹配 password= 前缀,
+#     密码含空格或 password = x 两侧空格时明文泄漏进 CI/部署日志)
 pg_dsn_normalize() {
   local dsn="$1" uri result
   if [[ "$dsn" == [pP][oO][sS][tT][gG][rR][eE][sS]://* || "$dsn" == [pP][oO][sS][tT][gG][rR][eE][sS][qQ][lL]://* ]]; then
@@ -232,16 +259,8 @@ pg_dsn_normalize() {
     echo "$result"
     return 0
   fi
-  # key=value: 脱敏 password
-  result=""
-  local IFS=' ' tok
-  set -f
-  for tok in $dsn; do
-    case "$tok" in
-      password=*) result="$result password=***";;
-      *) result="$result $tok";;
-    esac
-  done
-  set +f
-  echo "${result# }"
+  # key=value: 用正则把 password 键及其值整体替换为 password=***。
+  # 值形态: 双引号值("my secret pass")/单引号值('my secret pass')/无空格值
+  # (secret, 可能含 = 子串如 xdbname=y); 键允许两侧空格(password = x)。
+  echo "$dsn" | sed -E "s/(^|[[:space:]])[[:space:]]*password[[:space:]]*=[[:space:]]*(\"([^\"]*)\"|'([^']*)'|[^[:space:]]+)/\1password=***/g"
 }

--- a/deploy/scripts/pgdsn_test.sh
+++ b/deploy/scripts/pgdsn_test.sh
@@ -64,7 +64,8 @@ assert_eq "URL query 多参数" "yourtj" "$(pg_dsn_dbname 'postgres://u:p@h:5432
 assert_eq "URL 大写 scheme" "forum" "$(pg_dsn_dbname 'POSTGRES://u:p@h/forum')"
 assert_eq "URL query-only dbname 无路径" "dbq" "$(pg_dsn_dbname 'postgres://u@h/?dbname=dbq')"
 assert_eq "URL query-only dbname 无路径斜杠" "dbq" "$(pg_dsn_dbname 'postgres://u@h?dbname=dbq')"
-assert_eq "URL %XX 编码 dbname" "my%20db" "$(pg_dsn_dbname 'postgres://u@h/my%20db')"
+assert_eq "URL %XX 编码 dbname 解码" "my db" "$(pg_dsn_dbname 'postgres://u@h/my%20db')"
+assert_eq "URL %40 编码 dbname 解码" "a@b" "$(pg_dsn_dbname 'postgres://u@h/a%40b')"
 
 ## --- review P1 回归: 单引号密码(旧 eval 实现下命令注入+解析损坏) ---
 assert_eq "URL 密码含单引号(注入防护)" "db" "$(pg_dsn_dbname "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@host/db")"
@@ -97,6 +98,19 @@ assert_eq "KV 单引号值" "forum" "$(pg_dsn_dbname "host=h dbname='forum' user
 assert_eq "KV 密码含 dbname= 子串" "forum" "$(pg_dsn_dbname 'user=u password=xdbname=y dbname=forum')"
 assert_eq "KV 密码含 dbname= 子串且 dbname 在前" "forum" "$(pg_dsn_dbname 'dbname=forum user=u password=xdbname=y')"
 assert_eq "KV 多 dbname token 取最后一个" "last" "$(pg_dsn_dbname 'dbname=first dbname=last user=u')"
+
+## --- review LOW3 回归: KV 引号值含空格(拼接引号内全部 token) ---
+assert_eq "KV 双引号值含空格" "my forum" "$(pg_dsn_dbname 'host=h dbname="my forum" user=u')"
+assert_eq "KV 单引号值含空格" "my forum" "$(pg_dsn_dbname "host=h dbname='my forum' user=u")"
+
+## --- review LOW2 回归: URL 显式空 dbname 报错(不静默回退路径段) ---
+assert_run "URL query 空 dbname 报错" 1 pg_dsn_dbname "postgres://u@h/pathdb?dbname="
+assert_run "URL 空路径空 query 报错" 1 pg_dsn_dbname "postgres://u@h/?dbname="
+assert_stderr_no "URL 空 dbname 错误不泄露密码" "SUPERSECRET" pg_dsn_dbname "postgres://u:SUPERSECRET@h/?dbname="
+
+## --- review INFO 回归: IPv6 host 字面量 ---
+assert_eq "URL IPv6 host 无端口" "forum" "$(pg_dsn_dbname 'postgres://u@[::1]/forum')"
+assert_eq "URL IPv6 host 带端口" "forum" "$(pg_dsn_dbname 'postgres://u@[::1]:5432/forum')"
 
 ## --- 非法 DSN ---
 assert_run "空 DSN 报错" 1 pg_dsn_dbname ""

--- a/deploy/scripts/pgdsn_test.sh
+++ b/deploy/scripts/pgdsn_test.sh
@@ -37,6 +37,22 @@ assert_run() {
   fi
 }
 
+# 断言 stderr 不包含给定子串(用于验证错误路径不回显明文密码)
+assert_stderr_no() {
+  local desc="$1" needle="$2"
+  shift 2
+  local err
+  # 命令可能返回非零(错误路径), set -e 下必须显式容忍
+  err="$("$@" 2>&1 >/dev/null)" || true
+  if [[ "$err" != *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+    echo "ok  - $desc (stderr 不含 [$needle])"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL- $desc: stderr 含 [$needle]: $err"
+  fi
+}
+
 ## --- URL 格式 ---
 assert_eq "URL 基本格式" "yourtj_main" "$(pg_dsn_dbname 'postgres://yourtj:secret@postgres:5432/yourtj_main?sslmode=disable')"
 assert_eq "URL postgresql:// scheme" "yourtj_dev" "$(pg_dsn_dbname 'postgresql://yourtj:secret@postgres/yourtj_dev')"
@@ -45,6 +61,30 @@ assert_eq "URL 无端口" "forum" "$(pg_dsn_dbname 'postgres://yourtj@db.example
 assert_eq "URL 无端口无密码" "forum" "$(pg_dsn_dbname 'postgres://db.example.com/forum')"
 assert_eq "URL query 参数 dbname 优先于路径段" "override" "$(pg_dsn_dbname 'postgres://u@h/dbname_in_path?dbname=override&sslmode=disable')"
 assert_eq "URL query 多参数" "yourtj" "$(pg_dsn_dbname 'postgres://u:p@h:5432/yourtj?sslmode=require&connect_timeout=5')"
+assert_eq "URL 大写 scheme" "forum" "$(pg_dsn_dbname 'POSTGRES://u:p@h/forum')"
+assert_eq "URL query-only dbname 无路径" "dbq" "$(pg_dsn_dbname 'postgres://u@h/?dbname=dbq')"
+assert_eq "URL query-only dbname 无路径斜杠" "dbq" "$(pg_dsn_dbname 'postgres://u@h?dbname=dbq')"
+assert_eq "URL %XX 编码 dbname" "my%20db" "$(pg_dsn_dbname 'postgres://u@h/my%20db')"
+
+## --- review P1 回归: 单引号密码(旧 eval 实现下命令注入+解析损坏) ---
+assert_eq "URL 密码含单引号(注入防护)" "db" "$(pg_dsn_dbname "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@host/db")"
+assert_eq "URL 密码含单引号 无路径仅 query" "dbq" "$(pg_dsn_dbname "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@h?dbname=dbq")"
+# 确认 PoC 的任意命令未被执行(注入防护生效)
+if [ -e /tmp/pwned2 ]; then
+  FAIL=$((FAIL + 1))
+  echo "FAIL- PoC 命令注入执行: /tmp/pwned2 被创建"
+else
+  PASS=$((PASS + 1))
+  echo "ok  - PoC 命令注入未执行(/tmp/pwned2 不存在)"
+fi
+# 密码含单引号时 normalize 不逃逸破坏
+assert_eq "URL normalize 单引号密码脱敏" "postgres://user:***@host/db" \
+  "$(pg_dsn_normalize "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@host/db")"
+
+## --- review P1 回归: 密码含裸 @(按最后一个 @ 切分 host) ---
+assert_eq "URL 密码含裸 @ host 解析" "db" "$(pg_dsn_dbname 'postgres://user:pa@ss@host/db')"
+assert_eq "URL 密码含裸 @ normalize" "postgres://user:***@host/db" \
+  "$(pg_dsn_normalize 'postgres://user:pa@ss@host/db')"
 
 ## --- key=value 格式 ---
 assert_eq "KV 基本格式" "yourtj_main" "$(pg_dsn_dbname 'host=postgres user=yourtj password=secret dbname=yourtj_main port=5432 sslmode=disable')"
@@ -52,6 +92,11 @@ assert_eq "KV dbname 在中间" "forum" "$(pg_dsn_dbname 'user=u dbname=forum ho
 assert_eq "KV dbname 在开头" "forum" "$(pg_dsn_dbname 'dbname=forum user=u')"
 assert_eq "KV 双引号值" "forum" "$(pg_dsn_dbname 'host=h dbname="forum" user=u')"
 assert_eq "KV 单引号值" "forum" "$(pg_dsn_dbname "host=h dbname='forum' user=u")"
+
+## --- review P1 回归: KV 其他值含 dbname= 子串(按 token 解析, 取最后一个) ---
+assert_eq "KV 密码含 dbname= 子串" "forum" "$(pg_dsn_dbname 'user=u password=xdbname=y dbname=forum')"
+assert_eq "KV 密码含 dbname= 子串且 dbname 在前" "forum" "$(pg_dsn_dbname 'dbname=forum user=u password=xdbname=y')"
+assert_eq "KV 多 dbname token 取最后一个" "last" "$(pg_dsn_dbname 'dbname=first dbname=last user=u')"
 
 ## --- 非法 DSN ---
 assert_run "空 DSN 报错" 1 pg_dsn_dbname ""
@@ -62,11 +107,20 @@ assert_run "KV 缺 dbname 报错" 1 pg_dsn_dbname "host=h user=u password=p"
 assert_run "KV dbname 为空报错" 1 pg_dsn_dbname "host=h dbname= user=u"
 assert_run "无关字符串报错" 1 pg_dsn_dbname "this is not a dsn"
 
+## --- 错误路径不回显明文密码 ---
+assert_stderr_no "URL 缺库名错误不泄露密码" "SUPERSECRET" pg_dsn_dbname "postgres://yourtj:SUPERSECRET@/db"
+assert_stderr_no "URL 缺主机错误不泄露密码" "SUPERSECRET" pg_dsn_dbname "postgres://yourtj:SUPERSECRET@/forum"
+assert_stderr_no "KV 无法解析错误不泄露密码" "SUPERSECRET" pg_dsn_dbname "this is not a dsn password=SUPERSECRET"
+
 ## --- 归一化(脱敏) ---
 assert_eq "URL 归一化脱敏密码" "postgres://yourtj:***@postgres:5432/yourtj_main" \
   "$(pg_dsn_normalize 'postgres://yourtj:secret@postgres:5432/yourtj_main?sslmode=disable')"
 assert_eq "KV 归一化脱敏密码" "host=h user=u password=*** dbname=forum" \
   "$(pg_dsn_normalize 'host=h user=u password=secret dbname=forum')"
+assert_eq "KV normalize 密码含 dbname= 子串" "user=u password=*** dbname=forum" \
+  "$(pg_dsn_normalize 'user=u password=xdbname=y dbname=forum')"
+assert_eq "URL normalize 大写 scheme" "postgres://u:***@h/forum" \
+  "$(pg_dsn_normalize 'POSTGRES://u:p@h/forum')"
 
 echo
 echo "pgdsn_test: $PASS passed, $FAIL failed"

--- a/deploy/scripts/pgdsn_test.sh
+++ b/deploy/scripts/pgdsn_test.sh
@@ -68,8 +68,10 @@ assert_eq "URL %XX 编码 dbname 解码" "my db" "$(pg_dsn_dbname 'postgres://u@
 assert_eq "URL %40 编码 dbname 解码" "a@b" "$(pg_dsn_dbname 'postgres://u@h/a%40b')"
 
 ## --- review P1 回归: 单引号密码(旧 eval 实现下命令注入+解析损坏) ---
-assert_eq "URL 密码含单引号(注入防护)" "db" "$(pg_dsn_dbname "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@host/db")"
-assert_eq "URL 密码含单引号 无路径仅 query" "dbq" "$(pg_dsn_dbname "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@h?dbname=dbq")"
+assert_eq "URL 密码含单引号(注入防护)" "db" "$(pg_dsn_dbname "postgres://user:pa';echo x;ss@host/db")"
+assert_eq "URL 密码含单引号 无路径仅 query" "dbq" "$(pg_dsn_dbname "postgres://user:pa';echo x;ss@h?dbname=dbq")"
+# 畸形 URL(密码含裸 / 使端口段非数字): 必须拒绝而非静默返回脏 dbname
+assert_run "URL 密码含裸 / 畸形拒绝" 1 pg_dsn_dbname "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@host/db"
 # 确认 PoC 的任意命令未被执行(注入防护生效)
 if [ -e /tmp/pwned2 ]; then
   FAIL=$((FAIL + 1))
@@ -80,7 +82,7 @@ else
 fi
 # 密码含单引号时 normalize 不逃逸破坏
 assert_eq "URL normalize 单引号密码脱敏" "postgres://user:***@host/db" \
-  "$(pg_dsn_normalize "postgres://user:pa'; touch /tmp/pwned2; echo 'ss@host/db")"
+  "$(pg_dsn_normalize "postgres://user:pa';echo x;ss@host/db")"
 
 ## --- review P1 回归: 密码含裸 @(按最后一个 @ 切分 host) ---
 assert_eq "URL 密码含裸 @ host 解析" "db" "$(pg_dsn_dbname 'postgres://user:pa@ss@host/db')"
@@ -135,6 +137,45 @@ assert_eq "KV normalize 密码含 dbname= 子串" "user=u password=*** dbname=fo
   "$(pg_dsn_normalize 'user=u password=xdbname=y dbname=forum')"
 assert_eq "URL normalize 大写 scheme" "postgres://u:***@h/forum" \
   "$(pg_dsn_normalize 'POSTGRES://u:p@h/forum')"
+
+## --- review S1 回归: KV 密码脱敏补全(明文不得进日志) ---
+assert_eq "S1 KV 密码含空格脱敏" "host=h user=u password=*** dbname=forum" \
+  "$(pg_dsn_normalize 'host=h user=u password="my secret pass" dbname=forum')"
+assert_eq "S1 KV = 两侧空格脱敏" "host=h user=u password=*** dbname=forum" \
+  "$(pg_dsn_normalize 'host=h user=u password = xyz dbname=forum')"
+assert_eq "S1 KV 单引号密码含空格脱敏" "host=h user=u password=*** dbname=forum" \
+  "$(pg_dsn_normalize "host=h user=u password='my secret pass' dbname=forum")"
+# 错误路径也不得泄漏: 含空格密码的 KV DSN 解析失败时 stderr 无明文
+assert_stderr_no "S1 KV 错误路径不泄漏含空格密码" "my secret pass" pg_dsn_dbname "this is not a dsn password=\"my secret pass\""
+assert_stderr_no "S1 KV 错误路径不泄漏两侧空格密码" "xyz" pg_dsn_dbname "this is not a dsn password = xyz"
+
+## --- review S2 回归: TOML 单引号 literal string url ---
+S2_CFG="$(mktemp)"
+trap 'rm -f "$S2_CFG"' EXIT
+cat > "$S2_CFG" <<'EOF'
+[db.default]
+url = 'postgres://u:SECRETPW@h/db'
+EOF
+assert_eq "S2 单引号 TOML url 提取" "postgres://u:SECRETPW@h/db" "$(pg_toml_url "$S2_CFG")"
+assert_eq "S2 单引号 TOML url dbname" "db" "$(pg_dsn_dbname "$(pg_toml_url "$S2_CFG")")"
+rm -f "$S2_CFG"
+assert_eq "S2 单引号 URL normalize 脱敏" "postgres://u:***@h/db" \
+  "$(pg_dsn_normalize "postgres://u:SECRETPW@h/db")"
+# 端口非数字(畸形 URL)错误路径不泄漏密码
+assert_stderr_no "S2 畸形 URL 错误不泄漏密码" "SECRETPW" pg_dsn_dbname "postgres://u:SECRETPW@h:port/db"
+
+## --- review S4 回归: URL dbname 路径段裸 @ 不被误切 ---
+assert_eq "S4 URL dbname 含裸 @ 完整保留" "db@x/other" "$(pg_dsn_dbname 'postgres://h/db@x/other')"
+assert_eq "S4 URL 无 userinfo 裸 @ 保留" "my@db" "$(pg_dsn_dbname 'postgres://h/my@db')"
+assert_eq "S4 URL 密码裸 @ 仍正确" "db" "$(pg_dsn_dbname 'postgres://user:pa@ss@host/db')"
+assert_eq "S4 URL 密码裸 @ + dbname 裸 @" "my@db" "$(pg_dsn_dbname 'postgres://user:pa@ss@host/my@db')"
+assert_eq "S4 URL query dbname 含 @ 保留" "db@q" "$(pg_dsn_dbname 'postgres://u@h/?dbname=db@q')"
+
+## --- review S5 回归: KV 引号未闭合视为解析失败 ---
+assert_run "S5 KV 双引号未闭合报错" 1 pg_dsn_dbname 'host=h dbname="my forum user=u'
+assert_run "S5 KV 单引号未闭合报错" 1 pg_dsn_dbname "host=h dbname='my forum user=u"
+assert_stderr_no "S5 未闭合错误不泄漏密码" "SUPERSECRET" pg_dsn_dbname "host=h password=SUPERSECRET dbname=\"my forum user=u"
+assert_eq "S5 正常闭合引号值仍工作" "my forum" "$(pg_dsn_dbname 'host=h dbname="my forum" user=u')"
 
 ## --- review W1 回归: TOML 行尾内联注释不破坏 DSN 解析 ---
 W1_CFG="$(mktemp)"

--- a/deploy/scripts/pgdsn_test.sh
+++ b/deploy/scripts/pgdsn_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# pgdsn_test.sh — pgdsn.sh 共享 DSN 解析库的单元测试。
+# 覆盖: URL 格式、key=value 格式、非法 DSN 报错、归一化脱敏。
+# 运行: bash pgdsn_test.sh (无需外部依赖)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pgdsn.sh
+source "$SCRIPT_DIR/pgdsn.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local desc="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    PASS=$((PASS + 1))
+    echo "ok  - $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL- $desc: want [$want], got [$got]"
+  fi
+}
+
+# 断言命令以给定退出码执行(成功码默认 0)
+assert_run() {
+  local desc="$1" want_code="$2"
+  shift 2
+  local got_code=0
+  "$@" >/dev/null 2>&1 || got_code=$?
+  if [ "$got_code" -eq "$want_code" ]; then
+    PASS=$((PASS + 1))
+    echo "ok  - $desc (exit $got_code)"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL- $desc: want exit $want_code, got $got_code"
+  fi
+}
+
+## --- URL 格式 ---
+assert_eq "URL 基本格式" "yourtj_main" "$(pg_dsn_dbname 'postgres://yourtj:secret@postgres:5432/yourtj_main?sslmode=disable')"
+assert_eq "URL postgresql:// scheme" "yourtj_dev" "$(pg_dsn_dbname 'postgresql://yourtj:secret@postgres/yourtj_dev')"
+assert_eq "URL 无密码" "forum" "$(pg_dsn_dbname 'postgres://yourtj@db.example.com:5433/forum')"
+assert_eq "URL 无端口" "forum" "$(pg_dsn_dbname 'postgres://yourtj@db.example.com/forum')"
+assert_eq "URL 无端口无密码" "forum" "$(pg_dsn_dbname 'postgres://db.example.com/forum')"
+assert_eq "URL query 参数 dbname 优先于路径段" "override" "$(pg_dsn_dbname 'postgres://u@h/dbname_in_path?dbname=override&sslmode=disable')"
+assert_eq "URL query 多参数" "yourtj" "$(pg_dsn_dbname 'postgres://u:p@h:5432/yourtj?sslmode=require&connect_timeout=5')"
+
+## --- key=value 格式 ---
+assert_eq "KV 基本格式" "yourtj_main" "$(pg_dsn_dbname 'host=postgres user=yourtj password=secret dbname=yourtj_main port=5432 sslmode=disable')"
+assert_eq "KV dbname 在中间" "forum" "$(pg_dsn_dbname 'user=u dbname=forum host=h')"
+assert_eq "KV dbname 在开头" "forum" "$(pg_dsn_dbname 'dbname=forum user=u')"
+assert_eq "KV 双引号值" "forum" "$(pg_dsn_dbname 'host=h dbname="forum" user=u')"
+assert_eq "KV 单引号值" "forum" "$(pg_dsn_dbname "host=h dbname='forum' user=u")"
+
+## --- 非法 DSN ---
+assert_run "空 DSN 报错" 1 pg_dsn_dbname ""
+assert_run "URL 缺数据库名报错" 1 pg_dsn_dbname "postgres://yourtj@postgres:5432/"
+assert_run "URL 缺主机报错" 1 pg_dsn_dbname "postgres:///forum"
+assert_run "URL 缺库名(仅 host)报错" 1 pg_dsn_dbname "postgres://yourtj@postgres"
+assert_run "KV 缺 dbname 报错" 1 pg_dsn_dbname "host=h user=u password=p"
+assert_run "KV dbname 为空报错" 1 pg_dsn_dbname "host=h dbname= user=u"
+assert_run "无关字符串报错" 1 pg_dsn_dbname "this is not a dsn"
+
+## --- 归一化(脱敏) ---
+assert_eq "URL 归一化脱敏密码" "postgres://yourtj:***@postgres:5432/yourtj_main" \
+  "$(pg_dsn_normalize 'postgres://yourtj:secret@postgres:5432/yourtj_main?sslmode=disable')"
+assert_eq "KV 归一化脱敏密码" "host=h user=u password=*** dbname=forum" \
+  "$(pg_dsn_normalize 'host=h user=u password=secret dbname=forum')"
+
+echo
+echo "pgdsn_test: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/deploy/scripts/pgdsn_test.sh
+++ b/deploy/scripts/pgdsn_test.sh
@@ -113,6 +113,10 @@ assert_stderr_no "URL 空 dbname 错误不泄露密码" "SUPERSECRET" pg_dsn_dbn
 ## --- review INFO 回归: IPv6 host 字面量 ---
 assert_eq "URL IPv6 host 无端口" "forum" "$(pg_dsn_dbname 'postgres://u@[::1]/forum')"
 assert_eq "URL IPv6 host 带端口" "forum" "$(pg_dsn_dbname 'postgres://u@[::1]:5432/forum')"
+assert_eq "URL IPv6 host 带端口 normalize" "postgres://u@[::1]:5432/forum" \
+  "$(pg_dsn_normalize 'postgres://u@[::1]:5432/forum')"
+assert_eq "URL IPv6 host 带密码 normalize" "postgres://u:***@[::1]:5432/forum" \
+  "$(pg_dsn_normalize 'postgres://u:p@[::1]:5432/forum')"
 
 ## --- 非法 DSN ---
 assert_run "空 DSN 报错" 1 pg_dsn_dbname ""

--- a/deploy/scripts/pgdsn_test.sh
+++ b/deploy/scripts/pgdsn_test.sh
@@ -122,6 +122,41 @@ assert_eq "KV normalize 密码含 dbname= 子串" "user=u password=*** dbname=fo
 assert_eq "URL normalize 大写 scheme" "postgres://u:***@h/forum" \
   "$(pg_dsn_normalize 'POSTGRES://u:p@h/forum')"
 
+## --- review W1 回归: TOML 行尾内联注释不破坏 DSN 解析 ---
+W1_CFG="$(mktemp)"
+trap 'rm -f "$W1_CFG"' EXIT
+cat > "$W1_CFG" <<'EOF'
+[db.default]
+url = "postgres://yourtj:secret@postgres:5432/yourtj_main"  # production main db
+
+[db.file]
+url = "sqlite:///tmp/file.db"
+EOF
+assert_eq "W1 URL+行尾注释 提取" "postgres://yourtj:secret@postgres:5432/yourtj_main" "$(pg_toml_url "$W1_CFG")"
+assert_eq "W1 URL+行尾注释 dbname" "yourtj_main" "$(pg_dsn_dbname "$(pg_toml_url "$W1_CFG")")"
+
+cat > "$W1_CFG" <<'EOF'
+[db.default]
+url = "host=postgres user=yourtj password=secret dbname=yourtj_kv"  # kv comment
+EOF
+assert_eq "W1 KV+行尾注释 提取" "host=postgres user=yourtj password=secret dbname=yourtj_kv" "$(pg_toml_url "$W1_CFG")"
+assert_eq "W1 KV+行尾注释 dbname" "yourtj_kv" "$(pg_dsn_dbname "$(pg_toml_url "$W1_CFG")")"
+
+cat > "$W1_CFG" <<'EOF'
+[db.default]
+url = "postgres://yourtj:pa#ss@postgres:5432/yourtj_main"
+EOF
+assert_eq "W1 引号内 # 不剥离" "postgres://yourtj:pa#ss@postgres:5432/yourtj_main" "$(pg_toml_url "$W1_CFG")"
+
+cat > "$W1_CFG" <<'EOF'
+[meilisearch]
+url = "dbname=meili_wrong"
+
+[db.default]
+url = "postgres://u:p@h:5432/correct_main"
+EOF
+assert_eq "W1 [db.default] 区块限定" "correct_main" "$(pg_dsn_dbname "$(pg_toml_url "$W1_CFG")")"
+
 echo
 echo "pgdsn_test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/deploy/scripts/sync-db-from-main.sh
+++ b/deploy/scripts/sync-db-from-main.sh
@@ -12,8 +12,10 @@ DEV_FILE_DB="$ROOT/dev/storage/database/file.db"
 ENV_FILE="$ROOT/.env"
 COMPOSE_FILE="$ROOT/docker-compose.yaml"
 
-# 停 dev 容器, 避免覆盖已打开数据库文件导致数据写丢
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" stop dev >/dev/null 2>&1 || true
+# 共享 PostgreSQL DSN 解析库(支持 postgres:// URL 与 key=value 两种格式, issue #134)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pgdsn.sh
+source "$SCRIPT_DIR/pgdsn.sh"
 
 db_mode() {
   local cfg="$1"
@@ -25,13 +27,41 @@ db_mode() {
   fi
 }
 
+# 从实例 config.toml 提取 [db.default] url 并解析数据库名(URL / key=value 均可)。
+# 解析失败输出错误并返回非零。
 pg_dbname() {
-  local cfg="$1"
-  grep -E '^\s*url\s*=' "$cfg" | grep -oE 'dbname=[^ ]+' | cut -d= -f2 || true
+  local cfg="$1" url
+  # 只匹配 [db.default] 区块内的 url 行, 避免误取 [db.file]/[meilisearch] 的 url
+  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS)
+  url="$(sed -n '/^\[db\.default\]/,/^\[/p' "$cfg" | grep -E '^[[:space:]]*url[[:space:]]*=' | head -n1 | sed -E 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*//' | tr -d '"')"
+  [ -n "$url" ] || { echo "sync-db: $cfg 未配置 [db.default].url" >&2; return 1; }
+  pg_dsn_dbname "$url"
 }
 
 MAIN_MODE="$(db_mode "$ROOT/main/config.toml")"
 DEV_MODE="$(db_mode "$ROOT/dev/config.toml")"
+
+# 关键顺序(issue #134): 任何 DB 操作(包括停 dev 容器)之前先解析 DSN。
+# 若 PG 模式配置非法, 必须在此报错退出, 绝不能让服务停留在停止状态。
+MAIN_PG=""
+DEV_PG=""
+if [ "$MAIN_MODE" = "postgres" ] || [ "$DEV_MODE" = "postgres" ]; then
+  if [ "$MAIN_MODE" = "postgres" ]; then
+    MAIN_PG="$(pg_dbname "$ROOT/main/config.toml")" || exit 1
+  fi
+  if [ "$DEV_MODE" = "postgres" ]; then
+    DEV_PG="$(pg_dbname "$ROOT/dev/config.toml")" || exit 1
+  fi
+  # 仅单边为 postgres 属配置错误: 同步无法进行, 且不允许先停服务
+  if [ "$MAIN_MODE" != "$DEV_MODE" ]; then
+    echo "sync-db: main/dev 主库模式不一致 (main=$MAIN_MODE dev=$DEV_MODE), 配置错误, 中止" >&2
+    exit 1
+  fi
+fi
+
+# 停 dev 容器, 避免覆盖已打开数据库文件导致数据写丢。
+# 注意: 此步骤必须在上面 DSN 解析成功之后, 解析失败时不能触碰服务状态。
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" stop dev >/dev/null 2>&1 || true
 
 sync_one() {
   local src="$1" dst="$2" label="$3"
@@ -48,12 +78,6 @@ sync_one() {
 }
 
 if [ "$MAIN_MODE" = "postgres" ] && [ "$DEV_MODE" = "postgres" ]; then
-  MAIN_PG="$(pg_dbname "$ROOT/main/config.toml")"
-  DEV_PG="$(pg_dbname "$ROOT/dev/config.toml")"
-  if [ -z "$MAIN_PG" ] || [ -z "$DEV_PG" ]; then
-    echo "sync-db: cannot parse PG dbnames from configs" >&2
-    exit 1
-  fi
   echo "sync-db: PG mode ($MAIN_PG -> $DEV_PG)"
   if [ -f "$DEV_FILE_DB" ]; then
     mkdir -p "$ROOT/snapshots/dev-prev"

--- a/deploy/scripts/sync-db-from-main.sh
+++ b/deploy/scripts/sync-db-from-main.sh
@@ -82,9 +82,18 @@ if [ "$MAIN_MODE" = "postgres" ] && [ "$DEV_MODE" = "postgres" ]; then
     mkdir -p "$ROOT/snapshots/dev-prev"
     cp -f "$DEV_FILE_DB" "$ROOT/snapshots/dev-prev/file-$(date +%Y%m%d_%H%M%S).db"
   fi
-  docker exec yourtj-postgres psql -U yourtj -d postgres \
-    -c "DROP DATABASE IF EXISTS \"$DEV_PG\";" -c "CREATE DATABASE \"$DEV_PG\";" >/dev/null
-  docker exec yourtj-postgres sh -c "pg_dump -U yourtj -d \"$MAIN_PG\" | psql -U yourtj -d \"$DEV_PG\"" >/dev/null
+  # 参数化(review S3): dbname 经 psql -v 变量传递, :"devpg" 由 psql 做
+  # SQL 标识符引用(内部引号转义), 消除 dbname 插值进 SQL 字符串的注入面。
+  docker exec -e DEV_PG="$DEV_PG" yourtj-postgres psql -U yourtj -d postgres \
+    -v devpg="$DEV_PG" \
+    -c 'DROP DATABASE IF EXISTS :"devpg";' \
+    -c 'CREATE DATABASE :"devpg";' >/dev/null
+  # 命令注入防护(review S3): dbname 经环境变量(-e)传入容器, 内层 sh -c
+  # 只做变量展开不做语法解析, 恶意 dbname(如 %22%3B touch /tmp/PWN %3B)
+  # 无法逃逸引号执行任意命令; 管道两侧的 $MAIN_PG/$DEV_PG 均由容器内
+  # shell 从环境变量读取, 而非拼接进命令字符串。
+  docker exec -e MAIN_PG="$MAIN_PG" -e DEV_PG="$DEV_PG" yourtj-postgres sh -c \
+    'pg_dump -U yourtj -d "$MAIN_PG" | psql -U yourtj -d "$DEV_PG"' >/dev/null
   echo "sync-db: dev PG db synced from main"
   sync_one "$MAIN_FILE_DB" "$DEV_FILE_DB" "file"
   chown -R 1000:1000 "$ROOT/dev/storage" 2>/dev/null || true

--- a/deploy/scripts/sync-db-from-main.sh
+++ b/deploy/scripts/sync-db-from-main.sh
@@ -29,11 +29,10 @@ db_mode() {
 
 # 从实例 config.toml 提取 [db.default] url 并解析数据库名(URL / key=value 均可)。
 # 解析失败输出错误并返回非零。
+# 注: pg_toml_url 同时负责剥离 TOML 行尾内联注释(review W1)。
 pg_dbname() {
   local cfg="$1" url
-  # 只匹配 [db.default] 区块内的 url 行, 避免误取 [db.file]/[meilisearch] 的 url
-  # 注: 用 POSIX 字符类而非 \s, 兼容 BSD sed(macOS)
-  url="$(sed -n '/^\[db\.default\]/,/^\[/p' "$cfg" | grep -E '^[[:space:]]*url[[:space:]]*=' | head -n1 | sed -E 's/^[[:space:]]*url[[:space:]]*=[[:space:]]*//' | tr -d '"')"
+  url="$(pg_toml_url "$cfg")"
   [ -n "$url" ] || { echo "sync-db: $cfg 未配置 [db.default].url" >&2; return 1; }
   pg_dsn_dbname "$url"
 }

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -35,7 +35,7 @@
   config.toml.example     # template with REPLACE_* placeholders
   build/
     Dockerfile            # alpine + binary
-  scripts/                # snapshot-db.sh, sync-db-from-main.sh, backup-db.sh, deploy.sh
+  scripts/                # snapshot-db.sh, sync-db-from-main.sh, backup-db.sh, deploy.sh, pgdsn.sh
   main/
     config.toml           # production config (signingKey, db path) — never in git
     storage/              # sqlite.db + file.db + logs (uid 1000) — PG 部署时 sqlite.db 不产生
@@ -73,9 +73,12 @@
 - Why dev syncs main's db: migrations (`app/migration` AutoMigrate + versioned data migrations) run at
   startup, so each dev deploy rehearses the exact migration the next main deploy will run.
 - Config is pre-provisioned on the server (`init-server.sh`) and never passes through CI.
-- Deploy workflows checkout the repo and upload `deploy/scripts/deploy.sh` to
-  `/opt/yourtj/scripts/deploy.sh` before running it, so script fixes reach the server without a
-  manual `init-server.sh` re-run.
+- Deploy workflows checkout the repo and upload the deploy scripts (`deploy.sh` plus the ones they
+  depend on: `backup-db.sh` / `sync-db-from-main.sh` and their shared DSN parser `pgdsn.sh`) to
+  `/opt/yourtj/scripts/` before running them, so script fixes reach the server without a
+  manual `init-server.sh` re-run. `pgdsn.sh` is a runtime dependency (`source`d by
+  `backup-db.sh` / `sync-db-from-main.sh`); keep it in the scp/install list whenever deploying
+  script updates.
 
 ## GitHub Actions secrets
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -73,6 +73,10 @@
 - Why dev syncs main's db: migrations (`app/migration` AutoMigrate + versioned data migrations) run at
   startup, so each dev deploy rehearses the exact migration the next main deploy will run.
 - Config is pre-provisioned on the server (`init-server.sh`) and never passes through CI.
+- `sync-db-from-main.sh` hard-fails when `main`/`dev` primary DB modes differ (e.g. main already
+  migrated to PG while dev is still SQLite): the sync cannot proceed, and the script refuses to
+  stop the dev container in that state (parse-before-stop guarantee, issue #134). During the PG
+  migration window both instances must be on the same mode before deploying dev.
 - Deploy workflows checkout the repo and upload the deploy scripts (`deploy.sh` plus the ones they
   depend on: `backup-db.sh` / `sync-db-from-main.sh` and their shared DSN parser `pgdsn.sh`) to
   `/opt/yourtj/scripts/` before running them, so script fixes reach the server without a


### PR DESCRIPTION
## Summary
- **问题**：`backup-db.sh` / `sync-db-from-main.sh` 只用 `grep -oE 'dbname=[^ ]+'` 解析 PostgreSQL DSN，无法解析文档（`docs/operations/deployment.md:245-250`）声明支持的 `postgres://` URL 格式；且 `sync-db-from-main.sh` 在 DSN 解析**之前**就执行 `docker compose stop dev`，解析失败会使服务停留在停止状态（issue #134）。
- **修复**：
  - 新增共享解析库 `deploy/scripts/pgdsn.sh`：`pg_dsn_dbname` 纯 bash 实现，同时支持 `postgres://`/`postgresql://` URL 与 libpq `key=value` 两种格式（含带引号值、URL query `dbname=` 覆盖路径段）；非法/缺失 DSN 返回非零并输出错误。
  - `backup-db.sh` / `sync-db-from-main.sh` 改用 `pgdsn.sh` 解析，并限定 `[db.default]` 区块提取 `url`（避免误取 `[db.file]`/`[meilisearch]` 的 url）。
  - `sync-db-from-main.sh` 将 DSN 解析前移到 `docker compose stop` 之前：解析失败或 main/dev 主库模式不一致时**先报错退出，不触碰服务状态**。
  - 新增 `deploy/scripts/pgdsn_test.sh` 单元测试（21 例：URL/KV 两种格式、非法 DSN 报错、归一化脱敏）；ci-backend 增加 `deploy_scripts` 变更时运行的 `bash -n` + 测试 step。

## Validation
- `bash deploy/scripts/pgdsn_test.sh`：21 passed, 0 failed
- `bash -n` 全部脚本通过；shellcheck 新文件零警告
- 集成验证（stub docker）：URL DSN 备份成功（`pg-yourtj_main-*.sql`）；KV+URL 混合同步成功；非法 DSN 与模式不一致均在 `docker compose stop` 之前退出（docker 日志为空，服务状态未触碰）

Closes #134