### PR TITLE
fix(search): 取消发布/送审话题从公共搜索移除，聚合搜索按可见性过滤

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/adminController.go
+++ b/apps/gooseforum/app/http/controllers/api/adminController.go
@@ -1764,10 +1764,16 @@ func ReviewAction(req component.BetterRequest[ReviewActionReq]) component.Respon
 			_ = posts.UpdateProcessStatus(topic.FirstPostId, targetStatus)
 		}
 		hotdataserve.ClearTopicListCache()
+		// 审核后无条件重建搜索索引（issue #132）：拒绝（ProcessStatus→blocked）
+		// 时 BuildSingleTopicSearchDocument 会把文档从索引删除，避免被拒话题
+		// 残留在公共搜索；批准时 upsert 恢复（下方事件也会重建，幂等）。
+		firstPost := posts.Get(topic.FirstPostId)
+		if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
+			slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
+		}
 		// 批准后补发事件：新建主题发完整发布事件（搜索索引/统计/积分/活动/通知），
 		// 编辑主题仅重建索引与通知，避免重复积分。
 		if req.Params.Approve && topic.Status == 1 {
-			firstPost := posts.Get(topic.FirstPostId)
 			if userActivities.HasRecord(userActivities.ActionPost, userActivities.SubjectTopic, topic.Id) {
 				eventbus.Publish(context.Background(), &eventhandlers.TopicUpdatedEvent{Topic: &topic, FirstPost: &firstPost})
 			} else {

--- a/apps/gooseforum/app/http/controllers/api/topicController.go
+++ b/apps/gooseforum/app/http/controllers/api/topicController.go
@@ -25,6 +25,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/llmsservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/moderationservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/postservice"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/searchservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/topicunseenservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
 )
@@ -217,10 +218,15 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 		}
 		fileusageservice.ReplaceTopic(topic.Id, req.UserId, firstPost.Content)
 		hotdataserve.ClearTopicListCache()
-		// 编辑分支：下架（TopicStatus=0）或转入待审不发 TopicUpdatedEvent，
-		// 需同步清理 LLMS 投影缓存，避免下架内容在 10s 窗口内继续导出。
+		// 编辑分支：无条件重建搜索索引——下架（TopicStatus=0）或转入待审
+		// （ProcessStatus=Pending）时 BuildSingleTopicSearchDocument 会把文档
+		// 从索引删除，避免非公开内容残留在公共搜索（issue #132）。
+		// LLMS 投影缓存同步失效，避免下架内容在 10s 窗口内继续导出。
 		llmsservice.ClearCache()
-		// 待审（pendingReview）内容未上线，跳过事件发布（通知/webhook/统计/积分），
+		if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
+			slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
+		}
+		// 待审（pendingReview）内容未上线，跳过业务事件发布（通知/webhook/统计/积分），
 		// 由审核批准路径补发对应事件，避免敏感内容在审核前外泄。
 		if topic.Status == 1 && !pendingReview {
 			eventbus.Publish(context.Background(), &eventhandlers.TopicUpdatedEvent{Topic: &topic, FirstPost: &firstPost})
@@ -303,9 +309,14 @@ func UpdateTopicStatus(req component.BetterRequest[TopicStatusReq]) component.Re
 	}
 	firstPost := posts.Get(topic.FirstPostId)
 	hotdataserve.ClearTopicListCache()
-	// 无条件清理：下架（1→0）不发事件，此处同步失效 LLMS 投影缓存；0→1 复发的
-	// TopicPublishedEvent 也会清一次，幂等无害。
+	// 无条件重建搜索索引（issue #132）：1→0（取消发布）时
+	// BuildSingleTopicSearchDocument 会把文档从索引删除，避免已下架话题
+	// 残留在公共搜索；0→1（重新发布）时 upsert 恢复，幂等无害。
+	// 不发布 TopicUpdatedEvent：下架属用户隐私操作，不触发 webhook 通知。
 	llmsservice.ClearCache()
+	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
+		slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
+	}
 	if topic.Status == 1 {
 		eventbus.Publish(context.Background(), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
 	}

--- a/apps/gooseforum/app/service/eventhandlers/topic_visibility_search_e2e_test.go
+++ b/apps/gooseforum/app/service/eventhandlers/topic_visibility_search_e2e_test.go
@@ -1,0 +1,116 @@
+package eventhandlers
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/searchservice"
+)
+
+// TestTopicVisibilitySearchSyncEndToEnd 在真实 Meilisearch 上验证公开性转变的
+// 搜索索引同步（issue #132 核心回归）：
+//  1. 发布（Status=1, ProcessStatus=0）→ 索引 upsert，公共搜索可命中；
+//  2. 取消发布（Status→0）→ 索引删除，公共搜索不再命中；
+//  3. 重新发布（Status→1）→ 索引恢复，公共搜索重新命中；
+//  4. 送审（ProcessStatus→Pending）→ 索引删除，公共搜索不再命中；
+//  5. 审核批准恢复（ProcessStatus→Normal）→ 索引恢复。
+//
+// 由 TEST_MEILI_URL 门控（缺省跳过，CI 默认不跑），与 topic_deleted_e2e_test.go
+// 同模式。
+func TestTopicVisibilitySearchSyncEndToEnd(t *testing.T) {
+	if os.Getenv("TEST_MEILI_URL") == "" {
+		t.Skip("TEST_MEILI_URL not set; skipping Meilisearch end-to-end test")
+	}
+
+	topicID := uint64(time.Now().UnixNano() & 0x7fffffff)
+	title := "e2e-visibility-" + time.Now().Format("150405.000")
+	topic := &topics.Entity{
+		Id:               topicID,
+		Title:            title,
+		CategoryIds:      []uint64{1},
+		Status:           1, // 发布状态
+		ProcessStatus:    topics.ProcessStatusNormal,
+		VisibilityStatus: topics.VisibilityActive,
+		CreatedAt:        time.Now(),
+		UpdatedAt:        time.Now(),
+	}
+	firstPost := &posts.Entity{
+		Id:            topicID + 1,
+		TopicId:       topicID,
+		PostNo:        1,
+		Content:       "visibility e2e first post",
+		ProcessStatus: posts.ProcessStatusNormal,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+	}
+
+	// 1. 发布 → 可搜
+	task, err := searchservice.BuildSingleTopicSearchDocument(topic, firstPost)
+	if err != nil {
+		t.Fatalf("BuildSingleTopicSearchDocument(published) error: %v", err)
+	}
+	if task == nil {
+		t.Fatal("published topic produced no Meilisearch task (service unavailable?)")
+	}
+	waitTask(t, task.TaskUID)
+	if !topicExists(t, topicID, title) {
+		t.Fatalf("topic %d not found in index after publish", topicID)
+	}
+
+	// 2. 取消发布（Status→0）→ 不可搜（同 UpdateTopicStatus 的下架路径）
+	topic.Status = 0
+	if _, err := searchservice.BuildSingleTopicSearchDocument(topic, firstPost); err != nil {
+		t.Fatalf("BuildSingleTopicSearchDocument(unpublished) error: %v", err)
+	}
+	waitVisibilityGone(t, topicID, title, "unpublish")
+
+	// 3. 重新发布（Status→1）→ 恢复可搜
+	topic.Status = 1
+	task, err = searchservice.BuildSingleTopicSearchDocument(topic, firstPost)
+	if err != nil {
+		t.Fatalf("BuildSingleTopicSearchDocument(re-publish) error: %v", err)
+	}
+	waitTask(t, task.TaskUID)
+	if !topicExists(t, topicID, title) {
+		t.Fatalf("topic %d not found in index after re-publish", topicID)
+	}
+
+	// 4. 送审（ProcessStatus→Pending）→ 不可搜（敏感内容审核前不外泄）
+	topic.ProcessStatus = topics.ProcessStatusPending
+	if _, err := searchservice.BuildSingleTopicSearchDocument(topic, firstPost); err != nil {
+		t.Fatalf("BuildSingleTopicSearchDocument(pending) error: %v", err)
+	}
+	waitVisibilityGone(t, topicID, title, "pending review")
+
+	// 5. 审核批准（ProcessStatus→Normal）→ 恢复可搜
+	topic.ProcessStatus = topics.ProcessStatusNormal
+	task, err = searchservice.BuildSingleTopicSearchDocument(topic, firstPost)
+	if err != nil {
+		t.Fatalf("BuildSingleTopicSearchDocument(approved) error: %v", err)
+	}
+	waitTask(t, task.TaskUID)
+	if !topicExists(t, topicID, title) {
+		t.Fatalf("topic %d not found in index after approval", topicID)
+	}
+
+	// 清理：删除索引文档，避免污染其他 e2e
+	_, _ = searchservice.BuildSingleTopicSearchDocument(&topics.Entity{
+		Id: topicID, Status: 0, ProcessStatus: topics.ProcessStatusBlocked,
+	}, nil)
+}
+
+// waitVisibilityGone 轮询断言话题从索引移除（Meilisearch 任务异步生效）。
+func waitVisibilityGone(t *testing.T, id uint64, title, stage string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !topicExists(t, id, title) {
+			return // 已移除
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("topic %d (%s) still present in index 10s after %s", id, title, stage)
+}

--- a/apps/gooseforum/app/service/searchservice/aggregatesearch.go
+++ b/apps/gooseforum/app/service/searchservice/aggregatesearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/meiliconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/category"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/samber/lo"
@@ -208,13 +209,28 @@ func AggregateSearch(req AggregateSearchRequest) (*AggregateSearchResponse, erro
 func collectScopeResults(resp *AggregateSearchResponse, indexUID string, searchResp *meilisearch.SearchResponse) {
 	switch indexUID {
 	case TopicIndex:
-		results := lo.FilterMap(searchResp.Hits, func(hit meilisearch.Hit, _ int) (SearchResult, bool) {
-			item := SearchResult{}
+		type topicHit struct {
+			ID    uint64 `json:"id"`
+			Title string `json:"title"`
+		}
+		ids := lo.FilterMap(searchResp.Hits, func(hit meilisearch.Hit, _ int) (uint64, bool) {
+			item := topicHit{}
 			if err := hit.Decode(&item); err != nil {
 				slog.Error("failed to decode topic search hit", "err", err)
+				return 0, false
+			}
+			return item.ID, item.ID > 0
+		})
+		// 防御层（issue #132）：索引可能因事件时序与 DB 短暂不一致
+		// （如取消发布/送审后事件尚未落地），按 DB 当前状态过滤，
+		// 确保非公开话题绝不出现在公共搜索结果中。
+		topicMap := topics.GetMapByIds(ids)
+		results := lo.FilterMap(ids, func(id uint64, _ int) (SearchResult, bool) {
+			t, ok := topicMap[id]
+			if !ok || !isTopicPubliclySearchable(&t) {
 				return SearchResult{}, false
 			}
-			return item, item.ID > 0
+			return SearchResult{ID: t.Id, Title: t.Title}, true
 		})
 		resp.Topics = append(resp.Topics, results...)
 		resp.Total = searchResp.EstimatedTotalHits

--- a/apps/gooseforum/app/service/searchservice/aggregatesearch_test.go
+++ b/apps/gooseforum/app/service/searchservice/aggregatesearch_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/meilisearch/meilisearch-go"
 )
 
@@ -70,7 +72,27 @@ func TestAggregateSearchEmptyQuery(t *testing.T) {
 	}
 }
 
+// seedSearchableTopics 建表并插入指定可见性的话题，返回清理函数。
+func seedSearchableTopics(t *testing.T, list []topics.Entity) {
+	t.Helper()
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&topics.Entity{}); err != nil {
+		t.Fatalf("migrate topics: %v", err)
+	}
+	conn.Unscoped().Where("1 = 1").Delete(&topics.Entity{})
+	for i := range list {
+		if err := conn.Create(&list[i]).Error; err != nil {
+			t.Fatalf("create topic %d: %v", list[i].Id, err)
+		}
+	}
+	t.Cleanup(func() { conn.Unscoped().Where("1 = 1").Delete(&topics.Entity{}) })
+}
+
 func TestCollectScopeResultsTopics(t *testing.T) {
+	seedSearchableTopics(t, []topics.Entity{
+		{Id: 1, Title: "hello", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityActive},
+		{Id: 2, Title: "world", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityActive},
+	})
 	resp := &AggregateSearchResponse{Topics: []SearchResult{}, Users: []UserSearchResult{}, Categories: []CategorySearchResult{}}
 	searchResp := &meilisearch.SearchResponse{
 		Hits: []meilisearch.Hit{
@@ -92,6 +114,9 @@ func TestCollectScopeResultsTopics(t *testing.T) {
 }
 
 func TestCollectScopeResultsSkipsInvalidIDs(t *testing.T) {
+	seedSearchableTopics(t, []topics.Entity{
+		{Id: 3, Title: "good", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityActive},
+	})
 	resp := &AggregateSearchResponse{Topics: []SearchResult{}, Users: []UserSearchResult{}, Categories: []CategorySearchResult{}}
 	searchResp := &meilisearch.SearchResponse{
 		Hits: []meilisearch.Hit{
@@ -103,5 +128,37 @@ func TestCollectScopeResultsSkipsInvalidIDs(t *testing.T) {
 	collectScopeResults(resp, TopicIndex, searchResp)
 	if len(resp.Topics) != 1 || resp.Topics[0].ID != 3 {
 		t.Fatalf("invalid id should be skipped: %+v", resp.Topics)
+	}
+}
+
+// TestCollectScopeResultsFiltersNonPublicTopics 验证聚合搜索防御层：
+// 即使 Meili 索引中残留非公开话题文档（索引事件未落地窗口期），
+// 结果也按 DB 当前状态过滤，绝不返回已下架/待审/封禁/删除的话题（issue #132）。
+func TestCollectScopeResultsFiltersNonPublicTopics(t *testing.T) {
+	seedSearchableTopics(t, []topics.Entity{
+		{Id: 1, Title: "公开", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityActive},
+		{Id: 2, Title: "已下架", Status: 0, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityActive},
+		{Id: 3, Title: "待审", Status: 1, ProcessStatus: topics.ProcessStatusPending, VisibilityStatus: topics.VisibilityActive},
+		{Id: 4, Title: "已封禁", Status: 1, ProcessStatus: topics.ProcessStatusBlocked, VisibilityStatus: topics.VisibilityActive},
+		{Id: 5, Title: "用户删除", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityUserDeleted},
+		{Id: 6, Title: "管理删除", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityModeratorRemoved},
+	})
+	resp := &AggregateSearchResponse{Topics: []SearchResult{}, Users: []UserSearchResult{}, Categories: []CategorySearchResult{}}
+	searchResp := &meilisearch.SearchResponse{
+		Hits: []meilisearch.Hit{
+			{"id": json.RawMessage(`1`), "title": json.RawMessage(`"公开"`)},
+			{"id": json.RawMessage(`2`), "title": json.RawMessage(`"已下架"`)},
+			{"id": json.RawMessage(`3`), "title": json.RawMessage(`"待审"`)},
+			{"id": json.RawMessage(`4`), "title": json.RawMessage(`"已封禁"`)},
+			{"id": json.RawMessage(`5`), "title": json.RawMessage(`"用户删除"`)},
+			{"id": json.RawMessage(`6`), "title": json.RawMessage(`"管理删除"`)},
+			// ID 7 在 Meili 索引中但 DB 中不存在（索引幽灵）：同样应被过滤
+			{"id": json.RawMessage(`7`), "title": json.RawMessage(`"索引幽灵"`)},
+		},
+		EstimatedTotalHits: 7,
+	}
+	collectScopeResults(resp, TopicIndex, searchResp)
+	if len(resp.Topics) != 1 || resp.Topics[0].ID != 1 {
+		t.Fatalf("only public topic should survive DB filter, got %+v", resp.Topics)
 	}
 }

--- a/apps/gooseforum/app/service/searchservice/indexservice.go
+++ b/apps/gooseforum/app/service/searchservice/indexservice.go
@@ -40,6 +40,20 @@ func convertTopicToSearchDocument(topic *topics.Entity, firstPost *posts.Entity)
 	}
 }
 
+// isTopicPubliclySearchable 判断话题当前是否应出现在公共搜索：
+// 已发布、未封禁/待审、未软删、可见性正常。
+// 供索引构建（isIndexable）与聚合搜索防御过滤（issue #132）复用，
+// 保证"索引事件未落地"的窗口期也不泄露非公开话题。
+func isTopicPubliclySearchable(topic *topics.Entity) bool {
+	if topic == nil {
+		return false
+	}
+	return topic.Status == 1 &&
+		topic.ProcessStatus == topics.ProcessStatusNormal &&
+		!topic.DeletedAt.Valid &&
+		topic.VisibilityStatus == topics.VisibilityActive
+}
+
 func BuildSingleTopicSearchDocument(topic *topics.Entity, firstPost *posts.Entity) (*meilisearch.TaskInfo, error) {
 	if !meiliconnect.IsAvailable() {
 		return nil, nil

--- a/apps/gooseforum/app/service/searchservice/indexservice_test.go
+++ b/apps/gooseforum/app/service/searchservice/indexservice_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+	"gorm.io/gorm"
 )
 
 func TestConvertTopicToSearchDocument(t *testing.T) {
@@ -61,5 +62,32 @@ func TestTopicSearchDocumentDoesNotExposeLegacyType(t *testing.T) {
 func TestGetTaskUIDNil(t *testing.T) {
 	if got := getTaskUID(nil); got != nil {
 		t.Fatalf("getTaskUID(nil) = %v, want nil", got)
+	}
+}
+
+func TestIsTopicPubliclySearchable(t *testing.T) {
+	base := topics.Entity{Id: 1, Title: "t", Status: 1, ProcessStatus: topics.ProcessStatusNormal, VisibilityStatus: topics.VisibilityActive}
+	cases := []struct {
+		name  string
+		mut   func(*topics.Entity)
+		want  bool
+	}{
+		{"published normal", func(e *topics.Entity) {}, true},
+		{"unpublished (status 0)", func(e *topics.Entity) { e.Status = 0 }, false},
+		{"pending review", func(e *topics.Entity) { e.ProcessStatus = topics.ProcessStatusPending }, false},
+		{"blocked", func(e *topics.Entity) { e.ProcessStatus = topics.ProcessStatusBlocked }, false},
+		{"user deleted", func(e *topics.Entity) { e.VisibilityStatus = topics.VisibilityUserDeleted }, false},
+		{"moderator removed", func(e *topics.Entity) { e.VisibilityStatus = topics.VisibilityModeratorRemoved }, false},
+		{"soft deleted", func(e *topics.Entity) { e.DeletedAt = gorm.DeletedAt{Time: time.Now(), Valid: true} }, false},
+	}
+	for _, tc := range cases {
+		e := base
+		tc.mut(&e)
+		if got := isTopicPubliclySearchable(&e); got != tc.want {
+			t.Fatalf("isTopicPubliclySearchable(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+	if isTopicPubliclySearchable(nil) {
+		t.Fatal("isTopicPubliclySearchable(nil) = true, want false")
 	}
 }


### PR DESCRIPTION
## Summary
- **问题**：话题从公开变为非公开（取消发布 / 送审 / 审核拒绝）时，原代码不发任何搜索索引事件，标题/摘要残留在 Meilisearch 公共搜索；聚合搜索也只收集索引命中、无 DB 状态校验，事件落地窗口期仍会泄露非公开话题（issue #132）。
- **修复**：
  - `writeTopic` 编辑分支：下架（Status→0）或转待审（ProcessStatus→Pending）时无条件调用 `BuildSingleTopicSearchDocument`（不可索引自动删除文档）；不发布业务事件，避免待审内容触发通知/webhook 外泄。
  - `UpdateTopicStatus`：1→0 取消发布时同步重建索引（删除文档），0→1 重新发布时 upsert 恢复；不触发 webhook 通知。
  - `ReviewAction` 审核拒绝：ProcessStatus→blocked 时重建索引删除文档，避免被拒话题残留。
  - `AggregateSearch` 防御层：topic 结果按 DB 当前状态过滤（`isTopicPubliclySearchable`：Status=1 且 ProcessStatus=Normal 且未软删且可见性 ACTIVE），事件落地窗口期也不泄露。
- **测试**：
  - `collectScopeResults` 防御过滤单测（下架/待审/封禁/用户删除/管理删除/索引幽灵均被过滤）
  - `isTopicPubliclySearchable` 状态机单测
  - 真实 Meilisearch e2e（`TEST_MEILI_URL` 门控）：发布→可搜 → 取消发布→不可搜 → 重新发布→可搜 → 送审→不可搜 → 批准→可搜

## Validation
- `cd apps/gooseforum && go vet ./...` 通过
- `go test ./...` 通过（93 个包全部 ok）

Closes #132