### PR TITLE
fix(oidc): 修正 Waline 评论登录的 redirect_uris_globs 写法(dev 部署实测)

### DIFF
--- a/apps/gooseforum/app/service/oidcservice/provider_test.go
+++ b/apps/gooseforum/app/service/oidcservice/provider_test.go
@@ -336,6 +336,69 @@ func TestAuthorizeAcceptsRedirectGlobMatch(t *testing.T) {
 	}
 }
 
+// TestAuthorizeAcceptsWalineCallbackGlob 钉住真实 Waline 回调形状:
+// redirect_uri 内层页面 URL 仍带 %-编码(与 auth center 构造的一致), 而
+// zitadel/oidc 匹配前会再 QueryUnescape 一次——只有 ** 作末尾 segment 的
+// pattern 能命中(dev 部署实测: * 会让真实回调 400)。
+func TestAuthorizeAcceptsWalineCallbackGlob(t *testing.T) {
+	issuer := "https://forum.example.com/api/oauth"
+	clients := []map[string]any{
+		{
+			"id":   "yourtj-wiki-comment",
+			"name": "Wiki Comment",
+			"redirect_uris_globs": []any{
+				`https://comment.example.com/api/oauth\?redirect=https://wiki.example.com/**`,
+				`https://comment.example.com/api/oauth\?redirect=/**`,
+			},
+		},
+	}
+	setupProviderConfig(t, issuer, clients)
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&oidcAuthRequests.Entity{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	h, err := Router()
+	if err != nil {
+		t.Fatalf("Router() error = %v", err)
+	}
+	_, verifier := pkcePair(t)
+	target := authorizeURL(issuer, "yourtj-wiki-comment",
+		"https://comment.example.com/api/oauth?redirect=https%3A%2F%2Fwiki.example.com%2Fguide%2F&type=oidc",
+		"st", "no", verifier)
+	rec := doGet(t, h, target)
+	if !strings.HasPrefix(rec.Header().Get("Location"), "/login") {
+		t.Fatalf("waline callback glob must reach login bridge: %q", rec.Header().Get("Location"))
+	}
+}
+
+// TestAuthorizeRejectsWalineCallbackGlobEvilDomain 钉住 glob 不放宽到任意域:
+// 相同回调形状但页面 URL 是 evil 域, 必须仍被拒绝。
+func TestAuthorizeRejectsWalineCallbackGlobEvilDomain(t *testing.T) {
+	issuer := "https://forum.example.com/api/oauth"
+	clients := []map[string]any{
+		{
+			"id": "yourtj-wiki-comment",
+			"redirect_uris_globs": []any{
+				`https://comment.example.com/api/oauth\?redirect=https://wiki.example.com/**`,
+				`https://comment.example.com/api/oauth\?redirect=/**`,
+			},
+		},
+	}
+	setupProviderConfig(t, issuer, clients)
+	h, err := Router()
+	if err != nil {
+		t.Fatalf("Router() error = %v", err)
+	}
+	_, verifier := pkcePair(t)
+	target := authorizeURL(issuer, "yourtj-wiki-comment",
+		"https://comment.example.com/api/oauth?redirect=https%3A%2F%2Fevil.example.com%2F&type=oidc",
+		"st", "no", verifier)
+	rec := doGet(t, h, target)
+	if strings.HasPrefix(rec.Header().Get("Location"), "/login") {
+		t.Fatalf("evil-domain waline callback must not reach login bridge: %q", rec.Header().Get("Location"))
+	}
+}
+
 // TestAuthorizeRejectsRedirectGlobMismatch 验证 glob 兜底不会放宽成任意匹配:
 // 未命中任何 pattern 的 URI 依然被拒绝。
 func TestAuthorizeRejectsRedirectGlobMismatch(t *testing.T) {

--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -85,9 +85,15 @@ id_token_ttl = 3600
 # 第一方客户端（public 客户端不填 secret，PKCE 强制；confidential 客户端用 client_secret_basic）
 # redirect_uris 精确匹配；回调带动态 query/路径段时用 redirect_uris_globs
 # 兜底(doublestar pattern, 配置加载时校验, 非法 pattern 拒绝整个 OIDC 配置)。
-# 示例为 Waline 评论登录: 注册 Waline 服务端回调(带动态 redirect query),
-# \? 转义匹配字面 ?; TOML 单引号字面串保证反斜杠原样传给解析器
-# redirect_uris_globs = ['https://comment.example.com/api/oauth\?redirect=*&type=oidc']
+# 示例为 Waline 评论登录: 注册 Waline 服务端回调(带动态 redirect query)。
+# 注意(zitadel/oidc v3.49 实测): 匹配前会再 QueryUnescape 一次 redirect_uri,
+# 实际匹配串中内层页面 URL 的 %2F 已是字面 /; doublestar 的 * 嵌在 query
+# 值中不能跨 /, 只有 ** 作为末尾 segment 可以。因此按"钉死站点域名前缀"
+# 拆两条。\? 转义匹配字面 ?; TOML 单引号字面串保证反斜杠原样传给解析器
+# redirect_uris_globs = [
+#   'https://comment.example.com/api/oauth\?redirect=https://wiki.example.com/**',
+#   'https://comment.example.com/api/oauth\?redirect=/**',
+# ]
 [[oidc.clients]]
 id = "yourtj-mobile"
 name = "yourtj 移动端"

--- a/wiki/docs/deployment/oauth-center-oidc.md
+++ b/wiki/docs/deployment/oauth-center-oidc.md
@@ -42,9 +42,9 @@ redirect_uris_globs = ['https://comment.example.com/api/oauth\?redirect=*&type=o
   而 Waline 构造的是 `{comment serverURL}/api/oauth?redirect=<编码后页面>&type=oidc`
   ——所以 Hub 端必须注册 comment 域的这个回调。
 - **redirect_uris 精确匹配，redirect_uris_globs 兜底**（doublestar pattern，
-  加载时校验、非法即拒绝整个 OIDC 配置）。回调带动态 query 时用 glob；
-  示例 pattern 只匹配 `/api/oauth?redirect=*&type=oidc` 这一形状，
-  不会放宽成任意跳转。
+  加载时校验、非法即拒绝整个 OIDC 配置）。注意 zitadel/oidc 匹配前会再
+  `QueryUnescape` 一次 redirect_uri——`*` 嵌在 query 值中不能跨 `/`，用
+  `**` 作末尾 segment；示例 pattern 钉死站点域名前缀，evil 域不会被放行。
 
 ## 2. 部署 OAuth Center（walinejs/auth）
 


### PR DESCRIPTION
## Summary

dev 部署 Waline 评论登录链路时，端到端验证发现真实回调被 Hub 拒绝（`400: The requested redirect_uri is missing in the client configuration`）。根因定位后，修正仓库文档/示例中的 glob 写法并补上回归测试。

## Root cause（zitadel/oidc v3.49.2 源码 + doublestar 探针实测）

1. zitadel/oidc 在 glob 匹配前会再 `url.QueryUnescape` 一次 redirect_uri —— 实际参与匹配的串中，内层页面 URL 的 `%2F` 已变成字面 `/`；
2. doublestar 的 `*` 嵌在 query 值中（`redirect=*&type=oidc`）**不能跨 `/`**，只有 `**` 作为末尾 segment 可以跨任意层目录。

因此旧的 `\?redirect=*&type=oidc` 只匹配无斜杠的值（如 `redirect=abc`），真实回调（页面 URL 绝对地址/相对路径）必然失配。

## Changes

- `deploy/config.toml.example`、`wiki/docs/deployment/oauth-center-oidc.md`：pattern 改为按"钉死站点域名前缀"拆两条（dev 实测生效）：
  ```toml
  redirect_uris_globs = [
    'https://comment.example.com/api/oauth\?redirect=https://wiki.example.com/**',
    'https://comment.example.com/api/oauth\?redirect=/**',
  ]
  ```
- 新增两个回归测试钉住真实回调形状（带 %-编码的内层页面 URL，zitadel 再解码后含字面 `/`）：
  - `TestAuthorizeAcceptsWalineCallbackGlob`：命中 → 进登录桥
  - `TestAuthorizeRejectsWalineCallbackGlobEvilDomain`：evil 域 → 仍被拒

## Verification

- 探针实测：wiki 任意深度页面 ✓、相对路径（`/ui/profile`）✓、evil 域 ✗、`wiki.example.com.evil.com` ✗
- oidcservice 全量测试 `-count=1` 通过
- dev 线上实测授权链（auth center → Hub authorize）真实回调 302 到登录桥，evil 域 400
