### PR TITLE
fix(settings): 会话时间戳按 Unix 毫秒直接渲染,不再重复乘 1000

### DIFF
--- a/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
@@ -1080,9 +1080,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     showGfToast(context, message);
   }
 
-  String _formatTs(int tsSeconds) {
+  /// 会话创建时间渲染为 `YYYY-MM-DD`。
+  ///
+  /// 契约(`components/schemas.yaml#/UserSession` 与后端
+  /// `toSessionVO` 的 `UnixMilli()`)规定 createdAt 为 Unix **毫秒**,
+  /// 直接使用,不得再乘 1000(否则会变成微秒级,日期溢出)。
+  String _formatTs(int createdAtMs) {
     final DateTime t = DateTime.fromMillisecondsSinceEpoch(
-      tsSeconds * 1000,
+      createdAtMs,
     ).toLocal();
     return '${t.year}-${t.month.toString().padLeft(2, '0')}-${t.day.toString().padLeft(2, '0')}';
   }

--- a/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
+++ b/apps/mobile/packages/forum_app/test/pages_behavior_test.dart
@@ -1079,6 +1079,27 @@ class RevokingUserRepository extends UserRepository {
   }
 }
 
+/// 返回固定毫秒时间戳会话的 UserRepository,用于渲染时间戳测试。
+class FixedSessionsUserRepository extends UserRepository {
+  FixedSessionsUserRepository(super.client, this.createdAtMs);
+
+  final int createdAtMs;
+
+  @override
+  Future<List<UserSessionPayload>> listSessions() async {
+    return <UserSessionPayload>[
+      UserSessionPayload(
+        id: 1,
+        ipMasked: '10.0.0.1',
+        userAgent: 'test-agent',
+        createdAt: createdAtMs,
+        expiresAt: createdAtMs + 86400000,
+        isCurrent: true,
+      ),
+    ];
+  }
+}
+
 /// 构造最小 TopicPayload。
 TopicPayload makeTopic(int id, String title) {
   return TopicPayload(
@@ -2219,6 +2240,60 @@ void main() {
 
       expect(router.state.uri.path, '/host');
       expect(find.text('打开设置'), findsOneWidget);
+    });
+  });
+
+  group('设置页会话时间戳渲染', () {
+    testWidgets('Unix 毫秒 createdAt 直接渲染为正确日期(2026-08-07)', (tester) async {
+      // 2026-08-07 12:00:00 UTC(正午,任何时区本地日期均为 08-07)。
+      const int createdAtMs = 1786104000000;
+      final GfApiClient client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: MemTokenStorage(),
+        baseUrl: 'http://fake.local',
+      );
+      final ProviderContainer container = await makeContainer(
+        pageRepo: CountingPageRepository(client),
+        userRepo: FixedSessionsUserRepository(client, createdAtMs),
+      );
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(app(container, const SettingsPage()));
+      await tester.pumpAndSettle();
+
+      // 切到 Security tab 查看会话列表。
+      await tester.tap(find.text('安全'));
+      await tester.pumpAndSettle();
+
+      // 契约(Unix 毫秒)直接渲染,不得再乘 1000。
+      expect(find.textContaining('2026-08-07'), findsOneWidget);
+    });
+
+    testWidgets('2038 边界(毫秒)渲染正确年份而非溢出', (tester) async {
+      // 2038-01-19 12:00:00 UTC(2038 问题边界附近,秒级 int32 溢出点之后)。
+      const int createdAtMs = 2147515200000;
+      final GfApiClient client = GfApiClient(
+        dio: Dio(),
+        tokenStorage: MemTokenStorage(),
+        baseUrl: 'http://fake.local',
+      );
+      final ProviderContainer container = await makeContainer(
+        pageRepo: CountingPageRepository(client),
+        userRepo: FixedSessionsUserRepository(client, createdAtMs),
+      );
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(app(container, const SettingsPage()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('安全'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('2038-01-19'), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## Summary
- 修复移动端会话时间戳把 Unix 毫秒再次 ×1000 的问题：`_formatTs` 现按契约直接使用毫秒渲染 `YYYY-MM-DD`。
- 契约（`components/schemas.yaml#/UserSession` 与后端 `sessionController.go` `toSessionVO` 的 `UnixMilli()`）规定 `createdAt`/`expiresAt` 为 Unix **毫秒**；此前 `tsSeconds * 1000` 把毫秒当秒，日期被放大约 1000 倍甚至溢出（异常年份/无法判断会话新旧）。

## Root Cause
`apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart:1072-1076` 的 `_formatTs(int tsSeconds)` 调用 `DateTime.fromMillisecondsSinceEpoch(tsSeconds * 1000)`——参数实为毫秒却命名成 `tsSeconds` 并再乘 1000，变成微秒级。

## Changes
- `settings_page.dart`：`_formatTs` 参数重命名 `createdAtMs`，去掉 `* 1000`，直接 `fromMillisecondsSinceEpoch(createdAtMs)`；注释标明契约单位。
- 全库核查：`fromMillisecondsSinceEpoch`/`fromSecondsSinceEpoch` 转换仅此一处，无其他类似点。
- 测试：新增 `FixedSessionsUserRepository` + 2 个 widget 测试——常规 Unix 毫秒渲染正确日期（2026-08-07）；2038 边界毫秒渲染正确年份（2038-01-19，验证不再溢出）。测试用 UTC 正午保证任何时区稳定。

## Verification
- `flutter analyze`（lib+test）：No issues found。
- `flutter test`（forum_app）：92 passed（含 2 个新场景）。

Closes #136