### PR TITLE
fix(wiki): Waline SQLite 需手动导入建表 SQL(dev 部署实测修复)

### DIFF
--- a/deploy/wiki/waline/README.md
+++ b/deploy/wiki/waline/README.md
@@ -4,8 +4,10 @@
 
 ```bash
 cd deploy/wiki/waline
-cp .env.example .env      # 按需编辑（SQLite 零配置即可跑）
+cp .env.example .env      # 按需编辑
 docker compose up -d
+# SQLite 首次启动必须手动导入建表 SQL（Waline 不会自动建表），
+# 见下方"存储选择"的导入命令
 ```
 
 反向代理 `https://comment.example.com` → `127.0.0.1:8360`（compose 仅回环绑定，
@@ -13,7 +15,16 @@ docker compose up -d
 
 ## 存储选择
 
-- **SQLite**（默认）：`SQLITE_PATH=/app/data`（数据目录，不是文件路径），开箱即用，适合低流量。
+- **SQLite**（默认）：`SQLITE_PATH=/app/data`（数据目录，不是文件路径），适合低流量。
+  **注意：Waline 不会自动建表**（其 SQLite 适配器无建表逻辑），空库会报
+  `no such table: wl_Comment`。首次启动必须手动导入仓库附带的
+  `waline.sqlite.sql`（官方 `assets/waline.sqlite.sql` 副本）：
+  ```bash
+  docker cp waline.sqlite.sql waline-waline-1:/tmp/waline.sqlite.sql
+  docker compose exec waline node -e \
+    'const D=require("better-sqlite3"),fs=require("fs");D("/app/data/waline.sqlite").exec(fs.readFileSync("/tmp/waline.sqlite.sql","utf8"))'
+  ```
+  导入是幂等的（`CREATE TABLE IF NOT EXISTS`），重启容器不需重复执行。
 - **MySQL**（生产推荐）：取消 docker-compose.yml 中 `MYSQL_*` 注释并填 `.env`；
   需先导入建表 SQL（waline 仓库 `assets/waline.sql`，见 .env.example），Waline 不会自动建表。
 

--- a/deploy/wiki/waline/docker-compose.yml
+++ b/deploy/wiki/waline/docker-compose.yml
@@ -3,10 +3,13 @@
 # 用法：
 #   1. 复制 .env.example 为 .env 并填写（SQLite 或 MySQL 二选一）。
 #   2. docker compose up -d
-#   3. 反向代理 https://comment.example.com -> 127.0.0.1:8360（仅回环暴露）
+#   3. SQLite 首次启动必须导入建表 SQL（Waline 不会自动建表，见 README）：
+#      docker cp waline.sqlite.sql waline-waline-1:/tmp/ && docker compose
+#      exec waline node -e 'require("better-sqlite3")("/app/data/waline.sqlite").exec(require("fs").readFileSync("/tmp/waline.sqlite.sql","utf8"))'
+#   4. 反向代理 https://comment.example.com -> 127.0.0.1:8360（仅回环暴露）
 #
-# 存储：SQLite（零依赖）或 MySQL（生产推荐，需先导入建表 SQL，见 README）。
-#       不使用 LeanCloud（停服风险）。
+# 存储：SQLite（零依赖，需手动导 waline.sqlite.sql 建表）或 MySQL
+#       （生产推荐，需先导入 waline.sql，见 README）。不使用 LeanCloud。
 # 登录：Waline 通过 OAUTH_URL 指向 walinejs/auth OAuth Center（自托管或
 #       Vercel 部署，见 ../oauth-center/），OAuth Center 再对接 YourTJ-Hub
 #       OIDC provider。注意：OAUTH_URL 指向的是 OAuth Center 自身地址，
@@ -26,7 +29,8 @@ services:
       - JWT_TOKEN=${JWT_TOKEN:-replace-with-a-random-token}
 
       # --- 存储：二选一 ---
-      # SQLite（默认；SQLITE_PATH 是数据目录，不是文件路径）
+      # SQLite（默认；SQLITE_PATH 是数据目录，不是文件路径）。
+      # 注意：Waline 不会自动建表，首次启动必须手动导入 waline.sqlite.sql
       - SQLITE_PATH=/app/data
       # MySQL（生产推荐，取消注释并填 .env；需先导入 waline.sql 建表）
       # - MYSQL_DB=${MYSQL_DB:-waline}

--- a/deploy/wiki/waline/waline.sqlite.sql
+++ b/deploy/wiki/waline/waline.sqlite.sql
@@ -1,0 +1,61 @@
+BEGIN TRANSACTION;
+CREATE TABLE IF NOT EXISTS "wl_Comment" (
+	"id"	INTEGER,
+	"user_id"	INTEGER,
+	"comment"	TEXT,
+	"insertedAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	"ip"	TEXT,
+	"link"	TEXT,
+	"mail"	TEXT,
+	"nick"	TEXT,
+	"rid"	INTEGER,
+	"pid"	INTEGER,
+	"sticky"	NUMERIC,
+	"status"	TEXT NOT NULL,
+	"like"	INTEGER,
+	"ua"	TEXT,
+	"url"	TEXT,
+	"createdAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	"updatedAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	PRIMARY KEY("id" AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS "wl_Counter" (
+	"id"	INTEGER,
+	"time"	INTEGER,
+	"reaction0"	INTEGER,
+	"reaction1"	INTEGER,
+	"reaction2"	INTEGER,
+	"reaction3"	INTEGER,
+	"reaction4"	INTEGER,
+	"reaction5"	INTEGER,
+	"reaction6"	INTEGER,
+	"reaction7"	INTEGER,
+	"reaction8"	INTEGER,
+	"url"	TEXT,
+	"createdAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	"updatedAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	PRIMARY KEY("id" AUTOINCREMENT)
+);
+CREATE TABLE IF NOT EXISTS "wl_Users" (
+	"id"	INTEGER,
+	"display_name"	TEXT NOT NULL DEFAULT "",
+	"email"	TEXT NOT NULL DEFAULT "",
+	"password"	TEXT NOT NULL DEFAULT "",
+	"type"	TEXT NOT NULL DEFAULT "",
+	"label"	TEXT,
+	"github"	TEXT,
+	"twitter"	TEXT,
+	"facebook"	TEXT,
+	"google"	TEXT,
+	"weibo"	TEXT,
+	"qq"	TEXT,
+	"oidc"	TEXT,
+	"huawei"	TEXT,
+	"2fa"	TEXT,
+	"avatar"	TEXT,
+	"url"	TEXT,
+	"createdAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	"updatedAt"	DATETIME DEFAULT (datetime('now', 'localtime')),
+	PRIMARY KEY("id" AUTOINCREMENT)
+);
+COMMIT;

--- a/wiki/docs/deployment/waline.md
+++ b/wiki/docs/deployment/waline.md
@@ -28,6 +28,10 @@ docker compose up -d
 
 - 端口 `8360`（仅 `127.0.0.1` 回环绑定），反向代理到 `https://comment.example.com`。
 - 存储：SQLite（默认）或 MySQL（生产推荐，避免 LeanCloud 停服风险）。
+- **SQLite 首次启动必须手动导入建表 SQL**：Waline 不会自动建表（空库报
+  `no such table: wl_Comment`），执行
+  `docker cp waline.sqlite.sql waline-waline-1:/tmp/ && docker compose exec waline node -e 'require("better-sqlite3")("/app/data/waline.sqlite").exec(require("fs").readFileSync("/tmp/waline.sqlite.sql","utf8"))'`
+  （幂等，`CREATE TABLE IF NOT EXISTS`）。
 - 登录：`OAUTH_URL` 指向 OAuth Center（walinejs/auth），OAuth Center 再
   对接 YourTJ-Hub OIDC provider。
 


### PR DESCRIPTION
## Summary

dev 部署 Waline 评论服务后验证发现：**SQLite 存储的评论功能实际不可用**——Waline 的 SQLite 适配器不会自动建表，空库状态下评论接口报 `no such table: wl_Comment`。此前仓库文档写"SQLite 开箱即用"是错误的。

## Changes

- 新增 `deploy/wiki/waline/waline.sqlite.sql`（官方 `assets/waline.sqlite.sql` 副本，`CREATE TABLE IF NOT EXISTS` 幂等）
- 三处文档同步修正（`README.md` / `docker-compose.yml` 注释 / `wiki/docs/deployment/waline.md`）：
  - 首次启动必须手动导入建表 SQL，附 `docker cp` + `better-sqlite3` 一行导入命令
  - 说明导入幂等、重启不需重复执行

## Verification

- dev 服务器实际修复：导入后 `wl_Comment`/`wl_Counter`/`wl_Users` 三表就位，公网 `https://comment.yourtj.de/api/comment` 返回 200 空列表（此前 500）
- 带 `Origin: https://wiki-dev.yourtj.de` 的评论读取正常
