### PR TITLE
chore(ci): group workflow names under CI/Release/Deploy/Tool prefixes

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1,4 +1,4 @@
-name: ci-backend
+name: CI / backend
 
 on:
   push:

--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -1,4 +1,4 @@
-name: ci-contract
+name: CI / contract
 
 on:
   push:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,4 +1,4 @@
-name: ci-frontend
+name: CI / frontend
 
 on:
   push:

--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -1,4 +1,4 @@
-name: ci-mobile
+name: CI / mobile
 
 on:
   push:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: deploy-dev
+name: Deploy / dev
 
 on:
   push:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,4 +1,4 @@
-name: deploy-main
+name: Deploy / main
 
 on:
   # 生产部署唯一入口: release-to-main 显式触发, 不监听 push

--- a/.github/workflows/mobile-golden-refresh.yml
+++ b/.github/workflows/mobile-golden-refresh.yml
@@ -1,4 +1,4 @@
-name: mobile-golden-refresh
+name: Tool / mobile-golden-refresh
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -1,4 +1,4 @@
-name: release-to-main
+name: Release / main
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sync-project-board.yml
+++ b/.github/workflows/sync-project-board.yml
@@ -1,4 +1,4 @@
-name: sync-project-board
+name: Tool / sync-project-board
 
 # 把 issue / PR 自动同步到 GitHub Projects v2 看板（RPD 状态机）。
 # 配置依赖见 docs/development/project-board.md：

--- a/docs/development/project-board.md
+++ b/docs/development/project-board.md
@@ -54,7 +54,7 @@ sync-project-board.yml  ──►  sync-project-board.sh（幂等）
 3. **配置 variables**：
    - `YOURTJ_PROJECT_NUMBER` = 看板项目号（看板 URL 末尾数字，例如 `https://github.com/orgs/YourTongji/projects/5` 的项目号是 `5`）。**必填**。
    - `YOURTJ_PROJECT_OWNER` = 看板属主（不填默认 `YourTongji`）。
-4. 触发一次测试：新建一个测试 issue 或在仓库 Actions 页手动运行 `sync-project-board`（`workflow_dispatch`），确认看板出现该条目。
+4. 触发一次测试：新建一个测试 issue 或在仓库 Actions 页手动运行 `Tool / sync-project-board`（`workflow_dispatch`），确认看板出现该条目。
 
 配置完成前，本 workflow 会因未检测到 token 自动跳过，不会报错刷屏。
 
@@ -73,7 +73,7 @@ sync-project-board.yml  ──►  sync-project-board.sh（幂等）
 
 ## 5. 手动同步
 
-仓库 Actions 页 → `sync-project-board` → *Run workflow*：
+仓库 Actions 页 → `Tool / sync-project-board` → *Run workflow*：
 
 - `item_kind`：`issue` 或 `pr`
 - `item_number`：要同步的 issue/PR 编号

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -102,7 +102,7 @@
 - **Release gate**: `.github/workflows/release-to-main.yml` (manual `workflow_dispatch`) merges `dev` →
   `main`, bumps the version (`patch` / `minor` / `major`, computed from the latest `vX.Y.Z` tag, first
   release: patch → `v0.0.1`, minor → `v0.1.0`, major → `v1.0.0`), tags it, and pushes via a PAT
-  (secret `RELEASE_TOKEN`) so `deploy-main` triggers. Run it from Actions → Release to main → Run
+  (secret `RELEASE_TOKEN`) so `deploy-main` triggers. Run it from Actions → Release / main → Run
   workflow → choose bump type.
 - Why dev syncs main's db: migrations (`app/migration` AutoMigrate + versioned data migrations) run at
   startup, so each dev deploy rehearses the exact migration the next main deploy will run.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -102,7 +102,7 @@
 - **Release gate**: `.github/workflows/release-to-main.yml` (manual `workflow_dispatch`) merges `dev` →
   `main`, bumps the version (`patch` / `minor` / `major`, computed from the latest `vX.Y.Z` tag, first
   release: patch → `v0.0.1`, minor → `v0.1.0`, major → `v1.0.0`), tags it, and pushes via a PAT
-  (secret `RELEASE_TOKEN`) so `deploy-main` triggers. Run it from Actions → Release / main → Run
+  (secret `RELEASE_TOKEN`) so `deploy-main` triggers. Run it from Actions → `Release / main` → Run
   workflow → choose bump type.
 - Why dev syncs main's db: migrations (`app/migration` AutoMigrate + versioned data migrations) run at
   startup, so each dev deploy rehearses the exact migration the next main deploy will run.


### PR DESCRIPTION
## Summary

- 统一 GitHub Actions 侧边栏分组显示名，仅改 `name:` 字段，**不移动/改名文件，不改 job 名**
- 分组结果：
  - **CI**: `ci-backend` / `ci-contract` / `ci-frontend` / `ci-mobile`
  - **Deploy**: `deploy-dev` / `deploy-main`
  - **Release**: `release-to-main`
  - **Tool**: `mobile-golden-refresh` / `sync-project-board`
- 同步更新文档中引用旧显示名的两处（`docs/operations/deployment.md`、`docs/development/project-board.md`）

## Why

让 Actions 侧边栏按 CI / Release / Deploy / Tool 四个组清晰归类，为后续部署迁移（GHCR 镜像流 + PEM SSH）做准备。

## 兼容性说明

- **required status check 不受影响**：job 名（`ci-backend`、`ci-backend-pg`、`ci-contract` 等）未变，分支保护规则无需改动
- **`release-to-main.yml` 触发 `deploy-main` 不受影响**：`gh workflow run deploy-main.yml` 按文件名引用，未变
- `concurrency` group 基于 `github.workflow`（显示名）会随 name 改变，但同组内互斥语义不变

## 验证

- `git diff --check` 通过
- 9 个 workflow 的 `name:` 均为单行字符串，无 YAML 结构变化
- 本次只改 11 个文件的 12 行（每处仅 name 一行）

## Note

最新 dev 已随 #219 移除 `ci-wiki.yml` 与旧 wiki 部署，故本次不涉及。