### PR TITLE
fix(settings): revoke-all 成功后清除本地 JWT 并跳转登录页

### DIFF
--- a/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
@@ -605,19 +605,20 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     }
   }
 
+  /// 吊销全部会话:后端原子删除全部会话并递增 tokenVersion,当前 JWT
+  /// 立即失效,必须走统一登出清理(token/认证状态/离线缓存)并跳转登录页,
+  /// 否则本地继续持有已被后端撤销的 JWT。
   Future<void> _revokeAll() async {
     final AppLocalizations l10n = AppLocalizations.of(context);
     try {
       await ref.read(userRepositoryProvider).revokeAllSessions();
-      _loadSessions(silent: true);
-      if (mounted) {
-        showGfToast(context, l10n.settingsRevokeAllDone);
-      }
     } catch (e) {
       if (mounted) {
         showGfToast(context, l10n.settingsOpFailed('$e'), error: true);
       }
+      return;
     }
+    await _signOutLocally(successMessage: l10n.settingsRevokeAllDone);
   }
 
   void _toggleDarkMode(bool value) {
@@ -1052,9 +1053,16 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     } catch (_) {
       // 服务端失效失败不阻塞本地登出(会话已不可信)。
     }
+    await _signOutLocally();
+  }
+
+  /// 统一本地登出:清 token → 失效会话世代 → 清离线缓存 → 跳转登录页。
+  ///
+  /// 登出/吊销全部会话后当前 JWT 已不可信,必须清空本地 token 与离线
+  /// 缓存(否则同一设备换账号后仍可读到上一账号数据,造成跨账号泄漏)。
+  Future<void> _signOutLocally({String? successMessage}) async {
     await ref.read(tokenStorageProvider).clear();
-    // 登出即进入新会话边界:先使旧会话在途写入失效、当前用户身份失效,
-    // 再清空缓存。
+    // 会话边界:先使旧会话在途写入失效、当前用户身份失效,再清空缓存。
     ref.read(offlineCacheEpochProvider.notifier).invalidate();
     ref.invalidate(currentUserProvider);
     // 清空话题/会话/私信离线缓存;失败静默(下次登出/登录会重试)。
@@ -1062,6 +1070,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       ref.read(offlineTopicCacheProvider),
       ref.read(offlineChatCacheProvider),
     );
+    if (successMessage != null && mounted) {
+      showGfToast(context, successMessage);
+    }
     if (mounted) context.go('/login');
   }
 

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -1047,6 +1047,38 @@ class EmptySessionsUserRepository extends UserRepository {
   }
 }
 
+/// 可编程 revoke-all 的 UserRepository:记录调用并可注入失败。
+class RevokingUserRepository extends UserRepository {
+  RevokingUserRepository(super.client, {this.revokeAllFails = false});
+
+  int revokeAllCalls = 0;
+  bool revokeAllFails;
+
+  @override
+  Future<bool> revokeAllSessions() async {
+    revokeAllCalls++;
+    if (revokeAllFails) {
+      throw Exception('revoke-all failed');
+    }
+    return true;
+  }
+
+  @override
+  Future<List<UserSessionPayload>> listSessions() async {
+    // 非空会话列表,保证设置页安全 tab 渲染"吊销全部会话"按钮。
+    return <UserSessionPayload>[
+      UserSessionPayload(
+        id: 1,
+        ipMasked: '10.0.0.1',
+        userAgent: 'test-agent',
+        createdAt: 1750000000,
+        expiresAt: 1800000000,
+        isCurrent: true,
+      ),
+    ];
+  }
+}
+
 /// 构造最小 TopicPayload。
 TopicPayload makeTopic(int id, String title) {
   return TopicPayload(
@@ -2281,6 +2313,145 @@ void main() {
       );
       expect(router.state.uri.path, '/login', reason: '登出后应跳转登录页');
       expect(find.text('login-page'), findsOneWidget);
+    });
+  });
+
+  group('设置吊销全部会话', () {
+    testWidgets('revoke-all 成功后清 token/缓存并跳转登录页', (tester) async {
+      final userRepo = RevokingUserRepository(
+        GfApiClient(
+          dio: Dio(),
+          tokenStorage: MemTokenStorage(),
+          baseUrl: 'http://fake.local',
+        ),
+      );
+      final storage = MemTokenStorage()..write('token');
+      final topicCache = RecordingCache();
+      final chatCache = RecordingCache();
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          userRepositoryProvider.overrideWithValue(userRepo),
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/settings',
+        routes: [
+          GoRoute(path: '/settings', builder: (_, _) => const SettingsPage()),
+          GoRoute(
+            path: '/login',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('login-page'))),
+          ),
+        ],
+      );
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 切到 Security tab 找"吊销全部会话"按钮。
+      await tester.tap(find.text('安全'));
+      await tester.pumpAndSettle();
+      expect(find.text('吊销全部会话'), findsOneWidget);
+
+      await tester.tap(find.text('吊销全部会话'));
+      await tester.pumpAndSettle();
+
+      expect(userRepo.revokeAllCalls, 1, reason: '应调用 revokeAllSessions');
+      expect(await storage.read(), isNull, reason: 'revoke-all 后必须清空本地 JWT');
+      expect(
+        topicCache.clears + chatCache.clears,
+        2,
+        reason: 'revoke-all 后应清空离线缓存,防止跨账号数据泄漏',
+      );
+      expect(router.state.uri.path, '/login', reason: 'revoke-all 后应跳转登录页');
+      expect(find.text('login-page'), findsOneWidget);
+
+      // 走完 toast 展示定时器,避免测试结束时 pending timer。
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('revoke-all 失败保留当前会话与页面', (tester) async {
+      final userRepo = RevokingUserRepository(
+        GfApiClient(
+          dio: Dio(),
+          tokenStorage: MemTokenStorage(),
+          baseUrl: 'http://fake.local',
+        ),
+        revokeAllFails: true,
+      );
+      final storage = MemTokenStorage()..write('token');
+      final topicCache = RecordingCache();
+      final chatCache = RecordingCache();
+      final container = ProviderContainer(
+        overrides: [
+          tokenStorageProvider.overrideWithValue(storage),
+          userRepositoryProvider.overrideWithValue(userRepo),
+          offlineTopicCacheProvider.overrideWithValue(topicCache),
+          offlineChatCacheProvider.overrideWithValue(chatCache),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final router = GoRouter(
+        initialLocation: '/settings',
+        routes: [
+          GoRoute(path: '/settings', builder: (_, _) => const SettingsPage()),
+          GoRoute(
+            path: '/login',
+            builder: (_, _) =>
+                const Scaffold(body: Center(child: Text('login-page'))),
+          ),
+        ],
+      );
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('zh'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('安全'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('吊销全部会话'));
+      await tester.pumpAndSettle();
+
+      expect(userRepo.revokeAllCalls, 1);
+      expect(await storage.read(), 'token', reason: '失败时不得清空 token');
+      expect(topicCache.clears + chatCache.clears, 0, reason: '失败时不得清空离线缓存');
+      expect(router.state.uri.path, '/settings', reason: '失败时不得跳转登录页');
+
+      // 走完 toast 展示定时器,避免测试结束时 pending timer。
+      await tester.pump(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
     });
   });
 


### PR DESCRIPTION
## Summary
- 修复"撤销所有会话后仍保留失效 JWT"：`_revokeAll` 成功后不再只刷新会话列表，而是走统一登出清理（清 token → 失效会话世代 → 清离线缓存 → 跳转登录页）。
- 后端 `sessionservice.RevokeAllAndInvalidate` 原子删除全部会话并递增 `tokenVersion`，当前 JWT 已立即失效；本地必须同步清除，否则离线时凭据长期残留。

## Root Cause
`apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart:608-621` 的 `_revokeAll` 成功后仅 `_loadSessions(silent: true)` + toast，未清理 `TokenStorage`/认证状态，也未导航；与 `_logout`（完整清理流程）不一致。

## Changes
- `settings_page.dart`：提取统一本地登出 `_signOutLocally`（清 token → `offlineCacheEpoch` 失效 → 清离线缓存 → 跳 `/login`），`_logout` 与 `_revokeAll` 共用；`_revokeAll` 成功 → `_signOutLocally(successMessage: settingsRevokeAllDone)`，失败 → 保留会话与页面并展示错误。
- 测试：新增 `RevokingUserRepository` 与 2 个 widget 测试——revoke-all 成功后清 token/缓存并跳转登录页；失败时保留 token/缓存/页面。

## Verification
- `flutter analyze`（lib+test）：No issues found。
- `flutter test`（forum_app）：92 passed（含 2 个新场景）。

Closes #142