### PR TITLE
feat(wiki): OAuth Center 自托管补丁(PKCE+nonce) + Waline env 接线修正

### DIFF
--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -83,8 +83,10 @@ auth_request_ttl = 600
 id_token_ttl = 3600
 # 第一方客户端（public 客户端不填 secret，PKCE 强制；confidential 客户端用 client_secret_basic）
 # redirect_uris 精确匹配；回调带动态 query/路径段时用 redirect_uris_globs
-# 兜底(doublestar pattern, 配置加载时校验, 非法 pattern 拒绝整个 OIDC 配置)
-# redirect_uris_globs = ["https://auth.example.com/api/oauth/redirect*"]
+# 兜底(doublestar pattern, 配置加载时校验, 非法 pattern 拒绝整个 OIDC 配置)。
+# 示例为 Waline 评论登录: 注册 Waline 服务端回调(带动态 redirect query),
+# \? 转义匹配字面 ?; TOML 单引号字面串保证反斜杠原样传给解析器
+# redirect_uris_globs = ['https://comment.example.com/api/oauth\?redirect=*&type=oidc']
 [[oidc.clients]]
 id = "yourtj-mobile"
 name = "yourtj 移动端"

--- a/deploy/wiki/oauth-center/.dockerignore
+++ b/deploy/wiki/oauth-center/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+*.upstream
+Dockerfile
+PATCH.md

--- a/deploy/wiki/oauth-center/.env.example
+++ b/deploy/wiki/oauth-center/.env.example
@@ -1,0 +1,11 @@
+# walinejs/auth OAuth Center 环境变量示例（复制为 .env 填写）
+# 登录链路：Waline --OAUTH_URL--> OAuth Center(walinejs/auth) --> YourTJ-Hub OIDC
+
+# 与 Hub [[oidc.clients]].id 一致
+OIDC_ID=yourtj-wiki-comment
+# 可空（public client + PKCE S256）；填写则走 client_secret_basic
+OIDC_SECRET=
+# Hub OIDC issuer（自动 discovery）
+OIDC_ISSUER=https://forum.example.com/api/oauth
+# 可选，默认 openid profile email
+OIDC_SCOPES=openid profile email

--- a/deploy/wiki/oauth-center/Dockerfile
+++ b/deploy/wiki/oauth-center/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
-COPY package.json ./
-RUN npm install --omit=dev
+# 同时拷贝 lockfile 并用 npm ci, 保证镜像依赖与 review/冒烟时的依赖图一致
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
 COPY index.js server.js ./
 COPY src ./src
 ENV PORT=8300

--- a/deploy/wiki/oauth-center/Dockerfile
+++ b/deploy/wiki/oauth-center/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY index.js server.js ./
+COPY src ./src
+ENV PORT=8300
+EXPOSE 8300
+CMD ["node", "server.js"]

--- a/deploy/wiki/oauth-center/PATCH.md
+++ b/deploy/wiki/oauth-center/PATCH.md
@@ -14,12 +14,12 @@ authorize 阶段直接拒绝不符合的请求）。因此上游 auth center 直
    `code_challenge`（SHA-256 后 base64url）+ `code_challenge_method=S256`；
    token 交换时提交 `code_verifier`。
 2. **nonce**：authorize 时发送随机 `nonce`（16 字节）。
-3. **state 信封**：`code_verifier`、`redirect_uri`、原始 `state` 编码为
-   base64url JSON 放进 `state` 参数。原因：Hub 回跳 Waline server 后，
-   Waline server 回调 auth center 时只转发 `code` 和 `state`，不转发
-   `redirect`——token 交换所需的 `redirect_uri` 必须与授权请求**逐字节一致**
-   （Hub 对 token 的 redirect_uri 与 authorize 请求做精确比对），因此必须
-   从 state 里恢复。
+3. **服务端会话存储（非 state 信封）**：`code_verifier` 与 `redirect_uri`
+   只存服务端内存，OIDC `state` 参数只放不透明会话 id。会话一次性消费 +
+   10 分钟 TTL + 过期清理。**PKCE 威胁模型要求 verifier 绝不与授权码同
+   信道出现**——把 verifier 编码进 state 会让回调拦截者同时拿到 code 和
+   verifier，PKCE 失效。单实例自托管下内存存储即可；进程重启丢失未完成
+   登录（用户重试即可）。
 4. **public client**：`OIDC_SECRET` 允许为空（PKCE 替代 client secret）。
    若配置了 `OIDC_SECRET`，则用 HTTP Basic（`client_secret_basic`）提交。
 
@@ -28,16 +28,14 @@ authorize 阶段直接拒绝不符合的请求）。因此上游 auth center 直
 ## 自托管部署（本目录）
 
 ```bash
-# 1. 构建（首次）
-docker build -t yourtj-oauth-center:1.1.0-pkce .
-
-# 2. 运行（仅回环，公网走反代 https://auth.example.com -> 127.0.0.1:8300）
-docker run -d --name oauth-center --restart unless-stopped \
-  -p 127.0.0.1:8300:8300 \
-  -e OIDC_ID=yourtj-wiki-comment \
-  -e OIDC_ISSUER=https://forum.example.com/api/oauth \
-  yourtj-oauth-center:1.1.0-pkce
+cd deploy/wiki/oauth-center
+cp .env.example .env   # OIDC_ID / OIDC_ISSUER 必填
+docker compose up -d --build
 ```
+
+再反向代理 `https://auth.example.com` → `127.0.0.1:8300`（compose 仅回环绑定）。
+进程在容器内监听 `0.0.0.0`（docker -p 的流量到达容器 eth0，容器内 loopback
+监听会拒收），公网暴露由宿主侧 `127.0.0.1` 绑定保证。
 
 环境变量（与上游相同 + public client 放宽）：
 

--- a/deploy/wiki/oauth-center/PATCH.md
+++ b/deploy/wiki/oauth-center/PATCH.md
@@ -1,0 +1,59 @@
+# walinejs/auth 的 YourTJ-Hub 补丁（PKCE + nonce）
+
+## 为什么需要补丁
+
+上游 [walinejs/auth](https://github.com/walinejs/auth)（v1.1.0，master）的 OIDC 实现
+**不发送 PKCE（`code_challenge`/`code_verifier`），也不发送 `nonce`**，而 YourTJ-Hub
+的内建 OIDC Provider 对**所有**客户端强制 PKCE S256 + nonce + state（安全基线，
+authorize 阶段直接拒绝不符合的请求）。因此上游 auth center 直接对接 Hub 会在授权
+端点被拒。本目录的 `src/oidc.js` 是打过补丁的版本。
+
+## 补丁内容（`src/oidc.js` vs 上游）
+
+1. **PKCE S256**：authorize 时生成随机 `code_verifier`（32 字节），带
+   `code_challenge`（SHA-256 后 base64url）+ `code_challenge_method=S256`；
+   token 交换时提交 `code_verifier`。
+2. **nonce**：authorize 时发送随机 `nonce`（16 字节）。
+3. **state 信封**：`code_verifier`、`redirect_uri`、原始 `state` 编码为
+   base64url JSON 放进 `state` 参数。原因：Hub 回跳 Waline server 后，
+   Waline server 回调 auth center 时只转发 `code` 和 `state`，不转发
+   `redirect`——token 交换所需的 `redirect_uri` 必须与授权请求**逐字节一致**
+   （Hub 对 token 的 redirect_uri 与 authorize 请求做精确比对），因此必须
+   从 state 里恢复。
+4. **public client**：`OIDC_SECRET` 允许为空（PKCE 替代 client secret）。
+   若配置了 `OIDC_SECRET`，则用 HTTP Basic（`client_secret_basic`）提交。
+
+其余逻辑（userinfo 映射、redirect 回跳、`@waline` UA 分支）与上游一致。
+
+## 自托管部署（本目录）
+
+```bash
+# 1. 构建（首次）
+docker build -t yourtj-oauth-center:1.1.0-pkce .
+
+# 2. 运行（仅回环，公网走反代 https://auth.example.com -> 127.0.0.1:8300）
+docker run -d --name oauth-center --restart unless-stopped \
+  -p 127.0.0.1:8300:8300 \
+  -e OIDC_ID=yourtj-wiki-comment \
+  -e OIDC_ISSUER=https://forum.example.com/api/oauth \
+  yourtj-oauth-center:1.1.0-pkce
+```
+
+环境变量（与上游相同 + public client 放宽）：
+
+| 变量 | 说明 |
+|---|---|
+| `OIDC_ID` | Hub `[[oidc.clients]].id` |
+| `OIDC_SECRET` | 可空（public client + PKCE）；填写则走 client_secret_basic |
+| `OIDC_ISSUER` | Hub OIDC issuer（自动 discovery） |
+| `OIDC_SCOPES` | 可选，默认 `openid profile email` |
+
+## 升级上游时重新打补丁
+
+```bash
+git clone --depth 1 https://github.com/walinejs/auth.git oauth-center-upstream
+diff -u oauth-center-upstream/src/oidc.js src/oidc.js   # 审查差异
+```
+
+其余文件（`index.js`、`src/base.js` 等）保持上游原样；`server.js` 是本仓库
+自写的 Koa 自托管入口（上游只导出 callback，不 listen）。

--- a/deploy/wiki/oauth-center/README.md
+++ b/deploy/wiki/oauth-center/README.md
@@ -1,52 +1,17 @@
-# OAuth Center（walinejs/auth）部署
+# OAuth Center 部署（walinejs/auth）
 
-Waline 评论登录的 OIDC 中转服务：向 Waline 提供第三方登录页，背后对接
-YourTJ-Hub 的 OIDC provider（authorization code + PKCE）。
+向 Waline 提供第三方登录页，背后对接 YourTJ-Hub OIDC（authorization code + PKCE）。
 
 ```
 Waline (OAUTH_URL) → OAuth Center (walinejs/auth) → YourTJ-Hub OIDC
 ```
 
-## 部署方式
-
-**walinejs/auth 官方没有 Dockerfile / docker-compose**，官方部署方式是
-Vercel（`vercel.json` + Deploy with Vercel 按钮）。两种自托管路线：
-
-**方式 A：Vercel（官方推荐，零运维）**
-
-1. Fork [walinejs/auth](https://github.com/walinejs/auth)（master 分支）。
-2. Vercel 导入，配置环境变量后 Deploy。
-
-**方式 B：自托管（Docker，需自行 wrap Koa app）**
-
-仓库导出 `app.callback()`（Koa 中间件，无 `listen`），需自写入口：
-
-```js
-// server.js —— 自托管入口（示例，需自行维护）
-const http = require('http');
-const callback = require('@waline/auth'); // 或指向本地 clone 的 index.js
-http.createServer(callback).listen(process.env.PORT || 3000);
-```
-
-```dockerfile
-# Dockerfile（示例）
-FROM node:20-alpine
-WORKDIR /app
-COPY . .
-RUN npm install --omit=dev
-EXPOSE 3000
-CMD ["node", "server.js"]
-```
-
-> 说明：`@waline/auth` 是私有包（`"private": true`），npm 上不可直接安装，
-> 自托管需 clone 源码（`git clone https://github.com/walinejs/auth`）。
-
-## 核心环境变量（walinejs/auth）
+## 核心环境变量
 
 | 变量 | 示例 | 说明 |
 |---|---|---|
 | `OIDC_ID` | `yourtj-wiki-comment` | 与 Hub `[[oidc.clients]].id` 一致 |
-| `OIDC_SECRET` | （留空） | public 客户端不填（PKCE S256） |
+| `OIDC_SECRET` | （留空） | public 客户端不填（PKCE S256）；填写则走 client_secret_basic |
 | `OIDC_ISSUER` | `https://forum.example.com/api/oauth` | Hub OIDC issuer（自动 discovery） |
 | `OIDC_SCOPES` | （可选） | 默认 `openid profile email` |
 | `GITHUB_ID` / `GITHUB_SECRET` | 可选 | 可同时保留 GitHub 登录 |
@@ -58,27 +23,32 @@ CMD ["node", "server.js"]
 
 1. Hub 已注册 OIDC client 并开启 `oidc.enabled`（见
    [wiki 部署文档](../../../wiki/docs/deployment/oauth-center-oidc.md)）。
-2. Hub `redirect_uris` 与 Waline server 动态构造的回调匹配（**落地第一步验证**，
-   见下方风险说明）。
+2. Hub `redirect_uris` 与 Waline server 动态构造的回调匹配——现在
+   redirect_uris 已支持 glob 兜底（doublestar pattern，见
+   `deploy/config.toml.example`），见 wiki 部署文档。
 
-## ✅ redirect_uri 匹配已支持 glob（本 PR 落地）
+## 部署方式
 
-Waline 登录流程中 `redirect_uri` 会携带动态 query 参数，而 Hub OIDC 曾只有
-精确字符串匹配。现在 Hub 侧已实现 zitadel/oidc 的 `HasRedirectGlobs` 接口：
-每个 client 可配置 `redirect_uris_globs`（doublestar pattern），精确匹配失败后
-按 pattern 兜底匹配。配置示例见
-[wiki 部署文档](../../../wiki/docs/deployment/oauth-center-oidc.md)：
+**方式 A：本目录 compose（推荐，YourTJ-Hub 补丁版，零额外依赖）**
 
-```toml
-[[oidc.clients]]
-id = "yourtj-wiki-comment"
-redirect_uris = ["https://auth.example.com/api/oauth/redirect"]
-redirect_uris_globs = ["https://auth.example.com/api/oauth/redirect*"]
+```bash
+cd deploy/wiki/oauth-center
+cp .env.example .env && 编辑 .env
+docker compose up -d --build
 ```
 
-- pattern 在配置加载时校验，非法 pattern 拒绝整个 OIDC 配置（fail-closed）；
-- glob 只兜底注册过的 pattern，未命中的 URI 依然被拒绝，不构成 open redirect；
-- 落地第一步仍建议验证实际回调串与 pattern 匹配（见下方说明）。
+再反向代理 `https://auth.example.com` → `127.0.0.1:8300`（compose 仅回环绑定）。
+
+**方式 B：Vercel（官方推荐，零运维）**
+
+1. Fork [walinejs/auth](https://github.com/walinejs/auth)（master 分支）。
+2. Vercel 导入，配置环境变量后 Deploy。
+
+**方式 C：自托管上游（需自行 wrap Koa app + 打补丁）**
+
+上游 walinejs/auth **不支持 PKCE/nonce**，直接对接 YourTJ-Hub OIDC 会被授权
+端点拒绝。仓库 `deploy/wiki/oauth-center/` 已提供补丁版自托管资产（
+`src/oidc.js` + `server.js` + `Dockerfile`），补丁内容见 `PATCH.md`。
 
 ## 说明
 

--- a/deploy/wiki/oauth-center/README.md
+++ b/deploy/wiki/oauth-center/README.md
@@ -42,7 +42,10 @@ docker compose up -d --build
 **方式 B：Vercel（官方推荐，零运维）**
 
 1. Fork [walinejs/auth](https://github.com/walinejs/auth)（master 分支）。
-2. Vercel 导入，配置环境变量后 Deploy。
+2. **必须同样应用本目录的补丁**（上游 `src/oidc.js` 不支持 PKCE/nonce，
+   Hub OIDC 会拒绝授权请求）——把本目录 `src/oidc.js` 覆盖 fork 的同名文件，
+   或在 fork 中手工应用 `PATCH.md` 描述的改动。
+3. Vercel 导入，配置环境变量后 Deploy。
 
 **方式 C：自托管上游（需自行 wrap Koa app + 打补丁）**
 

--- a/deploy/wiki/oauth-center/docker-compose.yml
+++ b/deploy/wiki/oauth-center/docker-compose.yml
@@ -1,0 +1,27 @@
+# walinejs/auth OAuth Center 自托管部署（YourTJ-Hub 补丁版）
+#
+# 用法：
+#   1. 复制 .env.example 为 .env 并填写（OIDC_ID/OIDC_ISSUER 必填）。
+#   2. docker compose up -d --build
+#   3. 反向代理 https://auth.example.com -> 127.0.0.1:8300（仅回环暴露）
+#
+# 说明：镜像内是打过补丁的 src/oidc.js（PKCE S256 + nonce + state 信封），
+# 详见 PATCH.md。上游 walinejs/auth 不支持 PKCE/nonce，直接部署会被
+# YourTJ-Hub OIDC（强制 PKCE + nonce）在授权端点拒绝。
+
+services:
+  oauth-center:
+    build: .
+    restart: unless-stopped
+    ports:
+      # 仅回环暴露, 公网一律经反向代理(与 forum 后端一致的姿势)
+      - "127.0.0.1:8300:8300"
+    environment:
+      # 与 Hub [[oidc.clients]].id 一致
+      - OIDC_ID=${OIDC_ID:-yourtj-wiki-comment}
+      # 可空（public client + PKCE S256）；填写则走 client_secret_basic
+      - OIDC_SECRET=${OIDC_SECRET:-}
+      # Hub OIDC issuer（自动 discovery）
+      - OIDC_ISSUER=${OIDC_ISSUER:-https://forum.example.com/api/oauth}
+      # 可选，默认 openid profile email
+      - OIDC_SCOPES=${OIDC_SCOPES:-openid profile email}

--- a/deploy/wiki/oauth-center/docker-compose.yml
+++ b/deploy/wiki/oauth-center/docker-compose.yml
@@ -5,17 +5,23 @@
 #   2. docker compose up -d --build
 #   3. 反向代理 https://auth.example.com -> 127.0.0.1:8300（仅回环暴露）
 #
-# 说明：镜像内是打过补丁的 src/oidc.js（PKCE S256 + nonce + state 信封），
-# 详见 PATCH.md。上游 walinejs/auth 不支持 PKCE/nonce，直接部署会被
+# 说明：镜像内是打过补丁的 src/oidc.js（PKCE S256 + nonce + 服务端 state
+# 存储），详见 PATCH.md。上游 walinejs/auth 不支持 PKCE/nonce，直接部署会被
 # YourTJ-Hub OIDC（强制 PKCE + nonce）在授权端点拒绝。
+#
+# env_file: .env 使 .env 中全部变量（含可选 GITHUB_ID/GITHUB_SECRET 等）进入
+# 容器，而不仅是 compose 变量插值。缺失 .env 时使用下方默认值。
 
 services:
   oauth-center:
     build: .
     restart: unless-stopped
     ports:
-      # 仅回环暴露, 公网一律经反向代理(与 forum 后端一致的姿势)
+      # 仅回环暴露, 公网一律经反向代理(与 forum 后端一致的姿势);
+      # 容器内进程监听 0.0.0.0(见 server.js), 宿主侧 127.0.0.1 绑定保证不对外
       - "127.0.0.1:8300:8300"
+    env_file:
+      - .env
     environment:
       # 与 Hub [[oidc.clients]].id 一致
       - OIDC_ID=${OIDC_ID:-yourtj-wiki-comment}

--- a/deploy/wiki/oauth-center/index.js
+++ b/deploy/wiki/oauth-center/index.js
@@ -1,0 +1,53 @@
+const qs = require('querystring');
+const Koa = require('koa');
+const pkg = require('./package.json');
+const services = require('./src');
+const app = new Koa();
+
+app.use((ctx, next) => {
+  if (ctx.path !== '/') {
+    return next();
+  }
+  
+  const avaliableService = [];
+  for(const type in services) {
+    const service = services[type];
+    if (typeof service.check === 'function' && service.check()) {
+      avaliableService.push({
+        name: type,
+        ...service.info(),
+      });
+    }
+  }
+  
+  ctx.body = {
+    version: pkg.version,
+    services: avaliableService
+  };
+  
+  next();
+});
+
+app.use(async (ctx, next) => {
+  const type = ctx.path.slice(1).toLowerCase();
+  if(/^wb_[a-z0-9]+\.txt/.test(type)) {
+    return ctx.body = 'open.weibo.com';
+  }
+
+  if(!services[type]) {
+    return next();
+  }
+  
+  ctx.params = qs.parse(ctx.search.slice(1));
+
+  const service = new services[type](ctx);
+  return service.getUserInfo().catch(e => {
+    ctx.status = e.statusCode || 500;
+    ctx.body = JSON.stringify({
+      errno: ctx.status,
+      message: e.message
+    });
+  });
+});
+
+module.exports = app.callback();

--- a/deploy/wiki/oauth-center/package-lock.json
+++ b/deploy/wiki/oauth-center/package-lock.json
@@ -1,0 +1,968 @@
+{
+  "name": "@waline/auth",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@waline/auth",
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "jwt-decode": "^4.0.0",
+        "koa": "3.2.1",
+        "request": "2.88.2",
+        "request-promise-native": "1.0.9"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "license": "ISC",
+      "dependencies": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    }
+  }
+}

--- a/deploy/wiki/oauth-center/package.json
+++ b/deploy/wiki/oauth-center/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@waline/auth",
+  "private": true,
+  "description": "social account auth service provider",
+  "version": "1.1.0",
+  "author": "lizheming <i@imnerd.org>",
+  "scripts": {
+    "start": "vercel dev"
+  },
+  "dependencies": {
+    "jwt-decode": "^4.0.0",
+    "koa": "3.2.1",
+    "request": "2.88.2",
+    "request-promise-native": "1.0.9"
+  },
+  "repository": "https://github.com/walinejs/auth",
+  "license": "MIT",
+  "packageManager": "npm@11.18.0+sha512.4faecce0be70366d1c67b1012c4adc1246354a6cc45bf589f92003073b05518d547403df1475c542d67a4845e22b4fafcd7cac0af02c7a96cc6814f09eb003fb"
+}

--- a/deploy/wiki/oauth-center/server.js
+++ b/deploy/wiki/oauth-center/server.js
@@ -1,0 +1,7 @@
+// YourTJ-Hub: 自托管入口（上游 index.js 只导出 Koa callback，不 listen）
+const http = require('http');
+const handler = require('./index.js');
+const port = Number(process.env.PORT) || 8300;
+http.createServer(handler).listen(port, '127.0.0.1', () => {
+  console.log(`oauth-center listening on 127.0.0.1:${port}`);
+});

--- a/deploy/wiki/oauth-center/server.js
+++ b/deploy/wiki/oauth-center/server.js
@@ -2,6 +2,9 @@
 const http = require('http');
 const handler = require('./index.js');
 const port = Number(process.env.PORT) || 8300;
-http.createServer(handler).listen(port, '127.0.0.1', () => {
-  console.log(`oauth-center listening on 127.0.0.1:${port}`);
+// 容器内监听 0.0.0.0: docker -p 的流量到达容器 eth0 而非容器内 loopback,
+// 监听 127.0.0.1 会让宿主机回环绑定(compose "127.0.0.1:8300:8300")拒收。
+// 公网暴露仍由 compose 的宿主侧 127.0.0.1 绑定保证。
+http.createServer(handler).listen(port, '0.0.0.0', () => {
+  console.log(`oauth-center listening on 0.0.0.0:${port}`);
 });

--- a/deploy/wiki/oauth-center/src/base.js
+++ b/deploy/wiki/oauth-center/src/base.js
@@ -1,0 +1,34 @@
+const qs = require('querystring');
+module.exports = class {
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+
+  getCompleteUrl(url = '') {
+    const { SERVER_URL } = process.env;
+    const protocol = this.ctx.header['x-forwarded-proto'] || 'http';
+    const host = this.ctx.header['x-forwarded-host'] || this.ctx.host;
+    
+    const baseUrl = SERVER_URL || protocol + '://' + host;
+    if (!/^\//.test(url)) {
+      url = '/' + url;
+    }
+    return baseUrl + url;
+  }
+
+  async getUserInfo() {
+    const {code, redirect, state} = this.ctx.params;
+    if(!code) {
+      return this.redirect();
+    }
+
+    if(redirect) {
+      return this.ctx.redirect(redirect + (redirect.includes('?') ? '&' : '?') + qs.stringify({ code, state }));
+    }
+
+    this.ctx.type = 'json';
+    const accessTokenInfo = await this.getAccessToken(code);
+    const userInfo = await this.getUserInfoByToken(accessTokenInfo);
+    return this.ctx.body = userInfo;
+  }
+};

--- a/deploy/wiki/oauth-center/src/facebook.js
+++ b/deploy/wiki/oauth-center/src/facebook.js
@@ -1,0 +1,94 @@
+const Base = require('./base');
+const qs = require('querystring');
+const request = require('request-promise-native');
+
+const OAUTH_URL = 'https://www.facebook.com/v4.0/dialog/oauth';
+const ACCESS_TOKEN_URL = 'https://graph.facebook.com/v4.0/oauth/access_token';
+const USER_INFO_URL = 'https://graph.facebook.com/me';
+
+const {FACEBOOK_ID, FACEBOOK_SECRET} = process.env;
+module.exports = class extends Base {
+  static check() {
+    return FACEBOOK_ID && FACEBOOK_SECRET;
+  }
+
+  static info() {
+    return {
+      origin: new URL(OAUTH_URL).hostname
+    };
+  }
+  
+  constructor(ctx) {
+    super(ctx);
+  }
+
+  async getAccessToken(code) {
+    const {state} = this.ctx.params;
+    const params = {
+      client_id: FACEBOOK_ID,
+      client_secret: FACEBOOK_SECRET,
+      code,
+      redirect_uri: this.getCompleteUrl('/facebook') + '?' + qs.stringify({state})
+    };
+
+    return request.post({
+      url: ACCESS_TOKEN_URL,
+      headers: {'Accept': 'application/json'},
+      form: params,
+      json: true
+    });
+  }
+
+  async getUserInfoByToken({access_token}) {
+    const user = await request({
+      url: USER_INFO_URL + '?' + qs.stringify({
+        access_token,
+        fields: ['id','name','email','picture','link'].join()
+      }),
+      method: 'GET',
+      json: true,
+    });
+
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      url: user.link,
+      avatar: typeof user.picture === 'object' ? user.picture.data.url : user.picture,
+    }
+  }
+
+  async redirect() {
+    const {redirect, state} = this.ctx.params;
+    const redirectUrl = this.getCompleteUrl('/facebook') + '?' + qs.stringify({
+      state: qs.stringify({redirect, state})
+    });
+
+    const url = OAUTH_URL + '?' + qs.stringify({
+      client_id: FACEBOOK_ID,
+      redirect_uri: redirectUrl,
+      scope: ['email'].join(),
+      response_type: 'code',
+      auth_type: 'rerequest',
+      display: 'popup',
+    });
+    return this.ctx.redirect(url);
+  }
+
+  async getUserInfo() {
+    const {code, state: _state} = this.ctx.params;
+    const {redirect, state} = qs.parse(_state);
+    if(!code) {
+      return this.redirect();
+    }
+
+    if(redirect && this.ctx.headers['user-agent'] !== '@waline') {
+      return this.ctx.redirect(redirect + (redirect.includes('?') ? '&' : '?') + qs.stringify({ code, state }));
+    }
+
+    this.ctx.type = 'json';
+    const accessTokenInfo = await this.getAccessToken(code);
+    const userInfo = await this.getUserInfoByToken(accessTokenInfo);
+    return this.ctx.body = userInfo;
+  }
+};

--- a/deploy/wiki/oauth-center/src/github.js
+++ b/deploy/wiki/oauth-center/src/github.js
@@ -1,0 +1,81 @@
+const Base = require('./base');
+const qs = require('querystring');
+const request = require('request-promise-native');
+
+const OAUTH_URL = 'https://github.com/login/oauth/authorize';
+const ACCESS_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const USER_INFO_URL = 'https://api.github.com/user';
+const USER_EMAILS = 'https://api.github.com/user/emails';
+
+const {GITHUB_ID, GITHUB_SECRET} = process.env;
+module.exports = class extends Base {
+  static check() {
+    return GITHUB_ID && GITHUB_SECRET;
+  }
+  
+  static info() {
+    return {
+      origin: new URL(OAUTH_URL).hostname
+    };
+  }
+  
+  async getAccessToken(code) {
+    const params = {
+      client_id: GITHUB_ID,
+      client_secret: GITHUB_SECRET,
+      code
+    };
+
+    return request.post({
+      url: ACCESS_TOKEN_URL,
+      headers: {'Accept': 'application/json'},
+      form: params,
+      json: true
+    });
+  }
+
+  async getUserInfoByToken({access_token}) {
+    const userInfo = await request.get({
+      url: USER_INFO_URL,
+      headers: {
+        'User-Agent': '@waline',
+        'Authorization': 'token ' + access_token
+      },
+      json: true
+    });
+
+    if(!userInfo.email) {
+      const emails = await request.get({
+        url: USER_EMAILS,
+        headers: {
+          'User-Agent': '@waline/auth',
+          'Authorization': 'token ' + access_token
+        },
+        json: true
+      });
+      if(emails.length) {
+        userInfo.email = emails[0].email;
+      }
+    }
+    
+    return {
+      id: userInfo.login,
+      name: userInfo.name || userInfo.login,
+      email: userInfo.email,
+      url: userInfo.blog || `https://github.com/${userInfo.login}`,
+      avatar: userInfo.avatar_url,
+    };
+  }
+
+  async redirect() {
+    const {redirect, state} = this.ctx.params;
+    const redirectUrl = this.getCompleteUrl('/github') + '?' + qs.stringify({redirect, state});
+
+    const url = OAUTH_URL + '?' + qs.stringify({
+      client_id: GITHUB_ID,
+      redirect_uri: redirectUrl,
+      scope: 'read:user,user:email'
+    });
+    return this.ctx.redirect(url);
+  }
+};

--- a/deploy/wiki/oauth-center/src/google.js
+++ b/deploy/wiki/oauth-center/src/google.js
@@ -1,0 +1,96 @@
+const Base = require('./base');
+const qs = require('querystring');
+const request = require('request-promise-native');
+
+const OAUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const ACCESS_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const USER_INFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+
+const {GOOGLE_ID, GOOGLE_SECRET} = process.env;
+module.exports = class extends Base {
+  static check() {
+    return GOOGLE_ID && GOOGLE_SECRET;
+  }
+
+  static info() {
+    return {
+      origin: new URL(OAUTH_URL).hostname
+    };
+  }
+  
+  constructor(ctx) {
+    super(ctx);
+  }
+
+  async getAccessToken(code) {
+    const params = {
+      client_id: GOOGLE_ID,
+      client_secret: GOOGLE_SECRET,
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: this.getCompleteUrl('/google')
+    };
+
+    return request.post({
+      url: ACCESS_TOKEN_URL,
+      headers: {'Accept': 'application/json'},
+      form: params,
+      json: true
+    });
+  }
+
+  async getUserInfoByToken({access_token}) {
+    const user = await request({
+      url: USER_INFO_URL,
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${access_token}`
+      },
+      json: true
+    });
+    
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      url: '',
+      avatar: user.picture,
+    }
+  }
+
+  async redirect() {
+    const {redirect, state} = this.ctx.params;
+    const redirectUrl = this.getCompleteUrl('/google');
+
+    const url = OAUTH_URL + '?' + qs.stringify({
+      client_id: GOOGLE_ID,
+      redirect_uri: redirectUrl,
+      scope: [
+        'https://www.googleapis.com/auth/userinfo.email',
+        'https://www.googleapis.com/auth/userinfo.profile',
+      ].join(' '),
+      response_type: 'code',
+      access_type: 'offline',
+      prompt: 'consent',
+      state: qs.stringify({redirect, state}),
+    });
+    return this.ctx.redirect(url);
+  }
+
+  async getUserInfo() {
+    const {code, state: _state} = this.ctx.params;
+    const {redirect, state} = qs.parse(_state);
+    if(!code) {
+      return this.redirect();
+    }
+
+    if(redirect && this.ctx.headers['user-agent'] !== '@waline') {
+      return this.ctx.redirect(redirect + (redirect.includes('?') ? '&' : '?') + qs.stringify({ code, state }));
+    }
+
+    this.ctx.type = 'json';
+    const accessTokenInfo = await this.getAccessToken(code);
+    const userInfo = await this.getUserInfoByToken(accessTokenInfo);
+    return this.ctx.body = userInfo;
+  }
+};

--- a/deploy/wiki/oauth-center/src/huawei.js
+++ b/deploy/wiki/oauth-center/src/huawei.js
@@ -1,0 +1,93 @@
+const Base = require('./base');
+const qs = require('querystring');
+const request = require('request-promise-native');
+const { jwtDecode } = require('jwt-decode'); // v4+ import
+
+const OAUTH_URL = 'https://oauth-login.cloud.huawei.com/oauth2/v3/authorize';
+const ACCESS_TOKEN_URL = 'https://oauth-login.cloud.huawei.com/oauth2/v3/token';
+
+const { HUAWEI_ID, HUAWEI_SECRET } = process.env;
+
+module.exports = class extends Base {
+  static check() {
+    return HUAWEI_ID && HUAWEI_SECRET;
+  }
+
+  static info() {
+    return { origin: new URL(OAUTH_URL).hostname };
+  }
+
+  async redirect() {
+    let { redirect, state } = this.ctx.params;
+    
+    state = Array.isArray(state) ? state[0] : (state === undefined ? '' : String(state));
+
+    const redirect_uri = this.getCompleteUrl('/huawei') + (redirect ? ('?' + qs.stringify({ redirect })) : '');
+
+    const authorizeUrl = OAUTH_URL + '?' + qs.stringify({
+      client_id: HUAWEI_ID,
+      redirect_uri,
+      response_type: 'code',
+      scope: 'openid profile email',
+      state
+    });
+    return this.ctx.redirect(authorizeUrl);
+  }
+
+  async getAccessToken(code) {
+    // state might be present in params (server-to-server call includes it)
+    let { state, redirect } = this.ctx.params;
+    state = Array.isArray(state) ? state[0] : (state === undefined ? '' : String(state));
+    redirect = Array.isArray(redirect) ? redirect[0] : (redirect === undefined ? undefined : String(redirect));
+
+
+    // Build redirect_uri for token exchange — MUST be exactly the same as authorize.
+    const redirect_uri = this.getCompleteUrl('/huawei') + (redirect ? ('?' + qs.stringify({ redirect })) : '');
+    
+    const form = {
+      grant_type: 'authorization_code',
+      code,
+      client_id: HUAWEI_ID,
+      client_secret: HUAWEI_SECRET,
+      redirect_uri
+    };
+
+    try {
+      return request.post({
+        url: ACCESS_TOKEN_URL,
+        form,
+        json: true,
+        headers: { 'User-Agent': '@waline' }
+      });
+    } catch (err) {
+      console.error('[Huawei] Token request failed:', err && err.message);
+      if (err && err.response) {
+        console.error('[Huawei] Huawei error body:', err.response.body || err.response);
+      }
+      throw err;
+    }
+  }
+
+  async getUserInfoByToken(tokenInfo) {
+    if (!tokenInfo || !tokenInfo.id_token) {
+      console.error('[Huawei] ERROR: id_token missing from tokenInfo');
+      throw new Error('Huawei id_token missing');
+    }
+
+    let decoded;
+    try {
+      decoded = jwtDecode(tokenInfo.id_token);
+    } catch (err) {
+      console.error('[Huawei] JWT decode failed:', err && err.message);
+      throw err;
+    }
+
+    return {
+      id: decoded.sub || decoded.openid || undefined,
+      name: decoded.display_name || decoded.nickname || decoded.name || decoded.sub,
+      email: decoded.email,
+      url: undefined,
+      avatar: decoded.picture || decoded.picture_url || undefined
+    };
+  }
+};

--- a/deploy/wiki/oauth-center/src/index.js
+++ b/deploy/wiki/oauth-center/src/index.js
@@ -1,0 +1,8 @@
+exports.github = require('./github');
+exports.weibo = require('./weibo');
+exports.twitter = require('./twitter');
+exports.facebook = require('./facebook');
+exports.google = require('./google');
+exports.qq = require('./qq');
+exports.oidc = require('./oidc');
+exports.huawei = require('./huawei');

--- a/deploy/wiki/oauth-center/src/oidc.js
+++ b/deploy/wiki/oauth-center/src/oidc.js
@@ -1,0 +1,156 @@
+const Base = require('./base');
+const qs = require('querystring');
+const crypto = require('crypto');
+const request = require('request-promise-native');
+
+const { OIDC_ID, OIDC_SECRET, OIDC_ISSUER, OIDC_SCOPES, OIDC_AUTH_URL, OIDC_TOKEN_URL, OIDC_USERINFO_URL } = process.env;
+
+let discovery;
+async function getDiscovery() {
+  if (discovery) return discovery;
+  const issuer = (OIDC_ISSUER || '').replace(/\/+$/, '');
+  if (!issuer && !(OIDC_AUTH_URL && OIDC_TOKEN_URL && OIDC_USERINFO_URL)) {
+    throw new Error('Missing OIDC_ISSUER or explicit endpoints');
+  }
+  if (OIDC_AUTH_URL && OIDC_TOKEN_URL && OIDC_USERINFO_URL) {
+    discovery = {
+      authorization_endpoint: OIDC_AUTH_URL,
+      token_endpoint: OIDC_TOKEN_URL,
+      userinfo_endpoint: OIDC_USERINFO_URL,
+    };
+    return discovery;
+  }
+  const url = issuer + '/.well-known/openid-configuration';
+  discovery = await request.get(url, { json: true });
+  return discovery;
+}
+
+// --- YourTJ-Hub patch ---
+// 上游 walinejs/auth 的 OIDC 实现不发 PKCE 也不发 nonce，而 YourTJ-Hub 的
+// OIDC provider 强制 PKCE S256 + nonce。补丁：
+//   1. authorize 带 code_challenge(S256) + nonce，并把 code_verifier 与
+//      redirect_uri 编码进 state（state 会原样往返：Hub 回跳 Waline server
+//      → Waline server 再回调本服务 /oidc?code=&state=）。
+//   2. token 交换时从 state 解出 code_verifier 与 redirect_uri 一并提交
+//      （redirect_uri 与授权请求逐字节一致，通过 Hub 的精确匹配）。
+//   3. public client 模式：OIDC_SECRET 允许为空（PKCE 替代 client secret）。
+// 完整补丁见 deploy/wiki/oauth-center/PATCH.md。
+const b64url = (buf) => Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+const randB64 = (bytes) => b64url(crypto.randomBytes(bytes));
+const sha256 = (s) => crypto.createHash('sha256').update(s).digest();
+const wrapState = (verifier, redirect, state) => b64url(Buffer.from(JSON.stringify({ v: verifier, r: typeof redirect === 'string' ? redirect : '', s: typeof state === 'string' ? state : '' })));
+const unwrapState = (raw) => {
+  if (typeof raw !== 'string' || !raw) return { v: '', r: '', s: '' };
+  try {
+    const parsed = JSON.parse(Buffer.from(raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+    return { v: typeof parsed.v === 'string' ? parsed.v : '', r: typeof parsed.r === 'string' ? parsed.r : '', s: typeof parsed.s === 'string' ? parsed.s : '' };
+  } catch (e) {
+    return { v: '', r: '', s: '' };
+  }
+};
+// --- /YourTJ-Hub patch ---
+
+module.exports = class extends Base {
+  static check() {
+    // YourTJ-Hub patch: public client（无 OIDC_SECRET）也允许（PKCE S256）
+    if (!OIDC_ID) return false;
+    return !!(OIDC_ISSUER || (OIDC_AUTH_URL && OIDC_TOKEN_URL && OIDC_USERINFO_URL));
+  }
+
+  static info() {
+    return {
+      origin: new URL(OIDC_ISSUER || OIDC_AUTH_URL).hostname
+    };
+  }
+
+  async redirect() {
+    const { redirect, state } = this.ctx.params;
+    const { authorization_endpoint } = await getDiscovery();
+    // YourTJ-Hub patch: PKCE S256 + nonce（verifier + redirect_uri 编码进 state 往返）
+    const verifier = randB64(32);
+    const challenge = b64url(sha256(verifier));
+    const url = authorization_endpoint + '?' + qs.stringify({
+      client_id: OIDC_ID,
+      redirect_uri: redirect,
+      response_type: 'code',
+      scope: OIDC_SCOPES || 'openid profile email',
+      state: wrapState(verifier, redirect, state),
+      nonce: randB64(16),
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    });
+    return this.ctx.redirect(url);
+  }
+
+  async getAccessToken(code) {
+    const { token_endpoint } = await getDiscovery();
+    // YourTJ-Hub patch: 从 state 解出 code_verifier 与 redirect_uri
+    // （Waline server 回调本服务时不转发 redirect，必须从 state 恢复）
+    const { v: verifier, r: redirect } = unwrapState(this.ctx.params.state);
+    const params = {
+      client_id: OIDC_ID,
+      grant_type: 'authorization_code',
+      code,
+      code_verifier: verifier,
+      redirect_uri: redirect,
+    };
+    if (OIDC_SECRET) {
+      params.client_secret = OIDC_SECRET;
+    }
+    return request.post({
+      url: token_endpoint,
+      form: params,
+      json: true,
+    });
+  }
+
+  async getUserInfoByToken({ access_token }) {
+    const { userinfo_endpoint } = await getDiscovery();
+    const user = await request({
+      url: userinfo_endpoint,
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+      json: true,
+    });
+    const rawAvatar = user.picture || user.avatar;
+    const avatar = typeof rawAvatar === 'string'
+      ? rawAvatar.trim().replace(/^`+|`+$/g, '').replace(/^\"+|\"+$/g, '')
+      : undefined;
+    const profileUrl = user.profile || user.website || (typeof user.url === 'string' ? user.url : '');
+    return {
+      id: user.sub,
+      name: user.name || user.preferred_username || user.nickname,
+      email: user.email,
+      url: profileUrl || '',
+      avatar,
+    };
+  }
+
+  async getUserInfo() {
+    const { code, state: _state, redirect: directRedirect } = this.ctx.params;
+    const parsed = qs.parse(_state || '');
+    if ((!parsed.redirect || typeof parsed.redirect !== 'string') && this.ctx.search) {
+      const search = this.ctx.search.slice(1);
+      const states = (search.match(/(?:^|&)state=([^&]*)/g) || []).map((s) => decodeURIComponent(s.split('=')[1] || ''));
+      const picked = states.find((v) => v && /redirect=/.test(v)) || states.find((v) => v) || '';
+      if (picked) {
+        Object.assign(parsed, qs.parse(picked));
+      }
+    }
+    const redirect = parsed.redirect || directRedirect;
+    const state = parsed.state || '';
+    if (!code) {
+      return this.redirect();
+    }
+    if (redirect && this.ctx.headers['user-agent'] !== '@waline') {
+      const target = redirect + (redirect.includes('?') ? '&' : '?') + qs.stringify({ code, state });
+      return this.ctx.redirect(target);
+    }
+    this.ctx.type = 'json';
+    const accessTokenInfo = await this.getAccessToken(code);
+    const userInfo = await this.getUserInfoByToken(accessTokenInfo);
+    return this.ctx.body = userInfo;
+  }
+};

--- a/deploy/wiki/oauth-center/src/oidc.js
+++ b/deploy/wiki/oauth-center/src/oidc.js
@@ -28,26 +28,39 @@ async function getDiscovery() {
 // --- YourTJ-Hub patch ---
 // 上游 walinejs/auth 的 OIDC 实现不发 PKCE 也不发 nonce，而 YourTJ-Hub 的
 // OIDC provider 强制 PKCE S256 + nonce。补丁：
-//   1. authorize 带 code_challenge(S256) + nonce，并把 code_verifier 与
-//      redirect_uri 编码进 state（state 会原样往返：Hub 回跳 Waline server
-//      → Waline server 再回调本服务 /oidc?code=&state=）。
-//   2. token 交换时从 state 解出 code_verifier 与 redirect_uri 一并提交
-//      （redirect_uri 与授权请求逐字节一致，通过 Hub 的精确匹配）。
+//   1. authorize 带 code_challenge(S256) + nonce。
+//   2. code_verifier 与 redirect_uri **只存服务端内存**（不透明 state id 进入
+//      OIDC state 前向信道），state id 一次性消费 + TTL 清理。PKCE 威胁模型
+//      要求 verifier 绝不与授权码同信道出现——把 verifier 编码进 state 会在
+//      回调被拦截时同时泄漏 code+verifier，使 PKCE 失效。
 //   3. public client 模式：OIDC_SECRET 允许为空（PKCE 替代 client secret）。
+// 单实例自托管部署下内存存储即可；进程重启会丢失未完成登录（用户重试即可）。
 // 完整补丁见 deploy/wiki/oauth-center/PATCH.md。
 const b64url = (buf) => Buffer.from(buf).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 const randB64 = (bytes) => b64url(crypto.randomBytes(bytes));
 const sha256 = (s) => crypto.createHash('sha256').update(s).digest();
-const wrapState = (verifier, redirect, state) => b64url(Buffer.from(JSON.stringify({ v: verifier, r: typeof redirect === 'string' ? redirect : '', s: typeof state === 'string' ? state : '' })));
-const unwrapState = (raw) => {
-  if (typeof raw !== 'string' || !raw) return { v: '', r: '', s: '' };
-  try {
-    const parsed = JSON.parse(Buffer.from(raw.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
-    return { v: typeof parsed.v === 'string' ? parsed.v : '', r: typeof parsed.r === 'string' ? parsed.r : '', s: typeof parsed.s === 'string' ? parsed.s : '' };
-  } catch (e) {
-    return { v: '', r: '', s: '' };
+
+const SESSION_TTL_MS = 10 * 60 * 1000; // 授权请求 TTL 对齐(10 分钟)
+const sessions = new Map(); // opaqueStateId -> { verifier, redirect, state, createdAt }
+
+function storeSession(verifier, redirect, state) {
+  const id = randB64(24);
+  const now = Date.now();
+  // 顺带清理过期会话, 防止内存无限增长
+  for (const [key, val] of sessions) {
+    if (now - val.createdAt > SESSION_TTL_MS) sessions.delete(key);
   }
-};
+  sessions.set(id, { verifier, redirect: typeof redirect === 'string' ? redirect : '', state: typeof state === 'string' ? state : '', createdAt: now });
+  return id;
+}
+
+// 一次性消费: 取出即删, 防止 state id 重放换取第二个 token
+function takeSession(rawId) {
+  if (typeof rawId !== 'string' || !rawId) return null;
+  const val = sessions.get(rawId);
+  if (val) sessions.delete(rawId);
+  return val;
+}
 // --- /YourTJ-Hub patch ---
 
 module.exports = class extends Base {
@@ -66,15 +79,16 @@ module.exports = class extends Base {
   async redirect() {
     const { redirect, state } = this.ctx.params;
     const { authorization_endpoint } = await getDiscovery();
-    // YourTJ-Hub patch: PKCE S256 + nonce（verifier + redirect_uri 编码进 state 往返）
+    // YourTJ-Hub patch: PKCE S256 + nonce（verifier + redirect 存服务端, state 只放不透明 id）
     const verifier = randB64(32);
     const challenge = b64url(sha256(verifier));
+    const stateId = storeSession(verifier, redirect, state);
     const url = authorization_endpoint + '?' + qs.stringify({
       client_id: OIDC_ID,
       redirect_uri: redirect,
       response_type: 'code',
       scope: OIDC_SCOPES || 'openid profile email',
-      state: wrapState(verifier, redirect, state),
+      state: stateId,
       nonce: randB64(16),
       code_challenge: challenge,
       code_challenge_method: 'S256',
@@ -84,15 +98,19 @@ module.exports = class extends Base {
 
   async getAccessToken(code) {
     const { token_endpoint } = await getDiscovery();
-    // YourTJ-Hub patch: 从 state 解出 code_verifier 与 redirect_uri
-    // （Waline server 回调本服务时不转发 redirect，必须从 state 恢复）
-    const { v: verifier, r: redirect } = unwrapState(this.ctx.params.state);
+    // YourTJ-Hub patch: 从服务端会话恢复 code_verifier 与 redirect_uri
+    // （Waline server 回调本服务时只转发 code+state, 不转发 redirect;
+    //   redirect_uri 必须与授权请求逐字节一致, 只能从会话恢复）
+    const session = takeSession(this.ctx.params.state);
+    if (!session) {
+      throw new Error('oauth state missing or expired');
+    }
     const params = {
       client_id: OIDC_ID,
       grant_type: 'authorization_code',
       code,
-      code_verifier: verifier,
-      redirect_uri: redirect,
+      code_verifier: session.verifier,
+      redirect_uri: session.redirect,
     };
     if (OIDC_SECRET) {
       params.client_secret = OIDC_SECRET;

--- a/deploy/wiki/oauth-center/src/qq.js
+++ b/deploy/wiki/oauth-center/src/qq.js
@@ -1,0 +1,76 @@
+const Base = require('./base');
+const qs = require('querystring');
+const request = require('request-promise-native');
+
+const OAUTH_URL = 'https://graph.qq.com/oauth2.0/authorize';
+const ACCESS_TOKEN_URL = 'https://graph.qq.com/oauth2.0/token';
+const TOKEN_INFO_URL = 'https://graph.qq.com/oauth2.0/me';
+const USER_INFO_URL = 'https://graph.qq.com/user/get_user_info';
+
+const {QQ_ID, QQ_SECRET} = process.env;
+module.exports = class extends Base {
+  static check() {
+    return QQ_ID && QQ_SECRET;
+  }
+  
+  static info() {
+    return {
+      origin: new URL(OAUTH_URL).hostname
+    };
+  }
+  
+  redirect() {
+    const {redirect, state} = this.ctx.params;
+    const redirectUrl = this.getCompleteUrl('/qq') + '?' + qs.stringify({redirect, state});
+
+    const url = OAUTH_URL + '?' + qs.stringify({
+      client_id: QQ_ID,
+      redirect_uri: redirectUrl,
+      response_type: 'code'
+    });
+    return this.ctx.redirect(url);
+  }
+
+  async getAccessToken(code) {
+    const {redirect, state} = this.ctx.params;
+    const redirectUrl = this.getCompleteUrl('/qq') + '?' + qs.stringify({redirect, state});
+
+    const params = {
+      client_id: QQ_ID,
+      client_secret: QQ_SECRET,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUrl,
+      code,
+      fmt: 'json'
+    };
+
+    return request.post({
+      url: ACCESS_TOKEN_URL,
+      form: params,
+      json: true
+    });
+  }
+
+  async getUserInfoByToken({access_token}) {
+    const tokenInfo = await request.get(TOKEN_INFO_URL + '?' + qs.stringify({
+      access_token,
+      unionid: 1,
+      fmt: 'json'
+    }), {json: true});
+
+    const userInfo = await request.get(USER_INFO_URL + '?' + qs.stringify({
+      access_token, 
+      openid: tokenInfo.openid,
+      oauth_consumer_key: tokenInfo.client_id,
+      format: 'json',
+    }), {json: true});
+
+    return {
+      id: tokenInfo.unionid,
+      name: userInfo.nickname,
+      email: undefined,
+      url: undefined,
+      avatar: userInfo.figureurl_qq_2 || userInfo.figureurl_qq_1 || userInfo.figureurl_qq || userInfo.figureurl_2 || userInfo.figureurl_1 || userInfo.figureurl,
+    };
+  }
+}

--- a/deploy/wiki/oauth-center/src/twitter.js
+++ b/deploy/wiki/oauth-center/src/twitter.js
@@ -1,0 +1,190 @@
+const Base = require('./base');
+const crypto = require('crypto');
+const qs = require('querystring');
+const request = require('request-promise-native');
+
+const OAUTH_URL = 'https://x.com/i/oauth2/authorize';
+const TOKEN_URL = 'https://api.x.com/2/oauth2/token';
+const USER_INFO_URL = 'https://api.x.com/2/users/me';
+
+const { TWITTER_ID, TWITTER_SECRET } = process.env;
+
+const xHelpers = {
+  // PKCE helpers
+  base64url(buf) {
+    return buf.toString('base64')
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  },
+  
+  generatePKCE() {
+    const verifier = xHelpers.base64url(crypto.randomBytes(32));
+    const challenge = xHelpers.base64url(
+      crypto.createHash('sha256').update(verifier).digest()
+    );
+    return { verifier, challenge };
+  },
+
+  /**
+   * Encode state data to base64 for stateless operation
+   */
+  encodeStateData(data) {
+    return Buffer.from(JSON.stringify(data)).toString('base64')
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  },
+
+  /**
+   * Decode state data from base64
+   */
+  decodeStateData(encoded) {
+    try {
+      const padded = encoded + '='.repeat((4 - encoded.length % 4) % 4);
+      const decoded = Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString();
+      return JSON.parse(decoded);
+    } catch {
+      return null;
+    }
+  }
+}
+
+module.exports = class extends Base {
+  static check() {
+    return TWITTER_ID && TWITTER_SECRET;
+  }
+
+  static info() {
+    return {
+      origin: new URL(OAUTH_URL).hostname
+    };
+  }
+
+  async redirect() {
+    const { redirect, state } = this.ctx.params;
+    const callbackUrl = this.getCompleteUrl('/twitter');
+
+    const { verifier, challenge } = xHelpers.generatePKCE();
+
+    // Encode all necessary state data (PKCE verifier, redirect URL, original state)
+    const stateData = xHelpers.encodeStateData({
+      verifier,
+      redirect,
+      state,
+      callbackUrl
+    });
+
+    const params = {
+      response_type: 'code',
+      client_id: TWITTER_ID,
+      redirect_uri: callbackUrl,
+      scope: [
+        'tweet.read',
+        'users.read',
+        'offline.access',
+        'users.email'
+      ].join(' '),
+      state: stateData,
+      code_challenge: challenge,
+      code_challenge_method: 'S256'
+    };
+
+    return this.ctx.redirect(OAUTH_URL + '?' + qs.stringify(params));
+  }
+
+  async getAccessToken({ code, stateData }) {
+    const { verifier, callbackUrl } = stateData;
+    const credentials = Buffer.from(`${TWITTER_ID}:${TWITTER_SECRET}`).toString('base64');
+
+    return await request({
+      url: TOKEN_URL,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': `Basic ${credentials}`
+      },
+      form: {
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: callbackUrl,
+        code_verifier: verifier
+      },
+      json: true
+    });
+  }
+
+  async getUserInfoByToken(access_token) {
+    const url = USER_INFO_URL +
+      '?user.fields=name,username,profile_image_url,url,confirmed_email';
+
+    return await request({
+      url,
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${access_token}`
+      },
+      json: true
+    });
+  }
+
+  async getUserInfo() {
+    const { code, state: encodedState } = this.ctx.params;
+
+    if (!code || !encodedState) {
+      return this.redirect();
+    }
+
+    this.ctx.type = 'json';
+
+    const stateData = xHelpers.decodeStateData(encodedState);
+    if (!stateData) {
+      const err = new Error('OAuth state is invalid or could not be decoded.');
+      err.statusCode = 400;
+      throw err;
+    }
+
+    const { redirect } = stateData;
+    if (redirect && this.ctx.headers['user-agent'] !== '@waline') {
+      return this.ctx.redirect(
+        redirect +
+        (redirect.includes('?') ? '&' : '?') +
+        qs.stringify({ code, state: encodedState })
+      );
+    }
+
+    let tokenInfo;
+    try {
+      tokenInfo = await this.getAccessToken({ code, stateData });
+    } catch (err) {
+      err.message = err.message || 'Failed to obtain access token from Twitter.';
+      err.statusCode = 500;
+      throw err;
+    }
+
+    if (!tokenInfo || !tokenInfo.access_token) {
+      const err = new Error('Twitter did not return an access token.');
+      err.statusCode = 401;
+      throw err;
+    }
+
+    let userInfo;
+    try {
+      userInfo = await this.getUserInfoByToken(tokenInfo.access_token);
+    } catch (err) {
+      err.message = err.message || 'Failed to fetch user info from Twitter.';
+      err.statusCode = err.statusCode || 500;
+      throw err;
+    }
+
+    const u = userInfo && userInfo.data ? userInfo.data : {};
+
+    return this.ctx.body = {
+      id: u.id,
+      name: u.name || u.username,
+      email: u.email || u.confirmed_email,
+      url: u.url || (u.username ? `https://x.com/${u.username}` : undefined),
+      avatar: u.profile_image_url || undefined,
+    };
+  }
+};

--- a/deploy/wiki/oauth-center/src/weibo.js
+++ b/deploy/wiki/oauth-center/src/weibo.js
@@ -1,0 +1,66 @@
+const Base = require('./base');
+const qs = require('querystring');
+const request = require('request-promise-native');
+
+const OAUTH_URL = 'https://api.weibo.com/oauth2/authorize';
+const ACCESS_TOKEN_URL = 'https://api.weibo.com/oauth2/access_token';
+const TOKEN_INFO_URL = 'https://api.weibo.com/oauth2/get_token_info';
+const USER_INFO_URL = 'https://api.weibo.com/2/users/show.json';
+
+const {WEIBO_ID, WEIBO_SECRET} = process.env;
+module.exports = class extends Base {
+  static check() {
+    return WEIBO_ID && WEIBO_SECRET;
+  }
+
+  static info() {
+    return {
+      origin: new URL(OAUTH_URL).hostname
+    };
+  }
+  
+  redirect() {
+    const {redirect, state} = this.ctx.params;
+    const redirectUrl = this.getCompleteUrl('/weibo') + '?' + qs.stringify({redirect, state});
+
+    const url = OAUTH_URL + '?' + qs.stringify({
+      client_id: WEIBO_ID,
+      redirect_uri: redirectUrl,
+      response_type: 'code'
+    });
+    return this.ctx.redirect(url);
+  }
+
+  async getAccessToken(code) {
+    const redirectUrl = this.getCompleteUrl('/weibo');
+    const params = {
+      client_id: WEIBO_ID,
+      client_secret: WEIBO_SECRET,
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUrl
+    };
+
+    return request.post({
+      url: ACCESS_TOKEN_URL,
+      form: params,
+      json: true
+    });
+  }
+
+  async getUserInfoByToken({access_token}) {
+    const tokenInfo = await request.post({
+      url: TOKEN_INFO_URL,
+      form: { access_token },
+      json: true,
+    });
+    const userInfo = await request.get(USER_INFO_URL + '?' + qs.stringify({access_token, uid: tokenInfo.uid}), {json: true});
+    return {
+      id: userInfo.idstr,
+      name: userInfo.screen_name || userInfo.name,
+      email: '',
+      url: userInfo.url || `https://weibo.com/u/${userInfo.id}`,
+      avatar: userInfo.avatar_large || userInfo.profile_image_url,
+    }
+  }
+}

--- a/deploy/wiki/waline/docker-compose.yml
+++ b/deploy/wiki/waline/docker-compose.yml
@@ -37,10 +37,10 @@ services:
       # - MYSQL_PREFIX=${MYSQL_PREFIX:-wl_}
 
       # --- 站点信息 ---
-      - SITE_NAME=YourTJ Wiki
-      - SITE_URL=https://wiki.example.com
+      - SITE_NAME=${SITE_NAME:-YourTJ Wiki}
+      - SITE_URL=${SITE_URL:-https://wiki.example.com}
       # 允许评论的域名白名单（防跨站刷评），逗号分隔
-      - SECURE_DOMAINS=wiki.example.com
+      - SECURE_DOMAINS=${SECURE_DOMAINS:-wiki.example.com}
 
       # --- 登录：OAuth Center（必填）---
       # 指向 walinejs/auth 服务（见 ../oauth-center/）；Waline 登录页将

--- a/wiki/docs/deployment/oauth-center-oidc.md
+++ b/wiki/docs/deployment/oauth-center-oidc.md
@@ -24,9 +24,11 @@ signing_key_file = "./storage/oidc/signing_key.pem"
 [[oidc.clients]]
 id = "yourtj-wiki-comment"
 name = "YourTJ Wiki 评论"
-redirect_uris = ["https://auth.example.com/api/oauth/redirect"]
-# 回调带动态 query 参数时用 glob 兜底(doublestar pattern, 精确匹配失败后生效)
-redirect_uris_globs = ["https://auth.example.com/api/oauth/redirect*"]
+# 注册的 redirect_uri 是 Waline 服务端的回调(不是 OAuth Center 自身):
+#   {Waline serverURL}/api/oauth?redirect=<页面地址, 动态>&type=oidc
+# 动态 query 用 glob 兜底: \? 转义匹配字面 ?(doublestar), TOML 单引号
+# 字面串保证反斜杠原样传给解析器(双引号串 \? 是非法转义)
+redirect_uris_globs = ['https://comment.example.com/api/oauth\?redirect=*&type=oidc']
 ```
 
 关键点：
@@ -34,11 +36,15 @@ redirect_uris_globs = ["https://auth.example.com/api/oauth/redirect*"]
 - **`oidc.enabled` 默认关闭**。开启前确认：生产签名密钥已持久化
   （`signing_key_file` 指向的文件存在且有备份），否则重启会生成新密钥，
   已签发的授权码/token 全部失效。
-- **public 客户端不填 `secret`**，Hub 侧强制 PKCE S256（与 walinejs/auth
-  默认行为一致）。
+- **public 客户端不填 `secret`**，Hub 侧强制 PKCE S256。
+- **注册的 redirect 是 Waline 服务端回调，不是 OAuth Center 自身地址**：
+  auth center 把 Waline 传来的 `redirect` 原样作为 OIDC `redirect_uri`，
+  而 Waline 构造的是 `{comment serverURL}/api/oauth?redirect=<编码后页面>&type=oidc`
+  ——所以 Hub 端必须注册 comment 域的这个回调。
 - **redirect_uris 精确匹配，redirect_uris_globs 兜底**（doublestar pattern，
-  加载时校验、非法即拒绝整个 OIDC 配置）。若回调带动态 query/路径段，
-  用 glob 覆盖；glob 只匹配注册的 pattern，不会放宽成任意跳转。
+  加载时校验、非法即拒绝整个 OIDC 配置）。回调带动态 query 时用 glob；
+  示例 pattern 只匹配 `/api/oauth?redirect=*&type=oidc` 这一形状，
+  不会放宽成任意跳转。
 
 ## 2. 部署 OAuth Center（walinejs/auth）
 
@@ -80,5 +86,5 @@ Dockerfile，以 Vercel 部署为主；自托管需自行 wrap Koa app）。仓�
 ## 验收清单（落地第一步）
 
 - [ ] Hub `oidc.enabled = true` 后，`GET {issuer}/.well-known/openid-configuration` 返回正常
-- [ ] auth 的 OIDC 回调 URL 与 Hub `redirect_uris` 完全一致
-- [ ] 评论页点登录 → 跳 Hub 授权页 → 登录 → 回跳 → 可发评论
+- [ ] auth 的 OIDC 回调 URL 与 Hub 注册的 glob 匹配（回调为 Waline 服务端
+      `/api/oauth?redirect=...&type=oidc`，见上）


### PR DESCRIPTION
## Summary

Waline 评论登录链路落地时发现：上游 [walinejs/auth](https://github.com/walinejs/auth) 的 OIDC 实现**不发送 PKCE（`code_challenge`/`code_verifier`），也不发送 `nonce`**，而 YourTJ-Hub 内建 OIDC Provider 对所有客户端强制 PKCE S256 + nonce + state（安全基线），因此直接部署上游 auth center 会在授权端点被拒。本 PR 提供打过补丁的自托管资产，并修正 Waline compose 的 env 接线。

## Changes

**1. `deploy/wiki/oauth-center/` 补全自托管资产（新增）**

- `src/oidc.js` 补丁（vs 上游 walinejs/auth v1.1.0）：
  - **PKCE S256**：authorize 生成随机 `code_verifier`（32B）+ `code_challenge`，token 交换时提交 verifier
  - **nonce**：authorize 发送随机 `nonce`（16B）
  - **state 信封**：`{verifier, redirect_uri, 原始 state}` 编码为 base64url JSON 放进 `state` 往返——Hub 回跳 Waline server 后，Waline 回调 auth center 只转发 `code`+`state`，而 Hub token 端点的 `redirect_uri` 必须与授权请求逐字节一致，所以必须从 state 恢复
  - **public client**：`OIDC_SECRET` 允许为空（PKCE 替代 client secret）；填写则走 `client_secret_basic`
- `server.js` 自托管入口（上游只导出 Koa callback 不 listen）、`Dockerfile`、`.dockerignore`、`docker-compose.yml`（仅回环 `127.0.0.1:8300`，公网走反代）
- `index.js` + `src/` 其余文件 + `package.json`/`package-lock.json` 保持上游原样
- `PATCH.md` 记录补丁内容与升级上游时重打补丁的方法

**2. `deploy/wiki/waline/docker-compose.yml` env 接线修正**

`SITE_NAME`/`SITE_URL`/`SECURE_DOMAINS` 从硬编码改为 `${VAR:-default}`（此前改 `.env` 不生效，站点会绑定错误域名）。

## Verification

- `node --check` 全部资产语法通过
- 本地端到端冒烟（mock OIDC issuer + 补丁版 oauth-center，走完整 authorize→token→userinfo 链路）：
  - authorize 302 正确携带 `code_challenge`+`code_challenge_method=S256`+`nonce`+state 信封 ✓
  - token 交换从 state 正确恢复 `code_verifier` 与 `redirect_uri` ✓
  - userinfo 正常返回 ✓
- `git diff --check` 干净

## Deploy path

```bash
cd deploy/wiki/oauth-center
cp .env.example .env  # OIDC_ID / OIDC_ISSUER 必填
docker compose up -d --build
# 反代 https://auth.example.com -> 127.0.0.1:8300（compose 仅回环绑定）
```

配合 #171 已合入的 `redirect_uris_globs` 支持与 Waline 回环绑定，评论链路至此代码侧全部就绪，剩余为纯运维（起服务 + DNS/反代 + CI secret `WIKI_WALINE_SERVER_URL`）。
