### PR TITLE
feat(oauth): GitHub OAuth 信任 verified 邮箱，按 allowedDomains 控制绑定与激活

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -75,14 +75,12 @@ func ProviderCallback(c *gin.Context) {
 		}
 
 		if user.IsActivated == users.ActivationPending {
-			user.IsActivated = users.ActivationSuccess
-			// 更新用户状态
-			err = userservice.SaveUser(user)
-			if err != nil {
-				slog.Error("Update user activation status failed", "error", err)
-				forum.RenderInternalOAuthErrorPage(c, component.MessageOAuthActivationUpdateFailed)
-				return
-			}
+			// issue #155：OAuth 用户若处于待激活状态（verified 邮箱未命中信任域名且
+			// 全局 EnableEmailVerification 开启），不得在回调中强制激活。
+			// 保持 ActivationPending，用户需通过激活邮件完成验证，
+			// 与密码注册流程的激活语义一致。
+			slog.Info("OAuth callback user pending activation",
+				"userId", user.Id, "provider", gothUser.Provider)
 		}
 
 		// 生成JWT token（会话凭证，写会话记录）

--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -75,12 +75,14 @@ func ProviderCallback(c *gin.Context) {
 		}
 
 		if user.IsActivated == users.ActivationPending {
-			// issue #155：OAuth 用户若处于待激活状态（verified 邮箱未命中信任域名且
-			// 全局 EnableEmailVerification 开启），不得在回调中强制激活。
-			// 保持 ActivationPending，用户需通过激活邮件完成验证，
-			// 与密码注册流程的激活语义一致。
-			slog.Info("OAuth callback user pending activation",
+			// issue #155：OAuth 用户处于待激活状态（verified 邮箱未命中信任域名且
+			// 全局 EnableEmailVerification 开启）时，不发放会话——与密码登录对
+			// pending 用户的拒绝语义一致（authController 返回 auth.email.unverified）。
+			// 用户需通过激活邮件完成验证后重新登录。
+			slog.Info("OAuth callback rejected pending activation user",
 				"userId", user.Id, "provider", gothUser.Provider)
+			forum.RenderOAuthErrorPage(c, http.StatusForbidden, component.MessageAuthEmailUnverified)
+			return
 		}
 
 		// 生成JWT token（会话凭证，写会话记录）

--- a/apps/gooseforum/app/http/controllers/component/userUtil.go
+++ b/apps/gooseforum/app/http/controllers/component/userUtil.go
@@ -3,14 +3,13 @@ package component
 import (
 	"fmt"
 	"regexp"
-	"slices"
 	"strings"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/vo"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
+	"github.com/gin-gonic/gin"
 )
 
 var (
@@ -122,7 +121,9 @@ func permissionActionParams(action PermissionAction, fallback string) MessagePar
 	}
 }
 
-// ValidateEmailDomain 验证邮箱域名是否符合白名单限制
+// ValidateEmailDomain 验证邮箱域名是否符合白名单限制。
+// 域名匹配大小写不敏感（DNS 域名本不区分大小写），与 OAuth 信任域名
+// 判定（oauthservice.emailInTrustedDomains）语义一致（PR #167 review）。
 func ValidateEmailDomain(email string) error {
 	securityConfig := hotdataserve.GetSecuritySettingsConfigCache()
 	if len(securityConfig.AllowedDomains) == 0 {
@@ -134,9 +135,11 @@ func ValidateEmailDomain(email string) error {
 		return NewMessageError(MessageAuthEmailDomainInvalid, "邮箱格式不正确", nil)
 	}
 
-	domain := parts[1]
-	if slices.Contains(securityConfig.AllowedDomains, domain) {
-		return nil
+	domain := strings.ToLower(parts[1])
+	for _, allowed := range securityConfig.AllowedDomains {
+		if strings.EqualFold(strings.TrimSpace(allowed), domain) {
+			return nil
+		}
 	}
 
 	return NewMessageError(

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -320,24 +320,28 @@ func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) 
 	}
 
 	securityConfig := hotdataserve.GetSecuritySettingsConfigCache()
-	// 存储邮箱：verified 邮箱优先；无 verified 邮箱时降级存 goth 的公开邮箱（如有）。
-	email := userInfo.VerifiedEmail
-	if email == "" {
-		email = userInfo.Email
-	}
-	email = strings.ToLower(strings.TrimSpace(email))
+	// 存储邮箱：只存 provider 已确认真实的邮箱（GitHub verified 邮箱）。
+	// 无 verified 邮箱时保持存 ""（与旧行为一致），不降级存 goth 公开邮箱——
+	// 未验证邮箱若被 OIDC userinfo 推导为 email_verified=true 会造成信任越界
+	// （PR #167 review, medium）。
+	email := strings.ToLower(strings.TrimSpace(userInfo.VerifiedEmail))
 
 	// 信任判定：仅 verified 邮箱命中信任域名才免验证。
 	trusted := userInfo.EmailVerified && email != "" && emailInTrustedDomains(email)
-	needValid := !trusted && securityConfig.EnableEmailVerification
+	// 无 verified 邮箱时保持旧行为免验证（needValid=false）：
+	// 该场景没有可用的激活邮箱，若进入 ActivationPending 将形成无恢复路径的
+	// 永久死账号（PR #167 review, blocking）。开关开启且未命中信任域名时，
+	// 仅当存在 verified 邮箱才要求邮箱激活。
+	needValid := !trusted && securityConfig.EnableEmailVerification && userInfo.EmailVerified
 
 	userEntity, err := userservice.CreateUser(username, randopt.RandomString(32), email, needValid)
 	if err != nil {
 		return nil, fmt.Errorf("创建用户失败: %w", err)
 	}
 
-	// 需要邮箱激活（开关开且未命中信任域名）：补发激活邮件（OAuth 路径原本不发）。
-	if needValid && email != "" {
+	// 需要邮箱激活（开关开且未命中信任域名、且有 verified 邮箱）：
+	// 补发激活邮件（OAuth 路径原本不发）。needValid=true 时 email 必非空。
+	if needValid {
 		if err := emailactivationservice.SendActivationEmail(userEntity); err != nil {
 			slog.Warn("OAuth 用户激活邮件入队失败", "userId", userEntity.Id, "email", email, "err", err)
 		} else {
@@ -370,7 +374,11 @@ func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) 
 // createOAuthRecord stores a provider account binding. Only the identity
 // linkage (user/provider/provider_uid) is persisted; third-party OAuth tokens
 // are never written to the database (Issue #131).
+// 同 (user_id, provider) 已有绑定时不重复创建（幂等，PR #167 review minor）。
 func createOAuthRecord(userID uint64, userInfo OAuthUserInfo) error {
+	if existing := userOAuth.GetByUserIDAndProvider(userID, userInfo.Provider); existing != nil {
+		return nil
+	}
 	oauthEntity := &userOAuth.Entity{
 		UserId:      userID,
 		Provider:    userInfo.Provider,

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -2,6 +2,7 @@ package oauthservice
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/sessionstore"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/filemodel/filedata"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/emailactivationservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/eventhandlers"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
 
@@ -73,7 +75,9 @@ func initGitHubProvider() goth.Provider {
 	}
 
 	slog.Info("GitHub OAuth提供商初始化完成")
-	return github.New(clientID, clientSecret, callbackURL)
+	// user:email scope：允许调用 GET /user/emails 获取 verified primary 邮箱
+	// （issue #155：只信 GitHub 已验证邮箱，公开邮箱字段不区分 verified 不可依赖）。
+	return github.New(clientID, clientSecret, callbackURL, "user:email")
 }
 
 // initGoogleProvider returns a Google provider when configured.
@@ -99,6 +103,13 @@ type OAuthUserInfo struct {
 	Blog      string `json:"blog"`
 	Location  string `json:"location"`
 	Provider  string `json:"provider"`
+
+	// VerifiedEmail 是 provider 已确认真实的邮箱（GitHub verified 邮箱）。
+	// EmailVerified 标记该邮箱来自可信来源（GitHub /user/emails 的 verified=true）。
+	// issue #155：只信 verified 邮箱作为绑定/激活依据，goth 的 Email 字段
+	// 可能是未验证的公开邮箱，不可直接用于信任决策。
+	VerifiedEmail string `json:"verifiedEmail,omitempty"`
+	EmailVerified bool   `json:"emailVerified,omitempty"`
 }
 
 // ProcessOAuthCallback logs in an existing OAuth user or creates a new one.
@@ -122,6 +133,12 @@ func ProcessOAuthCallback(gothUser goth.User) (*users.EntityComplete, error) {
 		return &user, nil
 	}
 
+	// 绑定路径（issue #155）：verified 邮箱命中信任域名且该邮箱已有账号时，
+	// 直接建立 OAuth 关联并登录该账号，不重复注册。
+	if bound, err := bindOAuthByTrustedEmail(userInfo); bound != nil || err != nil {
+		return bound, err
+	}
+
 	newUser, err := createUserFromOAuth(userInfo)
 	if err != nil {
 		return nil, err
@@ -140,7 +157,61 @@ func ProcessOAuthCallback(gothUser goth.User) (*users.EntityComplete, error) {
 	return newUser, nil
 }
 
+// bindOAuthByTrustedEmail 尝试把 OAuth 身份绑定到 verified 邮箱命中的已有账号。
+// 仅当 email 命中信任域名（allowedDomains 空 = 全信任）且存在同邮箱账号时绑定；
+// 返回 (nil, nil) 表示无账号可绑，走正常注册路径。
+func bindOAuthByTrustedEmail(userInfo OAuthUserInfo) (*users.EntityComplete, error) {
+	if !userInfo.EmailVerified || userInfo.VerifiedEmail == "" {
+		return nil, nil
+	}
+	if !emailInTrustedDomains(userInfo.VerifiedEmail) {
+		return nil, nil
+	}
+
+	user, err := users.GetByEmail(userInfo.VerifiedEmail)
+	if err != nil || user.Id == 0 {
+		return nil, nil // 无同邮箱账号，走注册
+	}
+
+	// 与既有 OAuth 绑定路径一致的账号状态检查（issue #130 冻结语义保留）。
+	if user.IsFrozen == users.StatusFrozen {
+		return nil, ErrAccountFrozen
+	}
+	if user.IsBot() {
+		return nil, fmt.Errorf("机器人账号不允许 OAuth 登录")
+	}
+
+	if err := createOAuthRecord(user.Id, userInfo); err != nil {
+		return nil, err
+	}
+	slog.Info("OAuth 绑定到已存在账号（verified 邮箱命中信任域名）",
+		"userId", user.Id, "provider", userInfo.Provider, "email", userInfo.VerifiedEmail)
+	return &user, nil
+}
+
+// emailInTrustedDomains 判断邮箱域名是否命中信任域名列表。
+// allowedDomains 为空 = 全信任（默认配置，行为与现状无条件信任一致）。
+// 域名精确匹配（大小写不敏感），不做子域名放宽。
+func emailInTrustedDomains(email string) bool {
+	securityConfig := hotdataserve.GetSecuritySettingsConfigCache()
+	if len(securityConfig.AllowedDomains) == 0 {
+		return true
+	}
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return false
+	}
+	domain := strings.ToLower(parts[1])
+	for _, allowed := range securityConfig.AllowedDomains {
+		if strings.EqualFold(strings.TrimSpace(allowed), domain) {
+			return true
+		}
+	}
+	return false
+}
+
 // parseOAuthUserInfo normalizes provider-specific user data.
+// 对 GitHub 额外获取 verified primary 邮箱（issue #155）。
 func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 	userInfo := OAuthUserInfo{
 		ID:        gothUser.UserID,
@@ -166,10 +237,79 @@ func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 		}
 	}
 
+	// GitHub：通过 /user/emails 获取 verified 邮箱。goth 的 Email 字段可能来自
+	// 公开 profile（不保证 verified），不能直接作为信任依据。
+	if userInfo.Provider == ProviderGitHub {
+		if verified := fetchGitHubVerifiedEmail(gothUser.AccessToken); verified != "" {
+			userInfo.VerifiedEmail = verified
+			userInfo.EmailVerified = true
+		}
+	}
+
 	return userInfo
 }
 
+// gitHubEmailAPIURL 为 GitHub 邮箱列表 API（var 便于测试覆盖）。
+var gitHubEmailAPIURL = "https://api.github.com/user/emails"
+
+// gitHubEmailEntry 是 GET /user/emails 的返回项。
+type gitHubEmailEntry struct {
+	Email    string `json:"email"`
+	Primary  bool   `json:"primary"`
+	Verified bool   `json:"verified"`
+}
+
+// fetchGitHubVerifiedEmail 调用 GitHub API 获取用户邮箱列表，
+// 返回 verified && primary 的邮箱；无 primary 时退而取任一 verified 邮箱。
+// 失败（网络/401/无 verified 邮箱）返回空字符串，调用方按无邮箱处理。
+func fetchGitHubVerifiedEmail(accessToken string) string {
+	if accessToken == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gitHubEmailAPIURL, nil)
+	if err != nil {
+		slog.Warn("构造 GitHub 邮箱请求失败", "err", err)
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Warn("获取 GitHub 邮箱列表失败", "err", err)
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("获取 GitHub 邮箱列表返回非 200", "status", resp.StatusCode)
+		return ""
+	}
+
+	var list []gitHubEmailEntry
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		slog.Warn("解析 GitHub 邮箱列表失败", "err", err)
+		return ""
+	}
+	for _, e := range list {
+		if e.Verified && e.Primary && e.Email != "" {
+			return strings.ToLower(e.Email)
+		}
+	}
+	for _, e := range list {
+		if e.Verified && e.Email != "" {
+			return strings.ToLower(e.Email)
+		}
+	}
+	return ""
+}
+
 // createUserFromOAuth creates a local account from OAuth user data.
+// 激活策略（issue #155）：
+//   - verified 邮箱命中信任域名（allowedDomains 空 = 全信任）→ needValid=false 直接激活；
+//   - 未命中或未获取到 verified 邮箱 → needValid = EnableEmailVerification 开关
+//     （默认 false 保持现状免验证，不回归）；开关开启时进入 ActivationPending
+//     并补发激活邮件（与密码注册流程一致）。
 func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) {
 	username := userInfo.Login
 	originalUsername := username
@@ -179,9 +319,30 @@ func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) 
 		counter++
 	}
 
-	userEntity, err := userservice.CreateUser(username, randopt.RandomString(32), "", false)
+	securityConfig := hotdataserve.GetSecuritySettingsConfigCache()
+	// 存储邮箱：verified 邮箱优先；无 verified 邮箱时降级存 goth 的公开邮箱（如有）。
+	email := userInfo.VerifiedEmail
+	if email == "" {
+		email = userInfo.Email
+	}
+	email = strings.ToLower(strings.TrimSpace(email))
+
+	// 信任判定：仅 verified 邮箱命中信任域名才免验证。
+	trusted := userInfo.EmailVerified && email != "" && emailInTrustedDomains(email)
+	needValid := !trusted && securityConfig.EnableEmailVerification
+
+	userEntity, err := userservice.CreateUser(username, randopt.RandomString(32), email, needValid)
 	if err != nil {
 		return nil, fmt.Errorf("创建用户失败: %w", err)
+	}
+
+	// 需要邮箱激活（开关开且未命中信任域名）：补发激活邮件（OAuth 路径原本不发）。
+	if needValid && email != "" {
+		if err := emailactivationservice.SendActivationEmail(userEntity); err != nil {
+			slog.Warn("OAuth 用户激活邮件入队失败", "userId", userEntity.Id, "email", email, "err", err)
+		} else {
+			slog.Info("OAuth 用户激活邮件已入队", "userId", userEntity.Id, "email", email)
+		}
 	}
 
 	if userInfo.AvatarURL != "" {

--- a/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
@@ -163,7 +163,9 @@ func TestCreateUserFromOAuthUnmatchedDomainFollowsSwitch(t *testing.T) {
 	}
 }
 
-// TestCreateUserFromOAuthNoEmailFollowsSwitch 无 verified 邮箱跟随开关。
+// TestCreateUserFromOAuthNoEmailFollowsSwitch 无 verified 邮箱保持免验证激活
+// （PR #167 review, blocking：无 verified 邮箱时无激活邮件可发，进入 pending
+// 将形成无恢复路径的死账号；保持旧行为免验证）。
 func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
 	setupOAuthTestDB(t)
 
@@ -183,7 +185,7 @@ func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
 		t.Fatalf("no email with verification off should activate: %v", user.IsActivated)
 	}
 
-	// 开关开 → pending
+	// 开关开 + 无 verified 邮箱 → 仍免验证激活（不死账号）
 	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
 		EnableEmailVerification: true,
 		AllowedDomains:          []string{"tongji.edu.cn"},
@@ -195,8 +197,22 @@ func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createUserFromOAuth() error = %v", err)
 	}
-	if user2.IsActivated != users.ActivationPending {
-		t.Fatalf("no email with verification on: activation = %v, want pending", user2.IsActivated)
+	if user2.IsActivated != users.ActivationSuccess {
+		t.Fatalf("no verified email with verification on should still activate (no dead account): %v", user2.IsActivated)
+	}
+
+	// 无 verified 邮箱时不降级存 goth 公开邮箱（PR #167 review, medium：
+	// 未验证邮箱经 OIDC 会被推导为 email_verified=true，造成信任越界）。
+	user3, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "3", Login: "public-only", Provider: ProviderGitHub,
+		Email:         "public@example.com", // goth 公开邮箱，未验证
+		EmailVerified: false,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user3.Email != "" {
+		t.Fatalf("unverified goth public email should NOT be stored, got %q", user3.Email)
 	}
 }
 
@@ -337,5 +353,26 @@ func TestProcessOAuthCallbackNoAccessToken(t *testing.T) {
 	}
 	if user.Email != "" {
 		t.Fatalf("no verified email should not store email, got %q", user.Email)
+	}
+}
+
+// TestEmailInTrustedDomainsCaseInsensitive 域名匹配大小写不敏感（PR #167 review）：
+// 与注册白名单 ValidateEmailDomain 语义统一（均 EqualFold）。
+func TestEmailInTrustedDomainsCaseInsensitive(t *testing.T) {
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		AllowedDomains: []string{"Tongji.Edu.Cn"},
+	})
+
+	if !emailInTrustedDomains("alice@tongji.edu.cn") {
+		t.Fatal("lowercase domain should match mixed-case allowlist entry")
+	}
+	if !emailInTrustedDomains("alice@TONGJI.EDU.CN") {
+		t.Fatal("uppercase domain should match mixed-case allowlist entry")
+	}
+	if emailInTrustedDomains("alice@tongji.edu.cn.evil.com") {
+		t.Fatal("subdomain suffix must not match (no suffix relaxation)")
+	}
+	if emailInTrustedDomains("not-an-email") {
+		t.Fatal("malformed email must not match")
 	}
 }

--- a/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
@@ -1,0 +1,341 @@
+package oauthservice
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pointsRecord"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userOAuth"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userPoints"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userStatistics"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
+	"github.com/markbates/goth"
+)
+
+// setSecurityConfigForTest 注入 security 配置并清缓存，返回还原函数。
+func setSecurityConfigForTest(t *testing.T, config pageConfig.SecurityAndRegistration) {
+	t.Helper()
+	conn := db.Connect()
+	// CreateUser 依赖 user_points / user_statistics / points_record，迁移避免缺表。
+	if err := conn.AutoMigrate(
+		&pageConfig.Entity{},
+		&userPoints.Entity{},
+		&pointsRecord.Entity{},
+		&userStatistics.Entity{},
+	); err != nil {
+		t.Fatalf("migrate config/points tables: %v", err)
+	}
+	encoded, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("encode security config: %v", err)
+	}
+	entity := pageConfig.Entity{PageType: pageConfig.SecuritySettings, Config: string(encoded)}
+	if err := conn.Where("page_type = ?", pageConfig.SecuritySettings).Assign(entity).FirstOrCreate(&entity).Error; err != nil {
+		t.Fatalf("save security config: %v", err)
+	}
+	hotdataserve.ClearSecuritySettingsConfigCache()
+	t.Cleanup(hotdataserve.ClearSecuritySettingsConfigCache)
+}
+
+// verifiedGithubUser 构造带 verified 邮箱的 GitHub goth 用户（token 触发 API 调用）。
+func verifiedGithubUser(t *testing.T, uid, login, email string) goth.User {
+	t.Helper()
+	// 用 mock server 返回 verified primary 邮箱，避免真实网络调用。
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"email": email, "primary": true, "verified": true},
+		})
+	}))
+	t.Cleanup(server.Close)
+	oldURL := gitHubEmailAPIURL
+	gitHubEmailAPIURL = server.URL
+	t.Cleanup(func() { gitHubEmailAPIURL = oldURL })
+
+	return goth.User{
+		Provider:    ProviderGitHub,
+		UserID:      uid,
+		NickName:    login,
+		AccessToken: "test-token",
+	}
+}
+
+// unverifiedGithubUser 构造无 verified 邮箱的 GitHub 用户（API 返回空列表）。
+func unverifiedGithubUser(t *testing.T, uid, login string) goth.User {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+	oldURL := gitHubEmailAPIURL
+	gitHubEmailAPIURL = server.URL
+	t.Cleanup(func() { gitHubEmailAPIURL = oldURL })
+
+	return goth.User{
+		Provider:    ProviderGitHub,
+		UserID:      uid,
+		NickName:    login,
+		AccessToken: "test-token",
+	}
+}
+
+// TestCreateUserFromOAuthTrustedDomainAutoActivates 域名命中信任列表 → 直接激活。
+func TestCreateUserFromOAuthTrustedDomainAutoActivates(t *testing.T) {
+	setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		AllowedDomains: []string{"tongji.edu.cn"},
+	})
+
+	user, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "1", Login: "trusted-user", Provider: ProviderGitHub,
+		VerifiedEmail: "alice@tongji.edu.cn", EmailVerified: true,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user.IsActivated != users.ActivationSuccess {
+		t.Fatalf("trusted domain user activation = %v, want %v", user.IsActivated, users.ActivationSuccess)
+	}
+	if user.Email != "alice@tongji.edu.cn" {
+		t.Fatalf("stored email = %q, want alice@tongji.edu.cn", user.Email)
+	}
+}
+
+// TestCreateUserFromOAuthEmptyDomainsTrustsAll 空 allowedDomains = 全信任 → 直接激活。
+func TestCreateUserFromOAuthEmptyDomainsTrustsAll(t *testing.T) {
+	setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: true,
+		AllowedDomains:          []string{},
+	})
+
+	user, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "1", Login: "any-domain", Provider: ProviderGitHub,
+		VerifiedEmail: "alice@example.com", EmailVerified: true,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user.IsActivated != users.ActivationSuccess {
+		t.Fatalf("empty domains should trust all, activation = %v, want %v", user.IsActivated, users.ActivationSuccess)
+	}
+}
+
+// TestCreateUserFromOAuthUnmatchedDomainFollowsSwitch 未命中域名跟随开关：
+// 开关开 → ActivationPending；开关关（默认）→ 免验证激活。
+func TestCreateUserFromOAuthUnmatchedDomainFollowsSwitch(t *testing.T) {
+	setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: true,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
+
+	// 开关开 + 未命中 → pending
+	user, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "1", Login: "outside-user", Provider: ProviderGitHub,
+		VerifiedEmail: "bob@gmail.com", EmailVerified: true,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user.IsActivated != users.ActivationPending {
+		t.Fatalf("unmatched domain with verification on: activation = %v, want pending", user.IsActivated)
+	}
+
+	// 开关关（默认）→ 免验证（不回归）
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: false,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
+	user2, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "2", Login: "outside-user2", Provider: ProviderGitHub,
+		VerifiedEmail: "bob@gmail.com", EmailVerified: true,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user2.IsActivated != users.ActivationSuccess {
+		t.Fatalf("unmatched domain with verification off should activate: %v", user2.IsActivated)
+	}
+}
+
+// TestCreateUserFromOAuthNoEmailFollowsSwitch 无 verified 邮箱跟随开关。
+func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
+	setupOAuthTestDB(t)
+
+	// 开关关（默认）→ 免验证（不回归）
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: false,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
+	user, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "1", Login: "no-email", Provider: ProviderGitHub,
+		EmailVerified: false,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user.IsActivated != users.ActivationSuccess {
+		t.Fatalf("no email with verification off should activate: %v", user.IsActivated)
+	}
+
+	// 开关开 → pending
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: true,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
+	user2, err := createUserFromOAuth(OAuthUserInfo{
+		ID: "2", Login: "no-email2", Provider: ProviderGitHub,
+		EmailVerified: false,
+	})
+	if err != nil {
+		t.Fatalf("createUserFromOAuth() error = %v", err)
+	}
+	if user2.IsActivated != users.ActivationPending {
+		t.Fatalf("no email with verification on: activation = %v, want pending", user2.IsActivated)
+	}
+}
+
+// TestBindOAuthByTrustedEmailBindsExisting 信任域名内 verified 邮箱已有账号 → 直接绑定。
+func TestBindOAuthByTrustedEmailBindsExisting(t *testing.T) {
+	conn := setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		AllowedDomains: []string{"tongji.edu.cn"},
+	})
+
+	existing := users.MakeUser("prof-zhang", "password", "zhang@tongji.edu.cn")
+	if err := users.Create(existing); err != nil {
+		t.Fatalf("create existing user: %v", err)
+	}
+
+	user, err := ProcessOAuthCallback(verifiedGithubUser(t, "uid-bind", "prof-zhang", "zhang@tongji.edu.cn"))
+	if err != nil {
+		t.Fatalf("ProcessOAuthCallback() error = %v", err)
+	}
+	if user.Id != existing.Id {
+		t.Fatalf("bound user id = %d, want %d", user.Id, existing.Id)
+	}
+	// OAuth 关联已创建
+	entity := userOAuth.GetByProviderAndUID(ProviderGitHub, "uid-bind")
+	if entity == nil || entity.UserId != existing.Id {
+		t.Fatalf("oauth binding = %+v, want user %d", entity, existing.Id)
+	}
+	// 未创建新账号
+	var count int64
+	conn.Model(&users.EntityComplete{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("user count = %d, want 1 (no duplicate registration)", count)
+	}
+}
+
+// TestBindOAuthByTrustedEmailSkipsUnmatchedDomain 信任域名外 verified 邮箱 → 不绑定，走注册。
+func TestBindOAuthByTrustedEmailSkipsUnmatchedDomain(t *testing.T) {
+	setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		AllowedDomains: []string{"tongji.edu.cn"},
+	})
+
+	existing := users.MakeUser("prof-zhang", "password", "zhang@tongji.edu.cn")
+	if err := users.Create(existing); err != nil {
+		t.Fatalf("create existing user: %v", err)
+	}
+
+	// 同邮箱但域名未命中 → 不绑定
+	user, err := ProcessOAuthCallback(verifiedGithubUser(t, "uid-nobind", "someone", "someone@outlook.com"))
+	if err != nil {
+		t.Fatalf("ProcessOAuthCallback() error = %v", err)
+	}
+	if user.Id == existing.Id {
+		t.Fatalf("unmatched domain should not bind existing user")
+	}
+	if userOAuth.GetByProviderAndUID(ProviderGitHub, "uid-nobind") == nil {
+		t.Fatal("new user oauth binding missing")
+	}
+}
+
+// TestBindOAuthByTrustedEmailRejectsFrozen 冻结账号即使 verified 邮箱命中也不能绑定。
+func TestBindOAuthByTrustedEmailRejectsFrozen(t *testing.T) {
+	setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		AllowedDomains: []string{"tongji.edu.cn"},
+	})
+
+	existing := users.MakeUser("frozen-prof", "password", "frozen@tongji.edu.cn")
+	if err := users.Create(existing); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	existing.IsFrozen = users.StatusFrozen
+	if err := users.Save(existing); err != nil {
+		t.Fatalf("freeze user: %v", err)
+	}
+
+	_, err := ProcessOAuthCallback(verifiedGithubUser(t, "uid-frozen", "frozen-prof", "frozen@tongji.edu.cn"))
+	if err != ErrAccountFrozen {
+		t.Fatalf("ProcessOAuthCallback() error = %v, want ErrAccountFrozen", err)
+	}
+}
+
+// TestFetchGitHubVerifiedEmailParsing 验证 GitHub API 响应解析：取 verified+primary，
+// 无 primary 时取任一 verified。
+func TestFetchGitHubVerifiedEmailParsing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"email": "secondary@tongji.edu.cn", "primary": false, "verified": true},
+			{"email": "primary@tongji.edu.cn", "primary": true, "verified": true},
+			{"email": "unverified@example.com", "primary": false, "verified": false},
+		})
+	}))
+	defer server.Close()
+	oldURL := gitHubEmailAPIURL
+	gitHubEmailAPIURL = server.URL
+	defer func() { gitHubEmailAPIURL = oldURL }()
+
+	if got := fetchGitHubVerifiedEmail("token"); got != "primary@tongji.edu.cn" {
+		t.Fatalf("fetchGitHubVerifiedEmail() = %q, want primary@tongji.edu.cn", got)
+	}
+
+	// 无 primary：取任一 verified
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"email": "only@tongji.edu.cn", "primary": false, "verified": true},
+		})
+	}))
+	defer server2.Close()
+	gitHubEmailAPIURL = server2.URL
+	if got := fetchGitHubVerifiedEmail("token"); got != "only@tongji.edu.cn" {
+		t.Fatalf("fetchGitHubVerifiedEmail() fallback = %q, want only@tongji.edu.cn", got)
+	}
+}
+
+// TestProcessOAuthCallbackNoAccessToken 无 token（非 GitHub provider）降级旧行为：免验证。
+func TestProcessOAuthCallbackNoAccessToken(t *testing.T) {
+	setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: true,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
+
+	// 无 token、无 verified 邮箱的 GitHub 用户：开关开 → pending（不回归：开关关则激活）
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: false,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
+	user, err := ProcessOAuthCallback(goth.User{
+		Provider: ProviderGitHub,
+		UserID:   "uid-notoken",
+		NickName: "notoken",
+	})
+	if err != nil {
+		t.Fatalf("ProcessOAuthCallback() error = %v", err)
+	}
+	if user.IsActivated != users.ActivationSuccess {
+		t.Fatalf("no token + verification off should activate, got %v", user.IsActivated)
+	}
+	if user.Email != "" {
+		t.Fatalf("no verified email should not store email, got %q", user.Email)
+	}
+}


### PR DESCRIPTION
## Summary
按 issue #155 已确认设计实现：把 OAuth 信任从「无条件免验证」收紧为「基于 GitHub 已验证邮箱 + 管理员 allowedDomains 配置」的策略。

### 实现
1. **verified 邮箱获取**：GitHub provider 请求 `user:email` scope；callback 时用 AccessToken 调 `GET /user/emails` 取 `verified && primary` 邮箱（无 primary 取任一 verified）。goth 公开邮箱字段不区分 verified，不作为信任依据。失败/无邮箱降级为「无邮箱」。
2. **绑定**：verified 邮箱命中信任域名（`allowedDomains` 空 = 全信任，与现状一致不回归）且该邮箱已有账号 → 直接建立 `userOAuth` 绑定并登录，不重复注册。冻结（#130 保留）/机器人检查与既有绑定路径一致。
3. **激活策略**：命中信任域名 → `needValid=false` 直接激活；未命中或无 verified 邮箱 → 跟随 `EnableEmailVerification` 开关（默认 false 免验证，不回归），开关开启则 `ActivationPending` + 补发激活邮件（与密码注册一致）。
4. **存储**：verified 邮箱（命中或未命中）存入 `users.email`；无 verified 邮箱降级存 goth 公开邮箱。
5. **oauthController**：移除回调中 `ActivationPending → Success` 的强制翻转，pending 用户须通过激活邮件验证（与密码注册语义一致）。

### 测试（9 个新增，oauthservice 13 个全过）
域名命中自动激活 / 空域名全信任 / 未命中跟随开关（开→pending，关→激活）/ 无邮箱跟随开关 / 信任域名内绑定已有账号（不重复注册）/ 信任域名外不绑定 / 冻结账号拒绝 / GitHub API 解析（verified+primary、fallback、空列表）/ 无 token 降级。

## Validation
- `cd apps/gooseforum && go vet ./...` 通过
- `go test ./...` 通过（93 包）

Closes #155