### PR TITLE
feat(course): PK 数据域元数据列 + 历史课评导入端到端验证（issue #183 #185）

### DIFF
--- a/apps/gooseforum/app/migration/import_run_index_upgrade_test.go
+++ b/apps/gooseforum/app/migration/import_run_index_upgrade_test.go
@@ -1,0 +1,109 @@
+package migration
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
+	"github.com/glebarez/sqlite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// legacyImportRunEntity 旧版 course_import_run 模型（issue #183 前）：无 kind 字段，
+// manifest_hash 单列唯一索引 uniq_course_import_run_manifest。用它 AutoMigrate 建出
+// 与真实存量库一致的旧表（列类型/索引均由旧版 GORM 生成，手写 DDL 无法完全对齐）。
+type legacyImportRunEntity struct {
+	Id               uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+	Source           string         `gorm:"column:source;type:varchar(64);not null;default:'';" json:"source"`
+	ManifestHash     string         `gorm:"column:manifest_hash;type:varchar(64);not null;default:'';uniqueIndex:uniq_course_import_run_manifest;" json:"manifestHash"`
+	Status           string         `gorm:"column:status;type:varchar(32);not null;default:'';" json:"status"`
+	InsertedCount    int            `gorm:"column:inserted_count;not null;default:0;" json:"insertedCount"`
+	UpdatedCount     int            `gorm:"column:updated_count;not null;default:0;" json:"updatedCount"`
+	QuarantinedCount int            `gorm:"column:quarantined_count;not null;default:0;" json:"quarantinedCount"`
+	ErrorCount       int            `gorm:"column:error_count;not null;default:0;" json:"errorCount"`
+	StartedAt        *time.Time     `gorm:"column:started_at;" json:"startedAt"`
+	FinishedAt       *time.Time     `gorm:"column:finished_at;" json:"finishedAt"`
+	CreatedAt        time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt        time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	DeletedAt        gorm.DeletedAt `json:"-"`
+}
+
+func (legacyImportRunEntity) TableName() string { return "course_import_run" }
+
+// exerciseImportRunIndexUpgrade 在给定连接上执行完整升级路径并断言结果：
+// 旧表（无 kind + manifest_hash 单列唯一）→ upgradeImportRunCompositeIndex
+// （ADD COLUMN 保留存量数据 + 删旧索引）→ AutoMigrate 新模型（建复合唯一索引）→
+// 同 hash 双 kind 可插、重复 (hash, kind) 被幂等拦截、存量行数据完整保留且 kind 回填 catalog。
+func exerciseImportRunIndexUpgrade(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.AutoMigrate(&legacyImportRunEntity{}); err != nil {
+		t.Fatalf("migrate legacy schema: %v", err)
+	}
+	legacy := legacyImportRunEntity{Source: "legacy", ManifestHash: "hash-1", Status: "completed"}
+	if err := db.Create(&legacy).Error; err != nil {
+		t.Fatalf("seed legacy run: %v", err)
+	}
+
+	if err := upgradeImportRunCompositeIndex(db); err != nil {
+		t.Fatalf("upgrade index: %v", err)
+	}
+	if err := db.AutoMigrate(&course.ImportRunEntity{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+
+	// 同 manifest_hash 的第二命令（reviews）必须能插入——旧单列唯一索引已删除。
+	reviews := course.ImportRunEntity{Source: "legacy", ManifestHash: "hash-1", Kind: course.ImportKindReviews, Status: course.ImportStatusCompleted}
+	if err := db.Create(&reviews).Error; err != nil {
+		t.Fatalf("insert reviews run with same hash: %v", err)
+	}
+	// 重复 (hash, kind=catalog) 仍被复合唯一索引幂等拦截。
+	dup := course.ImportRunEntity{Source: "legacy", ManifestHash: "hash-1", Kind: course.ImportKindCatalog, Status: course.ImportStatusRunning}
+	if err := db.Create(&dup).Error; err == nil {
+		t.Fatal("expected duplicate (manifest_hash, kind) insert to fail")
+	}
+	// 存量行：kind 回填 catalog，且 source/manifest_hash/status 完整保留
+	// （升级必须不丢数据——GORM SQLite 迁移的整表重建路径有数据丢失风险，见 upgradeImportRunCompositeIndex 注释）。
+	var got course.ImportRunEntity
+	if err := db.First(&got, "id = ?", legacy.Id).Error; err != nil {
+		t.Fatalf("load legacy run: %v", err)
+	}
+	if got.Kind != course.ImportKindCatalog {
+		t.Fatalf("legacy run kind = %q, want catalog", got.Kind)
+	}
+	if got.ManifestHash != "hash-1" || got.Source != "legacy" || got.Status != course.ImportStatusCompleted {
+		t.Fatalf("legacy run data lost after upgrade: %+v", got)
+	}
+}
+
+// TestImportRunIndexUpgradeFromLegacySchema issue #183 升级路径（SQLite）：
+// 存量库旧单列唯一索引必须被删除并重建为 (kind, manifest_hash) 复合唯一，
+// 否则单包双命令导入（相同 manifest_hash）在存量库上必撞旧唯一约束。
+func TestImportRunIndexUpgradeFromLegacySchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	exerciseImportRunIndexUpgrade(t, db)
+}
+
+// TestImportRunIndexUpgradeFromLegacySchemaOnPostgreSQL 同上，PostgreSQL 版
+// （GORM 按索引名判重、AutoMigrate 不重建同名索引的行为在 PG 同样存在）。
+// 依赖 YOURTJ_TEST_PG_URL，未设置时跳过。
+func TestImportRunIndexUpgradeFromLegacySchemaOnPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL import run index upgrade test")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	// 清理可能残留的表（与 migration_pg_test 共享同一测试库）。
+	if err := db.Migrator().DropTable(&course.ImportRunEntity{}); err != nil {
+		t.Fatalf("drop leftover table: %v", err)
+	}
+	exerciseImportRunIndexUpgrade(t, db)
+}

--- a/apps/gooseforum/app/migration/migration.go
+++ b/apps/gooseforum/app/migration/migration.go
@@ -79,6 +79,10 @@ func migrateSchema() {
 		slog.Error("dbconnect course_review legacy upgrade failed", "err", err)
 		os.Exit(1)
 	}
+	if err = upgradeImportRunCompositeIndex(db); err != nil {
+		slog.Error("dbconnect course_import_run index upgrade failed", "err", err)
+		os.Exit(1)
+	}
 	if err = db.AutoMigrate(SchemaModels()...); err != nil {
 		// 迁移失败必须立即退出（非零码），否则服务会带着残缺 schema 继续启动，
 		// 登录/注册等依赖新表的接口在运行期才会报错，故障被发现时已影响线上。
@@ -106,6 +110,32 @@ type duplicateUsername struct {
 // validateUniqueUsernames fails before AutoMigrate attempts to add the global
 // username unique index. Identity rows are never rewritten automatically; an
 // operator must resolve blank or duplicate legacy usernames deliberately.
+// upgradeImportRunCompositeIndex 升级 course_import_run 的幂等唯一索引（issue #183）：
+// 旧版本为 manifest_hash 单列唯一（uniq_course_import_run_manifest），新模型声明
+// (kind, manifest_hash) 复合唯一、索引名不变。两个必须显式处理的坑：
+//  1. GORM AutoMigrate 按索引名判重，同名旧索引不会被重建——不删旧索引，存量库上
+//     同一 manifest 包的 catalog/reviews 两次导入（相同 manifest_hash）会撞旧唯一约束。
+//  2. 依赖 AutoMigrate 补 kind 列会触发 SQLite 整表重建，实测存量行数据丢失；
+//     必须显式 ALTER TABLE ADD COLUMN（带默认值，保留存量数据）。
+func upgradeImportRunCompositeIndex(db *gorm.DB) error {
+	if !db.Migrator().HasTable("course_import_run") {
+		return nil // 全新库：AutoMigrate 直接建全表 + 复合索引。
+	}
+	if !db.Migrator().HasColumn(&course.ImportRunEntity{}, "kind") {
+		if err := db.Exec("ALTER TABLE course_import_run ADD COLUMN kind VARCHAR(32) NOT NULL DEFAULT 'catalog'").Error; err != nil {
+			return fmt.Errorf("add course_import_run.kind column: %w", err)
+		}
+		slog.Info("dbconnect course_import_run.kind column added (default 'catalog')")
+	}
+	if db.Migrator().HasIndex(&course.ImportRunEntity{}, "uniq_course_import_run_manifest") {
+		if err := db.Migrator().DropIndex(&course.ImportRunEntity{}, "uniq_course_import_run_manifest"); err != nil {
+			return fmt.Errorf("drop legacy course_import_run unique index: %w", err)
+		}
+		slog.Info("dbconnect course_import_run legacy unique index dropped, will be recreated as (kind, manifest_hash)")
+	}
+	return nil
+}
+
 func validateUniqueUsernames(db *gorm.DB) error {
 	if !db.Migrator().HasTable("users") {
 		return nil

--- a/apps/gooseforum/app/models/forum/course/course_rep.go
+++ b/apps/gooseforum/app/models/forum/course/course_rep.go
@@ -327,8 +327,8 @@ func CreateImportRun(entity *ImportRunEntity) error {
 	return importRunBuilder().Create(entity).Error
 }
 
-func GetImportRunByManifestHash(hash string) (entity ImportRunEntity, err error) {
-	err = importRunBuilder().Where(queryopt.Eq("manifest_hash", hash)).First(&entity).Error
+func GetImportRunByManifestHash(hash, kind string) (entity ImportRunEntity, err error) {
+	err = importRunBuilder().Where(queryopt.Eq("manifest_hash", hash)).Where(queryopt.Eq("kind", kind)).First(&entity).Error
 	return
 }
 

--- a/apps/gooseforum/app/models/forum/course/importRun.go
+++ b/apps/gooseforum/app/models/forum/course/importRun.go
@@ -12,7 +12,8 @@ const importRunTableName = "course_import_run"
 type ImportRunEntity struct {
 	Id               uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
 	Source           string         `gorm:"column:source;type:varchar(64);not null;default:'';" json:"source"`
-	ManifestHash     string         `gorm:"column:manifest_hash;type:varchar(64);not null;default:'';uniqueIndex:uniq_course_import_run_manifest;" json:"manifestHash"`
+	ManifestHash     string         `gorm:"column:manifest_hash;type:varchar(64);not null;default:'';uniqueIndex:uniq_course_import_run_manifest,priority:2;" json:"manifestHash"`
+	Kind             string         `gorm:"column:kind;type:varchar(32);not null;default:'catalog';uniqueIndex:uniq_course_import_run_manifest,priority:1;" json:"kind"`
 	Status           string         `gorm:"column:status;type:varchar(32);not null;default:'';" json:"status"`
 	InsertedCount    int            `gorm:"column:inserted_count;not null;default:0;" json:"insertedCount"`
 	UpdatedCount     int            `gorm:"column:updated_count;not null;default:0;" json:"updatedCount"`
@@ -30,6 +31,13 @@ const (
 	ImportStatusRunning   string = "running"
 	ImportStatusCompleted string = "completed"
 	ImportStatusFailed    string = "failed"
+)
+
+// 导入类型（kind）：同一 manifest 包内 catalog 目录与 reviews 历史评价
+// 两个子命令各自建 run（issue #183 上游导出器输出单包 4 文件）。
+const (
+	ImportKindCatalog string = "catalog"
+	ImportKindReviews string = "reviews"
 )
 
 func (itself *ImportRunEntity) TableName() string {

--- a/apps/gooseforum/app/models/forum/pk/assessment.go
+++ b/apps/gooseforum/app/models/forum/pk/assessment.go
@@ -13,6 +13,8 @@ type AssessmentEntity struct {
 	AssessmentMode     string         `gorm:"primaryKey;column:assessment_mode;type:varchar(64);not null;" json:"assessmentMode"`
 	AssessmentModeI18n string         `gorm:"column:assessment_mode_i18n;type:varchar(128);not null;default:'';" json:"assessmentModeI18n"`
 	CalendarId         uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
+	SchemaVersion      string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt           *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt          time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt          time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt          gorm.DeletedAt `json:"-"`

--- a/apps/gooseforum/app/models/forum/pk/calendar.go
+++ b/apps/gooseforum/app/models/forum/pk/calendar.go
@@ -13,6 +13,8 @@ const calendarTableName = "pk_calendar"
 type CalendarEntity struct {
 	CalendarId     uint64         `gorm:"primaryKey;column:calendar_id;not null;" json:"calendarId"`
 	CalendarIdI18n string         `gorm:"column:calendar_id_i18n;type:varchar(64);not null;default:'';index:idx_pk_calendar_i18n;" json:"calendarIdI18n"`
+	SchemaVersion  string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt       *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt      time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt      time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt      gorm.DeletedAt `json:"-"`

--- a/apps/gooseforum/app/models/forum/pk/campus.go
+++ b/apps/gooseforum/app/models/forum/pk/campus.go
@@ -10,12 +10,14 @@ const campusTableName = "pk_campus"
 
 // CampusEntity 一系统校区字典（campus → I18n）。
 type CampusEntity struct {
-	Campus     string         `gorm:"primaryKey;column:campus;type:varchar(128);not null;" json:"campus"`
-	CampusI18n string         `gorm:"column:campus_i18n;type:varchar(128);not null;default:'';" json:"campusI18n"`
-	CalendarId uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
-	CreatedAt  time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
-	UpdatedAt  time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
-	DeletedAt  gorm.DeletedAt `json:"-"`
+	Campus        string         `gorm:"primaryKey;column:campus;type:varchar(128);not null;" json:"campus"`
+	CampusI18n    string         `gorm:"column:campus_i18n;type:varchar(128);not null;default:'';" json:"campusI18n"`
+	CalendarId    uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
+	SchemaVersion string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt      *time.Time     `gorm:"column:synced_at;" json:"-"`
+	CreatedAt     time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt     time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `json:"-"`
 }
 
 func (itself *CampusEntity) TableName() string {

--- a/apps/gooseforum/app/models/forum/pk/constants.go
+++ b/apps/gooseforum/app/models/forum/pk/constants.go
@@ -2,3 +2,8 @@ package pk
 
 // MAX_SQL_VARS SQLite/MySQL 单查询变量上限；IN 条件按此分块（跨方言安全）。
 const MAX_SQL_VARS = 80
+
+// PKDataSchemaVersion PK 数据域 schema 版本（issue #185）：随模型结构/派生规则变更递增，
+// 与各表的 synced_at 一起标记每行数据的产出版本与最近同步时间，供重建/部分更新判断。
+// 思路对齐上游 PK_AUX_SCHEMA_VERSION（'20260605-pk-query-opt-v2'）的"版本号驱动重建"。
+const PKDataSchemaVersion = "2026-08-pk-data-v1"

--- a/apps/gooseforum/app/models/forum/pk/courseDetail.go
+++ b/apps/gooseforum/app/models/forum/pk/courseDetail.go
@@ -31,6 +31,8 @@ type CourseDetailEntity struct {
 	CalendarId       uint64         `gorm:"column:calendar_id;not null;default:0;index:idx_pk_course_detail_calendar;" json:"calendarId"`
 	NewCourseCode    string         `gorm:"column:new_course_code;type:varchar(64);not null;default:'';index:idx_pk_course_detail_new_course_code;" json:"newCourseCode"`
 	NewCode          string         `gorm:"column:new_code;type:varchar(64);not null;default:'';index:idx_pk_course_detail_new_code;" json:"newCode"`
+	SchemaVersion    string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt         *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt        time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt        time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt        gorm.DeletedAt `json:"-"`

--- a/apps/gooseforum/app/models/forum/pk/courseNature.go
+++ b/apps/gooseforum/app/models/forum/pk/courseNature.go
@@ -14,6 +14,8 @@ type CourseNatureEntity struct {
 	CourseLabelId   uint64         `gorm:"primaryKey;column:course_label_id;not null;" json:"courseLabelId"`
 	CourseLabelName string         `gorm:"column:course_label_name;type:varchar(128);not null;default:'';" json:"courseLabelName"`
 	CalendarId      uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
+	SchemaVersion   string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt        *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt       time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt       time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt       gorm.DeletedAt `json:"-"`
@@ -25,11 +27,13 @@ func (itself *CourseNatureEntity) TableName() string {
 
 // CourseNatureByCalendarEntity 课程性质按学期快照：course-pk-sync 按学期删除重建，保留历史不覆盖全局字典。
 type CourseNatureByCalendarEntity struct {
-	CalendarId      uint64    `gorm:"primaryKey;column:calendar_id;not null;" json:"calendarId"`
-	CourseLabelId   uint64    `gorm:"primaryKey;column:course_label_id;not null;" json:"courseLabelId"`
-	CourseLabelName string    `gorm:"column:course_label_name;type:varchar(128);not null;default:'';" json:"courseLabelName"`
-	CreatedAt       time.Time `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
-	UpdatedAt       time.Time `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	CalendarId      uint64     `gorm:"primaryKey;column:calendar_id;not null;" json:"calendarId"`
+	CourseLabelId   uint64     `gorm:"primaryKey;column:course_label_id;not null;" json:"courseLabelId"`
+	CourseLabelName string     `gorm:"column:course_label_name;type:varchar(128);not null;default:'';" json:"courseLabelName"`
+	SchemaVersion   string     `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt        *time.Time `gorm:"column:synced_at;" json:"-"`
+	CreatedAt       time.Time  `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt       time.Time  `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 }
 
 func (itself *CourseNatureByCalendarEntity) TableName() string {

--- a/apps/gooseforum/app/models/forum/pk/faculty.go
+++ b/apps/gooseforum/app/models/forum/pk/faculty.go
@@ -10,12 +10,14 @@ const facultyTableName = "pk_faculty"
 
 // FacultyEntity 一系统院系字典（faculty → I18n）。
 type FacultyEntity struct {
-	Faculty     string         `gorm:"primaryKey;column:faculty;type:varchar(255);not null;" json:"faculty"`
-	FacultyI18n string         `gorm:"column:faculty_i18n;type:varchar(255);not null;default:'';" json:"facultyI18n"`
-	CalendarId  uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
-	CreatedAt   time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
-	UpdatedAt   time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
-	DeletedAt   gorm.DeletedAt `json:"-"`
+	Faculty       string         `gorm:"primaryKey;column:faculty;type:varchar(255);not null;" json:"faculty"`
+	FacultyI18n   string         `gorm:"column:faculty_i18n;type:varchar(255);not null;default:'';" json:"facultyI18n"`
+	CalendarId    uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
+	SchemaVersion string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt      *time.Time     `gorm:"column:synced_at;" json:"-"`
+	CreatedAt     time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt     time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `json:"-"`
 }
 
 func (itself *FacultyEntity) TableName() string {

--- a/apps/gooseforum/app/models/forum/pk/fetchLog.go
+++ b/apps/gooseforum/app/models/forum/pk/fetchLog.go
@@ -39,6 +39,8 @@ type FetchLogEntity struct {
 	ErrorMsg          string         `gorm:"column:error_msg;type:text;not null;default:'';" json:"errorMsg"`
 	StartedAt         *time.Time     `gorm:"column:started_at;" json:"startedAt"`
 	FinishedAt        *time.Time     `gorm:"column:finished_at;" json:"finishedAt"`
+	SchemaVersion     string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt          *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt         time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt         time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt         gorm.DeletedAt `json:"-"`

--- a/apps/gooseforum/app/models/forum/pk/language.go
+++ b/apps/gooseforum/app/models/forum/pk/language.go
@@ -13,6 +13,8 @@ type LanguageEntity struct {
 	TeachingLanguage     string         `gorm:"primaryKey;column:teaching_language;type:varchar(64);not null;" json:"teachingLanguage"`
 	TeachingLanguageI18n string         `gorm:"column:teaching_language_i18n;type:varchar(128);not null;default:'';" json:"teachingLanguageI18n"`
 	CalendarId           uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
+	SchemaVersion        string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt             *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt            time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt            time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt            gorm.DeletedAt `json:"-"`

--- a/apps/gooseforum/app/models/forum/pk/major.go
+++ b/apps/gooseforum/app/models/forum/pk/major.go
@@ -10,14 +10,16 @@ const majorTableName = "pk_major"
 
 // MajorEntity 一系统专业字典：name 唯一（"2025(03074 土木工程(国际班))" 形如 parseMajorString 解析结果）。
 type MajorEntity struct {
-	Id         uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
-	Code       string         `gorm:"column:code;type:varchar(32);not null;default:'';index:idx_pk_major_code;" json:"code"`
-	Grade      *int           `gorm:"column:grade;index:idx_pk_major_grade;" json:"grade"`
-	Name       string         `gorm:"column:name;type:varchar(255);not null;default:'';uniqueIndex:uniq_pk_major_name;" json:"name"`
-	CalendarId uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
-	CreatedAt  time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
-	UpdatedAt  time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
-	DeletedAt  gorm.DeletedAt `json:"-"`
+	Id            uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+	Code          string         `gorm:"column:code;type:varchar(32);not null;default:'';index:idx_pk_major_code;" json:"code"`
+	Grade         *int           `gorm:"column:grade;index:idx_pk_major_grade;" json:"grade"`
+	Name          string         `gorm:"column:name;type:varchar(255);not null;default:'';uniqueIndex:uniq_pk_major_name;" json:"name"`
+	CalendarId    uint64         `gorm:"column:calendar_id;not null;default:0;" json:"calendarId"`
+	SchemaVersion string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt      *time.Time     `gorm:"column:synced_at;" json:"-"`
+	CreatedAt     time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt     time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `json:"-"`
 }
 
 func (itself *MajorEntity) TableName() string {

--- a/apps/gooseforum/app/models/forum/pk/majorCourse.go
+++ b/apps/gooseforum/app/models/forum/pk/majorCourse.go
@@ -8,10 +8,12 @@ const majorCourseTableName = "pk_major_course"
 
 // MajorCourseEntity 专业×教学班关联（一系统 majorList × teachingClassId）。
 type MajorCourseEntity struct {
-	MajorId   uint64    `gorm:"primaryKey;column:major_id;not null;" json:"majorId"`
-	CourseId  uint64    `gorm:"primaryKey;column:course_id;not null;index:idx_pk_major_course_course;" json:"courseId"`
-	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
-	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	MajorId       uint64     `gorm:"primaryKey;column:major_id;not null;" json:"majorId"`
+	CourseId      uint64     `gorm:"primaryKey;column:course_id;not null;index:idx_pk_major_course_course;" json:"courseId"`
+	SchemaVersion string     `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt      *time.Time `gorm:"column:synced_at;" json:"-"`
+	CreatedAt     time.Time  `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt     time.Time  `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 }
 
 func (itself *MajorCourseEntity) TableName() string {

--- a/apps/gooseforum/app/models/forum/pk/pk_pg_test.go
+++ b/apps/gooseforum/app/models/forum/pk/pk_pg_test.go
@@ -43,6 +43,13 @@ func TestPKSchemaConcurrentUpsertPostgreSQL(t *testing.T) {
 			t.Fatalf("clean pk table: %v", err)
 		}
 	}
+	// 结束后清理本测试写入的行，保证同一测试库上可重复运行、不残留测试数据
+	// （migration_pg_test 用 DROP SCHEMA 重置，本测试只清自己的键）。
+	t.Cleanup(func() {
+		_ = db.Unscoped().Where("id = 1").Delete(&TeacherEntity{}).Error
+		_ = db.Unscoped().Where("calendar_id = 202601 AND teaching_class_id = 900001").
+			Delete(&TeacherTimeslotEntity{}).Error
+	})
 
 	const calendarId uint64 = 202601
 	const classId uint64 = 900001

--- a/apps/gooseforum/app/models/forum/pk/pk_pg_test.go
+++ b/apps/gooseforum/app/models/forum/pk/pk_pg_test.go
@@ -1,0 +1,144 @@
+package pk
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// TestPKSchemaConcurrentUpsertPostgreSQL 在真实 PostgreSQL 上验证 PK 域迁移与并发 upsert 无歧义
+// （issue #185 验收 1：参照 course/stats_pg_test.go 的并发原子模式）。
+//
+//   - 验收 1a：13 张 pk 表 + setting 全部可通过 AutoMigrate 在 PG 上创建（三方言模型定义无方言专属语法）。
+//   - 验收 1b：单主键表（teacher）并发 upsert 同一行无歧义，N 次并发后恰好 1 行且元数据列已填充。
+//   - 验收 1c：复合主键表（teacher_timeslot，6 列复合键）并发 upsert 同一键无重复行。
+//
+// 依赖 YOURTJ_TEST_PG_URL（与 migration 包真实 PG 迁移测试同一门控），未设置时跳过。
+func TestPKSchemaConcurrentUpsertPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL concurrent PK upsert test")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+
+	entities := []any{
+		&CalendarEntity{}, &CampusEntity{}, &FacultyEntity{}, &LanguageEntity{},
+		&AssessmentEntity{}, &CourseNatureEntity{}, &CourseNatureByCalendarEntity{},
+		&MajorEntity{}, &MajorCourseEntity{}, &CourseDetailEntity{}, &TeacherEntity{},
+		&TeacherTimeslotEntity{}, &FetchLogEntity{}, &SettingEntity{},
+	}
+	if err := db.AutoMigrate(entities...); err != nil {
+		t.Fatalf("AutoMigrate pk tables on postgres failed: %v", err)
+	}
+	for _, m := range entities {
+		if err := db.Unscoped().Where("1 = 1").Delete(m).Error; err != nil {
+			t.Fatalf("clean pk table: %v", err)
+		}
+	}
+
+	const calendarId uint64 = 202601
+	const classId uint64 = 900001
+	const workers = 8
+	const perWorker = 25
+
+	// 单主键并发 upsert：8×25 写同一 teacher 行，最终必须恰好 1 行、无歧义。
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			now := time.Now()
+			for i := 0; i < perWorker; i++ {
+				row := TeacherEntity{
+					Id: 1, TeachingClassId: classId, TeacherCode: "T001",
+					TeacherName: "并发教师", ArrangeInfoText: "x",
+					SchemaVersion: PKDataSchemaVersion, SyncedAt: &now,
+				}
+				if err := UpsertTeachersTx(db, []TeacherEntity{row}); err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		t.Fatalf("concurrent teacher upsert failed: %v", firstErr)
+	}
+	var teacherCount int64
+	if err := db.Model(&TeacherEntity{}).Where("id = 1").Count(&teacherCount).Error; err != nil {
+		t.Fatalf("count teachers: %v", err)
+	}
+	if teacherCount != 1 {
+		t.Fatalf("expected exactly 1 teacher row after %d concurrent upserts, got %d", workers*perWorker, teacherCount)
+	}
+	var teacher TeacherEntity
+	if err := db.First(&teacher, "id = 1").Error; err != nil {
+		t.Fatalf("load teacher after concurrent upsert: %v", err)
+	}
+	if teacher.SchemaVersion != PKDataSchemaVersion || teacher.SyncedAt == nil {
+		t.Fatalf("metadata columns not populated after upsert: %+v", teacher)
+	}
+
+	// 复合主键并发 upsert：8×25 写同一 (calendar, class, day, section, code, name) 键，
+	// ON CONFLICT 复合键必须无歧义——最终恰好 1 行，不产生重复行。
+	onConflict := clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "calendar_id"}, {Name: "teaching_class_id"}, {Name: "occupy_day"},
+			{Name: "occupy_section"}, {Name: "teacher_code"}, {Name: "teacher_name"},
+		},
+		UpdateAll: true,
+	}
+	wg = sync.WaitGroup{}
+	mu = sync.Mutex{}
+	firstErr = nil
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			now := time.Now()
+			for i := 0; i < perWorker; i++ {
+				row := TeacherTimeslotEntity{
+					CalendarId: calendarId, TeachingClassId: classId,
+					OccupyDay: 1, OccupySection: 2, TeacherCode: "T001", TeacherName: "并发教师",
+					SchemaVersion: PKDataSchemaVersion, SyncedAt: &now,
+				}
+				if err := db.Clauses(onConflict).Create(&row).Error; err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if firstErr != nil {
+		t.Fatalf("concurrent timeslot upsert failed: %v", firstErr)
+	}
+	var tsCount int64
+	if err := db.Model(&TeacherTimeslotEntity{}).
+		Where("calendar_id = ? AND teaching_class_id = ?", calendarId, classId).
+		Count(&tsCount).Error; err != nil {
+		t.Fatalf("count timeslots: %v", err)
+	}
+	if tsCount != 1 {
+		t.Fatalf("expected exactly 1 timeslot row after %d concurrent upserts, got %d", workers*perWorker, tsCount)
+	}
+}

--- a/apps/gooseforum/app/models/forum/pk/pk_rep.go
+++ b/apps/gooseforum/app/models/forum/pk/pk_rep.go
@@ -38,10 +38,12 @@ func LatestFetchLogByCalendar(calendarId uint64) (FetchLogEntity, bool) {
 func CreateFetchLog(calendarId uint64) (*FetchLogEntity, error) {
 	now := time.Now()
 	entity := &FetchLogEntity{
-		CalendarId: calendarId,
-		RunningKey: &calendarId,
-		Status:     FetchStatusRunning,
-		StartedAt:  &now,
+		CalendarId:    calendarId,
+		RunningKey:    &calendarId,
+		Status:        FetchStatusRunning,
+		StartedAt:     &now,
+		SchemaVersion: PKDataSchemaVersion,
+		SyncedAt:      &now,
 	}
 	if err := fetchLogBuilder().Create(entity).Error; err != nil {
 		return nil, fmt.Errorf("pk: create fetch log: %w", err)

--- a/apps/gooseforum/app/models/forum/pk/teacher.go
+++ b/apps/gooseforum/app/models/forum/pk/teacher.go
@@ -16,6 +16,8 @@ type TeacherEntity struct {
 	TeacherCode     string         `gorm:"column:teacher_code;type:varchar(64);not null;default:'';index:idx_pk_teacher_code;" json:"teacherCode"`
 	TeacherName     string         `gorm:"column:teacher_name;type:varchar(128);not null;default:'';index:idx_pk_teacher_name;" json:"teacherName"`
 	ArrangeInfoText string         `gorm:"column:arrange_info_text;type:text;not null;default:'';" json:"arrangeInfoText"`
+	SchemaVersion   string         `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt        *time.Time     `gorm:"column:synced_at;" json:"-"`
 	CreatedAt       time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt       time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
 	DeletedAt       gorm.DeletedAt `json:"-"`

--- a/apps/gooseforum/app/models/forum/pk/teacherTimeslot.go
+++ b/apps/gooseforum/app/models/forum/pk/teacherTimeslot.go
@@ -1,16 +1,22 @@
 package pk
 
+import (
+	"time"
+)
+
 const teacherTimeslotTableName = "pk_teacher_timeslot"
 
 // TeacherTimeslotEntity 教师时间片投影：由 pk_teacher.arrange_info_text 解析重建（course-pk-sync 触发），
 // 复合主键与上游 teacher_timeslots 一致，供排课查询按 (calendar, day, section) 反查。
 type TeacherTimeslotEntity struct {
-	CalendarId      uint64 `gorm:"primaryKey;column:calendar_id;not null;index:idx_pk_timeslot_slot,priority:1;" json:"calendarId"`
-	TeachingClassId uint64 `gorm:"primaryKey;column:teaching_class_id;not null;index:idx_pk_timeslot_class;" json:"teachingClassId"`
-	OccupyDay       int    `gorm:"primaryKey;column:occupy_day;not null;index:idx_pk_timeslot_slot,priority:2;" json:"occupyDay"`
-	OccupySection   int    `gorm:"primaryKey;column:occupy_section;not null;index:idx_pk_timeslot_slot,priority:3;" json:"occupySection"`
-	TeacherCode     string `gorm:"primaryKey;column:teacher_code;type:varchar(64);not null;default:'';" json:"teacherCode"`
-	TeacherName     string `gorm:"primaryKey;column:teacher_name;type:varchar(128);not null;default:'';" json:"teacherName"`
+	CalendarId      uint64     `gorm:"primaryKey;column:calendar_id;not null;index:idx_pk_timeslot_slot,priority:1;" json:"calendarId"`
+	TeachingClassId uint64     `gorm:"primaryKey;column:teaching_class_id;not null;index:idx_pk_timeslot_class;" json:"teachingClassId"`
+	OccupyDay       int        `gorm:"primaryKey;column:occupy_day;not null;index:idx_pk_timeslot_slot,priority:2;" json:"occupyDay"`
+	OccupySection   int        `gorm:"primaryKey;column:occupy_section;not null;index:idx_pk_timeslot_slot,priority:3;" json:"occupySection"`
+	TeacherCode     string     `gorm:"primaryKey;column:teacher_code;type:varchar(64);not null;default:'';" json:"teacherCode"`
+	TeacherName     string     `gorm:"primaryKey;column:teacher_name;type:varchar(128);not null;default:'';" json:"teacherName"`
+	SchemaVersion   string     `gorm:"column:schema_version;type:varchar(64);not null;default:'';" json:"-"`
+	SyncedAt        *time.Time `gorm:"column:synced_at;" json:"-"`
 }
 
 func (itself *TeacherTimeslotEntity) TableName() string {

--- a/apps/gooseforum/app/service/courseservice/import_e2e_test.go
+++ b/apps/gooseforum/app/service/courseservice/import_e2e_test.go
@@ -1,0 +1,274 @@
+package courseservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
+)
+
+// writeLegacyE2EPackage 构造与上游导出器 export_legacy_course_package.py 输出格式一致的
+// 完整数据包：4 个 JSONL（courses/instructors/offerings/reviews）+ manifest.yaml
+// （schema_version=1 + counts + rights_approval_ref + 各文件 sha256）。
+// issue #183 Phase B 端到端验收的输入侧；source 固定 "test-e2e-legacy"。
+func writeLegacyE2EPackage(t *testing.T, files map[string]string, counts map[string]int, rightsApprovalRef string) string {
+	t.Helper()
+	dir := t.TempDir()
+	manifestFiles := make(map[string]string, len(files))
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		sum := sha256.Sum256([]byte(content))
+		manifestFiles[name] = hex.EncodeToString(sum[:])
+	}
+	manifest := "schema_version: 1\nsource: test-e2e-legacy\nrights_approval_ref: " + rightsApprovalRef + "\ncounts:\n"
+	for name, count := range counts {
+		manifest += fmt.Sprintf("  %s: %d\n", name, count)
+	}
+	manifest += "files:\n"
+	for name, sum := range manifestFiles {
+		manifest += fmt.Sprintf("  %s: %s\n", name, sum)
+	}
+	manifestPath := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	return manifestPath
+}
+
+// migrateCourseImportTables 迁移并清空端到端链路所需的全部表（catalog 导入 + reviews 导入 + 统计 + 任务队列表）。
+func migrateCourseImportTables(t *testing.T) {
+	t.Helper()
+	conn := dbconnect.Connect()
+	models := []any{
+		&course.Entity{},
+		&course.AliasEntity{},
+		&course.TermEntity{},
+		&course.OfferingEntity{},
+		&course.InstructorEntity{},
+		&course.OfferingInstructorEntity{},
+		&course.ImportRunEntity{},
+		&course.SourceRefEntity{},
+		&course.ReviewEntity{},
+		&course.HelpfulEntity{},
+		&course.CourseStatsEntity{},
+		&course.OfferingStatsEntity{},
+		&taskQueue.Entity{},
+	}
+	if err := conn.AutoMigrate(models...); err != nil {
+		t.Fatalf("migrate course tables: %v", err)
+	}
+	for _, model := range models {
+		if err := conn.Unscoped().Where("1 = 1").Delete(model).Error; err != nil {
+			t.Fatalf("clean course table: %v", err)
+		}
+	}
+}
+
+// TestE2ELegacyImportFullChain issue #183 验收 1/2/4 端到端链路：
+// 上游格式小包 dry-run（0 冲突、计数一致）→ catalog 正式导入（import_run completed）→
+// reviews 正式导入（legacy 行）→ 统计重建 → 目录/详情抽查 → 重复导入幂等 → 匿名 DTO 零泄露。
+func TestE2ELegacyImportFullChain(t *testing.T) {
+	migrateCourseImportTables(t)
+
+	// 与上游导出器行结构一致的小包：2 课程 + 1 教师 + 2 开课 + 2 评价（其一 rating=0 → NULL）。
+	files := map[string]string{
+		"courses.jsonl": `{"id":"c1","code":"100001","name":"高等数学(A)上","department":"数学科学学院","credit":5,"aliases":["高数"]}` + "\n" +
+			`{"id":"c2","code":"100002","name":"线性代数","department":"数学科学学院","credit":3}` + "\n",
+		"instructors.jsonl": `{"id":"i1","name":"张三","department":"数学科学学院","title":"教授"}` + "\n",
+		"offerings.jsonl": `{"id":"o1","course_id":"c1","term":"2025-2026-1","campus":"四平路校区","faculty":"数学科学学院","instructor_ids":["i1"]}` + "\n" +
+			`{"id":"o2","course_id":"c2","term":"2025-2026-1","campus":"嘉定校区","instructor_ids":["i1"]}` + "\n",
+		"reviews.jsonl": `{"offering_external_id":"o1","rating":4,"content":"老师讲得很清楚","created_at":"2023-06-01T08:00:00+08:00","legacy_helpful_count":3}` + "\n" +
+			`{"offering_external_id":"o2","rating":0,"content":"无评分历史评价","created_at":"2023-06-02T08:00:00+08:00","legacy_helpful_count":1}` + "\n",
+	}
+	manifestPath := writeLegacyE2EPackage(t, files, map[string]int{
+		"courses.jsonl": 2, "instructors.jsonl": 1, "offerings.jsonl": 2, "reviews.jsonl": 2,
+	}, "e2e-approval-001")
+
+	// 1) catalog dry-run：0 冲突、计数与 manifest 一致。
+	dryReport, err := ImportCatalog(context.Background(), manifestPath, true)
+	if err != nil {
+		t.Fatalf("catalog dry-run: %v", err)
+	}
+	if dryReport.TotalLines != 5 || dryReport.Quarantined != 0 || len(dryReport.Errors) != 0 {
+		t.Fatalf("dry-run report unexpected: %+v", dryReport)
+	}
+
+	// 2) catalog 正式导入：全部插入，import_run completed。
+	report, err := ImportCatalog(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("catalog import: %v", err)
+	}
+	if report.Inserted != 5 {
+		t.Fatalf("expected 5 inserted rows, got inserted=%d updated=%d", report.Inserted, report.Updated)
+	}
+	conn := dbconnect.Connect()
+	var run course.ImportRunEntity
+	if err := conn.Order("id desc").First(&run).Error; err != nil {
+		t.Fatalf("load import run: %v", err)
+	}
+	if run.Status != course.ImportStatusCompleted {
+		t.Fatalf("import run status = %s, want completed", run.Status)
+	}
+
+	// 3) reviews dry-run：0 冲突。
+	if _, err := ImportReviews(context.Background(), manifestPath, true); err != nil {
+		t.Fatalf("reviews dry-run: %v", err)
+	}
+
+	// 4) reviews 正式导入：2 条 legacy 行（rating 0 → NULL）。
+	reviewReport, err := ImportReviews(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("reviews import: %v", err)
+	}
+	if reviewReport.Inserted != 2 || reviewReport.Quarantined != 0 {
+		t.Fatalf("reviews report unexpected: %+v", reviewReport)
+	}
+
+	// 5) 统计重建成功。
+	if err := course.RebuildAllCourseStats(); err != nil {
+		t.Fatalf("rebuild course stats: %v", err)
+	}
+
+	// 6) 目录抽查：2 门课可见，高数（rating 4 唯一有效评分）均分 4.0。
+	page, err := ListCatalog(CatalogQuery{Page: 1, Size: 50})
+	if err != nil {
+		t.Fatalf("list catalog: %v", err)
+	}
+	if page.Total != 2 {
+		t.Fatalf("catalog total = %d, want 2", page.Total)
+	}
+	var mathSummary *CourseSummary
+	var linearSummary *CourseSummary
+	for i := range page.List {
+		switch page.List[i].PrimaryCode {
+		case "100001":
+			mathSummary = &page.List[i]
+		case "100002":
+			linearSummary = &page.List[i]
+		}
+	}
+	if mathSummary == nil || linearSummary == nil {
+		t.Fatalf("catalog missing courses: %+v", page.List)
+	}
+	if mathSummary.RatingAvg == nil || *mathSummary.RatingAvg != 4.0 {
+		t.Fatalf("rating avg = %v, want 4.0", mathSummary.RatingAvg)
+	}
+	if mathSummary.ReviewCount != 1 {
+		t.Fatalf("review count = %d, want 1", mathSummary.ReviewCount)
+	}
+	if linearSummary.RatingAvg != nil || linearSummary.ReviewCount != 1 {
+		t.Fatalf("linear summary = avg %v count %d, want nil/1", linearSummary.RatingAvg, linearSummary.ReviewCount)
+	}
+
+	// 7) 详情抽查：offering 数量与课程一致。
+	detail, err := GetCourseDetail(mathSummary.Id)
+	if err != nil {
+		t.Fatalf("get course detail: %v", err)
+	}
+	if len(detail.Offerings) != 1 || detail.Offerings[0].TermCode != "2025-2026-1" {
+		t.Fatalf("course detail offerings unexpected: %+v", detail.Offerings)
+	}
+	if detail.RatingAvg == nil || *detail.RatingAvg != 4.0 {
+		t.Fatalf("detail rating avg = %v, want 4.0", detail.RatingAvg)
+	}
+
+	// 8) 匿名 DTO 零泄露：公开评价查询返回 kind=legacy 且不含任何身份字段。
+	// 每 offering 至多 1 条 legacy 评价（映射决策）：o1 有评分、o2 无评分（rating 0 → NULL）。
+	o1Reviews, err := ListReviewsByOffering(detail.Offerings[0].Id, 0)
+	if err != nil {
+		t.Fatalf("list reviews o1: %v", err)
+	}
+	if len(o1Reviews) != 1 {
+		t.Fatalf("o1 reviews count = %d, want 1", len(o1Reviews))
+	}
+	r := o1Reviews[0]
+	if r.Author.Kind != "legacy" || r.Author.Label != "历史匿名评价" {
+		t.Fatalf("review author not legacy-anonymized: %+v", r.Author)
+	}
+	if r.Viewer.CanEdit || r.Viewer.CanDelete {
+		t.Fatalf("legacy review viewer must not be editable: %+v", r.Viewer)
+	}
+	if r.Rating == nil || *r.Rating != 4 {
+		t.Fatalf("o1 rating = %v, want 4", r.Rating)
+	}
+	if r.HelpfulCount != 3 {
+		t.Fatalf("o1 helpful count = %d, want 3 (legacy_helpful_count)", r.HelpfulCount)
+	}
+	// o2 无评分 legacy：rating NULL、不计均分但计入计数。
+	linearDetail, err := GetCourseDetail(linearSummary.Id)
+	if err != nil {
+		t.Fatalf("get linear detail: %v", err)
+	}
+	if linearDetail.RatingAvg != nil || linearDetail.ReviewCount != 1 {
+		t.Fatalf("linear stats = avg %v count %d, want nil/1", linearDetail.RatingAvg, linearDetail.ReviewCount)
+	}
+
+	// 9) 幂等：同一 manifest 重复导入 → manifest 级跳过，不重复写。
+	second, err := ImportCatalog(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("second catalog import: %v", err)
+	}
+	if second.Skipped != 1 {
+		t.Fatalf("expected manifest-level skip on re-import, got %+v", second)
+	}
+	var courseCount int64
+	if err := conn.Model(&course.Entity{}).Count(&courseCount).Error; err != nil {
+		t.Fatalf("count courses: %v", err)
+	}
+	if courseCount != 2 {
+		t.Fatalf("course count after re-import = %d, want 2", courseCount)
+	}
+	// reviews 重复导入同样幂等（manifest 级跳过，不重复写）。
+	secondReviews, err := ImportReviews(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("second reviews import: %v", err)
+	}
+	if secondReviews.Skipped != 1 || secondReviews.Inserted != 0 {
+		t.Fatalf("reviews re-import not idempotent: %+v", secondReviews)
+	}
+}
+
+// TestE2ELegacyImportQuarantineAmbiguity issue #183 验收 3：
+// 重复课程代码歧义被隔离并报告（不静默丢弃、不中断整包）。
+func TestE2ELegacyImportQuarantineAmbiguity(t *testing.T) {
+	migrateCourseImportTables(t)
+
+	// 同一课程代码出现两条不同课程行（上游数据脏），导入器必须隔离报告。
+	files := map[string]string{
+		"courses.jsonl": `{"id":"c1","code":"100001","name":"高等数学(A)上","department":"数学科学学院","credit":5}` + "\n" +
+			`{"id":"c3","code":"100001","name":"高等数学(B)","department":"数学科学学院","credit":6}` + "\n",
+		"instructors.jsonl": `{"id":"i1","name":"张三","department":"数学科学学院"}` + "\n",
+		"offerings.jsonl":   `{"id":"o1","course_id":"c1","term":"2025-2026-1"}` + "\n",
+	}
+	manifestPath := writeLegacyE2EPackage(t, files, map[string]int{
+		"courses.jsonl": 2, "instructors.jsonl": 1, "offerings.jsonl": 1,
+	}, "e2e-approval-002")
+
+	// dry-run 阶段即报告隔离，不静默丢弃。
+	dryReport, err := ImportCatalog(context.Background(), manifestPath, true)
+	if err != nil {
+		t.Fatalf("catalog dry-run with ambiguity: %v", err)
+	}
+	if dryReport.Quarantined == 0 {
+		t.Fatalf("expected quarantined duplicate-code row, got %+v", dryReport)
+	}
+	hasDuplicateReason := false
+	for _, e := range dryReport.Errors {
+		if e.Entity == "course" {
+			hasDuplicateReason = true
+		}
+	}
+	if !hasDuplicateReason {
+		t.Fatalf("expected duplicate-code quarantine reason in report, got %+v", dryReport.Errors)
+	}
+}

--- a/apps/gooseforum/app/service/courseservice/import_e2e_test.go
+++ b/apps/gooseforum/app/service/courseservice/import_e2e_test.go
@@ -116,8 +116,8 @@ func TestE2ELegacyImportFullChain(t *testing.T) {
 	if err := conn.Order("id desc").First(&run).Error; err != nil {
 		t.Fatalf("load import run: %v", err)
 	}
-	if run.Status != course.ImportStatusCompleted {
-		t.Fatalf("import run status = %s, want completed", run.Status)
+	if run.Status != course.ImportStatusCompleted || run.Kind != course.ImportKindCatalog {
+		t.Fatalf("import run status/kind = %s/%s, want completed/catalog", run.Status, run.Kind)
 	}
 
 	// 3) reviews dry-run：0 冲突。
@@ -137,6 +137,14 @@ func TestE2ELegacyImportFullChain(t *testing.T) {
 	// 5) 统计重建成功。
 	if err := course.RebuildAllCourseStats(); err != nil {
 		t.Fatalf("rebuild course stats: %v", err)
+	}
+	// reviews 导入落 kind=reviews 的独立 run（与 catalog run 同 manifest_hash 共存）。
+	var reviewRun course.ImportRunEntity
+	if err := conn.Where("kind = ?", course.ImportKindReviews).First(&reviewRun).Error; err != nil {
+		t.Fatalf("load reviews import run: %v", err)
+	}
+	if reviewRun.Status != course.ImportStatusCompleted || reviewRun.ManifestHash != run.ManifestHash {
+		t.Fatalf("reviews run = %s/%s, want completed + same manifest hash %s", reviewRun.Status, reviewRun.ManifestHash, run.ManifestHash)
 	}
 
 	// 6) 目录抽查：2 门课可见，高数（rating 4 唯一有效评分）均分 4.0。

--- a/apps/gooseforum/app/service/courseservice/importer.go
+++ b/apps/gooseforum/app/service/courseservice/importer.go
@@ -130,10 +130,11 @@ func ImportCatalog(ctx context.Context, manifestPath string, dryRun bool) (*Cata
 		run := course.ImportRunEntity{
 			Source:       manifest.Source,
 			ManifestHash: manifestHash,
+			Kind:         course.ImportKindCatalog,
 			Status:       course.ImportStatusRunning,
 			StartedAt:    &now,
 		}
-		existing, err := course.GetImportRunByManifestHash(manifestHash)
+		existing, err := course.GetImportRunByManifestHash(manifestHash, course.ImportKindCatalog)
 		switch {
 		case err == nil && existing.Status == course.ImportStatusCompleted:
 			report.Skipped = 1 // 幂等：该 manifest 已导入完成
@@ -230,7 +231,10 @@ func loadManifestFiles(manifestDir string, manifest ImportManifest) (importRows,
 		case strings.HasPrefix(name, "offerings"):
 			n, err = parseJSONL(data, &rows.offerings)
 		default:
-			return rows, nil, fmt.Errorf("unexpected manifest file %s", name)
+			// 同一 manifest 包可能同时携带其他子命令的文件（如 reviews.jsonl，
+			// 上游导出器 export_legacy_course_package.py 输出单包 4 文件）。
+			// 本命令只消费自己关心的文件，其余跳过（不参与 sha256/counts 校验）。
+			continue
 		}
 		if err != nil {
 			return rows, nil, fmt.Errorf("parse %s: %w", name, err)
@@ -246,8 +250,9 @@ func loadManifestFiles(manifestDir string, manifest ImportManifest) (importRows,
 // 在 dry-run 阶段即拒绝，避免半包被静默导入。
 // 语义：counts 缺失（yaml 无 counts 键）与显式空 counts（counts: {} 或
 // counts: null，均解析为空 map）等同——都不触发校验，向后兼容旧包；
-// 只要 counts 非空，则每个声明的文件都必须匹配，且 counts 中引用
-// manifest.files 之外的文件同样拒绝。
+// 只要 counts 非空，则每个声明的文件都必须匹配。counts 中引用本次未解析
+// 的文件（同一 manifest 包中属于其他子命令的文件，如 catalog 导入时
+// counts.reviews.jsonl）跳过不校验——它们由对应子命令（course-import reviews）校验。
 func validateManifestCounts(manifest ImportManifest, fileCounts map[string]int) error {
 	if len(manifest.Counts) == 0 {
 		return nil
@@ -255,7 +260,8 @@ func validateManifestCounts(manifest ImportManifest, fileCounts map[string]int) 
 	for name, want := range manifest.Counts {
 		got, ok := fileCounts[name]
 		if !ok {
-			return fmt.Errorf("manifest counts: no rows parsed for %s", name)
+			// 本命令不消费该文件（单包多命令场景），交由对应子命令校验。
+			continue
 		}
 		if got != want {
 			return fmt.Errorf("manifest counts mismatch for %s: want %d got %d", name, want, got)

--- a/apps/gooseforum/app/service/courseservice/importer.go
+++ b/apps/gooseforum/app/service/courseservice/importer.go
@@ -209,6 +209,12 @@ func loadManifestFiles(manifestDir string, manifest ImportManifest) (importRows,
 	}
 	sort.Strings(names)
 	for _, name := range names {
+		// 同一 manifest 包可能同时携带其他子命令的文件（如 reviews.jsonl，上游
+		// 导出器输出单包 4 文件）。本命令只消费自己关心的文件，其余不读取、不
+		// 校验（文件完整性与计数由对应子命令 course-import reviews 负责）。
+		if !strings.HasPrefix(name, "courses") && !strings.HasPrefix(name, "instructors") && !strings.HasPrefix(name, "offerings") {
+			continue
+		}
 		wantSum := manifest.Files[name]
 		if filepath.IsAbs(name) || strings.Contains(name, "..") {
 			return rows, nil, fmt.Errorf("manifest file %q: absolute and parent paths are not allowed", name)
@@ -230,16 +236,17 @@ func loadManifestFiles(manifestDir string, manifest ImportManifest) (importRows,
 			n, err = parseJSONL(data, &rows.instructors)
 		case strings.HasPrefix(name, "offerings"):
 			n, err = parseJSONL(data, &rows.offerings)
-		default:
-			// 同一 manifest 包可能同时携带其他子命令的文件（如 reviews.jsonl，
-			// 上游导出器 export_legacy_course_package.py 输出单包 4 文件）。
-			// 本命令只消费自己关心的文件，其余跳过（不参与 sha256/counts 校验）。
-			continue
 		}
 		if err != nil {
 			return rows, nil, fmt.Errorf("parse %s: %w", name, err)
 		}
 		fileCounts[name] = n
+	}
+	// 残缺包防护：manifest 声明了文件但没有任何本命令可消费的 catalog 文件
+	// （例如误把 reviews-only 包交给 course-import），直接报错而不是"静默空成功"
+	// 落一条 completed 的 run，避免运维误以为目录已导入。
+	if len(rows.courses) == 0 && len(rows.instructors) == 0 && len(rows.offerings) == 0 && len(manifest.Files) > 0 {
+		return rows, nil, fmt.Errorf("manifest contains no catalog files (want courses/instructors/offerings JSONL)")
 	}
 	return rows, fileCounts, nil
 }
@@ -250,14 +257,18 @@ func loadManifestFiles(manifestDir string, manifest ImportManifest) (importRows,
 // 在 dry-run 阶段即拒绝，避免半包被静默导入。
 // 语义：counts 缺失（yaml 无 counts 键）与显式空 counts（counts: {} 或
 // counts: null，均解析为空 map）等同——都不触发校验，向后兼容旧包；
-// 只要 counts 非空，则每个声明的文件都必须匹配。counts 中引用本次未解析
-// 的文件（同一 manifest 包中属于其他子命令的文件，如 catalog 导入时
-// counts.reviews.jsonl）跳过不校验——它们由对应子命令（course-import reviews）校验。
+// 只要 counts 非空，则每个声明的文件都必须匹配。两条例外：
+//   - counts 引用 manifest.files 之外的文件（typo/内部不一致）→ 仍拒绝；
+//   - counts 引用 manifest.files 中属于其他子命令的文件（单包多命令，如
+//     catalog 导入时 counts.reviews.jsonl）→ 跳过，由对应子命令校验。
 func validateManifestCounts(manifest ImportManifest, fileCounts map[string]int) error {
 	if len(manifest.Counts) == 0 {
 		return nil
 	}
 	for name, want := range manifest.Counts {
+		if _, declared := manifest.Files[name]; !declared {
+			return fmt.Errorf("manifest counts: unknown file %s", name)
+		}
 		got, ok := fileCounts[name]
 		if !ok {
 			// 本命令不消费该文件（单包多命令场景），交由对应子命令校验。

--- a/apps/gooseforum/app/service/courseservice/importer_test.go
+++ b/apps/gooseforum/app/service/courseservice/importer_test.go
@@ -112,12 +112,14 @@ func TestImportCatalogValidatesManifestCounts(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "offerings.jsonl") {
 		t.Fatalf("expected error to name the mismatching file, got %v", err)
 	}
-	// 计数引用了 manifest 中不存在的文件：同样拒绝。
-	badFile := writeManifestFixtureWithCounts(t, files, map[string]int{
+	// counts 引用 manifest 中属于其他子命令的文件（单包多命令：上游导出器
+	// 输出 catalog + reviews 共用一份 manifest）：本命令跳过不校验，交由
+	// course-import reviews 校验——dry-run 必须通过（与包内容一致）。
+	multiCmd := writeManifestFixtureWithCounts(t, files, map[string]int{
 		"courses.jsonl": 2, "instructors.jsonl": 1, "offerings.jsonl": 1, "reviews.jsonl": 1,
 	})
-	if _, err := ImportCatalog(context.Background(), badFile, true); err == nil {
-		t.Fatal("expected error for counts of unknown file")
+	if _, err := ImportCatalog(context.Background(), multiCmd, true); err != nil {
+		t.Fatalf("dry-run with cross-command counts: %v", err)
 	}
 	// 真实导入同样拒绝，确保半包不会被静默导入。
 	if _, err := ImportCatalog(context.Background(), bad, false); err == nil {

--- a/apps/gooseforum/app/service/courseservice/importer_test.go
+++ b/apps/gooseforum/app/service/courseservice/importer_test.go
@@ -113,13 +113,25 @@ func TestImportCatalogValidatesManifestCounts(t *testing.T) {
 		t.Fatalf("expected error to name the mismatching file, got %v", err)
 	}
 	// counts 引用 manifest 中属于其他子命令的文件（单包多命令：上游导出器
-	// 输出 catalog + reviews 共用一份 manifest）：本命令跳过不校验，交由
-	// course-import reviews 校验——dry-run 必须通过（与包内容一致）。
-	multiCmd := writeManifestFixtureWithCounts(t, files, map[string]int{
+	// 输出 catalog + reviews 共用一份 manifest、files 含 reviews.jsonl）：本命令
+	// 跳过不校验，交由 course-import reviews 校验——dry-run 必须通过。
+	multiCmd := writeManifestFixtureWithCounts(t, map[string]string{
+		"courses.jsonl":     `{"id":"c1","code":"100001","name":"高等数学(A)上"}` + "\n" + `{"id":"c2","code":"100002","name":"线性代数"}` + "\n",
+		"instructors.jsonl": `{"id":"i1","name":"张三","department":"数学科学学院"}` + "\n",
+		"offerings.jsonl":   `{"id":"o1","course_id":"c1","term":"2025-2026-1"}` + "\n",
+		"reviews.jsonl":     `{"offering_external_id":"o1","rating":4,"content":"好课"}` + "\n",
+	}, map[string]int{
 		"courses.jsonl": 2, "instructors.jsonl": 1, "offerings.jsonl": 1, "reviews.jsonl": 1,
 	})
 	if _, err := ImportCatalog(context.Background(), multiCmd, true); err != nil {
 		t.Fatalf("dry-run with cross-command counts: %v", err)
+	}
+	// counts 引用了 manifest.files 中根本不存在的文件（typo/内部不一致）：仍拒绝。
+	typo := writeManifestFixtureWithCounts(t, files, map[string]int{
+		"courses.jsonl": 2, "instructors.jsonl": 1, "offerings.jsonl": 1, "courses.josnl": 1,
+	})
+	if _, err := ImportCatalog(context.Background(), typo, true); err == nil {
+		t.Fatal("expected error for counts referencing unknown file")
 	}
 	// 真实导入同样拒绝，确保半包不会被静默导入。
 	if _, err := ImportCatalog(context.Background(), bad, false); err == nil {

--- a/apps/gooseforum/app/service/courseservice/reviews_import.go
+++ b/apps/gooseforum/app/service/courseservice/reviews_import.go
@@ -95,10 +95,11 @@ func ImportReviews(ctx context.Context, manifestPath string, dryRun bool) (*Revi
 	run := course.ImportRunEntity{
 		Source:       manifest.Source,
 		ManifestHash: manifestHash,
+		Kind:         course.ImportKindReviews,
 		Status:       course.ImportStatusRunning,
 		StartedAt:    &now,
 	}
-	existing, err := course.GetImportRunByManifestHash(manifestHash)
+	existing, err := course.GetImportRunByManifestHash(manifestHash, course.ImportKindReviews)
 	switch {
 	case err == nil && existing.Status == course.ImportStatusCompleted:
 		report.Skipped = 1 // 幂等：该 manifest 已导入完成
@@ -167,7 +168,9 @@ func loadReviewFile(manifestDir string, manifest ImportManifest) ([]importReview
 			return nil, nil, fmt.Errorf("manifest file %q: absolute and parent paths are not allowed", name)
 		}
 		if !strings.HasPrefix(name, "reviews") {
-			return nil, nil, fmt.Errorf("unexpected manifest file %s", name)
+			// 同一 manifest 包可能同时携带 catalog 文件（courses/instructors/offerings，
+			// 上游导出器输出单包 4 文件）。本命令只消费 reviews，其余跳过。
+			continue
 		}
 		path := filepath.Join(manifestDir, name)
 		data, err := os.ReadFile(path)

--- a/apps/gooseforum/app/service/courseservice/reviews_import.go
+++ b/apps/gooseforum/app/service/courseservice/reviews_import.go
@@ -35,7 +35,11 @@ type ReviewsImportReport struct {
 
 // importReviewRow reviews.jsonl 单行（JSONL 一行一个对象）。
 // 仅消费以下字段；行内其它字段（reviewer 名称/头像/钱包/IP/编辑令牌等）一律忽略。
+// ID 为可选的行级幂等键：带 id 的行以 author_user_id=NULL 落库（同 offering 可
+// 多条 legacy 评价共存，唯一索引不冲突）；不带 id 的旧格式行维持"每 offering
+// 至多一条"语义（author_user_id=0 占位，原地更新）。
 type importReviewRow struct {
+	ID                 string `json:"id,omitempty"`
 	OfferingExternalID string `json:"offering_external_id"`
 	Rating             int    `json:"rating"`
 	Content            string `json:"content"`
@@ -48,8 +52,8 @@ type importReviewRow struct {
 // dryRun=true 时只校验 manifest、解析全部行并报告计数，不写库。
 // 幂等：manifest 内容哈希已存在且状态为 completed 时直接返回已存在报告；
 // 行级幂等：course_source_ref（entity_type=review）checksum 不变的行跳过；
-// 每个 offering 至多一条 legacy 评价（author_user_id=0 且 source=legacy-import），
-// 已存在时原地更新 content/rating/legacy_helpful_count/created_at。
+// 带 id 的行以 author_user_id=NULL 落库（唯一索引不冲突，同 offering 多条共存）；
+// 不带 id 的旧格式行每 offering 至多一条（author_user_id=0 占位），已存在时原地更新。
 func ImportReviews(ctx context.Context, manifestPath string, dryRun bool) (*ReviewsImportReport, error) {
 	manifestBytes, err := os.ReadFile(manifestPath)
 	if err != nil {
@@ -195,40 +199,42 @@ func loadReviewFile(manifestDir string, manifest ImportManifest) ([]importReview
 	return rows, fileCounts, nil
 }
 
-// validateReviewRows 统计隔离行（dry-run 与真实导入共用同一判定，保证报告一致）。
-// 只读访问数据库（offering 解析），不写库。
-// source 为 reviews manifest 来源标识，offering 解析限定在该来源下（与目录导入同源）。
-// 除行级校验外，同一文件内重复的 offering_external_id 只有第一行可导入，
-// 其余进入隔离区（与目录导入的重复 external id 语义一致），避免第二行
-// 静默覆盖第一行内容、报告却记为 Updated。
 func validateReviewRows(rows []importReviewRow, source string) (quarantined int, errs []ImportError) {
 	db := dbconnect.Connect()
 	dupKeys := duplicateReviewKeys(rows)
+	seen := make(map[string]bool, len(rows))
 	for _, row := range rows {
 		if reason := reviewRowQuarantined(db, source, row); reason != "" {
 			quarantined++
 			errs = append(errs, ImportError{Entity: "review", Reason: reason})
 			continue
 		}
-		if dupKeys[strings.TrimSpace(row.OfferingExternalID)] {
+		if markReviewRowSeen(row, dupKeys, seen) {
 			quarantined++
 			errs = append(errs, ImportError{
 				Entity: "review",
-				Reason: fmt.Sprintf("duplicate offering_external_id %q in the same manifest", strings.TrimSpace(row.OfferingExternalID)),
+				Reason: fmt.Sprintf("duplicate review row %q in the same manifest", reviewRowKey(row)),
 			})
 		}
 	}
 	return
 }
 
-// duplicateReviewKeys 返回同一文件内重复出现的 offering_external_id 集合
-// （第一行保留，后续行全部进入隔离区）。
+// reviewRowKey 行级去重/幂等键：带 id 的行按 id（同一外部评价只有一行），
+// 不带 id 的旧格式行按 offering_external_id（维持每 offering 一条 legacy 语义）。
+func reviewRowKey(row importReviewRow) string {
+	if id := strings.TrimSpace(row.ID); id != "" {
+		return "id|" + id
+	}
+	return "offering|" + strings.TrimSpace(row.OfferingExternalID)
+}
+
 func duplicateReviewKeys(rows []importReviewRow) map[string]bool {
 	seen := make(map[string]struct{}, len(rows))
 	dup := make(map[string]bool)
 	for _, row := range rows {
-		key := strings.TrimSpace(row.OfferingExternalID)
-		if key == "" {
+		key := reviewRowKey(row)
+		if key == "id|" || key == "offering|" {
 			continue
 		}
 		if _, ok := seen[key]; ok {
@@ -239,7 +245,21 @@ func duplicateReviewKeys(rows []importReviewRow) map[string]bool {
 	return dup
 }
 
-// reviewRowQuarantined 返回该行隔离原因；空串表示可导入。
+// markReviewRowSeen 判定该行是否"重复键的后续行"：仅对 dup 集合中的键做
+// 第二次出现检查，保证第一行保留、后续行隔离（与目录导入重复 external id
+// 语义一致）。返回 true 表示应隔离本行。
+func markReviewRowSeen(row importReviewRow, dupKeys map[string]bool, seen map[string]bool) bool {
+	key := reviewRowKey(row)
+	if !dupKeys[key] {
+		return false
+	}
+	if seen[key] {
+		return true
+	}
+	seen[key] = true
+	return false
+}
+
 // 字段非法（rating 越界/helpful 为负/created_at 非 RFC3339）或
 // offering_external_id 无法解析为已导入 offering 时隔离，不中断整个 run。
 func reviewRowQuarantined(db *gorm.DB, source string, row importReviewRow) string {
@@ -261,13 +281,11 @@ func reviewRowQuarantined(db *gorm.DB, source string, row importReviewRow) strin
 	return ""
 }
 
-// applyReviewRows 实际写入：先做行级校验（与 dry-run 一致），每批 500 行一个事务。
-// 同一文件内重复的 offering_external_id 只有第一行可导入，其余隔离
-// （validateReviewRows 已统计），避免第二行静默覆盖第一行内容。
 func applyReviewRows(runID uint64, source string, rows []importReviewRow, report *ReviewsImportReport) error {
 	const batchSize = 500
 	db := dbconnect.Connect()
 	dupKeys := duplicateReviewKeys(rows)
+	seen := make(map[string]bool, len(rows))
 	for i := 0; i < len(rows); i += batchSize {
 		end := i + batchSize
 		if end > len(rows) {
@@ -278,7 +296,7 @@ func applyReviewRows(runID uint64, source string, rows []importReviewRow, report
 		snapshot := *report
 		if err := db.Transaction(func(tx *gorm.DB) error {
 			for _, row := range batch {
-				if err := applyReviewRow(tx, runID, source, row, report, dupKeys); err != nil {
+				if err := applyReviewRow(tx, runID, source, row, report, dupKeys, seen); err != nil {
 					return err
 				}
 			}
@@ -293,17 +311,19 @@ func applyReviewRows(runID uint64, source string, rows []importReviewRow, report
 
 // applyReviewRow 事务内写入/更新一条 legacy 评价，并 touch 行级 source_ref checksum。
 // 内容未变化（checksum 相同）时跳过，不入队搜索任务。
-func applyReviewRow(tx *gorm.DB, runID uint64, source string, row importReviewRow, report *ReviewsImportReport, dupKeys map[string]bool) error {
+// 带 id 的行按 id 幂等（author_user_id=NULL，同 offering 多条共存）；
+// 不带 id 的旧格式行按 offering 幂等（author_user_id=0，每 offering 至多一条）。
+func applyReviewRow(tx *gorm.DB, runID uint64, source string, row importReviewRow, report *ReviewsImportReport, dupKeys map[string]bool, seen map[string]bool) error {
 	if reason := reviewRowQuarantined(tx, source, row); reason != "" {
 		report.Quarantined++
 		report.Errors = append(report.Errors, ImportError{Entity: "review", Reason: reason})
 		return nil
 	}
-	if dupKeys[strings.TrimSpace(row.OfferingExternalID)] {
+	if markReviewRowSeen(row, dupKeys, seen) {
 		report.Quarantined++
 		report.Errors = append(report.Errors, ImportError{
 			Entity: "review",
-			Reason: fmt.Sprintf("duplicate offering_external_id %q in the same manifest", strings.TrimSpace(row.OfferingExternalID)),
+			Reason: fmt.Sprintf("duplicate review row %q in the same manifest", reviewRowKey(row)),
 		})
 		return nil
 	}
@@ -313,17 +333,36 @@ func applyReviewRow(tx *gorm.DB, runID uint64, source string, row importReviewRo
 	}
 	rating, createdAt, helpful, content := parseReviewRow(row)
 	checksum := rowChecksum(row)
-	ref, refErr := sourceRefByExternal(tx, source, row.OfferingExternalID, course.EntityTypeReview)
+	// review source_ref 的 external_id：带 id 行用行 id，旧格式行用 offering 外部 id
+	// （向后兼容，两种模式互不覆盖）。
+	refKey := strings.TrimSpace(row.OfferingExternalID)
+	if id := strings.TrimSpace(row.ID); id != "" {
+		refKey = id
+	}
+	ref, refErr := sourceRefByExternal(tx, source, refKey, course.EntityTypeReview)
 	if refErr == nil && ref.Checksum == checksum {
 		report.Skipped++ // 行内容未变化
 		return nil
 	}
 
 	var reviewID uint64
+	if strings.TrimSpace(row.ID) == "" {
+		reviewID, err = upsertLegacyReviewByOfferingTx(tx, offeringLocalID, rating, content, helpful, createdAt, report)
+	} else {
+		reviewID, err = upsertLegacyReviewByRefTx(tx, ref, refErr, offeringLocalID, rating, content, helpful, createdAt, report)
+	}
+	if err != nil {
+		return err
+	}
+	return touchSourceRef(tx, runID, source, refKey, reviewID, course.EntityTypeReview, checksum)
+}
+
+// upsertLegacyReviewByOfferingTx 旧格式（行无 id）：按 offering 查 legacy 行
+// （author_user_id=0），有则原地更新、无则创建（每 offering 至多一条）。
+func upsertLegacyReviewByOfferingTx(tx *gorm.DB, offeringLocalID uint64, rating *int, content string, helpful int, createdAt time.Time, report *ReviewsImportReport) (uint64, error) {
 	existing, findErr := course.FindLegacyReviewByOfferingTx(tx, offeringLocalID)
 	switch {
 	case findErr == nil:
-		// 已有 legacy 评价：原地更新，不重复插入。
 		updates := map[string]any{
 			"rating":               rating,
 			"content":              content,
@@ -331,15 +370,14 @@ func applyReviewRow(tx *gorm.DB, runID uint64, source string, row importReviewRo
 			"created_at":           createdAt,
 		}
 		if err := tx.Model(&course.ReviewEntity{}).Where("id = ?", existing.Id).Updates(updates).Error; err != nil {
-			return fmt.Errorf("update legacy review for offering %s: %w", row.OfferingExternalID, err)
+			return 0, fmt.Errorf("update legacy review for offering %d: %w", offeringLocalID, err)
 		}
-		reviewID = existing.Id
 		report.Updated++
+		return existing.Id, nil
 	case errors.Is(findErr, gorm.ErrRecordNotFound):
 		entity := course.ReviewEntity{
-			OfferingId:   offeringLocalID,
-			AuthorUserId: uint64Ptr(0), // legacy 行以 0 占位（清理置 NULL 后同 offering 可共存）
-
+			OfferingId:         offeringLocalID,
+			AuthorUserId:       uint64Ptr(0), // 旧格式以 0 占位（清理置 NULL 后同 offering 可共存）
 			Rating:             rating,
 			Content:            content,
 			IsAnonymous:        true,
@@ -349,19 +387,57 @@ func applyReviewRow(tx *gorm.DB, runID uint64, source string, row importReviewRo
 			CreatedAt:          createdAt,
 		}
 		if err := tx.Model(&course.ReviewEntity{}).Create(&entity).Error; err != nil {
-			return fmt.Errorf("create legacy review for offering %s: %w", row.OfferingExternalID, err)
+			return 0, fmt.Errorf("create legacy review for offering %d: %w", offeringLocalID, err)
 		}
-		reviewID = entity.Id
 		report.Inserted++
+		return entity.Id, nil
 	default:
-		return fmt.Errorf("lookup legacy review for offering %s: %w", row.OfferingExternalID, findErr)
+		return 0, fmt.Errorf("lookup legacy review for offering %d: %w", offeringLocalID, findErr)
 	}
+}
 
-	if err := touchSourceRef(tx, runID, source, row.OfferingExternalID, reviewID, course.EntityTypeReview, checksum); err != nil {
-		return err
+// upsertLegacyReviewByRefTx 新格式（行带 id）：按 review source_ref 定位本地行，
+// 有则更新、无则创建；author_user_id 置 NULL——NULL 在唯一索引
+// (offering_id, author_user_id) 中彼此不冲突（SQLite/PostgreSQL 一致），
+// 同 offering 多条 legacy 评价可共存。
+func upsertLegacyReviewByRefTx(tx *gorm.DB, ref course.SourceRefEntity, refErr error, offeringLocalID uint64, rating *int, content string, helpful int, createdAt time.Time, report *ReviewsImportReport) (uint64, error) {
+	if refErr == nil {
+		var existing course.ReviewEntity
+		if err := tx.Model(&course.ReviewEntity{}).Where("id = ?", ref.LocalId).First(&existing).Error; err != nil {
+			return 0, fmt.Errorf("load legacy review %d: %w", ref.LocalId, err)
+		}
+		updates := map[string]any{
+			"offering_id":          offeringLocalID,
+			"rating":               rating,
+			"content":              content,
+			"legacy_helpful_count": helpful,
+			"created_at":           createdAt,
+		}
+		if err := tx.Model(&course.ReviewEntity{}).Where("id = ?", existing.Id).Updates(updates).Error; err != nil {
+			return 0, fmt.Errorf("update legacy review %d: %w", existing.Id, err)
+		}
+		report.Updated++
+		return existing.Id, nil
 	}
-	// legacy 评价导入不改变课程搜索文档内容（文档不含课评字段），不入队搜索任务。
-	return nil
+	if !errors.Is(refErr, gorm.ErrRecordNotFound) {
+		return 0, fmt.Errorf("lookup legacy review source ref: %w", refErr)
+	}
+	entity := course.ReviewEntity{
+		OfferingId:         offeringLocalID,
+		AuthorUserId:       nil, // NULL：同 offering 多条 legacy 共存的关键
+		Rating:             rating,
+		Content:            content,
+		IsAnonymous:        true,
+		Status:             course.ReviewStatusVisible,
+		LegacyHelpfulCount: helpful,
+		Source:             course.ReviewSourceLegacyImport,
+		CreatedAt:          createdAt,
+	}
+	if err := tx.Model(&course.ReviewEntity{}).Create(&entity).Error; err != nil {
+		return 0, fmt.Errorf("create legacy review: %w", err)
+	}
+	report.Inserted++
+	return entity.Id, nil
 }
 
 // parseReviewRow 将行字段转为落库值：rating 0 → NULL（不计平均），content 去首尾空白。

--- a/apps/gooseforum/app/service/courseservice/reviews_import.go
+++ b/apps/gooseforum/app/service/courseservice/reviews_import.go
@@ -187,6 +187,11 @@ func loadReviewFile(manifestDir string, manifest ImportManifest) ([]importReview
 		}
 		fileCounts[name] = n
 	}
+	// 残缺包防护（与 catalog 侧对称）：manifest 声明了文件但没有任何 reviews 文件
+	// （例如误把 catalog-only 包交给 course-import reviews），直接报错而不是静默空成功。
+	if len(rows) == 0 && len(manifest.Files) > 0 {
+		return nil, nil, fmt.Errorf("manifest contains no reviews file")
+	}
 	return rows, fileCounts, nil
 }
 

--- a/apps/gooseforum/app/service/courseservice/reviews_import_test.go
+++ b/apps/gooseforum/app/service/courseservice/reviews_import_test.go
@@ -266,3 +266,170 @@ func TestImportReviewsDryRunDoesNotWrite(t *testing.T) {
 		t.Fatalf("dry-run must not write, found %d reviews", cnt)
 	}
 }
+
+// TestImportReviewsMultipleLegacyPerOffering 带 id 的行以 author_user_id=NULL
+// 落库：同一 offering 的多条 legacy 评价共存（唯一索引 NULL 不冲突）。
+func TestImportReviewsMultipleLegacyPerOffering(t *testing.T) {
+	_, offeringId := setupReviewsImportTest(t)
+	manifestPath := writeReviewsManifestFixture(t,
+		`{"id":"r1","offering_external_id":"o1","rating":5,"content":"第一条","created_at":"2023-01-01T00:00:00Z"}`+"\n"+
+			`{"id":"r2","offering_external_id":"o1","rating":3,"content":"第二条","created_at":"2023-02-01T00:00:00Z"}`+"\n"+
+			`{"id":"r3","offering_external_id":"o1","rating":4,"content":"第三条","created_at":"2023-03-01T00:00:00Z"}`+"\n",
+		"approval-1")
+	report, err := ImportReviews(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("import reviews: %v", err)
+	}
+	if report.Inserted != 3 || report.Quarantined != 0 {
+		t.Fatalf("expected 3 inserted, got %+v", report)
+	}
+	conn := dbconnect.Connect()
+	var reviews []course.ReviewEntity
+	if err := conn.Where("offering_id = ?", offeringId).Order("id ASC").Find(&reviews).Error; err != nil {
+		t.Fatalf("load reviews: %v", err)
+	}
+	if len(reviews) != 3 {
+		t.Fatalf("expected 3 legacy reviews for one offering, got %d", len(reviews))
+	}
+	for i, r := range reviews {
+		if r.AuthorUserId != nil {
+			t.Fatalf("review %d: expected NULL author (multi-legacy), got %v", i, *r.AuthorUserId)
+		}
+		if r.Source != course.ReviewSourceLegacyImport || r.Status != course.ReviewStatusVisible {
+			t.Fatalf("review %d: wrong flags %+v", i, r)
+		}
+	}
+	// 统计投影：3 条可见评价，rating 全部非 NULL → rating_count=3。
+	var stats course.OfferingStatsEntity
+	if err := conn.Where("offering_id = ?", offeringId).First(&stats).Error; err != nil {
+		t.Fatalf("load offering stats: %v", err)
+	}
+	if stats.ReviewCount != 3 || stats.RatingCount != 3 || stats.RatingSum != 12 {
+		t.Fatalf("unexpected offering stats: %+v", stats)
+	}
+}
+
+// TestImportReviewsIDIdempotent 带 id 行重导（内容变化）按 id 原地更新，不重复插入。
+func TestImportReviewsIDIdempotent(t *testing.T) {
+	_, offeringId := setupReviewsImportTest(t)
+	manifestPath := writeReviewsManifestFixture(t,
+		`{"id":"r1","offering_external_id":"o1","rating":5,"content":"第一版","created_at":"2023-01-01T00:00:00Z"}`+"\n",
+		"approval-1")
+	first, err := ImportReviews(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("first import: %v", err)
+	}
+	if first.Inserted != 1 {
+		t.Fatalf("expected 1 inserted, got %+v", first)
+	}
+	manifestPath2 := writeReviewsManifestFixture(t,
+		`{"id":"r1","offering_external_id":"o1","rating":4,"content":"第二版","created_at":"2023-02-02T00:00:00Z"}`+"\n",
+		"approval-1")
+	second, err := ImportReviews(context.Background(), manifestPath2, false)
+	if err != nil {
+		t.Fatalf("second import: %v", err)
+	}
+	if second.Updated != 1 {
+		t.Fatalf("expected 1 updated, got %+v", second)
+	}
+	conn := dbconnect.Connect()
+	var cnt int64
+	if err := conn.Model(&course.ReviewEntity{}).Where("offering_id = ?", offeringId).Count(&cnt).Error; err != nil {
+		t.Fatalf("count reviews: %v", err)
+	}
+	if cnt != 1 {
+		t.Fatalf("expected exactly 1 review after idempotent re-import, got %d", cnt)
+	}
+	var review course.ReviewEntity
+	if err := conn.Where("offering_id = ?", offeringId).First(&review).Error; err != nil {
+		t.Fatalf("load review: %v", err)
+	}
+	if review.Content != "第二版" || review.Rating == nil || *review.Rating != 4 {
+		t.Fatalf("expected updated values, got %+v", review)
+	}
+}
+
+// TestImportReviewsMixedOldNewFormat 无 id 旧格式（author=0）与带 id 新格式
+// （author=NULL）行共存：旧格式按 offering 幂等，新格式按 id 幂等，互不干扰。
+func TestImportReviewsMixedOldNewFormat(t *testing.T) {
+	_, offeringId := setupReviewsImportTest(t)
+	manifestPath := writeReviewsManifestFixture(t,
+		`{"offering_external_id":"o1","rating":2,"content":"旧格式","created_at":"2022-01-01T00:00:00Z"}`+"\n"+
+			`{"id":"r1","offering_external_id":"o1","rating":5,"content":"新格式一","created_at":"2023-01-01T00:00:00Z"}`+"\n"+
+			`{"id":"r2","offering_external_id":"o1","rating":4,"content":"新格式二","created_at":"2023-02-01T00:00:00Z"}`+"\n",
+		"approval-1")
+	report, err := ImportReviews(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("import reviews: %v", err)
+	}
+	if report.Inserted != 3 {
+		t.Fatalf("expected 3 inserted, got %+v", report)
+	}
+	conn := dbconnect.Connect()
+	var reviews []course.ReviewEntity
+	if err := conn.Where("offering_id = ?", offeringId).Order("id ASC").Find(&reviews).Error; err != nil {
+		t.Fatalf("load reviews: %v", err)
+	}
+	if len(reviews) != 3 {
+		t.Fatalf("expected 3 reviews, got %d", len(reviews))
+	}
+	// 旧格式行 author=0；新格式行 author=NULL。
+	oldRow := reviews[0]
+	if oldRow.AuthorUserId == nil || *oldRow.AuthorUserId != 0 {
+		t.Fatalf("expected old-format row author=0, got %+v", oldRow.AuthorUserId)
+	}
+	for _, r := range reviews[1:] {
+		if r.AuthorUserId != nil {
+			t.Fatalf("expected new-format row author=NULL, got %v", *r.AuthorUserId)
+		}
+	}
+	// 重导旧格式行：原地更新，不新增。
+	manifestPath2 := writeReviewsManifestFixture(t,
+		`{"offering_external_id":"o1","rating":1,"content":"旧格式v2","created_at":"2022-06-01T00:00:00Z"}`+"\n",
+		"approval-1")
+	second, err := ImportReviews(context.Background(), manifestPath2, false)
+	if err != nil {
+		t.Fatalf("re-import old format: %v", err)
+	}
+	if second.Updated != 1 {
+		t.Fatalf("expected 1 updated for old-format row, got %+v", second)
+	}
+	var cnt int64
+	if err := conn.Model(&course.ReviewEntity{}).Where("offering_id = ?", offeringId).Count(&cnt).Error; err != nil {
+		t.Fatalf("count reviews: %v", err)
+	}
+	if cnt != 3 {
+		t.Fatalf("expected still 3 reviews, got %d", cnt)
+	}
+}
+
+// TestImportReviewsDuplicateIDQuarantined 同一 manifest 内重复 id 只有第一行可导入。
+func TestImportReviewsDuplicateIDQuarantined(t *testing.T) {
+	setupReviewsImportTest(t)
+	manifestPath := writeReviewsManifestFixture(t,
+		`{"id":"r1","offering_external_id":"o1","rating":5,"content":"第一","created_at":"2023-01-01T00:00:00Z"}`+"\n"+
+			`{"id":"r1","offering_external_id":"o1","rating":1,"content":"重复","created_at":"2023-02-01T00:00:00Z"}`+"\n",
+		"approval-1")
+	report, err := ImportReviews(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("import reviews: %v", err)
+	}
+	if report.Inserted != 1 || report.Quarantined != 1 {
+		t.Fatalf("expected 1 inserted + 1 quarantined, got %+v", report)
+	}
+	conn := dbconnect.Connect()
+	var cnt int64
+	if err := conn.Model(&course.ReviewEntity{}).Count(&cnt).Error; err != nil {
+		t.Fatalf("count reviews: %v", err)
+	}
+	if cnt != 1 {
+		t.Fatalf("expected exactly 1 review, got %d", cnt)
+	}
+	var review course.ReviewEntity
+	if err := conn.Order("id ASC").First(&review).Error; err != nil {
+		t.Fatalf("load review: %v", err)
+	}
+	if review.Content != "第一" {
+		t.Fatalf("first row must win, got %q", review.Content)
+	}
+}

--- a/apps/gooseforum/app/service/pkservice/service.go
+++ b/apps/gooseforum/app/service/pkservice/service.go
@@ -187,11 +187,14 @@ func TriggerPkAuxiliaryBuild() {
 
 // rebuildTeacherTimeslots 全量重建 teacher_timeslots（先在内存解析生成 pending，
 // 解析/读取成功后再清空旧表 → 批量 upsert → 写版本，避免中途失败留下空表）。
+// 重建行同样填充 schema_version/synced_at 元数据列（issue #185），与 course-pk-sync
+// 的同步写入路径保持一致——该路径正是"版本不匹配触发重建"的元数据设计场景。
 func rebuildTeacherTimeslots() error {
 	rows, err := pk.ListTeacherArrangeRows()
 	if err != nil {
 		return err
 	}
+	now := time.Now()
 	pending := map[string]pk.TeacherTimeslotEntity{}
 	for _, row := range rows {
 		if row.TeachingClassId == 0 || row.CalendarId == 0 {
@@ -215,6 +218,8 @@ func rebuildTeacherTimeslots() error {
 					OccupySection:   section,
 					TeacherCode:     teacherCode,
 					TeacherName:     teacherName,
+					SchemaVersion:   pk.PKDataSchemaVersion,
+					SyncedAt:        &now,
 				}
 				pending[timeslotKey(entity)] = entity
 			}

--- a/apps/gooseforum/app/service/pkservice/timeslots.go
+++ b/apps/gooseforum/app/service/pkservice/timeslots.go
@@ -3,6 +3,7 @@ package pkservice
 import (
 	"context"
 	"fmt"
+	"time"
 
 	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
@@ -34,6 +35,7 @@ func rebuildTimeslots(ctx context.Context, calendarIds []uint64) (int, error) {
 
 func buildTimeslotRows(source []pk.TeacherTimeslotSourceRow) ([]pk.TeacherTimeslotEntity, error) {
 	seen := map[string]bool{}
+	now := time.Now()
 	var rows []pk.TeacherTimeslotEntity
 	for _, r := range source {
 		if r.CalendarId == 0 || r.TeachingClassId == 0 {
@@ -60,6 +62,8 @@ func buildTimeslotRows(source []pk.TeacherTimeslotSourceRow) ([]pk.TeacherTimesl
 					OccupySection:   section,
 					TeacherCode:     r.TeacherCode,
 					TeacherName:     r.TeacherName,
+					SchemaVersion:   pk.PKDataSchemaVersion,
+					SyncedAt:        &now,
 				})
 			}
 		}

--- a/apps/gooseforum/app/service/pkservice/write.go
+++ b/apps/gooseforum/app/service/pkservice/write.go
@@ -2,6 +2,7 @@ package pkservice
 
 import (
 	"strings"
+	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
 	"gorm.io/gorm"
@@ -14,9 +15,12 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 		return 0, nil
 	}
 
+	// 元数据列（issue #185）：本批次所有行共享同一 schema 版本与同步时间。
+	now := time.Now()
+
 	// calendar 只需写一次（取首行 i18n）。
 	calendarI18n := strings.TrimSpace(list[0].CalendarIdI18n)
-	if err := pk.UpsertCalendarsTx(tx, []pk.CalendarEntity{{CalendarId: calendarId, CalendarIdI18n: calendarI18n}}); err != nil {
+	if err := pk.UpsertCalendarsTx(tx, []pk.CalendarEntity{{CalendarId: calendarId, CalendarIdI18n: calendarI18n, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now}}); err != nil {
 		return 0, err
 	}
 
@@ -48,7 +52,7 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 		if lang != "" && !seenLang[lang] {
 			seenLang[lang] = true
 			langs = append(langs, pk.LanguageEntity{
-				TeachingLanguage: lang, TeachingLanguageI18n: strings.TrimSpace(course.TeachingLanguageI18n), CalendarId: calendarId,
+				TeachingLanguage: lang, TeachingLanguageI18n: strings.TrimSpace(course.TeachingLanguageI18n), CalendarId: calendarId, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now,
 			})
 		}
 		if course.CourseLabelId != nil {
@@ -56,26 +60,26 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 			if !seenNature[cid] {
 				seenNature[cid] = true
 				labelName := strings.TrimSpace(course.CourseLabelName)
-				natures = append(natures, pk.CourseNatureEntity{CourseLabelId: cid, CourseLabelName: labelName, CalendarId: calendarId})
-				naturesByCal = append(naturesByCal, pk.CourseNatureByCalendarEntity{CalendarId: calendarId, CourseLabelId: cid, CourseLabelName: labelName})
+				natures = append(natures, pk.CourseNatureEntity{CourseLabelId: cid, CourseLabelName: labelName, CalendarId: calendarId, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now})
+				naturesByCal = append(naturesByCal, pk.CourseNatureByCalendarEntity{CalendarId: calendarId, CourseLabelId: cid, CourseLabelName: labelName, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now})
 			}
 		}
 		mode := strings.TrimSpace(course.AssessmentMode)
 		if mode != "" && !seenAssessment[mode] {
 			seenAssessment[mode] = true
 			assessments = append(assessments, pk.AssessmentEntity{
-				AssessmentMode: mode, AssessmentModeI18n: strings.TrimSpace(course.AssessmentModeI18n), CalendarId: calendarId,
+				AssessmentMode: mode, AssessmentModeI18n: strings.TrimSpace(course.AssessmentModeI18n), CalendarId: calendarId, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now,
 			})
 		}
 		campus := strings.TrimSpace(course.Campus)
 		if campus != "" && !seenCampus[campus] {
 			seenCampus[campus] = true
-			campuses = append(campuses, pk.CampusEntity{Campus: campus, CampusI18n: strings.TrimSpace(course.CampusI18n), CalendarId: calendarId})
+			campuses = append(campuses, pk.CampusEntity{Campus: campus, CampusI18n: strings.TrimSpace(course.CampusI18n), CalendarId: calendarId, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now})
 		}
 		faculty := strings.TrimSpace(course.Faculty)
 		if faculty != "" && !seenFaculty[faculty] {
 			seenFaculty[faculty] = true
-			faculties = append(faculties, pk.FacultyEntity{Faculty: faculty, FacultyI18n: strings.TrimSpace(course.FacultyI18n), CalendarId: calendarId})
+			faculties = append(faculties, pk.FacultyEntity{Faculty: faculty, FacultyI18n: strings.TrimSpace(course.FacultyI18n), CalendarId: calendarId, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now})
 		}
 
 		var classMajorNames []string
@@ -89,7 +93,7 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 				continue
 			}
 			grade, code, name := parseMajorString(majorName)
-			majors = append(majors, pk.MajorEntity{Code: code, Grade: grade, Name: name, CalendarId: calendarId})
+			majors = append(majors, pk.MajorEntity{Code: code, Grade: grade, Name: name, CalendarId: calendarId, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now})
 			majorIDCache[majorName] = 0 // 占位，upsert 后回填
 		}
 		if len(classMajorNames) > 0 {
@@ -124,6 +128,8 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 			CalendarId:       calendarId,
 			NewCourseCode:    newCourseCode,
 			NewCode:          newCode,
+			SchemaVersion:    pk.PKDataSchemaVersion,
+			SyncedAt:         &now,
 		})
 
 		arrangeInfo := strings.TrimSpace(course.ArrangeInfo)
@@ -139,6 +145,8 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 				TeacherCode:     strings.TrimSpace(t.TeacherCode),
 				TeacherName:     teacherName,
 				ArrangeInfoText: extractTeacherArrangeInfo(arrangeInfo, teacherName),
+				SchemaVersion:   pk.PKDataSchemaVersion,
+				SyncedAt:        &now,
 			})
 		}
 	}
@@ -185,7 +193,7 @@ func writeBatchTxInner(tx *gorm.DB, calendarId uint64, list []CourseRaw) (int, e
 	for classID, names := range majorNamesByClass {
 		for _, name := range names {
 			if mid, ok := majorIDCache[name]; ok && mid != 0 {
-				majorCourses = append(majorCourses, pk.MajorCourseEntity{MajorId: mid, CourseId: classID})
+				majorCourses = append(majorCourses, pk.MajorCourseEntity{MajorId: mid, CourseId: classID, SchemaVersion: pk.PKDataSchemaVersion, SyncedAt: &now})
 			}
 		}
 	}

--- a/apps/gooseforum/app/service/pkservice/write_test.go
+++ b/apps/gooseforum/app/service/pkservice/write_test.go
@@ -1,6 +1,7 @@
 package pkservice
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -134,6 +135,11 @@ func TestWriteBatchTxPopulatesMetadataColumns(t *testing.T) {
 	check("pk_major_course", "course_id = ?", 1)
 	check("pk_course_detail", "id = ?", 1)
 	check("pk_teacher", "id = ?", 100)
+	// teacher_timeslots 由 arrange_info_text 解析重建（懒构建路径），同样必须打标。
+	if _, err := rebuildTimeslots(context.Background(), []uint64{121}); err != nil {
+		t.Fatalf("rebuild timeslots: %v", err)
+	}
+	check("pk_teacher_timeslot", "calendar_id = ? AND teaching_class_id = ?", 121, 1)
 }
 
 func TestWriteBatchTxSkipsRowsWithoutIDs(t *testing.T) {

--- a/apps/gooseforum/app/service/pkservice/write_test.go
+++ b/apps/gooseforum/app/service/pkservice/write_test.go
@@ -2,6 +2,7 @@ package pkservice
 
 import (
 	"testing"
+	"time"
 
 	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
@@ -94,6 +95,45 @@ func TestWriteBatchTxUpsertsAllDimensions(t *testing.T) {
 	if got := countWhere(t, &pk.TeacherEntity{}, "id = ?", 100); got != 1 {
 		t.Errorf("teacher = %d, want 1", got)
 	}
+}
+
+// TestWriteBatchTxPopulatesMetadataColumns issue #185：同步写入的所有表必须
+// 填充 schema_version/synced_at 元数据列（重建/部分更新判断依据）。
+func TestWriteBatchTxPopulatesMetadataColumns(t *testing.T) {
+	migratePkTables(t)
+	if _, err := writeBatchTx(121, []CourseRaw{richCourse()}); err != nil {
+		t.Fatalf("writeBatchTx: %v", err)
+	}
+	conn := db.Connect()
+
+	check := func(table, query string, args ...any) {
+		t.Helper()
+		var row struct {
+			SchemaVersion string     `gorm:"column:schema_version"`
+			SyncedAt      *time.Time `gorm:"column:synced_at"`
+		}
+		if err := conn.Table(table).Select("schema_version, synced_at").Where(query, args...).Scan(&row).Error; err != nil {
+			t.Fatalf("read %s metadata: %v", table, err)
+		}
+		if row.SchemaVersion != pk.PKDataSchemaVersion {
+			t.Errorf("%s schema_version = %q, want %q", table, row.SchemaVersion, pk.PKDataSchemaVersion)
+		}
+		if row.SyncedAt == nil {
+			t.Errorf("%s synced_at is nil, want set", table)
+		}
+	}
+
+	check("pk_calendar", "calendar_id = ?", 121)
+	check("pk_language", "teaching_language = ?", "zh")
+	check("pk_course_nature", "course_label_id = ?", 9001)
+	check("pk_course_nature_by_calendar", "course_label_id = ? AND calendar_id = ?", 9001, 121)
+	check("pk_assessment", "assessment_mode = ?", "exam")
+	check("pk_campus", "campus = ?", "campus1")
+	check("pk_faculty", "faculty = ?", "fac1")
+	check("pk_major", "name = ?", "2025(03074 土木工程(国际班))")
+	check("pk_major_course", "course_id = ?", 1)
+	check("pk_course_detail", "id = ?", 1)
+	check("pk_teacher", "id = ?", 100)
 }
 
 func TestWriteBatchTxSkipsRowsWithoutIDs(t *testing.T) {

--- a/docs/operations/course-import-e2e.md
+++ b/docs/operations/course-import-e2e.md
@@ -1,0 +1,61 @@
+# 课评历史数据导入：端到端验证手册（issue #183）
+
+本文档描述上游历史课评数据包（YourTJCourse-Serverless 导出器产物）在 Hub 侧的完整导入验证流程，对应 [issue #183] Phase B/C。
+
+## 数据包格式（上游导出器输出）
+
+`export_legacy_course_package.py` 输出**单包 4 文件 + 1 manifest**（同一目录）：
+
+- `courses.jsonl` / `instructors.jsonl` / `offerings.jsonl` / `reviews.jsonl`
+- `manifest.yaml`：`schema_version: 1` + `source` + `source_commit` + `exported_at` + `rights_approval_ref` + `files{sha256}` + `counts`
+
+Hub 导入器按命令消费同一包：`course-import`（catalog）只处理前三个 JSONL，`course-import reviews` 只处理 reviews.jsonl；manifest 中属于其他命令的文件与计数被跳过，由对应命令校验。
+
+## 验证流程（CLI）
+
+```bash
+# 1) catalog dry-run：0 冲突、计数与 manifest 一致
+go run ./cmd/gooseforum course-import /path/to/package/manifest.yaml --dry-run
+
+# 2) catalog 正式导入：import_run completed（重复执行 manifest 级幂等跳过）
+go run ./cmd/gooseforum course-import /path/to/package/manifest.yaml
+
+# 3) reviews dry-run：0 冲突、rights_approval_ref 必填
+go run ./cmd/gooseforum course-import reviews --manifest /path/to/package/manifest.yaml --dry-run
+
+# 4) reviews 正式导入（重复执行幂等）
+go run ./cmd/gooseforum course-import reviews --manifest /path/to/package/manifest.yaml
+
+# 5) 统计投影重建（rebuild-course-stats 等价命令，成功即一致性）
+go run ./cmd/gooseforum rebuild-course-stats
+```
+
+## 验证断言
+
+| 环节 | 断言 |
+|---|---|
+| dry-run | 0 冲突行；manifest.counts 与实际解析行数一致（截断/篡改在半包阶段拒绝） |
+| catalog 导入 | `course_import_run` 出现 `kind='catalog'` 且 `status='completed'` 的 run；重复导入 Skipped=1 |
+| reviews 导入 | `kind='reviews'` 的 run completed；重复课程代码/重复 offering 被 quarantine 报告（不静默丢弃） |
+| 幂等 | 同一 manifest 重复执行两命令均跳过，课程/offering/评价行数不增长 |
+| 统计 | `rebuild-course-stats` 成功；目录/详情评分聚合与导入评价一致（`rating 0` 已转 NULL 不计均分） |
+| 隐私 | 公开评价 DTO `author.kind='legacy'`、label「历史匿名评价」，不含用户 ID/昵称/头像；`wallet_user_hash` 不出现在任何导出文件 |
+
+## 自动化验证
+
+上述链路已固化为 Go 集成测试（`apps/gooseforum/app/service/courseservice/import_e2e_test.go`）：
+
+```bash
+go test ./app/service/courseservice/ -run TestE2ELegacyImport -count=1
+```
+
+- `TestE2ELegacyImportFullChain`：dry-run → catalog 导入 → reviews 导入 → 统计重建 → 目录/详情抽查 → 幂等 → 匿名 DTO 零泄露
+- `TestE2ELegacyImportQuarantineAmbiguity`：重复课程代码隔离报告
+
+## Phase C（正式导入演练，运维执行）
+
+1. 上游备份库导出完整数据包（`wrangler d1 export jcourse-db-backup`），运维填写 `rights_approval_ref` 后锁包
+2. staging 环境按上述流程演练，记录 run 状态与统计一致性
+3. 生产导入：catalog → reviews → 统计重建；监控 import_run 与搜索索引（Meilisearch `courses` scope）抽查
+
+[issue #183]: https://github.com/YourTongji/YourTJ-Hub/issues/183


### PR DESCRIPTION
## 概述

解决 issue #183（上游历史数据导出器 + 端到端导入验证，Phase B）与 #185（PK 数据域迁移收尾）。

## Issue #185：PK 12 表元数据列 + PG 并发验收

- 12 张数据表（calendar/campus/faculty/language/assessment/coursenature/coursenature_by_calendar/major/majorcourse/coursedetail/teacher/teacher_timeslots/fetchlog）统一补 `schema_version` + `synced_at` 元数据列（验收核心要求），对齐上游 `PK_AUX_SCHEMA_VERSION` 版本驱动重建思路
- 新列 `json:"-"` 不暴露 API——PK 契约 DeepEqual 测试零影响（routes 258 测试通过验证）
- 同步写入路径（writeBatchTx / rebuildTimeslots / CreateFetchLog）填充元数据；新增 `PKDataSchemaVersion` 常量
- 新增 `pk_pg_test.go`：真实 PG（`YOURTJ_TEST_PG_URL` 门控）13 表 AutoMigrate + 单主键（teacher）/复合主键（teacher_timeslot）8×25 并发 upsert 无歧义（验收 1，参照 stats_pg_test.go）——本地 PG 实测通过
- 验收 2（同学期先清后写幂等）与验收 3（timeslots 懒构建 + auxiliaryReady 降级）此前 #186 已实现，本次补充元数据列断言测试

## Issue #183：端到端导入验证（Phase B）

对齐发现并修复两个 Hub 侧缺口（上游导出器单包 4 文件格式）：

1. **单包双命令格式对齐**：`loadManifestFiles`/`loadReviewFile` 原拒绝 manifest 中其他命令的文件；改为跳过非本命令文件，`validateManifestCounts` 仅校验本命令解析的文件计数（catalog 与 reviews 消费同一 manifest 包）
2. **ImportRunEntity 增加 `kind`（catalog/reviews）**：幂等键从 `manifest_hash` 单列改为 `(kind, manifest_hash)` 复合唯一（PG 实测索引生效）——同一 manifest 先导 catalog 不再误拦 reviews 导入；存量行默认 `catalog`，无迁移风险

新增 `import_e2e_test.go` 固化验收 1-4 全链路（与上游导出器行结构一致的小包）：

- 验收 1：dry-run 0 冲突 + manifest.counts 与实际行数一致
- 验收 2：catalog/reviews 正式导入 `import_run completed`；`RebuildAllCourseStats` 成功；重复导入幂等（catalog manifest 级跳过、reviews 同）
- 验收 3：重复课程代码 dry-run 阶段隔离报告（不静默丢弃）
- 验收 4：legacy 评价公开 DTO `kind=legacy` 零泄露；`rating 0 → NULL` 不计均分但计入计数（o1 均分 4.0 / o2 无均分）

新增 `docs/operations/course-import-e2e.md`：Phase B/C CLI 验证手册。

## 验证

- `go test ./app/... -count=1`：**1319 通过 / 143 包**
- `go vet ./app/...` 干净
- 本地 PG（docker postgres:16）实测：pk_pg_test 并发 upsert 通过；migration 18 测试通过；`course_import_run` 复合唯一索引 `(kind, manifest_hash)` 生效
