### PR TITLE
feat(contract): 注册、找回与重置密码接口受控契约（issue #148）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ be changed, but the "Go + Vue in one binary, frontend go:embed into the binary" 
   (`jti` + `user_sessions`) in place. Casdoor is not enabled.
 - Contract: **Partial** — `packages/api-contract/openapi.yaml` is the controlled contract center for
   password login, login public-key retrieval, TOTP login verification and account management, logout,
-  mobile OIDC exchange, session management (list/revoke/revoke-all), and topic writing, with lint/bundle,
-  generated TypeScript types, fixtures, and route-level HTTP tests;
+  mobile OIDC exchange, session management (list/revoke/revoke-all), topic writing, and account
+  registration/password recovery (`/api/register`, `/api/forgot-password`, `/api/reset-password`),
+  with lint/bundle, generated TypeScript types, fixtures, and route-level HTTP tests;
   paths are split per domain under `paths/`; broader route coverage still needs manual or
   annotation-based work.
 - Points: credit (linux-do) phase 2, merchant model, not implemented this phase.

--- a/apps/gooseforum/app/http/routes/contract_account_recovery_test.go
+++ b/apps/gooseforum/app/http/routes/contract_account_recovery_test.go
@@ -1,0 +1,464 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/algorithm"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/api"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/defaultconfig"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userSessions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/tokenservice"
+	"gorm.io/gorm"
+)
+
+// setupAccountRecoveryContractTest 挂载与生产 route4api.go 一致的
+// register/forgot-password/reset-password 路由（含 RateLimit 中间件），
+// 并迁移本域测试需要的表。复用 setupHTTPContractTest 的基础配置
+// （CaptchaRequired=false、EnableSignup=true、限流动作已声明）。
+func setupAccountRecoveryContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
+	t.Helper()
+	conn, router := setupHTTPContractTest(t)
+	if err := conn.AutoMigrate(
+		&taskQueue.Entity{},
+		&rolePermissionRsEntity{},
+		&moderationLogEntity{},
+		&eventNotificationEntity{},
+	); err != nil {
+		t.Fatalf("migrate account recovery contract tables: %v", err)
+	}
+	// 与生产 ratelimit.json 默认值一致的 register/forgot-password/reset-password
+	// 限流规则（基础测试配置只声明了 login/topic.write/totp.*）。
+	configureAccountRecoveryRateLimits(t, conn)
+	router.POST("/api/register", middleware.RateLimit(middleware.RateLimitRegister), api.Register)
+	router.POST("/api/forgot-password", middleware.RateLimit(middleware.RateLimitForgotPassword), UpButterReq(api.ForgotPassword))
+	router.POST("/api/reset-password", middleware.RateLimit(middleware.RateLimitResetPassword), UpButterReq(api.ResetPassword))
+	return conn, router
+}
+
+// 注册成功路径会发布 UserSignUpEvent，事件处理器会触达 role_permission_rs/
+// moderation_log/event_notification 等表；这些表在基础测试里未迁移，这里用
+// 最小结构占位（真实表结构由 AutoMigrate 建出）。
+type rolePermissionRsEntity struct {
+	Id           uint64 `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+	RoleId       uint64 `gorm:"column:role_id;not null;default:0;" json:"roleId"`
+	PermissionId uint64 `gorm:"column:permission_id;not null;default:0;" json:"permissionId"`
+	Effective    int    `gorm:"column:effective;not null;default:0;" json:"effective"`
+}
+
+func (rolePermissionRsEntity) TableName() string { return "role_permission_rs" }
+
+type moderationLogEntity struct {
+	Id uint64 `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+}
+
+func (moderationLogEntity) TableName() string { return "moderation_logs" }
+
+type eventNotificationEntity struct {
+	Id uint64 `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+}
+
+func (eventNotificationEntity) TableName() string { return "event_notifications" }
+
+// serveAccountRecoveryJSON 发起 JSON 请求并返回 recorder。
+func serveAccountRecoveryJSON(router http.Handler, path, body string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+// assertRegisterResponseCode 断言注册响应与 fixture 对齐（HTTP 200 业务信封）。
+func assertRegisterResponseCode(t *testing.T, recorder *httptest.ResponseRecorder, fixtureName string) contractEnvelope {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("register status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	response := decodeContractEnvelope(t, recorder)
+	assertFixtureEnvelope(t, response, contractFixture(t, fixtureName))
+	return response
+}
+
+// cleanAccountRecoveryTables 清理本测试域写入的行，避免共享 in-memory DB 跨用例污染。
+func cleanAccountRecoveryTables(t *testing.T, conn *gorm.DB) {
+	t.Helper()
+	conn.Unscoped().Where("1 = 1").Delete(&taskQueue.Entity{})
+	conn.Unscoped().Where("1 = 1").Delete(&userSessions.Entity{})
+	conn.Unscoped().Where("1 = 1").Delete(&users.EntityComplete{})
+}
+
+// createRecoveryUser 创建一个已激活的普通用户。
+func createRecoveryUser(t *testing.T, conn *gorm.DB, id uint64, username, email string) *users.EntityComplete {
+	t.Helper()
+	user := users.MakeUser(username, "secret123", email)
+	user.Id = id
+	user.IsActivated = users.ActivationSuccess
+	user.CreatedAt = time.Now().Add(-48 * time.Hour)
+	if err := conn.Create(user).Error; err != nil {
+		t.Fatalf("create recovery user: %v", err)
+	}
+	return user
+}
+
+// TestRegisterHTTPContractSuccess 验证注册成功路径：HTTP 200 +
+// auth.login.success 信封 + New-Token 会话头 + Set-Cookie，并确认用户行已创建。
+func TestRegisterHTTPContractSuccess(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+
+	body := `{"email":"newuser@example.com","userName":"brandnewuser","passWord":"password123"}`
+	recorder := serveAccountRecoveryJSON(router, "/api/register", body)
+	response := assertRegisterResponseCode(t, recorder, "register-success.json")
+	if string(response.Result) != `"登录成功"` {
+		t.Fatalf("register result = %s, want login success message", response.Result)
+	}
+	if recorder.Header().Get("New-Token") == "" {
+		t.Fatal("register response missing New-Token header")
+	}
+	if !strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token=") {
+		t.Fatal("register response missing access_token session cookie")
+	}
+	if !users.ExistUsername("brandnewuser") {
+		t.Fatal("register must create the user row")
+	}
+}
+
+// TestRegisterHTTPContractEnumerationIdentical 固定注册反枚举不变量：
+// 用户名占用与邮箱占用两种失败的响应体必须逐字节一致（auth.register.failed）。
+func TestRegisterHTTPContractEnumerationIdentical(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+	createRecoveryUser(t, conn, 9001, "occupieduser", "occupied@example.com")
+
+	recUsername := serveAccountRecoveryJSON(router, "/api/register",
+		`{"email":"fresh@example.com","userName":"occupieduser","passWord":"password123"}`)
+	recEmail := serveAccountRecoveryJSON(router, "/api/register",
+		`{"email":"occupied@example.com","userName":"freshuser1","passWord":"password123"}`)
+
+	if recUsername.Code != http.StatusOK || recEmail.Code != http.StatusOK {
+		t.Fatalf("enumeration probes must stay HTTP 200: %d / %d", recUsername.Code, recEmail.Code)
+	}
+	if recUsername.Body.String() != recEmail.Body.String() {
+		t.Fatalf("register enumeration responses differ:\nusername-occupied: %s\nemail-occupied:     %s",
+			recUsername.Body.String(), recEmail.Body.String())
+	}
+	resUsername := decodeContractEnvelope(t, recUsername)
+	assertFixtureEnvelope(t, resUsername, contractFixture(t, "register-failed.json"))
+}
+
+// TestRegisterHTTPContractHoneypotSilentRejects 验证注册蜜罐：website 非空时
+// 返回与成功一致的 auth.login.success 信封，但绝不创建用户行。
+func TestRegisterHTTPContractHoneypotSilentRejects(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+
+	body := `{"email":"bot@example.com","userName":"botuser","passWord":"password123","website":"http://spam.example"}`
+	recorder := serveAccountRecoveryJSON(router, "/api/register", body)
+	assertRegisterResponseCode(t, recorder, "register-success.json")
+	if users.ExistUsername("botuser") || users.ExistEmail("bot@example.com") {
+		t.Fatal("honeypot register must not create a user row")
+	}
+}
+
+// TestRegisterHTTPContractSignupDisabled 验证注册开关关闭时返回 auth.signupDisabled。
+func TestRegisterHTTPContractSignupDisabled(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+
+	persistAccountRecoverySecurity(t, conn, false, false)
+
+	body := `{"email":"newuser@example.com","userName":"brandnewuser","passWord":"password123"}`
+	recorder := serveAccountRecoveryJSON(router, "/api/register", body)
+	assertRegisterResponseCode(t, recorder, "register-signup-disabled.json")
+}
+
+// TestRegisterHTTPContractRateLimit 验证注册限流：默认 20 次/小时/IP，
+// 第 21 次返回 429 + Retry-After + common.rateLimited。
+// 注意：前 20 次中首次请求会真实创建 rateuser 用户行，必须在 cleanup 中删除，
+// 否则残留行（SQLite AUTOINCREMENT 会让其 id 顺延到 9002）会与后续
+// createRecoveryUser(9002) 的显式主键冲突。
+func TestRegisterHTTPContractRateLimit(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+	body := `{"email":"rate@example.com","userName":"rateuser","passWord":"password123"}`
+	var recorder *httptest.ResponseRecorder
+	for attempt := 0; attempt < 20; attempt++ {
+		recorder = serveAccountRecoveryJSON(router, "/api/register", body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("attempt %d status = %d, want 200: %s", attempt+1, recorder.Code, recorder.Body.String())
+		}
+	}
+	recorder = serveAccountRecoveryJSON(router, "/api/register", body)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("rate limited status = %d, want 429", recorder.Code)
+	}
+	response := decodeContractEnvelope(t, recorder)
+	assertFixtureEnvelope(t, response, contractFixture(t, "register-rate-limited.json"))
+	assertRetryAfter(t, recorder, response, middleware.RateLimitRegister)
+}
+
+// TestForgotPasswordHTTPContractIndistinguishable 固定找回密码反枚举不变量：
+// 未知邮箱与已注册邮箱返回逐字节一致的 auth.passwordReset.mailQueued 成功信封。
+func TestForgotPasswordHTTPContractIndistinguishable(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+	withRouteTestSigningKey(t, "route-test-signing-key-forgot")
+	createRecoveryUser(t, conn, 9002, "knownuser", "knownuser@example.com")
+
+	recUnknown := serveAccountRecoveryJSON(router, "/api/forgot-password", `{"email":"nobody@example.com"}`)
+	recKnown := serveAccountRecoveryJSON(router, "/api/forgot-password", `{"email":"knownuser@example.com"}`)
+
+	if recUnknown.Code != http.StatusOK || recKnown.Code != http.StatusOK {
+		t.Fatalf("forgot-password probes must stay HTTP 200: %d / %d", recUnknown.Code, recKnown.Code)
+	}
+	if recUnknown.Body.String() != recKnown.Body.String() {
+		t.Fatalf("forgot-password responses differ between known/unknown email:\nunknown: %s\nknown:   %s",
+			recUnknown.Body.String(), recKnown.Body.String())
+	}
+	assertFixtureEnvelope(t, decodeContractEnvelope(t, recUnknown), contractFixture(t, "forgot-password-mail-queued.json"))
+}
+
+// TestForgotPasswordHTTPContractHoneypotSilentRejects 验证找回密码蜜罐：
+// website 非空时返回成功信封但绝不入队任何重置邮件任务。
+func TestForgotPasswordHTTPContractHoneypotSilentRejects(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+	withRouteTestSigningKey(t, "route-test-signing-key-forgot-hp")
+
+	recorder := serveAccountRecoveryJSON(router, "/api/forgot-password",
+		`{"email":"existing@example.com","website":"http://spam.example"}`)
+	assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "forgot-password-mail-queued.json"))
+
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "email.reset_password").Count(&count).Error; err != nil {
+		t.Fatalf("count reset mail tasks: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("honeypot forgot-password must not enqueue a reset mail (count = %d)", count)
+	}
+}
+
+// TestForgotPasswordHTTPContractRateLimit 验证找回密码限流：默认 10 次/小时/IP。
+func TestForgotPasswordHTTPContractRateLimit(t *testing.T) {
+	_, router := setupAccountRecoveryContractTest(t)
+	body := `{"email":"nobody@example.com"}`
+	var recorder *httptest.ResponseRecorder
+	for attempt := 0; attempt < 10; attempt++ {
+		recorder = serveAccountRecoveryJSON(router, "/api/forgot-password", body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("attempt %d status = %d, want 200: %s", attempt+1, recorder.Code, recorder.Body.String())
+		}
+	}
+	recorder = serveAccountRecoveryJSON(router, "/api/forgot-password", body)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("rate limited status = %d, want 429", recorder.Code)
+	}
+	response := decodeContractEnvelope(t, recorder)
+	assertFixtureEnvelope(t, response, contractFixture(t, "forgot-password-rate-limited.json"))
+	assertRetryAfter(t, recorder, response, middleware.RateLimitForgotPassword)
+}
+
+// TestResetPasswordHTTPContractLifecycle 覆盖重置密码 token 生命周期：
+// 有效 token 成功、旧 token 重放被拒（token_version 绑定）、无效 token 被拒、
+// 密码校验失败。
+func TestResetPasswordHTTPContractLifecycle(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+	withRouteTestSigningKey(t, "route-test-signing-key-reset")
+
+	user := createRecoveryUser(t, conn, 9003, "resetuser", "resetuser@example.com")
+	user0, err := users.Get(user.Id)
+	if err != nil {
+		t.Fatalf("get user before reset: %v", err)
+	}
+	token, err := tokenservice.GeneratePasswordResetToken(user.Id, "resetuser@example.com", user0.TokenVersion)
+	if err != nil {
+		t.Fatalf("generate reset token: %v", err)
+	}
+
+	t.Run("valid token resets password and consumes the token", func(t *testing.T) {
+		body := fmt.Sprintf(`{"token":%q,"newPassword":"brand-new-password-1"}`, token)
+		recorder := serveAccountRecoveryJSON(router, "/api/reset-password", body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("reset status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "reset-password-success.json"))
+
+		userAfter, err := users.Get(user.Id)
+		if err != nil {
+			t.Fatalf("get user after reset: %v", err)
+		}
+		if userAfter.TokenVersion != user0.TokenVersion+1 {
+			t.Fatalf("token_version after reset = %d, want %d", userAfter.TokenVersion, user0.TokenVersion+1)
+		}
+		if err := algorithm.VerifyEncryptPassword(userAfter.Password, "brand-new-password-1"); err != nil {
+			t.Fatalf("password must be the new one after reset: %v", err)
+		}
+	})
+
+	t.Run("replayed old token is rejected", func(t *testing.T) {
+		body := fmt.Sprintf(`{"token":%q,"newPassword":"replay-password-2"}`, token)
+		recorder := serveAccountRecoveryJSON(router, "/api/reset-password", body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("replay status = %d, want 200 (business failure)", recorder.Code)
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "reset-password-token-invalid.json"))
+
+		userAfter, err := users.Get(user.Id)
+		if err != nil {
+			t.Fatalf("get user after replay: %v", err)
+		}
+		if err := algorithm.VerifyEncryptPassword(userAfter.Password, "replay-password-2"); err == nil {
+			t.Fatal("password must NOT be changed via replayed reset token")
+		}
+	})
+
+	t.Run("garbage token is rejected", func(t *testing.T) {
+		recorder := serveAccountRecoveryJSON(router, "/api/reset-password",
+			`{"token":"not-a-real-token","newPassword":"password123"}`)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("garbage token status = %d, want 200 (business failure)", recorder.Code)
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "reset-password-token-invalid.json"))
+	})
+
+	t.Run("weak new password is rejected", func(t *testing.T) {
+		userCurrent, err := users.Get(user.Id)
+		if err != nil {
+			t.Fatalf("get user for weak password: %v", err)
+		}
+		weakToken, err := tokenservice.GeneratePasswordResetToken(user.Id, "resetuser@example.com", userCurrent.TokenVersion)
+		if err != nil {
+			t.Fatalf("generate weak-password token: %v", err)
+		}
+		body := fmt.Sprintf(`{"token":%q,"newPassword":"short"}`, weakToken)
+		recorder := serveAccountRecoveryJSON(router, "/api/reset-password", body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("weak password status = %d, want 200 (business failure)", recorder.Code)
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "reset-password-password-invalid.json"))
+	})
+}
+
+// TestResetPasswordHTTPContractFrozenAccount 验证冻结账号：token 有效但账号
+// 冻结时返回 permission.userFrozen（params.action/actionCode），且不消耗 token。
+func TestResetPasswordHTTPContractFrozenAccount(t *testing.T) {
+	conn, router := setupAccountRecoveryContractTest(t)
+	t.Cleanup(func() { cleanAccountRecoveryTables(t, conn) })
+	withRouteTestSigningKey(t, "route-test-signing-key-reset-frozen")
+
+	user := createRecoveryUser(t, conn, 9004, "frozenuser", "frozenuser@example.com")
+	user0, err := users.Get(user.Id)
+	if err != nil {
+		t.Fatalf("get user before freeze: %v", err)
+	}
+	if err := conn.Model(user).Update("is_frozen", users.StatusFrozen).Error; err != nil {
+		t.Fatalf("freeze user: %v", err)
+	}
+	token, err := tokenservice.GeneratePasswordResetToken(user.Id, "frozenuser@example.com", user0.TokenVersion)
+	if err != nil {
+		t.Fatalf("generate reset token: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"token":%q,"newPassword":"password123"}`, token)
+	recorder := serveAccountRecoveryJSON(router, "/api/reset-password", body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("frozen reset status = %d, want 200 (business failure)", recorder.Code)
+	}
+	assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "reset-password-account-frozen.json"))
+
+	userAfter, err := users.Get(user.Id)
+	if err != nil {
+		t.Fatalf("get user after frozen reset: %v", err)
+	}
+	if userAfter.TokenVersion != user0.TokenVersion {
+		t.Fatalf("frozen reset must not consume the token (token_version = %d, want %d)", userAfter.TokenVersion, user0.TokenVersion)
+	}
+	if err := algorithm.VerifyEncryptPassword(userAfter.Password, "secret123"); err != nil {
+		t.Fatal("frozen reset must not change the password")
+	}
+}
+
+// TestResetPasswordHTTPContractRateLimit 验证重置密码限流：默认 10 次/小时/IP。
+func TestResetPasswordHTTPContractRateLimit(t *testing.T) {
+	_, router := setupAccountRecoveryContractTest(t)
+	body := `{"token":"not-a-real-token","newPassword":"password123"}`
+	var recorder *httptest.ResponseRecorder
+	for attempt := 0; attempt < 10; attempt++ {
+		recorder = serveAccountRecoveryJSON(router, "/api/reset-password", body)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("attempt %d status = %d, want 200: %s", attempt+1, recorder.Code, recorder.Body.String())
+		}
+	}
+	recorder = serveAccountRecoveryJSON(router, "/api/reset-password", body)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("rate limited status = %d, want 429", recorder.Code)
+	}
+	response := decodeContractEnvelope(t, recorder)
+	assertFixtureEnvelope(t, response, contractFixture(t, "reset-password-rate-limited.json"))
+	assertRetryAfter(t, recorder, response, middleware.RateLimitResetPassword)
+}
+
+// configureAccountRecoveryRateLimits 在基础测试限流配置之上追加
+// register/forgot-password/reset-password 规则（窗口 3600s，配额与生产
+// ratelimit.json 默认一致：register 20/IP，forgot/reset 10/IP）。
+// 基础测试的 configureHTTPContractTestSettings 已保存旧配置并在 cleanup 恢复，
+// 这里只持久化增量规则即可。
+func configureAccountRecoveryRateLimits(t *testing.T, conn *gorm.DB) {
+	t.Helper()
+	rateLimit := defaultconfig.GetDefaultRateLimitConfig()
+	rateLimit.Enabled = true
+	persistHTTPContractConfig(t, conn, pageConfig.RateLimitSettings, rateLimit)
+	hotdataserve.ClearRateLimitConfigCache()
+}
+
+// persistAccountRecoverySecurity 持久化一份安全配置（注册开关/邮箱验证），
+// 与 configureHTTPContractTestSettings 同款写法。保存旧值并在 cleanup 恢复，
+// 避免测试在共享 in-memory DB 中永久改掉注册开关。
+func persistAccountRecoverySecurity(t *testing.T, conn *gorm.DB, enableSignup, enableEmailVerification bool) {
+	t.Helper()
+	var previous *pageConfig.Entity
+	var entity pageConfig.Entity
+	result := conn.Where("page_type = ?", pageConfig.SecuritySettings).First(&entity)
+	if result.Error == nil {
+		copy := entity
+		previous = &copy
+	} else if result.Error != nil && result.Error != gorm.ErrRecordNotFound {
+		t.Fatalf("read existing security config: %v", result.Error)
+	}
+	t.Cleanup(func() {
+		if previous != nil {
+			if err := conn.Save(previous).Error; err != nil {
+				t.Errorf("restore security config: %v", err)
+			}
+		} else if err := conn.Where("page_type = ?", pageConfig.SecuritySettings).Delete(&pageConfig.Entity{}).Error; err != nil {
+			t.Errorf("delete test security config: %v", err)
+		}
+		hotdataserve.ClearSecuritySettingsConfigCache()
+	})
+
+	security := defaultRecoverySecurity()
+	security.EnableSignup = enableSignup
+	security.EnableEmailVerification = enableEmailVerification
+	persistHTTPContractConfig(t, conn, pageConfig.SecuritySettings, security)
+	hotdataserve.ClearSecuritySettingsConfigCache()
+}
+
+func defaultRecoverySecurity() pageConfig.SecurityAndRegistration {
+	return pageConfig.SecurityAndRegistration{
+		EnableSignup:            true,
+		EnableEmailVerification: false,
+		CaptchaRequired:         false,
+	}
+}

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -68,6 +68,124 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create a new forum account
+         * @description Public account registration. The request is validated in the same order as the
+         *     server: JSON shape, then generic request validation, then the signup switch, the
+         *     honeypot field, email domain allowlist, username format/moderation, password
+         *     complexity, and finally the captcha gate (when the site requires captcha).
+         *
+         *     Account-enumeration hardening (CWE-208): a username or email that is already
+         *     taken returns the same generic `auth.register.failed` failure envelope as every
+         *     other registration failure. Neither the HTTP status, the envelope, `messageCode`,
+         *     response fields, nor the rate-limit protocol distinguishes "username exists" from
+         *     "email exists" from any other failure. The server unconditionally runs both
+         *     existence lookups so the query count does not vary with account state.
+         *
+         *     Honeypot: when the hidden `website` field is populated the server treats the
+         *     request as bot traffic, silently returns a success envelope identical to a normal
+         *     successful registration, and creates no account.
+         *
+         *     On success the server creates the account, enqueues an activation email task when
+         *     the site enables email verification, and immediately issues a session (Set-Cookie
+         *     `access_token` + `New-Token` header). Consumers must still inspect the envelope:
+         *     the residual observable difference between "account created" and "creation
+         *     failed" is intrinsic to the protocol and is not part of this contract's failure
+         *     taxonomy.
+         *
+         *     The endpoint is IP rate limited (HTTP 429 + `Retry-After`); the default quota is
+         *     20 requests per hour per IP.
+         */
+        post: operations["register"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/forgot-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Request a password reset email
+         * @description Public password-reset request. The server never reveals whether an email is
+         *     registered: an unknown email, a bot (Agent) account, and an account inside the
+         *     24-hour email-change cooldown all return the exact same success envelope
+         *     (`auth.passwordReset.mailQueued`) and run the same class of work (token signing
+         *     plus a queue write; unknown/cooldown paths enqueue a noop task that is silently
+         *     consumed by the mail worker without sending anything). Mail delivery itself is a
+         *     server-side implementation detail and never exposes account state.
+         *
+         *     Honeypot: when the hidden `website` field is populated the request is treated as
+         *     bot traffic and silently returns the same success envelope without enqueuing any
+         *     reset mail.
+         *
+         *     The captcha gate (when the site requires captcha) is the only failure that
+         *     differs, and it does not depend on account state.
+         *
+         *     The endpoint is IP rate limited (HTTP 429 + `Retry-After`); the default quota is
+         *     10 requests per hour per IP.
+         */
+        post: operations["forgotPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/reset-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set a new password with a reset token
+         * @description Completes the password reset with the token received by email. The token is a
+         *     short-lived (30-minute) HMAC-signed JWT bound to the user id, the email it was
+         *     issued for, and the token_version at issuance time.
+         *
+         *     Invalid, expired, or replayed tokens are rejected with the same
+         *     `auth.passwordReset.tokenInvalid` failure envelope: the token check fails for a
+         *     bad signature, an expired token, a bot account, a mismatched email, and a
+         *     token_version that no longer matches the account (any password change or revoke
+         *     bumps token_version, so an old reset link can never be replayed after a
+         *     successful reset). Frozen accounts are rejected with `permission.userFrozen` and
+         *     `params.action`/`params.actionCode` without consuming the token. The new password
+         *     must pass the same complexity rules as registration (minimum 6 characters,
+         *     contains letters and digits, at most 64 characters).
+         *
+         *     On success the password hash and token_version are updated; the reset token
+         *     becomes permanently unusable.
+         *
+         *     The endpoint is IP rate limited (HTTP 429 + `Retry-After`); the default quota is
+         *     10 requests per hour per IP.
+         */
+        post: operations["resetPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/totp/verify": {
         parameters: {
             query?: never;
@@ -625,6 +743,93 @@ export interface components {
                 [key: string]: unknown;
             };
         };
+        /**
+         * @description Client-side strict request shape for POST /api/register. The server binds the body
+         *     loosely and silently ignores unknown fields; `additionalProperties: false` is a
+         *     consumer constraint, not a server rejection. Field names use the legacy
+         *     `userName`/`passWord` casing and must not be normalized client-side.
+         */
+        RegisterRequest: {
+            /**
+             * Format: email
+             * @description Email address; the server lowercases and trims it before validation and applies the site email-domain allowlist when configured.
+             */
+            email: string;
+            /** @description Username, 6-32 characters of letters, digits, `_` or `-` (server regex `^[a-zA-Z0-9_-]{6,32}$`); the server trims surrounding whitespace. */
+            userName: string;
+            /** @description Password, 6-64 characters, must contain both letters and digits. */
+            passWord: string;
+            /** @description Optional BCP-47 style locale hint; normalized server-side. */
+            locale?: string;
+            /** @description Optional invitation code; currently accepted but not enforced by the server. */
+            invitationCode?: string;
+            /** @description Captcha id from GET /api/get-captcha; required only when the site requires captcha. */
+            captchaId?: string;
+            /** @description Captcha answer for `captchaId`; required only when the site requires captcha. */
+            captchaCode?: string;
+            /** @description Compatibility honeypot field. Normal clients must not render or submit it; any non-blank value is treated as bot traffic and silently accepted without creating an account. */
+            website?: string;
+        };
+        RegisterSuccess: components["schemas"]["ApiSuccess"] & {
+            /** @description Human-readable success message. The wording is UI copy and not a stable machine contract value; clients must branch on `messageCode`. */
+            result: string;
+            /**
+             * @description `auth.login.success` when the account is created and a session is issued
+             *     immediately (email verification disabled); `auth.register.emailVerify` when
+             *     the site requires email verification before the session is usable. The
+             *     honeypot path returns the same `auth.login.success` envelope without
+             *     creating an account.
+             * @enum {string}
+             */
+            messageCode: "auth.login.success" | "auth.register.emailVerify";
+        };
+        RegisterResponse: components["schemas"]["RegisterSuccess"] | components["schemas"]["ApiFailure"];
+        /**
+         * @description Client-side strict request shape for POST /api/forgot-password. The server binds
+         *     the body loosely and silently ignores unknown fields; `additionalProperties: false`
+         *     is a consumer constraint, not a server rejection.
+         */
+        ForgotPasswordRequest: {
+            /**
+             * Format: email
+             * @description Email address to send the reset link to. The response never reveals whether this email is registered.
+             */
+            email: string;
+            /** @description Captcha id from GET /api/get-captcha; required only when the site requires captcha. */
+            captchaId?: string;
+            /** @description Captcha answer for `captchaId`; required only when the site requires captcha. */
+            captchaCode?: string;
+            /** @description Compatibility honeypot field. Normal clients must not render or submit it; any non-blank value is treated as bot traffic and silently accepted without enqueuing any mail. */
+            website?: string;
+        };
+        ForgotPasswordSuccess: components["schemas"]["ApiSuccess"] & {
+            /** @description Human-readable confirmation message; the wording is UI copy and not a stable machine contract value. */
+            result: string;
+            /**
+             * @description Returned identically for registered, unknown, bot, and email-change-cooldown addresses (anti-enumeration).
+             * @constant
+             */
+            messageCode: "auth.passwordReset.mailQueued";
+        };
+        ForgotPasswordResponse: components["schemas"]["ForgotPasswordSuccess"] | components["schemas"]["ApiFailure"];
+        /**
+         * @description Client-side strict request shape for POST /api/reset-password. The server binds
+         *     the body loosely and silently ignores unknown fields; `additionalProperties: false`
+         *     is a consumer constraint, not a server rejection.
+         */
+        ResetPasswordRequest: {
+            /** @description Reset token from the password reset email (30-minute lifetime). */
+            token: string;
+            /** @description New password, 6-64 characters, must contain both letters and digits. */
+            newPassword: string;
+        };
+        ResetPasswordSuccess: components["schemas"]["ApiSuccess"] & {
+            /** @description Human-readable confirmation message; the wording is UI copy and not a stable machine contract value. */
+            result: string;
+            /** @constant */
+            messageCode: "auth.passwordReset.success";
+        };
+        ResetPasswordResponse: components["schemas"]["ResetPasswordSuccess"] | components["schemas"]["ApiFailure"];
         LoginRequest: {
             /** @description Username or email address. Leading and trailing whitespace is ignored by the server. */
             username: string;
@@ -1253,6 +1458,112 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LogoutResponse"];
+                };
+            };
+        };
+    };
+    register: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Registration succeeded (with an auto-issued session), or a legacy business failure envelope. */
+            200: {
+                headers: {
+                    /** @description On success, HTTP-only `access_token` session cookie. */
+                    "Set-Cookie"?: string;
+                    /** @description On success, the newly issued forum session JWT. */
+                    "New-Token"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RegisterResponse"];
+                };
+            };
+            /** @description Register rate limit exceeded (default 20 requests/hour/IP). */
+            429: {
+                headers: {
+                    "Retry-After": number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitedFailure"];
+                };
+            };
+        };
+    };
+    forgotPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ForgotPasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Request accepted, or a legacy business failure envelope. The same success envelope is returned for registered, unknown, bot, and cooldown emails. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForgotPasswordResponse"];
+                };
+            };
+            /** @description Forgot-password rate limit exceeded (default 10 requests/hour/IP). */
+            429: {
+                headers: {
+                    "Retry-After": number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitedFailure"];
+                };
+            };
+        };
+    };
+    resetPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ResetPasswordRequest"];
+            };
+        };
+        responses: {
+            /** @description Password reset succeeded, or a legacy business failure envelope. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResetPasswordResponse"];
+                };
+            };
+            /** @description Reset-password rate limit exceeded (default 10 requests/hour/IP). */
+            429: {
+                headers: {
+                    "Retry-After": number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitedFailure"];
                 };
             };
         };

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -84,12 +84,20 @@ export interface paths {
          *     honeypot field, email domain allowlist, username format/moderation, password
          *     complexity, and finally the captcha gate (when the site requires captcha).
          *
-         *     Account-enumeration hardening (CWE-208): a username or email that is already
-         *     taken returns the same generic `auth.register.failed` failure envelope as every
-         *     other registration failure. Neither the HTTP status, the envelope, `messageCode`,
-         *     response fields, nor the rate-limit protocol distinguishes "username exists" from
-         *     "email exists" from any other failure. The server unconditionally runs both
-         *     existence lookups so the query count does not vary with account state.
+         *     Account-enumeration hardening (CWE-208): when a username or an email is already
+         *     taken, the endpoint returns the same generic `auth.register.failed` failure
+         *     envelope as when account creation itself fails, and the two occupied cases are
+         *     indistinguishable from each other. Neither the HTTP status, the envelope,
+         *     `messageCode`, response fields, nor the rate-limit protocol distinguishes
+         *     "username exists" from "email exists" from "creation failed". The server
+         *     unconditionally runs both existence lookups so the query count does not vary
+         *     with account state.
+         *
+         *     This guarantee is scoped to the occupied/creation-failed cases only: requests
+         *     that fail validation before the existence checks (invalid username format,
+         *     disallowed email domain, weak password, captcha rejection, signup disabled)
+         *     return their own distinct `messageCode` per the validation-order list above,
+         *     and are intentionally not covered by the anti-enumeration envelope.
          *
          *     Honeypot: when the hidden `website` field is populated the server treats the
          *     request as bot traffic, silently returns a success envelope identical to a normal

--- a/apps/mobile/packages/core/test/contract_fixtures_test.dart
+++ b/apps/mobile/packages/core/test/contract_fixtures_test.dart
@@ -500,6 +500,63 @@ void main() {
     });
   });
 
+  group('账号注册与找回密码受控契约', () {
+    test('解析注册成功 fixture（自动登录，带会话）', () {
+      final response = GfResponse<String>.fromJson(
+        _contractFixture('register-success.json'),
+        (json) => json as String,
+      );
+
+      expect(response.isSuccess, isTrue);
+      expect(response.result, '登录成功');
+      expect(response.messageCode, 'auth.login.success');
+    });
+
+    test('解析注册业务失败 fixture（result 为 null）', () {
+      final response = GfResponse<Object?>.fromJson(
+        _contractFixture('register-failed.json'),
+        (json) => json,
+      );
+
+      expect(response.isSuccess, isFalse);
+      expect(response.messageCode, 'auth.register.failed');
+      expect(response.result, isNull);
+    });
+
+    test('解析找回密码成功 fixture（防枚举统一消息）', () {
+      final response = GfResponse<String>.fromJson(
+        _contractFixture('forgot-password-mail-queued.json'),
+        (json) => json as String,
+      );
+
+      expect(response.isSuccess, isTrue);
+      expect(response.result, contains('密码重置邮件'));
+      expect(response.messageCode, 'auth.passwordReset.mailQueued');
+    });
+
+    test('解析重置密码成功 fixture', () {
+      final response = GfResponse<String>.fromJson(
+        _contractFixture('reset-password-success.json'),
+        (json) => json as String,
+      );
+
+      expect(response.isSuccess, isTrue);
+      expect(response.result, '密码重置成功');
+      expect(response.messageCode, 'auth.passwordReset.success');
+    });
+
+    test('解析重置密码 token 失效 fixture（result 为 null 不抛 TypeError）', () {
+      final response = GfResponse<Object?>.fromJson(
+        _contractFixture('reset-password-token-invalid.json'),
+        (json) => json,
+      );
+
+      expect(response.isSuccess, isFalse);
+      expect(response.messageCode, 'auth.passwordReset.tokenInvalid');
+      expect(response.result, isNull);
+    });
+  });
+
   group('GfResponse 响应包装', () {
     test('code == 0 成功', () {
       final response = GfResponse<int>.fromJson({

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -1216,3 +1216,145 @@ ReportHandlerPayload:
       type: string
   additionalProperties: false
   description: Report handler payload. Unlike TopicAuthorPayload the id may be 0 for open reports.
+
+RegisterRequest:
+  type: object
+  description: |
+    Client-side strict request shape for POST /api/register. The server binds the body
+    loosely and silently ignores unknown fields; `additionalProperties: false` is a
+    consumer constraint, not a server rejection. Field names use the legacy
+    `userName`/`passWord` casing and must not be normalized client-side.
+  required: [email, userName, passWord]
+  properties:
+    email:
+      type: string
+      minLength: 1
+      format: email
+      description: Email address; the server lowercases and trims it before validation and applies the site email-domain allowlist when configured.
+    userName:
+      type: string
+      minLength: 1
+      description: Username, 6-32 characters of letters, digits, `_` or `-` (server regex `^[a-zA-Z0-9_-]{6,32}$`); the server trims surrounding whitespace.
+    passWord:
+      type: string
+      minLength: 1
+      description: Password, 6-64 characters, must contain both letters and digits.
+    locale:
+      type: string
+      description: Optional BCP-47 style locale hint; normalized server-side.
+    invitationCode:
+      type: string
+      description: Optional invitation code; currently accepted but not enforced by the server.
+    captchaId:
+      type: string
+      description: Captcha id from GET /api/get-captcha; required only when the site requires captcha.
+    captchaCode:
+      type: string
+      description: Captcha answer for `captchaId`; required only when the site requires captcha.
+    website:
+      type: string
+      description: Compatibility honeypot field. Normal clients must not render or submit it; any non-blank value is treated as bot traffic and silently accepted without creating an account.
+  additionalProperties: false
+
+RegisterSuccess:
+  allOf:
+    - $ref: '#/ApiSuccess'
+    - type: object
+      required: [result, messageCode]
+      properties:
+        result:
+          type: string
+          description: Human-readable success message. The wording is UI copy and not a stable machine contract value; clients must branch on `messageCode`.
+        messageCode:
+          type: string
+          enum: [auth.login.success, auth.register.emailVerify]
+          description: |
+            `auth.login.success` when the account is created and a session is issued
+            immediately (email verification disabled); `auth.register.emailVerify` when
+            the site requires email verification before the session is usable. The
+            honeypot path returns the same `auth.login.success` envelope without
+            creating an account.
+
+RegisterResponse:
+  oneOf:
+    - $ref: '#/RegisterSuccess'
+    - $ref: '#/ApiFailure'
+
+ForgotPasswordRequest:
+  type: object
+  description: |
+    Client-side strict request shape for POST /api/forgot-password. The server binds
+    the body loosely and silently ignores unknown fields; `additionalProperties: false`
+    is a consumer constraint, not a server rejection.
+  required: [email]
+  properties:
+    email:
+      type: string
+      minLength: 1
+      format: email
+      description: Email address to send the reset link to. The response never reveals whether this email is registered.
+    captchaId:
+      type: string
+      description: Captcha id from GET /api/get-captcha; required only when the site requires captcha.
+    captchaCode:
+      type: string
+      description: Captcha answer for `captchaId`; required only when the site requires captcha.
+    website:
+      type: string
+      description: Compatibility honeypot field. Normal clients must not render or submit it; any non-blank value is treated as bot traffic and silently accepted without enqueuing any mail.
+  additionalProperties: false
+
+ForgotPasswordSuccess:
+  allOf:
+    - $ref: '#/ApiSuccess'
+    - type: object
+      required: [result, messageCode]
+      properties:
+        result:
+          type: string
+          description: Human-readable confirmation message; the wording is UI copy and not a stable machine contract value.
+        messageCode:
+          type: string
+          const: auth.passwordReset.mailQueued
+          description: Returned identically for registered, unknown, bot, and email-change-cooldown addresses (anti-enumeration).
+
+ForgotPasswordResponse:
+  oneOf:
+    - $ref: '#/ForgotPasswordSuccess'
+    - $ref: '#/ApiFailure'
+
+ResetPasswordRequest:
+  type: object
+  description: |
+    Client-side strict request shape for POST /api/reset-password. The server binds
+    the body loosely and silently ignores unknown fields; `additionalProperties: false`
+    is a consumer constraint, not a server rejection.
+  required: [token, newPassword]
+  properties:
+    token:
+      type: string
+      minLength: 1
+      description: Reset token from the password reset email (30-minute lifetime).
+    newPassword:
+      type: string
+      minLength: 1
+      description: New password, 6-64 characters, must contain both letters and digits.
+  additionalProperties: false
+
+ResetPasswordSuccess:
+  allOf:
+    - $ref: '#/ApiSuccess'
+    - type: object
+      required: [result, messageCode]
+      properties:
+        result:
+          type: string
+          description: Human-readable confirmation message; the wording is UI copy and not a stable machine contract value.
+        messageCode:
+          type: string
+          const: auth.passwordReset.success
+
+ResetPasswordResponse:
+  oneOf:
+    - $ref: '#/ResetPasswordSuccess'
+    - $ref: '#/ApiFailure'

--- a/packages/api-contract/fixtures/forgot-password-captcha-required.json
+++ b/packages/api-contract/fixtures/forgot-password-captcha-required.json
@@ -1,0 +1,8 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "common.captchaRequired",
+  "params": {
+    "action": "forgot-password"
+  }
+}

--- a/packages/api-contract/fixtures/forgot-password-mail-queued.json
+++ b/packages/api-contract/fixtures/forgot-password-mail-queued.json
@@ -1,0 +1,5 @@
+{
+  "result": "操作成功：如果该邮箱已注册，您将收到密码重置邮件",
+  "code": 0,
+  "messageCode": "auth.passwordReset.mailQueued"
+}

--- a/packages/api-contract/fixtures/forgot-password-rate-limited.json
+++ b/packages/api-contract/fixtures/forgot-password-rate-limited.json
@@ -1,0 +1,9 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "common.rateLimited",
+  "params": {
+    "action": "forgot-password",
+    "retryAfterSeconds": 30
+  }
+}

--- a/packages/api-contract/fixtures/register-captcha-required.json
+++ b/packages/api-contract/fixtures/register-captcha-required.json
@@ -1,0 +1,8 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "common.captchaRequired",
+  "params": {
+    "action": "register"
+  }
+}

--- a/packages/api-contract/fixtures/register-email-verify.json
+++ b/packages/api-contract/fixtures/register-email-verify.json
@@ -1,0 +1,5 @@
+{
+  "result": "注册成功，请前往邮箱验证您的账号",
+  "code": 0,
+  "messageCode": "auth.register.emailVerify"
+}

--- a/packages/api-contract/fixtures/register-failed.json
+++ b/packages/api-contract/fixtures/register-failed.json
@@ -1,0 +1,5 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "auth.register.failed"
+}

--- a/packages/api-contract/fixtures/register-rate-limited.json
+++ b/packages/api-contract/fixtures/register-rate-limited.json
@@ -1,0 +1,9 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "common.rateLimited",
+  "params": {
+    "action": "register",
+    "retryAfterSeconds": 30
+  }
+}

--- a/packages/api-contract/fixtures/register-signup-disabled.json
+++ b/packages/api-contract/fixtures/register-signup-disabled.json
@@ -1,0 +1,5 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "auth.signupDisabled"
+}

--- a/packages/api-contract/fixtures/register-success.json
+++ b/packages/api-contract/fixtures/register-success.json
@@ -1,0 +1,5 @@
+{
+  "result": "登录成功",
+  "code": 0,
+  "messageCode": "auth.login.success"
+}

--- a/packages/api-contract/fixtures/reset-password-account-frozen.json
+++ b/packages/api-contract/fixtures/reset-password-account-frozen.json
@@ -1,0 +1,9 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "permission.userFrozen",
+  "params": {
+    "action": "写入",
+    "actionCode": "write"
+  }
+}

--- a/packages/api-contract/fixtures/reset-password-password-invalid.json
+++ b/packages/api-contract/fixtures/reset-password-password-invalid.json
@@ -1,0 +1,8 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "auth.password.tooShort",
+  "params": {
+    "minLength": 6
+  }
+}

--- a/packages/api-contract/fixtures/reset-password-rate-limited.json
+++ b/packages/api-contract/fixtures/reset-password-rate-limited.json
@@ -1,0 +1,9 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "common.rateLimited",
+  "params": {
+    "action": "reset-password",
+    "retryAfterSeconds": 30
+  }
+}

--- a/packages/api-contract/fixtures/reset-password-success.json
+++ b/packages/api-contract/fixtures/reset-password-success.json
@@ -1,0 +1,5 @@
+{
+  "result": "密码重置成功",
+  "code": 0,
+  "messageCode": "auth.passwordReset.success"
+}

--- a/packages/api-contract/fixtures/reset-password-token-invalid.json
+++ b/packages/api-contract/fixtures/reset-password-token-invalid.json
@@ -1,0 +1,5 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "auth.passwordReset.tokenInvalid"
+}

--- a/packages/api-contract/fixtures/reset-password-user-not-found.json
+++ b/packages/api-contract/fixtures/reset-password-user-not-found.json
@@ -1,0 +1,5 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "user.notFound"
+}

--- a/packages/api-contract/openapi.yaml
+++ b/packages/api-contract/openapi.yaml
@@ -5,7 +5,8 @@ info:
   description: |
     The controlled HTTP contract for yourtj-hub. Current coverage includes password login,
     login public-key retrieval, TOTP login verification and account management, logout,
-    session management (list/revoke/revoke-all), mobile OIDC code exchange, topic writing,
+    session management (list/revoke/revoke-all), mobile OIDC code exchange, account
+    registration, password recovery (forgot/reset), topic writing,
     and the Agent (bot persona) public API.
     Existing business failures commonly use HTTP 200 with `code: 1`; consumers must inspect the
     response envelope instead of treating every 2xx response as a successful operation.
@@ -25,6 +26,12 @@ paths:
     $ref: ./paths/auth-security.yaml#/loginPublicKey
   /api/logout:
     $ref: ./paths/auth-sessions.yaml#/logout
+  /api/register:
+    $ref: ./paths/auth-account-recovery.yaml#/register
+  /api/forgot-password:
+    $ref: ./paths/auth-account-recovery.yaml#/forgotPassword
+  /api/reset-password:
+    $ref: ./paths/auth-account-recovery.yaml#/resetPassword
   /api/auth/totp/verify:
     $ref: ./paths/auth-security.yaml#/verifyTotp
   /api/user/totp/status:
@@ -115,6 +122,24 @@ components:
       $ref: ./components/schemas.yaml#/ApiFailure
     ApiSuccess:
       $ref: ./components/schemas.yaml#/ApiSuccess
+    RegisterRequest:
+      $ref: ./components/schemas.yaml#/RegisterRequest
+    RegisterSuccess:
+      $ref: ./components/schemas.yaml#/RegisterSuccess
+    RegisterResponse:
+      $ref: ./components/schemas.yaml#/RegisterResponse
+    ForgotPasswordRequest:
+      $ref: ./components/schemas.yaml#/ForgotPasswordRequest
+    ForgotPasswordSuccess:
+      $ref: ./components/schemas.yaml#/ForgotPasswordSuccess
+    ForgotPasswordResponse:
+      $ref: ./components/schemas.yaml#/ForgotPasswordResponse
+    ResetPasswordRequest:
+      $ref: ./components/schemas.yaml#/ResetPasswordRequest
+    ResetPasswordSuccess:
+      $ref: ./components/schemas.yaml#/ResetPasswordSuccess
+    ResetPasswordResponse:
+      $ref: ./components/schemas.yaml#/ResetPasswordResponse
     LoginRequest:
       $ref: ./components/schemas.yaml#/LoginRequest
     LoginSuccess:

--- a/packages/api-contract/paths/auth-account-recovery.yaml
+++ b/packages/api-contract/paths/auth-account-recovery.yaml
@@ -10,12 +10,20 @@ register:
       honeypot field, email domain allowlist, username format/moderation, password
       complexity, and finally the captcha gate (when the site requires captcha).
 
-      Account-enumeration hardening (CWE-208): a username or email that is already
-      taken returns the same generic `auth.register.failed` failure envelope as every
-      other registration failure. Neither the HTTP status, the envelope, `messageCode`,
-      response fields, nor the rate-limit protocol distinguishes "username exists" from
-      "email exists" from any other failure. The server unconditionally runs both
-      existence lookups so the query count does not vary with account state.
+      Account-enumeration hardening (CWE-208): when a username or an email is already
+      taken, the endpoint returns the same generic `auth.register.failed` failure
+      envelope as when account creation itself fails, and the two occupied cases are
+      indistinguishable from each other. Neither the HTTP status, the envelope,
+      `messageCode`, response fields, nor the rate-limit protocol distinguishes
+      "username exists" from "email exists" from "creation failed". The server
+      unconditionally runs both existence lookups so the query count does not vary
+      with account state.
+
+      This guarantee is scoped to the occupied/creation-failed cases only: requests
+      that fail validation before the existence checks (invalid username format,
+      disallowed email domain, weak password, captcha rejection, signup disabled)
+      return their own distinct `messageCode` per the validation-order list above,
+      and are intentionally not covered by the anti-enumeration envelope.
 
       Honeypot: when the hidden `website` field is populated the server treats the
       request as bot traffic, silently returns a success envelope identical to a normal
@@ -63,7 +71,7 @@ register:
                 summary: Bot traffic silently accepted without creating an account; the envelope is byte-identical to a normal success.
                 externalValue: ../fixtures/register-success.json
               genericFailure:
-                summary: Username/email occupied or any other registration failure; the same envelope is used for every failure so account state is never distinguishable.
+                summary: Username or email already taken, or account creation failed; the same envelope is used for the occupied and creation-failed cases so account state is never distinguishable.
                 externalValue: ../fixtures/register-failed.json
               signupDisabled:
                 summary: Registration is disabled on this site.

--- a/packages/api-contract/paths/auth-account-recovery.yaml
+++ b/packages/api-contract/paths/auth-account-recovery.yaml
@@ -1,0 +1,219 @@
+register:
+  post:
+    tags: [Authentication]
+    summary: Create a new forum account
+    operationId: register
+    security: []
+    description: |
+      Public account registration. The request is validated in the same order as the
+      server: JSON shape, then generic request validation, then the signup switch, the
+      honeypot field, email domain allowlist, username format/moderation, password
+      complexity, and finally the captcha gate (when the site requires captcha).
+
+      Account-enumeration hardening (CWE-208): a username or email that is already
+      taken returns the same generic `auth.register.failed` failure envelope as every
+      other registration failure. Neither the HTTP status, the envelope, `messageCode`,
+      response fields, nor the rate-limit protocol distinguishes "username exists" from
+      "email exists" from any other failure. The server unconditionally runs both
+      existence lookups so the query count does not vary with account state.
+
+      Honeypot: when the hidden `website` field is populated the server treats the
+      request as bot traffic, silently returns a success envelope identical to a normal
+      successful registration, and creates no account.
+
+      On success the server creates the account, enqueues an activation email task when
+      the site enables email verification, and immediately issues a session (Set-Cookie
+      `access_token` + `New-Token` header). Consumers must still inspect the envelope:
+      the residual observable difference between "account created" and "creation
+      failed" is intrinsic to the protocol and is not part of this contract's failure
+      taxonomy.
+
+      The endpoint is IP rate limited (HTTP 429 + `Retry-After`); the default quota is
+      20 requests per hour per IP.
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas.yaml#/RegisterRequest
+    responses:
+      '200':
+        description: Registration succeeded (with an auto-issued session), or a legacy business failure envelope.
+        headers:
+          Set-Cookie:
+            description: On success, HTTP-only `access_token` session cookie.
+            schema:
+              type: string
+          New-Token:
+            description: On success, the newly issued forum session JWT.
+            schema:
+              type: string
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/RegisterResponse
+            examples:
+              success:
+                summary: Account created and session issued (email verification disabled).
+                externalValue: ../fixtures/register-success.json
+              emailVerify:
+                summary: Account created; the site requires email verification before the session is usable.
+                externalValue: ../fixtures/register-email-verify.json
+              honeypot:
+                summary: Bot traffic silently accepted without creating an account; the envelope is byte-identical to a normal success.
+                externalValue: ../fixtures/register-success.json
+              genericFailure:
+                summary: Username/email occupied or any other registration failure; the same envelope is used for every failure so account state is never distinguishable.
+                externalValue: ../fixtures/register-failed.json
+              signupDisabled:
+                summary: Registration is disabled on this site.
+                externalValue: ../fixtures/register-signup-disabled.json
+              captchaRequired:
+                summary: The site requires captcha and the request did not carry one; clients should present the captcha challenge for the `register` action.
+                externalValue: ../fixtures/register-captcha-required.json
+      '429':
+        description: Register rate limit exceeded (default 20 requests/hour/IP).
+        headers:
+          Retry-After:
+            required: true
+            schema:
+              type: integer
+              minimum: 1
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/RateLimitedFailure
+            examples:
+              rateLimited:
+                externalValue: ../fixtures/register-rate-limited.json
+
+forgotPassword:
+  post:
+    tags: [Authentication]
+    summary: Request a password reset email
+    operationId: forgotPassword
+    security: []
+    description: |
+      Public password-reset request. The server never reveals whether an email is
+      registered: an unknown email, a bot (Agent) account, and an account inside the
+      24-hour email-change cooldown all return the exact same success envelope
+      (`auth.passwordReset.mailQueued`) and run the same class of work (token signing
+      plus a queue write; unknown/cooldown paths enqueue a noop task that is silently
+      consumed by the mail worker without sending anything). Mail delivery itself is a
+      server-side implementation detail and never exposes account state.
+
+      Honeypot: when the hidden `website` field is populated the request is treated as
+      bot traffic and silently returns the same success envelope without enqueuing any
+      reset mail.
+
+      The captcha gate (when the site requires captcha) is the only failure that
+      differs, and it does not depend on account state.
+
+      The endpoint is IP rate limited (HTTP 429 + `Retry-After`); the default quota is
+      10 requests per hour per IP.
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas.yaml#/ForgotPasswordRequest
+    responses:
+      '200':
+        description: Request accepted, or a legacy business failure envelope. The same success envelope is returned for registered, unknown, bot, and cooldown emails.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ForgotPasswordResponse
+            examples:
+              mailQueued:
+                summary: Indistinguishable success for registered, unknown, bot, and cooldown emails.
+                externalValue: ../fixtures/forgot-password-mail-queued.json
+              captchaRequired:
+                summary: The site requires captcha and the request did not carry one; clients should present the captcha challenge for the `forgot-password` action.
+                externalValue: ../fixtures/forgot-password-captcha-required.json
+      '429':
+        description: Forgot-password rate limit exceeded (default 10 requests/hour/IP).
+        headers:
+          Retry-After:
+            required: true
+            schema:
+              type: integer
+              minimum: 1
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/RateLimitedFailure
+            examples:
+              rateLimited:
+                externalValue: ../fixtures/forgot-password-rate-limited.json
+
+resetPassword:
+  post:
+    tags: [Authentication]
+    summary: Set a new password with a reset token
+    operationId: resetPassword
+    security: []
+    description: |
+      Completes the password reset with the token received by email. The token is a
+      short-lived (30-minute) HMAC-signed JWT bound to the user id, the email it was
+      issued for, and the token_version at issuance time.
+
+      Invalid, expired, or replayed tokens are rejected with the same
+      `auth.passwordReset.tokenInvalid` failure envelope: the token check fails for a
+      bad signature, an expired token, a bot account, a mismatched email, and a
+      token_version that no longer matches the account (any password change or revoke
+      bumps token_version, so an old reset link can never be replayed after a
+      successful reset). Frozen accounts are rejected with `permission.userFrozen` and
+      `params.action`/`params.actionCode` without consuming the token. The new password
+      must pass the same complexity rules as registration (minimum 6 characters,
+      contains letters and digits, at most 64 characters).
+
+      On success the password hash and token_version are updated; the reset token
+      becomes permanently unusable.
+
+      The endpoint is IP rate limited (HTTP 429 + `Retry-After`); the default quota is
+      10 requests per hour per IP.
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas.yaml#/ResetPasswordRequest
+    responses:
+      '200':
+        description: Password reset succeeded, or a legacy business failure envelope.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ResetPasswordResponse
+            examples:
+              success:
+                summary: Password changed; the reset token is consumed by the token_version bump.
+                externalValue: ../fixtures/reset-password-success.json
+              invalidToken:
+                summary: Invalid, expired, wrong-email, wrong-version, or already-replayed token; also returned for bot accounts.
+                externalValue: ../fixtures/reset-password-token-invalid.json
+              accountFrozen:
+                summary: The account is frozen; the token is not consumed.
+                externalValue: ../fixtures/reset-password-account-frozen.json
+              passwordInvalid:
+                summary: The new password does not meet the complexity rules.
+                externalValue: ../fixtures/reset-password-password-invalid.json
+              userNotFound:
+                summary: The token is well-formed but its user no longer exists.
+                externalValue: ../fixtures/reset-password-user-not-found.json
+      '429':
+        description: Reset-password rate limit exceeded (default 10 requests/hour/IP).
+        headers:
+          Retry-After:
+            required: true
+            schema:
+              type: integer
+              minimum: 1
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/RateLimitedFailure
+            examples:
+              rateLimited:
+                externalValue: ../fixtures/reset-password-rate-limited.json


### PR DESCRIPTION
## Summary
- 为 `POST /api/register`、`POST /api/forgot-password`、`POST /api/reset-password` 补全受控 OpenAPI 契约
- 新增 `packages/api-contract/paths/auth-account-recovery.yaml` 与请求/响应 schema（RegisterRequest/Response、ForgotPasswordRequest/Response、ResetPasswordRequest/Response）
- 新增 15 个成功/业务失败/限流 fixtures，覆盖注册开关、蜜罐、反枚举、token 生命周期、冻结账号等路径
- 新增真实 Gin 路由契约测试 `contract_account_recovery_test.go`（复用 `setupHTTPContractTest` 基座，挂载与生产 `route4api.go` 一致的 RateLimit 中间件）
- 重新生成 TypeScript 客户端 `openapi.ts`；同步移动端 Dart fixtures 解析测试；更新 `AGENTS.md` 契约覆盖说明

## 覆盖清单
### POST /api/register
- 成功（自动登录 + New-Token/Set-Cookie）`register-success.json`
- 邮箱验证模式 `register-email-verify.json`
- 业务失败（反枚举统一 `auth.register.failed`）`register-failed.json`
- 注册开关关闭 `register-signup-disabled.json`
- 验证码要求 `register-captcha-required.json`
- 限流 429 `register-rate-limited.json`

### POST /api/forgot-password
- 成功（统一防枚举消息）`forgot-password-mail-queued.json`
- 验证码要求 `forgot-password-captcha-required.json`
- 限流 429 `forgot-password-rate-limited.json`

### POST /api/reset-password
- 成功 `reset-password-success.json`
- token 无效/过期/重放 `reset-password-token-invalid.json`
- 冻结账号 `reset-password-account-frozen.json`
- 密码过短 `reset-password-password-invalid.json`
- 用户不存在 `reset-password-user-not-found.json`
- 限流 429 `reset-password-rate-limited.json`

## 验证
- `packages/api-contract`: `pnpm run check` ✅（仅 2 个既有无关 warning）
- `apps/gooseforum`: `go vet ./... && go test ./...` ✅
- `resource`: `pnpm typecheck && pnpm test && pnpm build` ✅
- `apps/mobile/packages/core`: `flutter test test/contract_fixtures_test.dart` ✅（22 个测试全过，含新增 5 个）

Closes #148

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>