### PR TITLE
docs(wiki): SECURE_DOMAINS 必须包含 Waline 服务自身域名(dev 部署实测)

### DIFF
--- a/deploy/wiki/waline/.env.example
+++ b/deploy/wiki/waline/.env.example
@@ -4,7 +4,10 @@
 # 站点
 SITE_URL=https://wiki.example.com
 SITE_NAME=YourTJ Wiki
-SECURE_DOMAINS=wiki.example.com
+# 允许评论的域名白名单，防跨站刷评。
+# 注意：必须包含 Waline 服务自身域名（/ui 管理后台登录按钮的 Referer
+# 校验会检查它，缺了按钮 403）。示例：站点域名 + comment 服务域名
+SECURE_DOMAINS=wiki.example.com,comment.example.com
 
 # OAuth Center 地址（walinejs/auth，自托管或 Vercel）
 OAUTH_URL=https://auth.example.com

--- a/deploy/wiki/waline/README.md
+++ b/deploy/wiki/waline/README.md
@@ -38,7 +38,7 @@ Waline 登录页 → OAUTH_URL（walinejs/auth）→ YourTJ-Hub OIDC → 回跳
 | `JWT_TOKEN` | 是 | 登录 token 密钥（`openssl rand -hex 32` 生成） |
 | `SQLITE_PATH` / `MYSQL_*` | 二选一 | 存储 |
 | `SITE_NAME` | 否 | 站点名（评论框展示） |
-| `SECURE_DOMAINS` | 否 | 允许评论的域名白名单，防跨站刷评 |
+| `SECURE_DOMAINS` | 否 | 允许评论的域名白名单，防跨站刷评；**必须包含 Waline 服务自身域名**（`/ui` 登录按钮的 Referer 校验），如 `wiki.example.com,comment.example.com` |
 | `SMTP_*` | 否 | 评论邮件通知 |
 | `AKISMET_KEY` | 否 | Akismet 反垃圾 |
 
@@ -47,4 +47,6 @@ Waline 登录页 → OAUTH_URL（walinejs/auth）→ YourTJ-Hub OIDC → 回跳
 ## 管理
 
 - 评论管理后台：`https://comment.example.com/ui`，登录方式同评论（OIDC）。
+  注意 `/ui/login` 的邮箱/密码表单是 Waline **本地账号**用的（Hub 账号不在
+  其密码表，用论坛密码登录必然失败），正确入口是 oidc 第三方登录按钮。
 - 站点侧 `VITE_WALINE_SERVER_URL` 指向本服务后，评论即在前端渲染。

--- a/wiki/docs/deployment/waline.md
+++ b/wiki/docs/deployment/waline.md
@@ -30,6 +30,9 @@ docker compose up -d
 - 存储：SQLite（默认）或 MySQL（生产推荐，避免 LeanCloud 停服风险）。
 - 登录：`OAUTH_URL` 指向 OAuth Center（walinejs/auth），OAuth Center 再
   对接 YourTJ-Hub OIDC provider。
+- `SECURE_DOMAINS` 必须包含 Waline 服务自身域名（如 `comment.example.com`），
+  否则 `/ui` 管理后台的 oidc 登录按钮 403（Referer 白名单校验）；
+  `/ui/login` 的邮箱/密码表单仅供 Waline 本地账号使用，Hub 账号走 oidc 按钮。
 
 ## 相关文档
 


### PR DESCRIPTION
## Summary

dev 部署 Waline 评论服务后实测发现：`/ui` 管理后台的 oidc 登录按钮点击后 **403**。

## Root cause（读 Waline 源码定位）

`OAuthLogic` 进控制器前先跑 `BaseLogic.__before()` → `referrerCheck()`（`logic/base.js:14-18`），校验请求 Referer 的 hostname 是否在 `secureDomains` 白名单（`SECURE_DOMAINS` + `localhost`/`127.0.0.1` + OAuth Center origin）。而 `/ui/login` 点 oidc 按钮时，浏览器请求 `/api/oauth` 的 Referer 是 **Waline 服务自身域名**（`comment.yourtj.de`）——它不在我们配置的白名单里（只配了站点域名 `wiki-dev.yourtj.de`），直接 403。

## Changes

- `.env.example`：`SECURE_DOMAINS` 示例改为「站点域名 + Waline 服务自身域名」双域名，并注释原因
- `README.md` / `wiki/docs/deployment/waline.md`：同步该要求，并澄清 `/ui/login` 邮箱/密码表单是 Waline **本地账号**登录（Hub 账号不在其密码表，用论坛密码登录必然失败），正确入口是 oidc 按钮

## Verification（dev 线上实测）

- 修复前：`/ui` oidc 按钮 → `/api/oauth` 403
- 修复后：`/ui` oidc 按钮 → `auth.yourtj.de` → Hub authorize（glob 命中 `/ui/profile` 回调）→ `/login` 登录桥，全链路 302 通过
