### PR TITLE
fix(theme): 主题切换卡顿——去掉根快照 blur、抑制元素级过渡

### DIFF
--- a/apps/gooseforum/resource/src/runtime/site-theme.ts
+++ b/apps/gooseforum/resource/src/runtime/site-theme.ts
@@ -8,6 +8,7 @@ const COOKIE_KEY = 'goose-site-theme'
 const themes: SiteTheme[] = ['gf-light', 'gf-dark']
 const THEME_LINK_ID = 'goose-site-theme-link'
 const THEME_PREVIEW_STYLE_ID = 'goose-site-theme-preview'
+const THEME_SWITCHING_CLASS = 'theme-switching'
 const themeColors: Record<SiteTheme, string> = {
   'gf-light': '#fbfdff',
   'gf-dark': '#101010',
@@ -77,8 +78,8 @@ export function toggleTheme() {
 }
 
 /**
- * 主题切换（带 View Transitions 圆形模糊扩散动画）。
- * 从页面中心向外扩散（circle SVG mask + blur，参考 theme-toggle.rdsx.dev），
+ * 主题切换（带 View Transitions 圆形扩散动画）。
+ * 从页面中心向外扩散（circle mask，参考 theme-toggle.rdsx.dev），
  * 旧层垫底被圆形边缘逐步覆盖。无 startViewTransition 时直接切换。
  */
 export function toggleThemeFromElement(_trigger?: Element | null) {
@@ -103,10 +104,23 @@ export function setTheme(theme: SiteTheme) {
 
 function applyThemeWithTransition(theme: SiteTheme) {
   const apply = () => setTheme(theme)
-  if (typeof document.startViewTransition === 'function') {
-    document.startViewTransition(apply)
-  } else {
+  if (typeof document.startViewTransition !== 'function') {
     apply()
+    return
+  }
+  // 抑制元素级 CSS transition（导航/标签/按钮上并发 color/background 过渡，
+  // 与 view transition 叠加会拥塞主线程样式与绘制），只保留 view transition 自身。
+  // 在 startViewTransition 之前同步加上，确保新旧快照捕获时都处于抑制状态。
+  const root = document.documentElement
+  root.classList.add(THEME_SWITCHING_CLASS)
+  try {
+    const transition = document.startViewTransition(apply)
+    transition.finished
+      .catch(() => {})
+      .finally(() => root.classList.remove(THEME_SWITCHING_CLASS))
+  } catch {
+    apply()
+    root.classList.remove(THEME_SWITCHING_CLASS)
   }
 }
 

--- a/apps/gooseforum/resource/src/runtime/site-theme.ts
+++ b/apps/gooseforum/resource/src/runtime/site-theme.ts
@@ -101,6 +101,19 @@ export function setTheme(theme: SiteTheme) {
     // Ignore storage failures in private or restricted browsing contexts.
   }
 }
+// 引用计数：连续快速切换时，每个进行中的 view transition 占一个引用，
+// 只有最后一个完成（或全部失败回退）才移除抑制 class。
+let themeSwitchingRefs = 0
+
+function setThemeSwitching(active: boolean) {
+  themeSwitchingRefs = Math.max(0, themeSwitchingRefs + (active ? 1 : -1))
+  const root = document.documentElement
+  if (themeSwitchingRefs > 0) {
+    root.classList.add(THEME_SWITCHING_CLASS)
+  } else {
+    root.classList.remove(THEME_SWITCHING_CLASS)
+  }
+}
 
 function applyThemeWithTransition(theme: SiteTheme) {
   const apply = () => setTheme(theme)
@@ -111,16 +124,15 @@ function applyThemeWithTransition(theme: SiteTheme) {
   // 抑制元素级 CSS transition（导航/标签/按钮上并发 color/background 过渡，
   // 与 view transition 叠加会拥塞主线程样式与绘制），只保留 view transition 自身。
   // 在 startViewTransition 之前同步加上，确保新旧快照捕获时都处于抑制状态。
-  const root = document.documentElement
-  root.classList.add(THEME_SWITCHING_CLASS)
+  setThemeSwitching(true)
   try {
     const transition = document.startViewTransition(apply)
     transition.finished
       .catch(() => {})
-      .finally(() => root.classList.remove(THEME_SWITCHING_CLASS))
+      .finally(() => setThemeSwitching(false))
   } catch {
     apply()
-    root.classList.remove(THEME_SWITCHING_CLASS)
+    setThemeSwitching(false)
   }
 }
 

--- a/apps/gooseforum/resource/src/styles/view-transition.css
+++ b/apps/gooseforum/resource/src/styles/view-transition.css
@@ -1,21 +1,32 @@
 /*
- * 主题切换动画（View Transitions API + circle SVG mask with blur）
+ * 主题切换动画（View Transitions API + circle mask 扩散）
  *
- * 完全对齐 theme-toggle.rdsx.dev 的 circle-with-blur 示例：
- * - new(root) 圆形模糊 mask 以视口中心为圆心，mask-size 0 → 200vmax 扩散
- * - 只动画 mask-size 单个属性，mask-position 固定 center，配合 1s 时长，丝滑无顿挫
- * - old(root) 静止垫底（z-index: -1），被 new 的圆形边缘逐步覆盖
- * - 无 startViewTransition 支持时 JS 直接切换，样式不参与
+ * 回归修复（引入于 PR #99 / 9d573ec）：
+ * - 去掉 SVG feGaussianBlur：全页根快照 + filter 导致动画期间每帧整页重栅格化
+ *   （trace 中 RasterTask 200–500ms 集群 + 切换瞬间 ~50ms 主线程长任务）
+ * - 时长 1s → 0.5s 弱化；保留 circle mask 扩散，只动画 mask-size 单属性（合成器友好）
+ * - 元素级 CSS transition 的抑制见 site-theme.ts 的 theme-switching class
  */
 ::view-transition-group(root) {
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 ::view-transition-new(root) {
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'%3E%3Cdefs%3E%3Cfilter id='blur'%3E%3CfeGaussianBlur stdDeviation='2'/%3E%3C/filter%3E%3C/defs%3E%3Ccircle cx='20' cy='20' r='18' fill='white' filter='url(%23blur)'/%3E%3C/svg%3E")
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 40 40'%3E%3Ccircle cx='20' cy='20' r='20' fill='white'/%3E%3C/svg%3E")
     center / 0 no-repeat;
-  animation: gf-theme-scale 1s;
+  animation: gf-theme-scale 0.5s;
   animation-fill-mode: both;
+}
+
+/*
+ * 主题切换期间抑制页面内元素级 transition（导航/标签/按钮上并发 ~45 条
+ * color/background-color/border 过渡，与 view transition 叠加拥塞主线程）。
+ * ::view-transition-* 是伪元素，不受 * 匹配，view transition 动画不受影响。
+ */
+html.theme-switching *,
+html.theme-switching *::before,
+html.theme-switching *::after {
+  transition: none !important;
 }
 
 ::view-transition-old(root) {


### PR DESCRIPTION
## Summary

修复主题切换（明暗切换）动画卡顿。回归来自 PR #99 引入的 circle-with-blur 扩散动画（`9d573ec`）。

## 根因（DevTools trace 证据）

- **全页根快照带 `feGaussianBlur`**：View Transition 捕获整页 2510px 快照 + SVG filter，切换瞬间主线程 ~50ms 不透明长任务（首帧延迟），随后 2 个 `DroppedFrame`；动画期间每帧整页重栅格化（RasterTask 200–500ms 集群）
- **~45 条元素级 CSS transition 并发**：`color`×27 / `background-color`×11 / `border-*-color`×4 / `opacity`×2 / `transform`×2，来自 `.gf-tab`/`.gf-button`/导航/卡片（`components.css` 180ms），与 view transition 叠加拥塞主线程

## 改动

- `resource/src/styles/view-transition.css`：去掉 SVG blur → 纯圆形 mask；时长 `1s → 0.5s`；新增 `html.theme-switching * { transition: none !important }` 抑制规则（`::view-transition-*` 伪元素不受影响）
- `resource/src/runtime/site-theme.ts`：`applyThemeWithTransition()` 在 `startViewTransition` 前给 `<html>` 加 `theme-switching` class（确保新旧快照捕获时都处于抑制状态），`transition.finished` 后移除；无 `startViewTransition` 时直接切换

## 验证

- 本地 demo（Go + Vite dev）Playwright 实测：
  - 切换后主题正确翻转（gf-light ↔ gf-dark）✅
  - 动画进行中采样：`transitionCount: 0`（元素过渡全抑制）、`gf-theme-scale` 正常 ✅
  - 动画结束后 `theme-switching` class 正确移除 ✅
- `pnpm typecheck` 通过 ✅