### PR TITLE
feat(course): B2 评价列表 cursor 分页——替换 200 硬截断

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/course_review.go
+++ b/apps/gooseforum/app/http/controllers/forum/course_review.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/i18n"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
@@ -18,6 +17,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/optlogger"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
+	"github.com/gin-gonic/gin"
 )
 
 // ---- 写评 / 编辑 / 删除 / helpful / 举报 ----
@@ -134,20 +134,33 @@ func ReportCourseReview(req component.BetterRequest[ReportCourseReviewReq]) comp
 
 // ---- 公开读：课程评价列表 ----
 
-// ListCourseReviewsReq 课程评价列表（URI courseId；可选 offeringId 过滤）。
+// ListCourseReviewsReq 课程评价列表（URI courseId；可选 offeringId 过滤；
+// B2: cursor/pageSize 分页, issue #174）。
 type ListCourseReviewsReq struct {
 	CourseId   uint64 `uri:"courseId" validate:"required"`
 	OfferingId uint64 `form:"offeringId"`
+	Cursor     string `form:"cursor"`
+	PageSize   int    `form:"pageSize"`
 }
 
-// ListCourseReviews 返回课程（或指定 offering）的可见评价列表；可选 JWT 提供 viewer 状态。
+// ListCourseReviews 返回课程（或指定 offering）的可见评价分页；可选 JWT 提供 viewer 状态。
 // offeringId 路径必须属于 courseId 且可见，否则 404（防止列出隐藏 offering 的评价，
-// 或跨课程指定无归属的 offering）。
+// 或跨课程指定无归属的 offering）。非法 cursor 或 pageSize 超限 → 400（B2, issue #174）。
 func ListCourseReviews(req component.BetterRequest[ListCourseReviewsReq]) component.Response {
-	var (
-		payloads []courseservice.ReviewPayload
-		err      error
-	)
+	// B2：pageSize 上限 50；非法 cursor 格式 → 400 友好提示（非 500）。
+	if req.Params.PageSize > courseservice.MaxReviewPageSize {
+		return component.BuildResponse(http.StatusBadRequest,
+			component.FailDataCode(component.MessageRequestInvalidParams, nil))
+	}
+	cursor, err := courseservice.DecodeCursor(req.Params.Cursor)
+	if err != nil {
+		return component.BuildResponse(http.StatusBadRequest,
+			component.FailDataCode(component.MessageRequestInvalidParams, nil))
+	}
+	// offering 过滤时 cursor 只用 reviewId 段（忽略 offering 段）。
+	if req.Params.OfferingId > 0 {
+		cursor.OfferingId = 0
+	}
 	if req.Params.OfferingId > 0 {
 		offering, gErr := course.GetOffering(req.Params.OfferingId)
 		if gErr != nil || offering.Id == 0 ||
@@ -156,16 +169,14 @@ func ListCourseReviews(req component.BetterRequest[ListCourseReviewsReq]) compon
 			return component.BuildResponse(http.StatusNotFound,
 				component.FailDataCode(component.MessageReviewOfferingNotFound, nil))
 		}
-		payloads, err = courseservice.ListReviewsByOffering(req.Params.OfferingId, req.UserId)
-	} else {
-		payloads, err = courseservice.ListReviewsByCourse(req.Params.CourseId, req.UserId)
 	}
+	page, err := courseservice.ListReviewsPage(req.Params.CourseId, req.Params.OfferingId, req.UserId, cursor, req.Params.PageSize)
 	if err != nil {
 		slog.Error("course_review_list_failed", "courseId", req.Params.CourseId, "error", err)
 		return component.BuildResponse(http.StatusInternalServerError,
 			component.FailDataCode(component.MessageReviewListFailed, nil))
 	}
-	return component.SuccessResponse(payloads)
+	return component.SuccessResponse(page)
 }
 
 // ---- 审核：隐藏/恢复、举报队列、身份揭示 ----

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -890,3 +890,49 @@ func TestCourseReviewPaginationHTTPContract(t *testing.T) {
 		}
 	}
 }
+
+// TestCourseReviewPaginationHiddenOfferingExcluded 验证 PR #201 security F1：
+// 隐藏 offering 后，其评价不出现在课程级分页的 list 与 total 中。
+func TestCourseReviewPaginationHiddenOfferingExcluded(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 901)
+	// 第二个 offering（course 42）
+	if err := conn.Create(&course.OfferingEntity{Id: 903, CourseId: 42, TermId: 101, Status: course.OfferingStatusVisible}).Error; err != nil {
+		t.Fatalf("create offering 903: %v", err)
+	}
+	conn.Unscoped().Where("1 = 1").Delete(&course.ReviewEntity{})
+	seedCourseReview(t, conn, 1, 901, 1, nil, "可见", true, "", course.ReviewStatusVisible)
+	seedCourseReview(t, conn, 2, 903, 2, nil, "隐藏开课", true, "", course.ReviewStatusVisible)
+
+	// 初始：2 条（两个 offering 都可见）
+	rec := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=50", "", "")
+	response := decodeContractEnvelope(t, rec)
+	var page struct {
+		List  []map[string]any `json:"list"`
+		Total float64          `json:"total"`
+	}
+	_ = json.Unmarshal(response.Result, &page)
+	if page.Total != 2 || len(page.List) != 2 {
+		t.Fatalf("initial total=%v len=%d, want 2/2", page.Total, len(page.List))
+	}
+
+	// 隐藏 offering 903 → 其评价（id=2）从 list + total 消失
+	if err := conn.Model(&course.OfferingEntity{}).Where("id = ?", 903).Update("status", course.OfferingStatusHidden).Error; err != nil {
+		t.Fatalf("hide offering 903: %v", err)
+	}
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=50", "", "")
+	response = decodeContractEnvelope(t, rec)
+	_ = json.Unmarshal(response.Result, &page)
+	if page.Total != 1 {
+		t.Fatalf("total after hide = %v, want 1 (hidden offering excluded)", page.Total)
+	}
+	if len(page.List) != 1 || page.List[0]["id"] != float64(1) {
+		t.Fatalf("list after hide = %#v, want only review 1", page.List)
+	}
+
+	// offering 过滤路径仍可读隐藏 offering 前的可见评价？不——offering 过滤需 offering 可见（404）
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?offeringId=903", "", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("hidden offering scoped list status = %d, want 404", rec.Code)
+	}
+}

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -2,14 +2,15 @@ package routes
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/ratelimit"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/forum"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
@@ -21,6 +22,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
+	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
@@ -161,6 +163,18 @@ func assertNoReviewIdentityKeys(t *testing.T, value any) {
 	}
 }
 
+// decodeReviewPageList 解析评价列表分页响应的 list 数组（B2 分页对象结构）。
+func decodeReviewPageList(t *testing.T, response contractEnvelope) []map[string]any {
+	t.Helper()
+	var page struct {
+		List []map[string]any `json:"list"`
+	}
+	if err := json.Unmarshal(response.Result, &page); err != nil {
+		t.Fatalf("decode review page list %q: %v", response.Result, err)
+	}
+	return page.List
+}
+
 func isRFC3339(raw string) bool {
 	_, err := time.Parse(time.RFC3339, raw)
 	return err == nil
@@ -239,10 +253,17 @@ func TestCourseReviewListHTTPContract(t *testing.T) {
 	if response.Code != 0 {
 		t.Fatalf("course review list code = %d, want 0: %s", response.Code, rec.Body.String())
 	}
-	var items []map[string]any
-	if err := json.Unmarshal(response.Result, &items); err != nil {
+	var page struct {
+		List  []map[string]any `json:"list"`
+		Total float64          `json:"total"`
+	}
+	if err := json.Unmarshal(response.Result, &page); err != nil {
 		t.Fatalf("decode course review list result %q: %v", response.Result, err)
 	}
+	if page.Total != 3 {
+		t.Fatalf("course review list total = %v, want 3", page.Total)
+	}
+	items := page.List
 	if len(items) != 3 {
 		t.Fatalf("course review list length = %d, want 3", len(items))
 	}
@@ -253,10 +274,13 @@ func TestCourseReviewListHTTPContract(t *testing.T) {
 		assertNoReviewIdentityKeys(t, items[i])
 	}
 	fixture := contractFixture(t, "course-reviews-list-success.json")
-	var fixtureItems []map[string]any
-	if err := json.Unmarshal(fixture.Result, &fixtureItems); err != nil {
+	var fixturePage struct {
+		List []map[string]any `json:"list"`
+	}
+	if err := json.Unmarshal(fixture.Result, &fixturePage); err != nil {
 		t.Fatalf("decode course review list fixture %q: %v", fixture.Result, err)
 	}
+	fixtureItems := fixturePage.List
 	for i := range items {
 		assertReviewItemShape(t, items[i], fixtureItems[i])
 	}
@@ -434,10 +458,7 @@ func TestCourseReviewUpdateDeleteHTTPContract(t *testing.T) {
 		if list.Code != http.StatusOK {
 			t.Fatalf("post-delete list status = %d, want 200: %s", list.Code, list.Body.String())
 		}
-		var items []map[string]any
-		if err := json.Unmarshal(decodeContractEnvelope(t, list).Result, &items); err != nil {
-			t.Fatalf("decode post-delete list result: %v", err)
-		}
+		items := decodeReviewPageList(t, decodeContractEnvelope(t, list))
 		if len(items) != 0 {
 			t.Fatalf("deleted review still listed: %#v", items)
 		}
@@ -467,10 +488,7 @@ func TestCourseReviewHelpfulHTTPContract(t *testing.T) {
 		if rec.Code != http.StatusOK {
 			t.Fatalf("marked list status = %d, want 200: %s", rec.Code, rec.Body.String())
 		}
-		var items []map[string]any
-		if err := json.Unmarshal(decodeContractEnvelope(t, rec).Result, &items); err != nil {
-			t.Fatalf("decode marked list result: %v", err)
-		}
+		items := decodeReviewPageList(t, decodeContractEnvelope(t, rec))
 		if len(items) != 1 || items[0]["id"] != float64(301) {
 			t.Fatalf("marked list = %#v, want exactly review 301", items)
 		}
@@ -493,10 +511,7 @@ func TestCourseReviewHelpfulHTTPContract(t *testing.T) {
 		if list.Code != http.StatusOK {
 			t.Fatalf("unmarked list status = %d, want 200: %s", list.Code, list.Body.String())
 		}
-		var items []map[string]any
-		if err := json.Unmarshal(decodeContractEnvelope(t, list).Result, &items); err != nil {
-			t.Fatalf("decode unmarked list result: %v", err)
-		}
+		items := decodeReviewPageList(t, decodeContractEnvelope(t, list))
 		if len(items) != 1 {
 			t.Fatalf("unmarked list = %#v, want exactly one review", items)
 		}
@@ -601,10 +616,7 @@ func TestCourseReviewModerationHTTPContract(t *testing.T) {
 		if list.Code != http.StatusOK {
 			t.Fatalf("hidden list status = %d, want 200: %s", list.Code, list.Body.String())
 		}
-		var hiddenItems []map[string]any
-		if err := json.Unmarshal(decodeContractEnvelope(t, list).Result, &hiddenItems); err != nil {
-			t.Fatalf("decode hidden list result: %v", err)
-		}
+		hiddenItems := decodeReviewPageList(t, decodeContractEnvelope(t, list))
 		if len(hiddenItems) != 0 {
 			t.Fatalf("hidden review still listed: %#v", hiddenItems)
 		}
@@ -619,10 +631,7 @@ func TestCourseReviewModerationHTTPContract(t *testing.T) {
 		if listed.Code != http.StatusOK {
 			t.Fatalf("shown list status = %d, want 200: %s", listed.Code, listed.Body.String())
 		}
-		var shownItems []map[string]any
-		if err := json.Unmarshal(decodeContractEnvelope(t, listed).Result, &shownItems); err != nil {
-			t.Fatalf("decode shown list result: %v", err)
-		}
+		shownItems := decodeReviewPageList(t, decodeContractEnvelope(t, listed))
 		if len(shownItems) != 1 || shownItems[0]["id"] != float64(303) {
 			t.Fatalf("shown list = %#v, want exactly review 303", shownItems)
 		}
@@ -747,14 +756,137 @@ func TestCourseReviewLegacyHelpfulCountHTTPContract(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("list status = %d, want 200: %s", rec.Code, rec.Body.String())
 	}
-	var items []map[string]any
-	if err := json.Unmarshal(decodeContractEnvelope(t, rec).Result, &items); err != nil {
-		t.Fatalf("decode list result: %v", err)
-	}
+	items := decodeReviewPageList(t, decodeContractEnvelope(t, rec))
 	if len(items) != 1 {
 		t.Fatalf("expected 1 review, got %d", len(items))
 	}
 	if items[0]["helpfulCount"] != float64(7) {
 		t.Fatalf("helpfulCount = %#v, want 7 (legacy count exposed)", items[0]["helpfulCount"])
+	}
+}
+
+// TestCourseReviewPaginationHTTPContract 验证 B2 cursor 分页（issue #174 验收）：
+//  1. 250 条评价 pageSize=20 → 13 页，无重复无遗漏（集合比对一致）；
+//  2. 非法 cursor / pageSize>50 → 400 + common.request.invalidParams；
+//  3. 删除一条评价（隔离窗口）后续页 cursor 稳定不跳页。
+func TestCourseReviewPaginationHTTPContract(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 901)
+
+	// 清空并插入 250 条评价（offering 901；id 1..250，按 id DESC 排序）
+	// 注意：必须硬删（Unscoped），软删行会与显式主键 Create 冲突。
+	conn.Unscoped().Where("1 = 1").Delete(&course.ReviewEntity{})
+	// authorID 用唯一值（(offering_id, author_user_id) 唯一约束）
+	for i := uint64(1); i <= 250; i++ {
+		seedCourseReview(t, conn, i, 901, i, nil, fmt.Sprintf("评价 %d", i), true, course.ReviewSourceLegacyImport, course.ReviewStatusVisible)
+	}
+
+	// --- 验收 1：pageSize=20 共 13 页，无重复无遗漏 ---
+	seen := map[float64]bool{}
+	pageCount := 0
+	cursor := ""
+	expectTotal := float64(250)
+	for {
+		path := fmt.Sprintf("/api/forum/courses/42/reviews?pageSize=20&cursor=%s", url.QueryEscape(cursor))
+		rec := serveAuthSecurityJSON(router, http.MethodGet, path, "", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d status = %d, want 200: %s", pageCount+1, rec.Code, rec.Body.String())
+		}
+		response := decodeContractEnvelope(t, rec)
+		var page struct {
+			List       []map[string]any `json:"list"`
+			NextCursor string           `json:"nextCursor"`
+			Total      float64          `json:"total"`
+		}
+		if err := json.Unmarshal(response.Result, &page); err != nil {
+			t.Fatalf("decode page %d: %v", pageCount+1, err)
+		}
+		if page.Total != expectTotal {
+			t.Fatalf("page %d total = %v, want %v", pageCount+1, page.Total, expectTotal)
+		}
+		if len(page.List) > 20 {
+			t.Fatalf("page %d length = %d, want <= 20", pageCount+1, len(page.List))
+		}
+		for _, item := range page.List {
+			id := item["id"].(float64)
+			if seen[id] {
+				t.Fatalf("duplicate review id %v on page %d", id, pageCount+1)
+			}
+			seen[id] = true
+		}
+		pageCount++
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if pageCount != 13 {
+		t.Fatalf("page count = %d, want 13", pageCount)
+	}
+	if len(seen) != 250 {
+		t.Fatalf("collected %d unique reviews, want 250", len(seen))
+	}
+
+	// --- 验收 2：非法 cursor / pageSize 超限 → 400 ---
+	rec := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?cursor=not-a-cursor", "", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid cursor status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	assertFixtureEnvelope(t, decodeContractEnvelope(t, rec), contractFixture(t, "course-review-invalid-params.json"))
+
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=999", "", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("oversized pageSize status = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	assertFixtureEnvelope(t, decodeContractEnvelope(t, rec), contractFixture(t, "course-review-invalid-params.json"))
+
+	// --- 验收 3：删除一条（隔离窗口）后翻页不跳页 ---
+	// 第一页取前 20 条（id 250..231），删除其中一条（id 240），
+	// 从第一页 cursor 继续翻页：后续集合 = 全集 - 已见 - 被删。
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=20", "", "")
+	response := decodeContractEnvelope(t, rec)
+	var page struct {
+		List       []map[string]any `json:"list"`
+		NextCursor string           `json:"nextCursor"`
+	}
+	_ = json.Unmarshal(response.Result, &page)
+	if len(page.List) != 20 {
+		t.Fatalf("first page length = %d, want 20", len(page.List))
+	}
+	firstPageIDs := map[float64]bool{}
+	for _, item := range page.List {
+		firstPageIDs[item["id"].(float64)] = true
+	}
+	// 删除 id=240（隔离窗口内软删）
+	if err := conn.Where("id = ?", 240).Delete(&course.ReviewEntity{}).Error; err != nil {
+		t.Fatalf("delete review 240: %v", err)
+	}
+	// 从第一页 cursor 继续：只应看到 id < 231 的剩余评价，无跳页无重复
+	rec = serveAuthSecurityJSON(router, http.MethodGet,
+		"/api/forum/courses/42/reviews?pageSize=20&cursor="+url.QueryEscape(page.NextCursor), "", "")
+	response = decodeContractEnvelope(t, rec)
+	var page2 struct {
+		List       []map[string]any `json:"list"`
+		NextCursor string           `json:"nextCursor"`
+	}
+	_ = json.Unmarshal(response.Result, &page2)
+	seenAfter := map[float64]bool{}
+	for _, item := range page2.List {
+		id := item["id"].(float64)
+		if firstPageIDs[id] {
+			t.Fatalf("review %v reappeared after cursor (skip/jump)", id)
+		}
+		if seenAfter[id] {
+			t.Fatalf("duplicate review %v in page 2", id)
+		}
+		seenAfter[id] = true
+	}
+	if len(page2.List) != 20 {
+		t.Fatalf("page 2 length = %d, want 20 (no skipped page due to deletion)", len(page2.List))
+	}
+	for _, item := range page2.List {
+		if item["id"].(float64) == 240 {
+			t.Fatalf("deleted review 240 should not appear")
+		}
 	}
 }

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/rolePermissionRs"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/courseservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -857,8 +858,9 @@ func TestCourseReviewPaginationHTTPContract(t *testing.T) {
 	for _, item := range page.List {
 		firstPageIDs[item["id"].(float64)] = true
 	}
-	// 删除 id=240（隔离窗口内软删）
-	if err := conn.Where("id = ?", 240).Delete(&course.ReviewEntity{}).Error; err != nil {
+	// 删除 id=240（隔离窗口内；用生产 DeleteReview 路径——status=deleted 软删，
+	// 与 gorm 直接软删（deleted_at）语义不同；spec S1）。
+	if err := courseservice.DeleteReview(240, 240); err != nil {
 		t.Fatalf("delete review 240: %v", err)
 	}
 	// 从第一页 cursor 继续：只应看到 id < 231 的剩余评价，无跳页无重复
@@ -868,8 +870,13 @@ func TestCourseReviewPaginationHTTPContract(t *testing.T) {
 	var page2 struct {
 		List       []map[string]any `json:"list"`
 		NextCursor string           `json:"nextCursor"`
+		Total      float64          `json:"total"`
 	}
 	_ = json.Unmarshal(response.Result, &page2)
+	// total 同步递减（生产删除路径扣减；spec S1：断言 total 口径一致）
+	if page2.Total != 249 {
+		t.Fatalf("total after delete = %v, want 249 (deleted review excluded)", page2.Total)
+	}
 	seenAfter := map[float64]bool{}
 	for _, item := range page2.List {
 		id := item["id"].(float64)
@@ -934,5 +941,75 @@ func TestCourseReviewPaginationHiddenOfferingExcluded(t *testing.T) {
 	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?offeringId=903", "", "")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("hidden offering scoped list status = %d, want 404", rec.Code)
+	}
+}
+
+// TestCourseReviewPaginationMultiOfferingCursor 验证 PR #201 spec S2：
+// 2+ offering 复合游标 (offering_id DESC, id DESC) 交错翻页——
+// 元组比较逻辑在跨 offering 场景下无重复无遗漏。
+func TestCourseReviewPaginationMultiOfferingCursor(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 901)
+	// 第二个 offering 902（course 42）
+	if err := conn.Create(&course.OfferingEntity{Id: 902, CourseId: 42, TermId: 101, Status: course.OfferingStatusVisible}).Error; err != nil {
+		t.Fatalf("create offering 902: %v", err)
+	}
+	conn.Unscoped().Where("1 = 1").Delete(&course.ReviewEntity{})
+	// offering 901: id 1..15（新→旧），offering 902: id 101..115
+	// 交错后的全局序（offering_id DESC, id DESC）：
+	// 902(115..101) → 901(15..1)
+	for i := uint64(1); i <= 15; i++ {
+		seedCourseReview(t, conn, i, 901, i, nil, fmt.Sprintf("a%d", i), true, "", course.ReviewStatusVisible)
+		seedCourseReview(t, conn, 100+i, 902, 200+i, nil, fmt.Sprintf("b%d", i), true, "", course.ReviewStatusVisible)
+	}
+
+	// pageSize=10 翻页：全局序 902:115..101, 901:15..1 → 30 条 / 10 = 3 页
+	seen := map[float64]bool{}
+	cursor := ""
+	pages := 0
+	for {
+		path := fmt.Sprintf("/api/forum/courses/42/reviews?pageSize=10&cursor=%s", url.QueryEscape(cursor))
+		rec := serveAuthSecurityJSON(router, http.MethodGet, path, "", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("page %d status = %d: %s", pages+1, rec.Code, rec.Body.String())
+		}
+		response := decodeContractEnvelope(t, rec)
+		var page struct {
+			List       []map[string]any `json:"list"`
+			NextCursor string           `json:"nextCursor"`
+			Total      float64          `json:"total"`
+		}
+		_ = json.Unmarshal(response.Result, &page)
+		if page.Total != 30 {
+			t.Fatalf("page %d total = %v, want 30", pages+1, page.Total)
+		}
+		for _, item := range page.List {
+			id := item["id"].(float64)
+			if seen[id] {
+				t.Fatalf("duplicate review %v across pages", id)
+			}
+			seen[id] = true
+		}
+		pages++
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if pages != 3 {
+		t.Fatalf("pages = %d, want 3", pages)
+	}
+	if len(seen) != 30 {
+		t.Fatalf("collected %d unique reviews, want 30 (no skip/dup across offerings)", len(seen))
+	}
+	// 验证全局序首元素为 902 的最大 id（115）
+	rec := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=10", "", "")
+	response := decodeContractEnvelope(t, rec)
+	var first struct {
+		List []map[string]any `json:"list"`
+	}
+	_ = json.Unmarshal(response.Result, &first)
+	if len(first.List) == 0 || first.List[0]["id"] != float64(115) {
+		t.Fatalf("first item = %#v, want id 115 (offering 902 newest first)", first.List[0])
 	}
 }

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -1013,3 +1013,59 @@ func TestCourseReviewPaginationMultiOfferingCursor(t *testing.T) {
 		t.Fatalf("first item = %#v, want id 115 (offering 902 newest first)", first.List[0])
 	}
 }
+
+// TestCourseReviewPaginationOfferingStats 验证跨 PR 接线（#195 字段 → #201 分页路径）：
+// reviews?offeringId= 分页响应的 ReviewPayload 携带 offeringRatingAvg/
+// offeringReviewCount 且值正确（数据来自 offering_review_stats 投影）。
+func TestCourseReviewPaginationOfferingStats(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 901)
+	conn.Unscoped().Where("1 = 1").Delete(&course.ReviewEntity{})
+	conn.Unscoped().Where("1 = 1").Delete(&course.OfferingStatsEntity{})
+
+	// 3 条评价（5/4/NULL）+ offering 统计投影（2 评分 sum=9 → avg=4.5, reviewCount=3）
+	r5, r4 := 5, 4
+	seedCourseReview(t, conn, 1, 901, 1, &r5, "五星", true, "", course.ReviewStatusVisible)
+	seedCourseReview(t, conn, 2, 901, 2, &r4, "四星", true, "", course.ReviewStatusVisible)
+	seedCourseReview(t, conn, 3, 901, 3, nil, "无评分", true, "", course.ReviewStatusVisible)
+	if err := conn.Create(&course.OfferingStatsEntity{OfferingId: 901, RatingCount: 2, RatingSum: 9, ReviewCount: 3}).Error; err != nil {
+		t.Fatalf("create offering stats: %v", err)
+	}
+
+	rec := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?offeringId=901&pageSize=50", "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	response := decodeContractEnvelope(t, rec)
+	var page struct {
+		List []map[string]any `json:"list"`
+	}
+	_ = json.Unmarshal(response.Result, &page)
+	if len(page.List) != 3 {
+		t.Fatalf("list length = %d, want 3", len(page.List))
+	}
+	// 每条 payload 都带 offering 级统计（同 offering 901）
+	for i, item := range page.List {
+		if got := item["offeringRatingAvg"]; got != 4.5 {
+			t.Fatalf("item %d offeringRatingAvg = %#v, want 4.5", i, got)
+		}
+		if got := item["offeringReviewCount"]; got != float64(3) {
+			t.Fatalf("item %d offeringReviewCount = %#v, want 3", i, got)
+		}
+	}
+	// 无 offeringId 过滤（course 级）→ 不填充 offering 统计
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=50", "", "")
+	response = decodeContractEnvelope(t, rec)
+	var coursePage struct {
+		List []map[string]any `json:"list"`
+	}
+	_ = json.Unmarshal(response.Result, &coursePage)
+	if len(coursePage.List) != 3 {
+		t.Fatalf("course list length = %d, want 3", len(coursePage.List))
+	}
+	for i, item := range coursePage.List {
+		if _, present := item["offeringRatingAvg"]; present {
+			t.Fatalf("course-level item %d should omit offeringRatingAvg, got %#v", i, item["offeringRatingAvg"])
+		}
+	}
+}

--- a/apps/gooseforum/app/models/forum/course/review_rep.go
+++ b/apps/gooseforum/app/models/forum/course/review_rep.go
@@ -263,9 +263,11 @@ func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
 		}
 		build = build.Order("id DESC")
 	} else {
+		// course 级：仅统计可见 offering——隐藏 offering 的评价不出现，
+		// 与 ListOfferingsByCourse/详情页可见性一致（PR #201 security F1）。
 		build = build.Where(
-			"offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL)",
-			q.CourseId,
+			"offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL AND status = ?)",
+			q.CourseId, OfferingStatusVisible,
 		)
 		if q.CursorOfferingId > 0 || q.CursorReviewId > 0 {
 			build = build.Where(
@@ -283,10 +285,12 @@ func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
 }
 
 // CountVisibleReviewsByCourse 课程下可见评价总数（分页 total）。
+// 与 ListReviewsPage course 级口径一致：仅统计可见 offering
+// （PR #201 security F1：隐藏 offering 的评价不计入 total）。
 func CountVisibleReviewsByCourse(courseId uint64) (int64, error) {
 	var count int64
 	err := reviewBuilder().
-		Where("offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL)", courseId).
+		Where("offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL AND status = ?)", courseId, OfferingStatusVisible).
 		Where(queryopt.Eq("status", ReviewStatusVisible)).
 		Count(&count).Error
 	return count, err

--- a/apps/gooseforum/app/models/forum/course/review_rep.go
+++ b/apps/gooseforum/app/models/forum/course/review_rep.go
@@ -255,7 +255,10 @@ type ReviewPageQuery struct {
 
 // ListReviewsPage 按 cursor 分页列出可见评价（时间倒序）。
 func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
-	build := reviewBuilder().Where(queryopt.Eq("status", ReviewStatusVisible))
+	build := reviewBuilder().Where(queryopt.Eq("status", ReviewStatusVisible)).
+		// 软删条件显式写（spec S1：Table() 模式不依赖 gorm schema 推断，
+		// 与 Count 口径一致，防未来漂移）。
+		Where("deleted_at IS NULL")
 	if q.OfferingId > 0 {
 		build = build.Where(queryopt.Eq("offering_id", q.OfferingId))
 		if q.CursorReviewId > 0 {
@@ -285,23 +288,27 @@ func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
 }
 
 // CountVisibleReviewsByCourse 课程下可见评价总数（分页 total）。
-// 与 ListReviewsPage course 级口径一致：仅统计可见 offering
-// （PR #201 security F1：隐藏 offering 的评价不计入 total）。
+// 与 ListReviewsPage course 级口径一致：仅统计可见 offering 且未软删
+// （PR #201 security F1：隐藏 offering 的评价不计入 total；spec S1：
+// Count 走 *int64 dest 不解析 schema，软删条件必须显式写，防口径漂移）。
 func CountVisibleReviewsByCourse(courseId uint64) (int64, error) {
 	var count int64
 	err := reviewBuilder().
 		Where("offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL AND status = ?)", courseId, OfferingStatusVisible).
 		Where(queryopt.Eq("status", ReviewStatusVisible)).
+		Where("deleted_at IS NULL").
 		Count(&count).Error
 	return count, err
 }
 
 // CountVisibleReviewsByOffering offering 下可见评价总数（分页 total）。
+// 软删条件显式写（spec S1：Count 不解析 schema，需显式过滤软删行）。
 func CountVisibleReviewsByOffering(offeringId uint64) (int64, error) {
 	var count int64
 	err := reviewBuilder().
 		Where(queryopt.Eq("offering_id", offeringId)).
 		Where(queryopt.Eq("status", ReviewStatusVisible)).
+		Where("deleted_at IS NULL").
 		Count(&count).Error
 	return count, err
 }

--- a/apps/gooseforum/app/models/forum/course/review_rep.go
+++ b/apps/gooseforum/app/models/forum/course/review_rep.go
@@ -239,6 +239,69 @@ func ListReviewsByOfferings(offeringIds []uint64) (entities []ReviewEntity, err 
 	return
 }
 
+// ---- B2: cursor 分页（issue #174） ----
+
+// ReviewPageQuery cursor 分页查询条件。排序：course 级按
+// (offering_id DESC, id DESC)，offering 级按 id DESC（时间倒序）。
+// Cursor 语义：返回 (offering_id, id) 严格小于 cursor 的可见评价
+// （位置游标——删除/隐藏行不影响后续页游标稳定性）。
+type ReviewPageQuery struct {
+	CourseId         uint64
+	OfferingId       uint64 // 0 = 课程级全部 offering
+	CursorOfferingId uint64 // cursor 中的 offering_id（offering 级时为 0）
+	CursorReviewId   uint64 // cursor 中的 review_id（无 cursor 时为 0）
+	Limit            int
+}
+
+// ListReviewsPage 按 cursor 分页列出可见评价（时间倒序）。
+func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
+	build := reviewBuilder().Where(queryopt.Eq("status", ReviewStatusVisible))
+	if q.OfferingId > 0 {
+		build = build.Where(queryopt.Eq("offering_id", q.OfferingId))
+		if q.CursorReviewId > 0 {
+			build = build.Where("id < ?", q.CursorReviewId)
+		}
+		build = build.Order("id DESC")
+	} else {
+		build = build.Where(
+			"offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL)",
+			q.CourseId,
+		)
+		if q.CursorOfferingId > 0 || q.CursorReviewId > 0 {
+			build = build.Where(
+				"(offering_id < ? OR (offering_id = ? AND id < ?))",
+				q.CursorOfferingId, q.CursorOfferingId, q.CursorReviewId,
+			)
+		}
+		build = build.Order("offering_id DESC, id DESC")
+	}
+	if q.Limit > 0 {
+		build = build.Limit(q.Limit)
+	}
+	err = build.Find(&entities).Error
+	return
+}
+
+// CountVisibleReviewsByCourse 课程下可见评价总数（分页 total）。
+func CountVisibleReviewsByCourse(courseId uint64) (int64, error) {
+	var count int64
+	err := reviewBuilder().
+		Where("offering_id IN (SELECT id FROM "+offeringTableName+" WHERE course_id = ? AND deleted_at IS NULL)", courseId).
+		Where(queryopt.Eq("status", ReviewStatusVisible)).
+		Count(&count).Error
+	return count, err
+}
+
+// CountVisibleReviewsByOffering offering 下可见评价总数（分页 total）。
+func CountVisibleReviewsByOffering(offeringId uint64) (int64, error) {
+	var count int64
+	err := reviewBuilder().
+		Where(queryopt.Eq("offering_id", offeringId)).
+		Where(queryopt.Eq("status", ReviewStatusVisible)).
+		Count(&count).Error
+	return count, err
+}
+
 // ---- Helpful ----
 
 // CreateHelpful 标记 helpful（唯一约束 (review_id, user_id) 防重）。

--- a/apps/gooseforum/app/models/forum/course/review_rep.go
+++ b/apps/gooseforum/app/models/forum/course/review_rep.go
@@ -1,6 +1,7 @@
 package course
 
 import (
+	"log/slog"
 	"time"
 
 	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -364,6 +365,26 @@ func GetCourseStats(courseId uint64) (entity CourseStatsEntity, err error) {
 func GetOfferingStats(offeringId uint64) (entity OfferingStatsEntity, err error) {
 	err = offeringStatsBuilder().Where("offering_id = ?", offeringId).First(&entity).Error
 	return
+}
+
+// ListOfferingStatsByIDs 批量读取 offering 级统计投影（分页响应 offering 统计 N+1 防护）。
+// 无统计行的 offering 返回空实体（ratingCount=0/reviewCount=0）。
+// 依赖说明（PR #195 跨 PR 接线）：字段名与 #195 ReviewPayload 的
+// offeringRatingAvg/offeringReviewCount 对齐；#195 先于 #201 合入。
+func ListOfferingStatsByIDs(offeringIds []uint64) map[uint64]OfferingStatsEntity {
+	result := make(map[uint64]OfferingStatsEntity, len(offeringIds))
+	if len(offeringIds) == 0 {
+		return result
+	}
+	var list []OfferingStatsEntity
+	if err := offeringStatsBuilder().Where("offering_id IN ?", offeringIds).Find(&list).Error; err != nil {
+		slog.Warn("ListOfferingStatsByIDs: 查询失败", "offeringIds", offeringIds, "err", err)
+		return result
+	}
+	for _, s := range list {
+		result[s.OfferingId] = s
+	}
+	return result
 }
 
 // UpsertCourseStatsTx 事务内课程级统计原子累加（INSERT ... ON CONFLICT DO UPDATE + delta）。

--- a/apps/gooseforum/app/service/courseservice/review.go
+++ b/apps/gooseforum/app/service/courseservice/review.go
@@ -353,8 +353,10 @@ const ReviewListMaxItems = 200
 // ---- B2: cursor 分页（issue #174） ----
 
 // DefaultReviewPageSize 评价列表默认页大小；MaxReviewPageSize 上限。
+// 默认 50 与前端 api.ts 默认值及契约 default 对齐（PR #201 security N1：
+// 契约文档/前端/服务端三方一致，省略 pageSize 时返回 50 条）。
 const (
-	DefaultReviewPageSize = 20
+	DefaultReviewPageSize = 50
 	MaxReviewPageSize     = 50
 )
 
@@ -400,7 +402,7 @@ func DecodeCursor(raw string) (ReviewCursor, error) {
 }
 
 // ListReviewsPage 按 cursor 分页返回课程（或指定 offering）的可见评价。
-// pageSize 默认 20、上限 50；结果多取一条判断 hasNext（无重复无遗漏）。
+// pageSize 默认 50、上限 50；结果多取一条判断 hasNext（无重复无遗漏）。
 // total 为当前筛选下的可见评价总数（offering 过滤时同口径）。
 // 边界语义（PR #201 spec O3）：pageSize<=0 静默回落默认值（契约 minimum=1，
 // 宽松容忍无害，控制器仅拦 >50）；cursor 非法格式由控制器 DecodeCursor 拦 400。

--- a/apps/gooseforum/app/service/courseservice/review.go
+++ b/apps/gooseforum/app/service/courseservice/review.go
@@ -2,6 +2,9 @@ package courseservice
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -338,6 +341,103 @@ func SetReviewHelpful(userId, reviewId uint64, helpful bool) error {
 
 // ReviewListMaxItems 评价列表单次返回上限（防止热门课程响应无界；分页由后续 slice 增强）。
 const ReviewListMaxItems = 200
+
+// ---- B2: cursor 分页（issue #174） ----
+
+// DefaultReviewPageSize 评价列表默认页大小；MaxReviewPageSize 上限。
+const (
+	DefaultReviewPageSize = 20
+	MaxReviewPageSize     = 50
+)
+
+// ErrReviewInvalidCursor 非法 cursor（格式/取值错误，控制器映射 400）。
+var ErrReviewInvalidCursor = errors.New("invalid review cursor")
+
+// ReviewPageResult cursor 分页结果。
+type ReviewPageResult struct {
+	List       []ReviewPayload `json:"list"`
+	NextCursor string          `json:"nextCursor,omitempty"`
+	Total      int64           `json:"total"`
+}
+
+// ReviewCursor 复合游标（offering_id, review_id）。
+// Course 级列表按 (offering_id DESC, id DESC) 排序，cursor 是上一页
+// 最后一条的 (offeringId, id)；offering 级列表只用 reviewId。
+type ReviewCursor struct {
+	OfferingId uint64
+	ReviewId   uint64
+}
+
+// EncodeCursor 编码 cursor 为明文 "offeringId:reviewId"。
+func EncodeCursor(c ReviewCursor) string {
+	return fmt.Sprintf("%d:%d", c.OfferingId, c.ReviewId)
+}
+
+// DecodeCursor 解析 cursor；非法格式返回 ErrReviewInvalidCursor。
+func DecodeCursor(raw string) (ReviewCursor, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ReviewCursor{}, nil
+	}
+	parts := strings.Split(raw, ":")
+	if len(parts) != 2 {
+		return ReviewCursor{}, ErrReviewInvalidCursor
+	}
+	oid, err1 := strconv.ParseUint(parts[0], 10, 64)
+	rid, err2 := strconv.ParseUint(parts[1], 10, 64)
+	if err1 != nil || err2 != nil {
+		return ReviewCursor{}, ErrReviewInvalidCursor
+	}
+	return ReviewCursor{OfferingId: oid, ReviewId: rid}, nil
+}
+
+// ListReviewsPage 按 cursor 分页返回课程（或指定 offering）的可见评价。
+// pageSize 默认 20、上限 50；结果多取一条判断 hasNext（无重复无遗漏）。
+// total 为当前筛选下的可见评价总数（offering 过滤时同口径）。
+func ListReviewsPage(courseId, offeringId, viewerId uint64, cursor ReviewCursor, pageSize int) (ReviewPageResult, error) {
+	if pageSize <= 0 {
+		pageSize = DefaultReviewPageSize
+	}
+	if pageSize > MaxReviewPageSize {
+		pageSize = MaxReviewPageSize
+	}
+	query := course.ReviewPageQuery{
+		CourseId:         courseId,
+		OfferingId:       offeringId,
+		CursorOfferingId: cursor.OfferingId,
+		CursorReviewId:   cursor.ReviewId,
+		Limit:            pageSize + 1,
+	}
+	entities, err := course.ListReviewsPage(query)
+	if err != nil {
+		return ReviewPageResult{}, err
+	}
+	hasNext := len(entities) > pageSize
+	if hasNext {
+		entities = entities[:pageSize]
+	}
+	payloads, err := listReviewPayloads(entities, viewerId)
+	if err != nil {
+		return ReviewPageResult{}, err
+	}
+	result := ReviewPageResult{
+		List:  payloads,
+		Total: 0,
+	}
+	if offeringId > 0 {
+		result.Total, err = course.CountVisibleReviewsByOffering(offeringId)
+	} else {
+		result.Total, err = course.CountVisibleReviewsByCourse(courseId)
+	}
+	if err != nil {
+		return ReviewPageResult{}, err
+	}
+	if hasNext {
+		last := entities[len(entities)-1]
+		result.NextCursor = EncodeCursor(ReviewCursor{OfferingId: last.OfferingId, ReviewId: last.Id})
+	}
+	return result, nil
+}
 
 // ListReviewsByOffering 返回 offering 的可见评价列表（匿名 DTO，最多 ReviewListMaxItems 条）。
 func ListReviewsByOffering(offeringId, viewerId uint64) ([]ReviewPayload, error) {

--- a/apps/gooseforum/app/service/courseservice/review.go
+++ b/apps/gooseforum/app/service/courseservice/review.go
@@ -340,6 +340,9 @@ func SetReviewHelpful(userId, reviewId uint64, helpful bool) error {
 }
 
 // ReviewListMaxItems 评价列表单次返回上限（防止热门课程响应无界；分页由后续 slice 增强）。
+// 注意：B2 分页（issue #174）上线后 HTTP 列表走 ListReviewsPage，旧路径
+// ListReviewsByOffering/ListReviewsByCourse 仅供内部调用（如无 HTTP 调用方时
+// 待后续清理，PR #201 security F3）。
 const ReviewListMaxItems = 200
 
 // ---- B2: cursor 分页（issue #174） ----

--- a/apps/gooseforum/app/service/courseservice/review.go
+++ b/apps/gooseforum/app/service/courseservice/review.go
@@ -60,6 +60,11 @@ type ReviewPayload struct {
 	HelpfulCount int64               `json:"helpfulCount"`
 	CreatedAt    string              `json:"createdAt"`
 	UpdatedAt    string              `json:"updatedAt"`
+	// OfferingRatingAvg / OfferingReviewCount：offering 级统计
+	// （PRD §5.1 B1，reviews?offeringId= 端点展示；依赖 #195 字段定义，
+	// 合入顺序 #195 先于 #201）。
+	OfferingRatingAvg   *float64 `json:"offeringRatingAvg,omitempty"`
+	OfferingReviewCount int      `json:"offeringReviewCount,omitempty"`
 }
 
 // CreateReviewInput 写评请求。
@@ -425,6 +430,12 @@ func ListReviewsPage(courseId, offeringId, viewerId uint64, cursor ReviewCursor,
 	if err != nil {
 		return ReviewPageResult{}, err
 	}
+	// offering 级统计（PRD §5.1 B1：reviews?offeringId= 端点展示；跨 PR 接线，
+	// 依赖 #195 的 ReviewPayload 字段定义，合入顺序 #195 先于 #201）。
+	// 仅 offeringId 过滤场景填充（course 级跨 offering 无单一 offering 统计）。
+	if offeringId > 0 {
+		fillOfferingStats(payloads)
+	}
 	result := ReviewPageResult{
 		List:  payloads,
 		Total: 0,
@@ -593,7 +604,33 @@ func listReviewPayloads(entities []course.ReviewEntity, viewerId uint64) ([]Revi
 	return payloads, nil
 }
 
-// fillReviewAuthorLabel 为写路径单条 member 评价回填展示用户名；匿名/legacy 不查询、不泄漏。
+// fillOfferingStats 为评价 payload 批量填充 offering 级统计
+// （PRD §5.1 B1：reviews?offeringId= 端点展示；跨 PR 接线，依赖 #195 字段定义）。
+// 数据来自 offering_review_stats 投影；查询错误由 ListOfferingStatsByIDs
+// 内部 slog.Warn 记录（fail-open：不阻断列表返回）。
+func fillOfferingStats(payloads []ReviewPayload) {
+	ids := make([]uint64, 0, len(payloads))
+	seen := map[uint64]bool{}
+	for _, p := range payloads {
+		if !seen[p.OfferingId] {
+			seen[p.OfferingId] = true
+			ids = append(ids, p.OfferingId)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	stats := course.ListOfferingStatsByIDs(ids)
+	for i := range payloads {
+		if s, ok := stats[payloads[i].OfferingId]; ok {
+			if s.RatingCount > 0 {
+				avg := float64(s.RatingSum) / float64(s.RatingCount)
+				payloads[i].OfferingRatingAvg = &avg
+			}
+			payloads[i].OfferingReviewCount = s.ReviewCount
+		}
+	}
+}
 func fillReviewAuthorLabel(p *ReviewPayload, authorUserId uint64) {
 	if p == nil || p.Author.Kind != "member" || authorUserId == 0 {
 		return

--- a/apps/gooseforum/app/service/courseservice/review.go
+++ b/apps/gooseforum/app/service/courseservice/review.go
@@ -397,6 +397,8 @@ func DecodeCursor(raw string) (ReviewCursor, error) {
 // ListReviewsPage 按 cursor 分页返回课程（或指定 offering）的可见评价。
 // pageSize 默认 20、上限 50；结果多取一条判断 hasNext（无重复无遗漏）。
 // total 为当前筛选下的可见评价总数（offering 过滤时同口径）。
+// 边界语义（PR #201 spec O3）：pageSize<=0 静默回落默认值（契约 minimum=1，
+// 宽松容忍无害，控制器仅拦 >50）；cursor 非法格式由控制器 DecodeCursor 拦 400。
 func ListReviewsPage(courseId, offeringId, viewerId uint64, cursor ReviewCursor, pageSize int) (ReviewPageResult, error) {
 	if pageSize <= 0 {
 		pageSize = DefaultReviewPageSize

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -1232,8 +1232,21 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
-        /** @description The raw review array; an empty listing is an empty array, never null. */
-        ReviewListResult: components["schemas"]["ReviewPayload"][];
+        ReviewListResult: {
+            /** @description The current page of visible reviews; an empty listing is an empty array, never null. */
+            list: components["schemas"]["ReviewPayload"][];
+            /**
+             * @description Cursor for the next page, present only when more reviews exist.
+             *     Format is "offeringId:reviewId" of the last item of the current page
+             *     (course-level ordering is (offering_id DESC, id DESC)). Omit to stop paging.
+             */
+            nextCursor?: string;
+            /**
+             * Format: int64
+             * @description Total number of visible reviews matching the current scope (course or offering filter).
+             */
+            total: number;
+        };
         ReviewListResponse: (components["schemas"]["ApiSuccess"] & {
             result: components["schemas"]["ReviewListResult"];
         }) | components["schemas"]["ApiFailure"];
@@ -2600,6 +2613,8 @@ export interface operations {
         parameters: {
             query?: {
                 offeringId?: number;
+                cursor?: string;
+                pageSize?: number;
             };
             header?: never;
             path: {

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -1231,6 +1231,15 @@ export interface components {
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
+            /**
+             * Format: double
+             * @description Non-NULL rating average of the review's offering (PRD §5.1 B1).
+             *     Present only when the listing is scoped to a single offering and the
+             *     offering has at least one rated review.
+             */
+            offeringRatingAvg?: number;
+            /** @description Number of visible reviews of the review's offering (offering-scoped listing only). */
+            offeringReviewCount?: number;
         };
         ReviewListResult: {
             /** @description The current page of visible reviews; an empty listing is an empty array, never null. */

--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -436,6 +436,7 @@ export default {
     noOfferings: 'No offerings yet.',
     reviewsTitle: 'Course reviews',
     reviewsLoading: 'Loading reviews…',
+    loadMoreReviews: 'Load more reviews',
     reviewsEmpty: 'No reviews yet',
     reviewsEmptyDescription: 'No one has reviewed this course yet. Be the first.',
     reviewsLoadFailed: 'Failed to load reviews. Please try again later.',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -436,6 +436,7 @@ export default {
     noOfferings: 'Ancora nessuna offerta.',
     reviewsTitle: 'Recensioni del corso',
     reviewsLoading: 'Caricamento delle recensioni…',
+    loadMoreReviews: 'Carica altre recensioni',
     reviewsEmpty: 'Ancora nessuna recensione',
     reviewsEmptyDescription: 'Nessuno ha ancora recensito questo corso. Scrivi la prima recensione.',
     reviewsLoadFailed: 'Caricamento delle recensioni non riuscito. Riprova più tardi.',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -436,6 +436,7 @@ export default {
     noOfferings: '開講記録はまだありません。',
     reviewsTitle: 'コース評価',
     reviewsLoading: '評価を読み込み中…',
+    loadMoreReviews: 'さらに評価を読み込む',
     reviewsEmpty: 'まだ評価はありません',
     reviewsEmptyDescription: 'このコースの評価はまだありません。最初の評価を書きましょう。',
     reviewsLoadFailed: '評価の読み込みに失敗しました。あとでもう一度お試しください。',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -436,6 +436,7 @@ export default {
     noOfferings: '暂无开课记录。',
     reviewsTitle: '课程评价',
     reviewsLoading: '正在加载评价…',
+    loadMoreReviews: '加载更多评价',
     reviewsEmpty: '暂无评价',
     reviewsEmptyDescription: '还没有同学评价这门课，来写第一条吧。',
     reviewsLoadFailed: '评价加载失败，请稍后重试。',

--- a/apps/gooseforum/resource/src/runtime/api.ts
+++ b/apps/gooseforum/resource/src/runtime/api.ts
@@ -1316,16 +1316,24 @@ export async function getCourseRelated(courseId: number): Promise<CourseRelatedR
   return readApiResponse<CourseRelatedResult>(response, t('api.courseRelatedLoadFailed'))
 }
 
-export async function listCourseReviews(courseId: number, offeringId = 0): Promise<ReviewPayload[]> {
+export interface ReviewPage {
+  list: ReviewPayload[]
+  nextCursor?: string
+  total: number
+}
+
+export async function listCourseReviews(courseId: number, offeringId = 0, cursor = '', pageSize = 20): Promise<ReviewPage> {
   const params = new URLSearchParams()
   if (offeringId > 0) params.set('offeringId', String(offeringId))
+  if (cursor) params.set('cursor', cursor)
+  params.set('pageSize', String(pageSize))
   const query = params.toString()
   const response = await fetch(`/api/forum/courses/${courseId}/reviews${query ? `?${query}` : ''}`, {
     headers: {
       Accept: 'application/json',
     },
   })
-  return readApiResponse<ReviewPayload[]>(response, t('api.reviewsLoadFailed'))
+  return readApiResponse<ReviewPage>(response, t('api.reviewsLoadFailed'))
 }
 
 export async function createCourseReview(input: CreateCourseReviewInput): Promise<ReviewPayload> {

--- a/apps/gooseforum/resource/src/runtime/api.ts
+++ b/apps/gooseforum/resource/src/runtime/api.ts
@@ -1322,7 +1322,9 @@ export interface ReviewPage {
   total: number
 }
 
-export async function listCourseReviews(courseId: number, offeringId = 0, cursor = '', pageSize = 20): Promise<ReviewPage> {
+// 默认 pageSize=50（PR #201 security F2：减少共享 IP 限流下的翻页请求量，
+// 200 条只需 4 次请求而非 10 次）。
+export async function listCourseReviews(courseId: number, offeringId = 0, cursor = '', pageSize = 50): Promise<ReviewPage> {
   const params = new URLSearchParams()
   if (offeringId > 0) params.set('offeringId', String(offeringId))
   if (cursor) params.set('cursor', cursor)

--- a/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
@@ -73,6 +73,9 @@ function authorLabel(author: ReviewPayload['author']) {
 
 // ---- 评价列表 ----
 const reviews = ref<ReviewPayload[]>([])
+const reviewTotal = ref(0)
+const reviewNextCursor = ref('')
+const reviewLoadingMore = ref(false)
 const reviewLoading = ref(false)
 const reviewError = ref('')
 const reviewLoaded = ref(false)
@@ -82,12 +85,30 @@ async function loadReviews() {
   reviewLoading.value = true
   reviewError.value = ''
   try {
-    reviews.value = await listCourseReviews(page.props.course.id)
+    const reviewPage = await listCourseReviews(page.props.course.id)
+    reviews.value = reviewPage.list
+    reviewTotal.value = reviewPage.total
+    reviewNextCursor.value = reviewPage.nextCursor ?? ''
   } catch (error) {
     reviewError.value = error instanceof Error ? error.message : t('courseDetailPage.reviewsLoadFailed')
   } finally {
     reviewLoading.value = false
     reviewLoaded.value = true
+  }
+}
+
+// 加载更多（B2 cursor 分页，issue #174）
+async function loadMoreReviews() {
+  if (!reviewNextCursor.value || reviewLoadingMore.value) return
+  reviewLoadingMore.value = true
+  try {
+    const reviewPage = await listCourseReviews(page.props.course.id, 0, reviewNextCursor.value)
+    reviews.value = reviews.value.concat(reviewPage.list)
+    reviewNextCursor.value = reviewPage.nextCursor ?? ''
+  } catch (error) {
+    reviewError.value = error instanceof Error ? error.message : t('courseDetailPage.reviewsLoadFailed')
+  } finally {
+    reviewLoadingMore.value = false
   }
 }
 
@@ -605,6 +626,16 @@ onMounted(() => {
           </div>
         </li>
       </ul>
+      <div v-if="reviewNextCursor" class="mt-4 flex justify-center">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          :disabled="reviewLoadingMore"
+          @click="loadMoreReviews"
+        >
+          {{ reviewLoadingMore ? t('courseDetailPage.reviewsLoading') : t('courseDetailPage.loadMoreReviews') }}
+        </button>
+      </div>
     </section>
 
     <!-- 举报弹窗 -->

--- a/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
@@ -428,7 +428,7 @@ onMounted(() => {
       <div class="mb-3 flex items-center justify-between gap-2">
         <h2 class="text-base font-semibold text-base-content">
           {{ t('courseDetailPage.reviewsTitle') }}
-          <span v-if="reviews.length" class="ml-1 text-[13px] font-normal text-base-content/45">{{ reviews.length }}</span>
+          <span v-if="reviewTotal" class="ml-1 text-[13px] font-normal text-base-content/45">{{ reviewTotal }}</span>
         </h2>
         <button
           v-if="page.layout.viewer.isAuthenticated && props.course.offerings?.length"

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -1267,10 +1267,25 @@ ReviewPayload:
   additionalProperties: false
 
 ReviewListResult:
-  type: array
-  items:
-    $ref: '#/ReviewPayload'
-  description: The raw review array; an empty listing is an empty array, never null.
+  type: object
+  required: [list, total]
+  properties:
+    list:
+      type: array
+      items:
+        $ref: '#/ReviewPayload'
+      description: The current page of visible reviews; an empty listing is an empty array, never null.
+    nextCursor:
+      type: string
+      description: |
+        Cursor for the next page, present only when more reviews exist.
+        Format is "offeringId:reviewId" of the last item of the current page
+        (course-level ordering is (offering_id DESC, id DESC)). Omit to stop paging.
+    total:
+      type: integer
+      format: int64
+      description: Total number of visible reviews matching the current scope (course or offering filter).
+  additionalProperties: false
 
 ReviewListResponse:
   oneOf:

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -1264,6 +1264,16 @@ ReviewPayload:
     updatedAt:
       type: string
       format: date-time
+    offeringRatingAvg:
+      type: number
+      format: double
+      description: |
+        Non-NULL rating average of the review's offering (PRD §5.1 B1).
+        Present only when the listing is scoped to a single offering and the
+        offering has at least one rated review.
+    offeringReviewCount:
+      type: integer
+      description: Number of visible reviews of the review's offering (offering-scoped listing only).
   additionalProperties: false
 
 ReviewListResult:

--- a/packages/api-contract/fixtures/course-reviews-list-success.json
+++ b/packages/api-contract/fixtures/course-reviews-list-success.json
@@ -1,62 +1,65 @@
 {
-  "result": [
-    {
-      "id": 3,
-      "offeringId": 901,
-      "rating": null,
-      "content": "历史评价",
-      "contentHtml": "<p>历史评价</p>\n",
-      "author": {
-        "kind": "legacy",
-        "label": "历史匿名评价"
+  "result": {
+    "list": [
+      {
+        "id": 3,
+        "offeringId": 901,
+        "rating": null,
+        "content": "历史评价",
+        "contentHtml": "<p>历史评价</p>\n",
+        "author": {
+          "kind": "legacy",
+          "label": "历史匿名评价"
+        },
+        "viewer": {
+          "canEdit": false,
+          "canDelete": false,
+          "isHelpful": false
+        },
+        "helpfulCount": 0,
+        "createdAt": "2026-08-01T10:00:00+08:00",
+        "updatedAt": "2026-08-01T10:00:00+08:00"
       },
-      "viewer": {
-        "canEdit": false,
-        "canDelete": false,
-        "isHelpful": false
+      {
+        "id": 2,
+        "offeringId": 901,
+        "rating": 4,
+        "content": "匿名评价",
+        "contentHtml": "<p>匿名评价</p>\n",
+        "author": {
+          "kind": "anonymous",
+          "label": "匿名同学"
+        },
+        "viewer": {
+          "canEdit": false,
+          "canDelete": false,
+          "isHelpful": false
+        },
+        "helpfulCount": 0,
+        "createdAt": "2026-08-01T09:00:00+08:00",
+        "updatedAt": "2026-08-01T09:00:00+08:00"
       },
-      "helpfulCount": 0,
-      "createdAt": "2026-08-01T10:00:00+08:00",
-      "updatedAt": "2026-08-01T10:00:00+08:00"
-    },
-    {
-      "id": 2,
-      "offeringId": 901,
-      "rating": 4,
-      "content": "匿名评价",
-      "contentHtml": "<p>匿名评价</p>\n",
-      "author": {
-        "kind": "anonymous",
-        "label": "匿名同学"
-      },
-      "viewer": {
-        "canEdit": false,
-        "canDelete": false,
-        "isHelpful": false
-      },
-      "helpfulCount": 0,
-      "createdAt": "2026-08-01T09:00:00+08:00",
-      "updatedAt": "2026-08-01T09:00:00+08:00"
-    },
-    {
-      "id": 1,
-      "offeringId": 901,
-      "rating": 5,
-      "content": "好课",
-      "contentHtml": "<p>好课</p>\n",
-      "author": {
-        "kind": "member",
-        "label": "bob"
-      },
-      "viewer": {
-        "canEdit": false,
-        "canDelete": false,
-        "isHelpful": false
-      },
-      "helpfulCount": 0,
-      "createdAt": "2026-08-01T08:00:00+08:00",
-      "updatedAt": "2026-08-01T08:00:00+08:00"
-    }
-  ],
+      {
+        "id": 1,
+        "offeringId": 901,
+        "rating": 5,
+        "content": "好课",
+        "contentHtml": "<p>好课</p>\n",
+        "author": {
+          "kind": "member",
+          "label": "bob"
+        },
+        "viewer": {
+          "canEdit": false,
+          "canDelete": false,
+          "isHelpful": false
+        },
+        "helpfulCount": 0,
+        "createdAt": "2026-08-01T08:00:00+08:00",
+        "updatedAt": "2026-08-01T08:00:00+08:00"
+      }
+    ],
+    "total": 3
+  },
   "code": 0
 }

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -37,8 +37,8 @@ listCourseReviews:
           type: integer
           minimum: 1
           maximum: 50
-          default: 20
-          description: Page size (default 20, max 50).
+          default: 50
+          description: Page size (default 50, max 50; server/client default aligned).
     responses:
       '200':
         description: Visible reviews ordered newest first.

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -24,6 +24,21 @@ listCourseReviews:
           format: uint64
           minimum: 1
           description: When present, only reviews of this offering are returned.
+      - name: cursor
+        in: query
+        schema:
+          type: string
+          description: |
+            Pagination cursor returned as nextCursor in the previous response
+            (format "offeringId:reviewId"). Omit for the first page.
+      - name: pageSize
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 20
+          description: Page size (default 20, max 50).
     responses:
       '200':
         description: Visible reviews ordered newest first.


### PR DESCRIPTION
## Summary
PRD §5.1 B2：`ReviewListMaxItems=200` 硬截断替换为 cursor 分页（issue #174, P0）。

### 实现
1. **cursor 分页**：`GET /api/forum/courses/:courseId/reviews` 支持 `cursor`（`"offeringId:reviewId"` 复合，course 级按 `(offering_id DESC, id DESC)` 时间倒序；offering 级只用 reviewId 段）与 `pageSize`（默认 20、上限 50）。
2. **响应**：`{list, nextCursor, total}`——`nextCursor` 有下一页时返回，`total` 为当前筛选（course/offering）可见评价总数。
3. **位置游标**：删除评价（隔离窗口内）后续页不跳页、不重复（cursor 基于最后一条的 offeringId/reviewId）。
4. **参数校验**：非法 cursor 格式 / pageSize>50 → 400 + `common.request.invalidParams`（非 500）。
5. **契约**：`ReviewListResult` 数组 → 分页对象（list/nextCursor/total）+ cursor/pageSize 参数 + fixture 同步 + 生成 `openapi.ts` 无额外 diff。
6. **前端**：`api.ts listCourseReviews` 返回 `ReviewPage`（cursor/pageSize）；`CourseDetailPage`「加载更多」按钮 + 总数展示 + 4 locale。

### 验收（TestCourseReviewPaginationHTTPContract 覆盖）
- [x] Given 250 条评价 When pageSize=20 依次请求 Then 13 页，无重复无遗漏（集合比对一致）
- [x] Given 非法 cursor / pageSize=999 When 请求 Then 400 + common.request.invalidParams（非 500）
- [x] Given 删除一条评价（隔离窗口内）When 翻页 Then cursor 稳定不跳页（后续页无跳页无重复，被删行不出现）

## Validation
- `cd apps/gooseforum && go vet ./...` 通过；`go test ./...` 93 包全过（新增分页契约测试 PASS；既有 9 个评价契约测试适配分页结构后全过）
- `cd packages/api-contract && pnpm run check` 通过
- `cd apps/gooseforum/resource && pnpm typecheck && pnpm test && pnpm build` 通过

Closes #174