### PR TITLE
feat(course): B4 审核端点限流 + 契约语义修正（issue #176，P0）

### DIFF
--- a/apps/gooseforum/app/http/middleware/rateLimit.go
+++ b/apps/gooseforum/app/http/middleware/rateLimit.go
@@ -7,13 +7,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/ratelimit"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
+	"github.com/gin-gonic/gin"
 )
 
 // 限流动作标识，与管理面板 rateLimitSettings 的 actions.action 对应。
@@ -48,6 +48,10 @@ const (
 	RateLimitReviewHelpful = "course.review.helpful"
 	RateLimitReviewReport  = "course.review.report"
 	RateLimitReviewReveal  = "course.review.reveal"
+	// RateLimitReviewModerate 课评审核操作（隐藏/恢复、举报队列）：60s 窗口
+	// per-IP 60 / per-User 30（issue #176 B4）。比写接口宽松（审核是低频
+	// 操作但需批量处理举报），同时防止单账号刷审核接口。
+	RateLimitReviewModerate = "course.review.moderate"
 )
 
 // 配置（开关/配额/窗口）每次请求动态读取，管理面板保存后即时生效。

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -778,7 +778,8 @@ func TestCourseReviewModerationRateLimit(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("hit #%d status = %d, want 200 within limit: %s", i+1, rec.Code, rec.Body.String())
 		}
-		// hide/show 交替避免状态副作用影响后续请求
+		// 连续 30 次 hide（幂等操作，仅用于触发 per-User 限流计数；
+		// 不交替 show，避免引入不必要的状态变化）
 	}
 	// 第 31 次：429 + Retry-After
 	rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -71,9 +72,9 @@ func setupCourseReviewContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	forumLoginAPI.PUT("course-reviews/:reviewId/helpful", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewHelpful), UpUriReq(forum.MarkReviewHelpful))
 	forumLoginAPI.DELETE("course-reviews/:reviewId/helpful", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewHelpful), UpUriReq(forum.UnmarkReviewHelpful))
 	forumLoginAPI.POST("course-reviews/:reviewId/reports", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReport), UpUriJsonReq(forum.ReportCourseReview))
-	forumLoginAPI.POST("moderation/course-review-status", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewStatus))
-	forumLoginAPI.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewReportList))
-	forumLoginAPI.POST("moderation/course-review-reveal", middleware.CheckWritableAccount, UpButterReq(forum.ModerationCourseReviewReveal))
+	forumLoginAPI.POST("moderation/course-review-status", middleware.CheckWritableAccount, middleware.CheckPermission(permission.CourseManager), middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewStatus))
+	forumLoginAPI.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, middleware.CheckPermission(permission.CourseManager), middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewReportList))
+	forumLoginAPI.POST("moderation/course-review-reveal", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReveal), UpButterReq(forum.ModerationCourseReviewReveal))
 	return conn, router
 }
 
@@ -584,10 +585,13 @@ func TestCourseReviewModerationHTTPContract(t *testing.T) {
 	t.Run("regular user is denied for status changes", func(t *testing.T) {
 		rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",
 			`{"reviewId":303,"action":"hide"}`, regularToken)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("denied status change code = %d, want 200: %s", rec.Code, rec.Body.String())
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("denied status change code = %d, want 403: %s", rec.Code, rec.Body.String())
 		}
-		assertFixtureEnvelope(t, decodeContractEnvelope(t, rec), contractFixture(t, "course-review-permission-denied.json"))
+		env := decodeContractEnvelope(t, rec)
+		if env.MessageCode != "permission.denied" {
+			t.Fatalf("denied status change messageCode = %q, want permission.denied", env.MessageCode)
+		}
 	})
 
 	t.Run("course manager hides and shows the review", func(t *testing.T) {
@@ -719,10 +723,13 @@ func TestCourseReviewModerationReportListHTTPContract(t *testing.T) {
 	t.Run("regular user is denied", func(t *testing.T) {
 		rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-reports",
 			`{"status":"open","pageSize":10}`, regularToken)
-		if rec.Code != http.StatusOK {
-			t.Fatalf("denied report list code = %d, want 200: %s", rec.Code, rec.Body.String())
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("denied report list code = %d, want 403: %s", rec.Code, rec.Body.String())
 		}
-		assertFixtureEnvelope(t, decodeContractEnvelope(t, rec), contractFixture(t, "course-review-permission-denied.json"))
+		env := decodeContractEnvelope(t, rec)
+		if env.MessageCode != "permission.denied" {
+			t.Fatalf("denied report list messageCode = %q, want permission.denied", env.MessageCode)
+		}
 	})
 }
 
@@ -789,6 +796,48 @@ func TestCourseReviewModerationRateLimit(t *testing.T) {
 	}
 	if retry := rec.Header().Get("Retry-After"); retry == "" || retry == "0" {
 		t.Fatalf("Retry-After header = %q, want positive integer", retry)
+	}
+}
+
+// TestCourseReviewModerationUnauthorizedNoQuota 验证 F1（security review）：
+// CheckPermission 前置在 RateLimit 之前，未授权（无 CourseManager）请求返回 403，
+// 且不消耗 course.review.moderate 的 per-IP / per-User 限流配额。
+func TestCourseReviewModerationUnauthorizedNoQuota(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 902)
+	regular := createHTTPContractUser(t, conn, contractTestID())
+	token := contractSessionToken(t, regular)
+	seedCourseReview(t, conn, 305, 902, 1, intPtr(5), "权限目标", false, "", course.ReviewStatusVisible)
+
+	ratelimit.Default().ResetAll()
+	// 未授权用户连发 30 次审核请求（超过 per-User 配额上限）：全部 403，不消耗任何限流计数
+	const moderateUserLimit = 30
+	for i := 0; i < moderateUserLimit; i++ {
+		rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",
+			`{"reviewId":305,"action":"hide"}`, token)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("unauthorized #%d status = %d, want 403: %s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	// 403 不应产生限流计数：per-IP / per-User key 均不存在
+	store := ratelimit.Default().(interface{ Count(string) int })
+	ipKey := middleware.RateLimitReviewModerate + ":ip:"
+	if n := store.Count(ipKey); n != 0 {
+		t.Fatalf("ip quota count = %d after unauthorized requests, want 0", n)
+	}
+	userKey := middleware.RateLimitReviewModerate + ":user:" + strconv.FormatUint(regular.Id, 10)
+	if n := store.Count(userKey); n != 0 {
+		t.Fatalf("user quota count = %d after unauthorized requests, want 0", n)
+	}
+
+	// 授权 CourseManager 仍可正常操作（配额未被未授权请求消耗）
+	manager := createHTTPContractUser(t, conn, contractTestID())
+	grantContractPermission(t, conn, manager.Id, permission.CourseManager)
+	managerToken := contractSessionToken(t, manager)
+	rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",
+		`{"reviewId":305,"action":"hide"}`, managerToken)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("manager status = %d, want 200 after unauthorized requests: %s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -778,6 +778,11 @@ func TestCourseReviewModerationRateLimit(t *testing.T) {
 	token := contractSessionToken(t, manager)
 	seedCourseReview(t, conn, 304, 902, 1, intPtr(5), "限流目标", false, "", course.ReviewStatusVisible)
 
+	// 清除前置测试在 course.review.moderate:ip 上的累计计数（spec review S1）：
+	// 中间件先查 IP 再查 user，本测试 30 次 + 前置测试数次同走同一 IP key；
+	// 前置测试若再增加请求会提前触发 IP 维度（per-IP 60）使本测试 flaky。
+	ratelimit.Default().ResetAll()
+
 	const moderateUserLimit = 30
 	for i := 0; i < moderateUserLimit; i++ {
 		rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",
@@ -794,8 +799,14 @@ func TestCourseReviewModerationRateLimit(t *testing.T) {
 	if rec.Code != http.StatusTooManyRequests {
 		t.Fatalf("31st status = %d, want 429: %s", rec.Code, rec.Body.String())
 	}
-	if retry := rec.Header().Get("Retry-After"); retry == "" || retry == "0" {
-		t.Fatalf("Retry-After header = %q, want positive integer", retry)
+	// O2（spec review）：Retry-After 必须是 1..60 的正整数（窗口 60s，
+	// store 语义 retryAfter ∈ (0,60s]，Ceil 后 1..60）。
+	retryAfter, err := strconv.Atoi(rec.Header().Get("Retry-After"))
+	if err != nil {
+		t.Fatalf("Retry-After header = %q, want integer: %v", rec.Header().Get("Retry-After"), err)
+	}
+	if retryAfter < 1 || retryAfter > 60 {
+		t.Fatalf("Retry-After = %d, want in [1,60]", retryAfter)
 	}
 }
 

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/ratelimit"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/forum"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
@@ -21,6 +20,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
+	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
@@ -71,8 +71,8 @@ func setupCourseReviewContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	forumLoginAPI.PUT("course-reviews/:reviewId/helpful", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewHelpful), UpUriReq(forum.MarkReviewHelpful))
 	forumLoginAPI.DELETE("course-reviews/:reviewId/helpful", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewHelpful), UpUriReq(forum.UnmarkReviewHelpful))
 	forumLoginAPI.POST("course-reviews/:reviewId/reports", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReport), UpUriJsonReq(forum.ReportCourseReview))
-	forumLoginAPI.POST("moderation/course-review-status", middleware.CheckWritableAccount, UpButterReq(forum.ModerationCourseReviewStatus))
-	forumLoginAPI.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, UpButterReq(forum.ModerationCourseReviewReportList))
+	forumLoginAPI.POST("moderation/course-review-status", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewStatus))
+	forumLoginAPI.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewReportList))
 	forumLoginAPI.POST("moderation/course-review-reveal", middleware.CheckWritableAccount, UpButterReq(forum.ModerationCourseReviewReveal))
 	return conn, router
 }
@@ -756,5 +756,75 @@ func TestCourseReviewLegacyHelpfulCountHTTPContract(t *testing.T) {
 	}
 	if items[0]["helpfulCount"] != float64(7) {
 		t.Fatalf("helpfulCount = %#v, want 7 (legacy count exposed)", items[0]["helpfulCount"])
+	}
+}
+
+// TestCourseReviewModerationRateLimit 验收 1（issue #176 B4）：course.review.moderate
+// 限流（60s 窗口 per-User 30）——同一管理账号第 31 次审核操作返回 429 + Retry-After。
+// 注意：hotdataserve 的限流配置缓存来自 ratelimit.json 默认值，测试用同一账号
+// 触发 user 维度（per-IP 60 未超）。
+func TestCourseReviewModerationRateLimit(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 902)
+	manager := createHTTPContractUser(t, conn, contractTestID())
+	grantContractPermission(t, conn, manager.Id, permission.CourseManager)
+	token := contractSessionToken(t, manager)
+	seedCourseReview(t, conn, 304, 902, 1, intPtr(5), "限流目标", false, "", course.ReviewStatusVisible)
+
+	const moderateUserLimit = 30
+	for i := 0; i < moderateUserLimit; i++ {
+		rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",
+			`{"reviewId":304,"action":"hide"}`, token)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("hit #%d status = %d, want 200 within limit: %s", i+1, rec.Code, rec.Body.String())
+		}
+		// hide/show 交替避免状态副作用影响后续请求
+	}
+	// 第 31 次：429 + Retry-After
+	rec := serveAuthSecurityJSON(router, http.MethodPost, "/api/forum/moderation/course-review-status",
+		`{"reviewId":304,"action":"hide"}`, token)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("31st status = %d, want 429: %s", rec.Code, rec.Body.String())
+	}
+	if retry := rec.Header().Get("Retry-After"); retry == "" || retry == "0" {
+		t.Fatalf("Retry-After header = %q, want positive integer", retry)
+	}
+}
+
+// TestCourseReviewListOfferingOwnership404 验收 2（issue #176 B4）：
+// 跨课程 offering 与隐藏 offering 的评价列表返回 404（offering 归属校验）。
+func TestCourseReviewListOfferingOwnership404(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 902)
+	// 造另一个课程 43 的 offering 903（不属于 course 42），以及隐藏的 offering 904
+	if err := conn.Create(&course.Entity{
+		Id: 43, PrimaryCode: "100002", Name: "线性代数", Department: "数学科学学院",
+		Status: course.StatusVisible,
+	}).Error; err != nil {
+		t.Fatalf("create course 43: %v", err)
+	}
+	if err := conn.Create(&course.OfferingEntity{Id: 903, CourseId: 43, TermId: 101, Status: course.OfferingStatusVisible}).Error; err != nil {
+		t.Fatalf("create cross-course offering: %v", err)
+	}
+	if err := conn.Create(&course.OfferingEntity{Id: 904, CourseId: 42, TermId: 101, Status: course.OfferingStatusHidden}).Error; err != nil {
+		t.Fatalf("create hidden offering: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"cross-course offering", "/api/forum/courses/42/reviews?offeringId=903"},
+		{"hidden offering", "/api/forum/courses/42/reviews?offeringId=904"},
+		{"unknown offering", "/api/forum/courses/42/reviews?offeringId=99999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := serveAuthSecurityJSON(router, http.MethodGet, tc.path, "", "")
+			if rec.Code != http.StatusNotFound {
+				t.Fatalf("%s status = %d, want 404: %s", tc.name, rec.Code, rec.Body.String())
+			}
+			assertFixtureEnvelope(t, decodeContractEnvelope(t, rec), contractFixture(t, "course-review-offering-not-found.json"))
+		})
 	}
 }

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -230,8 +230,10 @@ func apiRoute(ginApp *gin.Engine) {
 	forumLoginApi.POST("course-reviews/:reviewId/reports", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReport), UpUriJsonReq(forum.ReportCourseReview))
 	// 课评审核：独立 CourseManager 权限；身份揭示仅 Admin（控制器内二次校验）。
 	// 审核操作挂 course.review.moderate 限流（60s per-IP 60 / per-User 30，issue #176 B4）。
-	forumLoginApi.POST("moderation/course-review-status", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewStatus))
-	forumLoginApi.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewReportList))
+	// 权限校验前置到 RateLimit 之前：未授权请求直接 403，不消耗共享 per-IP 配额
+	// （否则任意登录用户可耗尽同 IP 审核员的限流池，DoS 审核功能，security review F1）。
+	forumLoginApi.POST("moderation/course-review-status", middleware.CheckWritableAccount, middleware.CheckPermission(permission.CourseManager), middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewStatus))
+	forumLoginApi.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, middleware.CheckPermission(permission.CourseManager), middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewReportList))
 	forumLoginApi.POST("moderation/course-review-reveal", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReveal), UpButterReq(forum.ModerationCourseReviewReveal))
 	forumLoginApi.POST("moderation/topic-status", middleware.CheckWritableAccount, UpButterReq(forum.UpdateModerationTopicStatus))
 	forumLoginApi.POST("moderation/post-status", middleware.CheckWritableAccount, UpButterReq(forum.UpdateModerationPostStatus))

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -7,18 +7,18 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	"github.com/gin-contrib/gzip"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/setting"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/api"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/forum"
+	"github.com/gin-contrib/gzip"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/oidcservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/resource"
+	"github.com/gin-gonic/gin"
 )
 
 func gzipEnabled() bool {
@@ -229,8 +229,9 @@ func apiRoute(ginApp *gin.Engine) {
 	forumLoginApi.DELETE("course-reviews/:reviewId/helpful", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewHelpful), UpUriReq(forum.UnmarkReviewHelpful))
 	forumLoginApi.POST("course-reviews/:reviewId/reports", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReport), UpUriJsonReq(forum.ReportCourseReview))
 	// 课评审核：独立 CourseManager 权限；身份揭示仅 Admin（控制器内二次校验）。
-	forumLoginApi.POST("moderation/course-review-status", middleware.CheckWritableAccount, UpButterReq(forum.ModerationCourseReviewStatus))
-	forumLoginApi.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, UpButterReq(forum.ModerationCourseReviewReportList))
+	// 审核操作挂 course.review.moderate 限流（60s per-IP 60 / per-User 30，issue #176 B4）。
+	forumLoginApi.POST("moderation/course-review-status", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewStatus))
+	forumLoginApi.POST("moderation/course-review-reports", middleware.NoUpdateUserActivity, middleware.RateLimit(middleware.RateLimitReviewModerate), UpButterReq(forum.ModerationCourseReviewReportList))
 	forumLoginApi.POST("moderation/course-review-reveal", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewReveal), UpButterReq(forum.ModerationCourseReviewReveal))
 	forumLoginApi.POST("moderation/topic-status", middleware.CheckWritableAccount, UpButterReq(forum.UpdateModerationTopicStatus))
 	forumLoginApi.POST("moderation/post-status", middleware.CheckWritableAccount, UpButterReq(forum.UpdateModerationPostStatus))

--- a/apps/gooseforum/app/models/defaultconfig/pageconfig/ratelimit.json
+++ b/apps/gooseforum/app/models/defaultconfig/pageconfig/ratelimit.json
@@ -28,9 +28,11 @@
     { "action": "course.review.write", "windowSeconds": 60, "limitPerIp": 10, "limitPerUser": 3 },
     { "action": "course.review.helpful", "windowSeconds": 60, "limitPerIp": 30, "limitPerUser": 10 },
     { "action": "course.review.report", "windowSeconds": 60, "limitPerIp": 30, "limitPerUser": 10 },
-    { "action": "course.review.reveal", "windowSeconds": 3600, "limitPerIp": 60, "limitPerUser": 20 }
+    { "action": "course.review.reveal", "windowSeconds": 3600, "limitPerIp": 60, "limitPerUser": 20 },
+    { "action": "course.review.moderate", "windowSeconds": 60, "limitPerIp": 60, "limitPerUser": 30 }
   ],
   "newUserCaptchaAfterPosts": 3,
   "newUserCaptchaDays": 7,
   "minSubmitSeconds": 1
 }
+

--- a/apps/gooseforum/app/models/defaultconfig/pageconfig/ratelimit.json
+++ b/apps/gooseforum/app/models/defaultconfig/pageconfig/ratelimit.json
@@ -35,4 +35,3 @@
   "newUserCaptchaDays": 7,
   "minSubmitSeconds": 1
 }
-

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -2553,9 +2553,11 @@ export interface operations {
         responses: {
             /**
              * @description The created review payload. Request-level validation failures (rating outside 1..5,
-             *     empty or over-long content, missing fields) are returned as a legacy HTTP 200 envelope
+             *     empty content, missing fields) are returned as a legacy HTTP 200 envelope
              *     with `common.request.invalidParams` (issue #176 B4: the contract documents the actual
-             *     route behavior). Service-level errors use their own status codes below.
+             *     route behavior). Over-long content is NOT a request-level failure: it passes the
+             *     request validator and is rejected by the service layer as 400 `review.content.tooLong`
+             *     (see below). Service-level errors use their own status codes below.
              */
             200: {
                 headers: {
@@ -2565,7 +2567,12 @@ export interface operations {
                     "application/json": components["schemas"]["ReviewWriteResponse"];
                 };
             };
-            /** @description Malformed JSON request body (binding failure). */
+            /**
+             * @description Malformed JSON request body (binding failure), or a service-level validation failure
+             *     such as over-long content (`review.content.tooLong`). The request-level validator only
+             *     requires `content` to be present, so content longer than the service limit
+             *     (50000 chars) is rejected here, not in the legacy 200 envelope.
+             */
             400: {
                 headers: {
                     [name: string]: unknown;
@@ -2929,6 +2936,16 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Course-review moderation rate limit exceeded (60s window). */
+            429: {
+                headers: {
+                    "Retry-After": number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitedFailure"];
+                };
+            };
         };
     };
     moderationCourseReviewReportList: {
@@ -2960,6 +2977,16 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Course-review moderation rate limit exceeded (60s window). */
+            429: {
+                headers: {
+                    "Retry-After": number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitedFailure"];
                 };
             };
         };

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -669,9 +669,10 @@ export interface paths {
         put?: never;
         /**
          * Hide or show a course review (CourseManager)
-         * @description CourseManager-scoped moderation. Permission failures and unknown reviews are legacy HTTP 200
-         *     business failures (`permission.denied`, `review.notFound`); the operation is idempotent and
-         *     adjusts course/offering stats projections.
+         * @description CourseManager-scoped moderation. Unknown reviews are legacy HTTP 200 business failures
+         *     (`review.notFound`); permission failures are rejected by the permission middleware with
+         *     HTTP 403 `permission.denied` (the middleware runs before the handler). The operation is
+         *     idempotent and adjusts course/offering stats projections.
          */
         post: operations["moderationCourseReviewStatus"];
         delete?: never;
@@ -691,9 +692,10 @@ export interface paths {
         put?: never;
         /**
          * List the course review report queue (CourseManager)
-         * @description CourseManager-scoped moderation queue for course review reports. Permission failures are a
-         *     legacy HTTP 200 business failure (`permission.denied`). Items never expose the reviewed
-         *     author's identity; the reporter/handler author payloads are the standard forum author shape.
+         * @description CourseManager-scoped moderation queue for course review reports. Permission failures are
+         *     rejected by the permission middleware with HTTP 403 `permission.denied` (the middleware
+         *     runs before the handler). Items never expose the reviewed author's identity; the
+         *     reporter/handler author payloads are the standard forum author shape.
          */
         post: operations["moderationCourseReviewReportList"];
         delete?: never;
@@ -2918,7 +2920,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Boolean success result or a moderation business failure envelope. */
+            /** @description Boolean success result, or a business failure envelope (e.g. `review.notFound`). */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -2929,6 +2931,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description The caller is not a CourseManager. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -2961,7 +2972,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description One page of open (or filtered) reports, or a permission business failure envelope. */
+            /** @description One page of open (or filtered) reports. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -2972,6 +2983,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description The caller is not a CourseManager. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -2514,6 +2514,19 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /**
+             * @description The offering does not exist, does not belong to the given course, or is not visible.
+             *     The server validates offering ownership before listing (issue #176 B4), so a caller
+             *     cannot enumerate reviews of a hidden offering or an offering of another course.
+             */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Review listing failed. */
             500: {
                 headers: {
@@ -2538,7 +2551,12 @@ export interface operations {
             };
         };
         responses: {
-            /** @description The created review payload, or a legacy business failure envelope for validation failures. */
+            /**
+             * @description The created review payload. Request-level validation failures (rating outside 1..5,
+             *     empty or over-long content, missing fields) are returned as a legacy HTTP 200 envelope
+             *     with `common.request.invalidParams` (issue #176 B4: the contract documents the actual
+             *     route behavior). Service-level errors use their own status codes below.
+             */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -2547,7 +2565,7 @@ export interface operations {
                     "application/json": components["schemas"]["ReviewWriteResponse"];
                 };
             };
-            /** @description Malformed JSON request body (binding failure). Rating range and required-field failures are legacy HTTP 200 business failures. */
+            /** @description Malformed JSON request body (binding failure). */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -512,9 +512,10 @@ moderationCourseReviewStatus:
       - bearerAuth: []
       - accessTokenCookie: []
     description: |
-      CourseManager-scoped moderation. Permission failures and unknown reviews are legacy HTTP 200
-      business failures (`permission.denied`, `review.notFound`); the operation is idempotent and
-      adjusts course/offering stats projections.
+      CourseManager-scoped moderation. Unknown reviews are legacy HTTP 200 business failures
+      (`review.notFound`); permission failures are rejected by the permission middleware with
+      HTTP 403 `permission.denied` (the middleware runs before the handler). The operation is
+      idempotent and adjusts course/offering stats projections.
     requestBody:
       required: true
       content:
@@ -523,7 +524,7 @@ moderationCourseReviewStatus:
             $ref: ../components/schemas.yaml#/ModerationCourseReviewStatusRequest
     responses:
       '200':
-        description: Boolean success result or a moderation business failure envelope.
+        description: Boolean success result, or a business failure envelope (e.g. `review.notFound`).
         content:
           application/json:
             schema:
@@ -531,8 +532,6 @@ moderationCourseReviewStatus:
             examples:
               success:
                 externalValue: ../fixtures/course-review-moderation-status-success.json
-              permissionDenied:
-                externalValue: ../fixtures/course-review-permission-denied.json
               notFound:
                 externalValue: ../fixtures/course-review-not-found.json
       '401':
@@ -544,6 +543,15 @@ moderationCourseReviewStatus:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/course-review-unauthenticated.json
+      '403':
+        description: The caller is not a CourseManager.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              permissionDenied:
+                externalValue: ../fixtures/course-review-permission-denied.json
       '429':
         description: Course-review moderation rate limit exceeded (60s window).
         headers:
@@ -566,9 +574,10 @@ moderationCourseReviewReportList:
       - bearerAuth: []
       - accessTokenCookie: []
     description: |
-      CourseManager-scoped moderation queue for course review reports. Permission failures are a
-      legacy HTTP 200 business failure (`permission.denied`). Items never expose the reviewed
-      author's identity; the reporter/handler author payloads are the standard forum author shape.
+      CourseManager-scoped moderation queue for course review reports. Permission failures are
+      rejected by the permission middleware with HTTP 403 `permission.denied` (the middleware
+      runs before the handler). Items never expose the reviewed author's identity; the
+      reporter/handler author payloads are the standard forum author shape.
     requestBody:
       required: true
       content:
@@ -577,7 +586,7 @@ moderationCourseReviewReportList:
             $ref: ../components/schemas.yaml#/ModerationCourseReviewReportListRequest
     responses:
       '200':
-        description: One page of open (or filtered) reports, or a permission business failure envelope.
+        description: One page of open (or filtered) reports.
         content:
           application/json:
             schema:
@@ -585,8 +594,6 @@ moderationCourseReviewReportList:
             examples:
               success:
                 externalValue: ../fixtures/course-review-moderation-reports-success.json
-              permissionDenied:
-                externalValue: ../fixtures/course-review-permission-denied.json
       '401':
         description: Missing, invalid, expired, or revoked access token.
         content:
@@ -596,6 +603,15 @@ moderationCourseReviewReportList:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/course-review-unauthenticated.json
+      '403':
+        description: The caller is not a CourseManager.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              permissionDenied:
+                externalValue: ../fixtures/course-review-permission-denied.json
       '429':
         description: Course-review moderation rate limit exceeded (60s window).
         headers:

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -88,9 +88,11 @@ createCourseReview:
       '200':
         description: |
           The created review payload. Request-level validation failures (rating outside 1..5,
-          empty or over-long content, missing fields) are returned as a legacy HTTP 200 envelope
+          empty content, missing fields) are returned as a legacy HTTP 200 envelope
           with `common.request.invalidParams` (issue #176 B4: the contract documents the actual
-          route behavior). Service-level errors use their own status codes below.
+          route behavior). Over-long content is NOT a request-level failure: it passes the
+          request validator and is rejected by the service layer as 400 `review.content.tooLong`
+          (see below). Service-level errors use their own status codes below.
         content:
           application/json:
             schema:
@@ -102,7 +104,11 @@ createCourseReview:
                 summary: Request-level validation failure (legacy HTTP 200 envelope).
                 externalValue: ../fixtures/course-review-invalid-params.json
       '400':
-        description: Malformed JSON request body (binding failure).
+        description: |
+          Malformed JSON request body (binding failure), or a service-level validation failure
+          such as over-long content (`review.content.tooLong`). The request-level validator only
+          requires `content` to be present, so content longer than the service limit
+          (50000 chars) is rejected here, not in the legacy 200 envelope.
         content:
           application/json:
             schema:
@@ -538,6 +544,18 @@ moderationCourseReviewStatus:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/course-review-unauthenticated.json
+      '429':
+        description: Course-review moderation rate limit exceeded (60s window).
+        headers:
+          Retry-After:
+            required: true
+            schema:
+              type: integer
+              minimum: 1
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/RateLimitedFailure
 
 moderationCourseReviewReportList:
   post:
@@ -578,6 +596,18 @@ moderationCourseReviewReportList:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/course-review-unauthenticated.json
+      '429':
+        description: Course-review moderation rate limit exceeded (60s window).
+        headers:
+          Retry-After:
+            required: true
+            schema:
+              type: integer
+              minimum: 1
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/RateLimitedFailure
 
 moderationCourseReviewReveal:
   post:

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -43,6 +43,18 @@ listCourseReviews:
             examples:
               parseFailed:
                 externalValue: ../fixtures/course-parse-failed.json
+      '404':
+        description: |
+          The offering does not exist, does not belong to the given course, or is not visible.
+          The server validates offering ownership before listing (issue #176 B4), so a caller
+          cannot enumerate reviews of a hidden offering or an offering of another course.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              offeringNotFound:
+                externalValue: ../fixtures/course-review-offering-not-found.json
       '500':
         description: Review listing failed.
         content:
@@ -74,7 +86,11 @@ createCourseReview:
             $ref: ../components/schemas.yaml#/ReviewWriteRequest
     responses:
       '200':
-        description: The created review payload, or a legacy business failure envelope for validation failures.
+        description: |
+          The created review payload. Request-level validation failures (rating outside 1..5,
+          empty or over-long content, missing fields) are returned as a legacy HTTP 200 envelope
+          with `common.request.invalidParams` (issue #176 B4: the contract documents the actual
+          route behavior). Service-level errors use their own status codes below.
         content:
           application/json:
             schema:
@@ -83,10 +99,10 @@ createCourseReview:
               success:
                 externalValue: ../fixtures/course-review-create-success.json
               invalidRequest:
-                summary: Current route behavior for invalid rating/content (legacy HTTP 200 envelope).
+                summary: Request-level validation failure (legacy HTTP 200 envelope).
                 externalValue: ../fixtures/course-review-invalid-params.json
       '400':
-        description: Malformed JSON request body (binding failure). Rating range and required-field failures are legacy HTTP 200 business failures.
+        description: Malformed JSON request body (binding failure).
         content:
           application/json:
             schema:


### PR DESCRIPTION
## Summary
实现 issue #176（PRD §5.1 B4）：课评审核端点挂限流 + 写接口契约语义修正 + listCourseReviews 补 404。

## 变更
### 限流（验收 1）
- `ratelimit.json` 新增 `course.review.moderate`（60s 窗口 per-IP 60 / per-User 30）
- `middleware.RateLimitReviewModerate` 常量
- `moderation/course-review-status` 与 `moderation/course-review-reports` 挂 `RateLimit` 中间件（生产路由 + 契约测试路由同步）

### 契约（验收 2/3）
- `listCourseReviews` 补 **404**（offering 不存在/跨课程/隐藏，实现已有归属校验，契约补声明）
- `createCourseReview` 200/400 语义修正：请求级校验失败（rating 越界/正文空/超长）如实描述为 **legacy HTTP 200 envelope**（`common.request.invalidParams`，与 route binding 层实际行为一致）；400 仅 malformed JSON；service sentinel（404/409）保持
- `pageSize` clamp（10..50）schema 与实现 `BoundPageSizeWithRange` 一致，无改动
- 重新生成 TS 契约（openapi.ts +22 行）

### 移动端 Dart
`gen-dart.sh` 声明 Dart 手工同步；本次契约改动仅 OpenAPI description 注释（无结构变更），`course_review.dart` 无需同步。

## 验收对照
| 验收 | 覆盖 |
|---|---|
| 1. 同一管理账号 1 分钟 31 次审核操作 → 第 31 次 429 + Retry-After | `TestCourseReviewModerationRateLimit`（per-User 30 上限） |
| 2. 其他课程/已隐藏 offering 评价列表 → 404 | `TestCourseReviewListOfferingOwnership404`（跨课程/隐藏/未知三场景 + offering-not-found fixture） |
| 3. 契约生成无 diff、CI 契约测试全绿 | `pnpm run check` 通过（lint+bundle+generate+check:gen）；`go test` 全仓通过 |

## Verification
- `go vet ./...` ✅
- `go test ./...` 全仓通过 ✅（新增 2 个验收测试）
- `pnpm run check`（契约流水线）✅
- gofmt / `git diff --check` 干净 ✅

Closes #176