### PR TITLE
feat(deploy): GHCR 镜像流 + 自管 nginx 反代（新服务器迁移 Phase 1）

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -87,7 +87,7 @@ jobs:
         if: steps.filter.outputs.deploy_scripts == 'true'
         run: |
           # bash -n 只语法检查第一个文件参数, 多文件写法会静默跳过其余文件, 必须逐个检查
-          for f in deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh deploy/scripts/init-server.sh; do
+          for f in deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh deploy/scripts/init-server.sh deploy/scripts/deploy.sh; do
             bash -n "$f"
           done
           bash deploy/scripts/pgdsn_test.sh

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -27,26 +27,40 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-binary
 
-  deploy:
-    needs: [build]
+  build-image:
+    needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: yourtj-hub
           path: ./bin
-      - name: Upload binary to dev host
-        uses: appleboy/scp-action@v0.1.7
+      - name: Stage binary into build context
+        run: cp bin/yourtj-hub deploy/yourtj-hub
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          host: ${{ secrets.VM_HOST }}
-          username: ${{ secrets.VM_USER }}
-          key: ${{ secrets.VM_SSH_KEY }}
-          port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "bin/yourtj-hub"
-          target: "/tmp"
-          strip_components: 1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: deploy/
+          file: deploy/Dockerfile
+          push: true
+          tags: ghcr.io/yourtongji/yourtj-hub:dev-${{ github.sha }}
+
+  deploy:
+    needs: [build, build-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
       - name: Upload deploy scripts to dev host
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -57,7 +71,7 @@ jobs:
           source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh"
           target: "/tmp"
           strip_components: 2
-      - name: Deploy to dev (sync db from main + build image + restart + smoke)
+      - name: Deploy to dev (sync db from main + pull image + restart + smoke)
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.VM_HOST }}
@@ -74,6 +88,6 @@ jobs:
             install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
             # 1. 同步 main 数据库一致性快照(dev 用 main 真实数据预演迁移)
             /opt/yourtj/scripts/sync-db-from-main.sh
-            # 2. 构建镜像 + 部署 + 健康检查(失败自动回滚), dev 对外端口 5235
+            # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), dev 对外端口 5235
             #    dev 部署频繁, 镜像只保留最近 3 个(含当前) + prev
-            IMAGE_KEEP_N=3 /opt/yourtj/scripts/deploy.sh dev /tmp/yourtj-hub dev-${{ github.sha }} 5235
+            IMAGE_KEEP_N=3 /opt/yourtj/scripts/deploy.sh dev dev-${{ github.sha }} 5235

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,13 +40,19 @@ jobs:
           name: yourtj-hub
           path: ./bin
       - name: Stage binary into build context
-        run: cp bin/yourtj-hub deploy/yourtj-hub
+        run: |
+          cp bin/yourtj-hub deploy/yourtj-hub
+          # upload/download-artifact 不保留 Unix 执行位, 必须显式恢复,
+          # 否则镜像入口 /app/yourtj-hub 无执行权限导致部署回滚
+          chmod +x deploy/yourtj-hub
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # GHCR 包首次创建默认 private: 首次运行后需手动把包设为 public,
+      # 否则服务器匿名 pull 401(见 docs/operations/deployment.md 迁移 runbook)
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -68,7 +74,7 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh,deploy/docker-compose.yaml,deploy/nginx/yourtj.conf"
           target: "/tmp"
           strip_components: 2
       - name: Deploy to dev (sync db from main + pull image + restart + smoke)
@@ -86,6 +92,10 @@ jobs:
             install -m 0755 /tmp/deploy.sh /opt/yourtj/scripts/deploy.sh
             install -m 0755 /tmp/sync-db-from-main.sh /opt/yourtj/scripts/sync-db-from-main.sh
             install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
+            # 0.5 同步新 compose + nginx 反代配置(存量服务器升级 GHCR 流必需,
+            #     旧 compose 引用本地镜像 yourtj-hub:* 与 pull 流不兼容)
+            install -m 0644 /tmp/docker-compose.yaml /opt/yourtj/docker-compose.yaml
+            install -D -m 0644 /tmp/yourtj.conf /opt/yourtj/nginx/yourtj.conf
             # 1. 同步 main 数据库一致性快照(dev 用 main 真实数据预演迁移)
             /opt/yourtj/scripts/sync-db-from-main.sh
             # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), dev 对外端口 5235

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -12,27 +12,41 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-binary
 
-  deploy:
-    needs: [build]
+  build-image:
+    needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment: production
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: yourtj-hub
           path: ./bin
-      - name: Upload binary to prod host
-        uses: appleboy/scp-action@v0.1.7
+      - name: Stage binary into build context
+        run: cp bin/yourtj-hub deploy/yourtj-hub
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          host: ${{ secrets.VM_HOST }}
-          username: ${{ secrets.VM_USER }}
-          key: ${{ secrets.VM_SSH_KEY }}
-          port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "bin/yourtj-hub"
-          target: "/tmp"
-          strip_components: 1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: deploy/
+          file: deploy/Dockerfile
+          push: true
+          tags: ghcr.io/yourtongji/yourtj-hub:main-${{ github.sha }}
+
+  deploy:
+    needs: [build, build-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
       - name: Upload deploy scripts to prod host
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -43,7 +57,7 @@ jobs:
           source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh"
           target: "/tmp"
           strip_components: 2
-      - name: Deploy to main (backup db + build image + restart + smoke + rollback)
+      - name: Deploy to main (backup db + pull image + restart + smoke + rollback)
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.VM_HOST }}
@@ -60,6 +74,6 @@ jobs:
             install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
             # 1. 部署前一致性备份(保留最近 7 份)
             /opt/yourtj/scripts/backup-db.sh main
-            # 2. 构建镜像 + 部署 + 健康检查(失败自动回滚), main 对外端口 5234
+            # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), main 对外端口 5234
             #    生产保留更多回滚候选, 镜像保留最近 5 个(含当前) + prev
-            IMAGE_KEEP_N=5 /opt/yourtj/scripts/deploy.sh main /tmp/yourtj-hub main-${{ github.sha }} 5234
+            IMAGE_KEEP_N=5 /opt/yourtj/scripts/deploy.sh main main-${{ github.sha }} 5234

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -25,13 +25,19 @@ jobs:
           name: yourtj-hub
           path: ./bin
       - name: Stage binary into build context
-        run: cp bin/yourtj-hub deploy/yourtj-hub
+        run: |
+          cp bin/yourtj-hub deploy/yourtj-hub
+          # upload/download-artifact 不保留 Unix 执行位, 必须显式恢复,
+          # 否则镜像入口 /app/yourtj-hub 无执行权限导致部署回滚
+          chmod +x deploy/yourtj-hub
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # GHCR 包首次创建默认 private: 首次运行后需手动把包设为 public,
+      # 否则服务器匿名 pull 401(见 docs/operations/deployment.md 迁移 runbook)
       - name: Build and push image
         uses: docker/build-push-action@v6
         with:
@@ -54,7 +60,7 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh,deploy/docker-compose.yaml,deploy/nginx/yourtj.conf"
           target: "/tmp"
           strip_components: 2
       - name: Deploy to main (backup db + pull image + restart + smoke + rollback)
@@ -72,6 +78,10 @@ jobs:
             install -m 0755 /tmp/deploy.sh /opt/yourtj/scripts/deploy.sh
             install -m 0755 /tmp/backup-db.sh /opt/yourtj/scripts/backup-db.sh
             install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
+            # 0.5 同步新 compose + nginx 反代配置(存量服务器升级 GHCR 流必需,
+            #     旧 compose 引用本地镜像 yourtj-hub:* 与 pull 流不兼容)
+            install -m 0644 /tmp/docker-compose.yaml /opt/yourtj/docker-compose.yaml
+            install -D -m 0644 /tmp/yourtj.conf /opt/yourtj/nginx/yourtj.conf
             # 1. 部署前一致性备份(保留最近 7 份)
             /opt/yourtj/scripts/backup-db.sh main
             # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), main 对外端口 5234

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ research/
 bin/
 *.exe
 *.test
+deploy/yourtj-hub
 
 # Node（apps/gooseforum/resource 自带 pnpm workspace，产物在 resource/static/dist）
 node_modules/

--- a/deploy/.dockerignore
+++ b/deploy/.dockerignore
@@ -1,0 +1,7 @@
+# 构建上下文仅需 Dockerfile + 由 CI 放入的 yourtj-hub 二进制
+scripts/
+nginx/
+config.toml.example
+env.example
+docker-compose.yaml
+*.md

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache ca-certificates tzdata \
     && adduser -D -u 1000 app
 
 WORKDIR /app
-COPY yourtj-hub /app/yourtj-hub
+COPY --chmod=0755 yourtj-hub /app/yourtj-hub
 
 # 挂载卷:
 #   config.toml -> /app/config.toml (只读)

--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -15,6 +15,9 @@ url = "REPLACE_SERVER_URL"
 port = 5234
 accessLog = false
 gzip = true
+# 信任的反向代理网段: nginx 容器在 compose 网络(默认 172.16.0.0/12)内访问本服务,
+# 必须信任该网段才能正确解析 X-Forwarded-For(限流按真实客户端 IP 归并)
+trusted_proxies = ["172.16.0.0/12"]
 
 [jwtopt]
 validTime = 604800
@@ -47,8 +50,8 @@ maxLifeSeconds = 300
 
 
 [meilisearch]
-url = "http://localhost:7700"
-masterkey = ""
+url = "http://meilisearch:7700"
+masterkey = "REPLACE_MEILI_KEY"
 
 [log]
 type = "file"

--- a/deploy/docker-compose.yaml
+++ b/deploy/docker-compose.yaml
@@ -1,9 +1,9 @@
-# yourtj-hub 双实例编排(main 正式 / dev 测试)
-# 用法: docker compose up -d [main|dev]
-# 环境变量来自 /opt/yourtj/.env(见 init-server.sh)
+# yourtj-hub 双实例编排(main 正式 / dev 测试) + 自管 nginx 反向代理
+# 用法: docker compose up -d [main|dev|nginx]
+# 镜像来自 GHCR(CI 构建推送, 服务器匿名 pull), 环境变量来自 /opt/yourtj/.env(见 init-server.sh)
 services:
   main:
-    image: yourtj-hub:${MAIN_TAG:-latest}
+    image: ${IMAGE_REPO:-ghcr.io/yourtongji/yourtj-hub}:${MAIN_TAG:-latest}
     container_name: yourtj-main
     restart: unless-stopped
     ports:
@@ -22,7 +22,7 @@ services:
       start_period: 10s
 
   dev:
-    image: yourtj-hub:${DEV_TAG:-latest}
+    image: ${IMAGE_REPO:-ghcr.io/yourtongji/yourtj-hub}:${DEV_TAG:-latest}
     container_name: yourtj-dev
     restart: unless-stopped
     ports:
@@ -39,6 +39,24 @@ services:
       timeout: 5s
       retries: 30
       start_period: 10s
+
+  # 反向代理: Cloudflare 终止 TLS 后回源本容器(80)。
+  #   公网流量一律走 nginx(0.0.0.0:80); 后端容器只绑 127.0.0.1。
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: yourtj-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/yourtj.conf:/etc/nginx/conf.d/default.conf:ro
+    # 不依赖 main/dev: 后端寻址用变量 + Docker DNS resolver,
+    # 避免 compose 因 depends_on 把未部署的实例一起拉起(拉取不存在的 tag)
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/healthz >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
   postgres:
     image: postgres:16-alpine
@@ -72,8 +90,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-
-
 
 volumes:
   pgdata:

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -18,3 +18,6 @@ MEILI_MASTER_KEY=yourtj-dev-master-key
 POSTGRES_USER=yourtj
 POSTGRES_PASSWORD=
 POSTGRES_DB=postgres
+
+# OCI 镜像仓库(CI 构建推送 GHCR; 服务器匿名 pull 公开镜像, 无需凭证)
+IMAGE_REPO=ghcr.io/yourtongji/yourtj-hub

--- a/deploy/nginx/yourtj.conf
+++ b/deploy/nginx/yourtj.conf
@@ -1,8 +1,14 @@
 # yourtj-hub 反向代理(容器版, nginx:alpine)
 #
 # 部署形态: Cloudflare 终止 TLS 后回源 HTTP(本配置监听 80)。
-# 两个域名(forum.yourtj.de / dev.yourtj.de)均只经 Cloudflare https 访问,
-# 故向业务容器固定转发 X-Forwarded-Proto: https。
+# 域名默认 forum.yourtj.de / dev.yourtj.de; init-server.sh 传入自定义域名时
+# 会 sed 替换这两个 server_name(见 init-server.sh)。
+# 两个域名均只经 Cloudflare https 访问, 故向业务容器固定转发 X-Forwarded-Proto: https。
+#
+# 真实客户端 IP:
+#   Cloudflare 在 CF-Connecting-IP 头携带已验证的客户端地址, nginx 用 map 取它
+#   (缺失时回退 $remote_addr), 只把一个地址放进 X-Forwarded-For,
+#   避免把 Cloudflare 边缘地址混入导致后端限流按边缘 IP 归并。
 #
 # 后端寻址用「变量 + Docker 内嵌 DNS resolver」:
 #   - nginx 不再在启动时解析 upstream, 另一实例未启动/重启时本容器照常可用
@@ -18,6 +24,11 @@ resolver 127.0.0.11 valid=10s ipv6=off;
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      '';
+}
+
+map $http_cf_connecting_ip $client_ip {
+    default $http_cf_connecting_ip;
+    ''      $remote_addr;
 }
 
 # 健康检查探针(compose nginx healthcheck 使用), 仅限本机/回环
@@ -48,8 +59,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $client_ip;
+        proxy_set_header X-Forwarded-For $client_ip;
         proxy_set_header X-Forwarded-Proto https;
     }
 }
@@ -67,8 +78,8 @@ server {
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $client_ip;
+        proxy_set_header X-Forwarded-For $client_ip;
         proxy_set_header X-Forwarded-Proto https;
     }
 }

--- a/deploy/nginx/yourtj.conf
+++ b/deploy/nginx/yourtj.conf
@@ -1,0 +1,74 @@
+# yourtj-hub 反向代理(容器版, nginx:alpine)
+#
+# 部署形态: Cloudflare 终止 TLS 后回源 HTTP(本配置监听 80)。
+# 两个域名(forum.yourtj.de / dev.yourtj.de)均只经 Cloudflare https 访问,
+# 故向业务容器固定转发 X-Forwarded-Proto: https。
+#
+# 后端寻址用「变量 + Docker 内嵌 DNS resolver」:
+#   - nginx 不再在启动时解析 upstream, 另一实例未启动/重启时本容器照常可用
+#     (避免 compose depends_on 把未部署的实例一起拉起, 拉取不存在的 tag);
+#   - 容器重启/后端重建后自动重新解析, 无需重启 nginx。
+#
+# 注意: 论坛 config.toml 的 server.trusted_proxies 必须包含 docker 网段
+# (见 deploy/config.toml.example, 默认 ["172.16.0.0/12"]),
+# 否则 X-Forwarded-For 不被信任, 限流按 nginx 容器 IP 归并。
+
+resolver 127.0.0.11 valid=10s ipv6=off;
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      '';
+}
+
+# 健康检查探针(compose nginx healthcheck 使用), 仅限本机/回环
+server {
+    listen 80;
+    server_name 127.0.0.1 localhost;
+    location = /healthz { return 200; }
+    location / { return 404; }
+}
+
+# 默认 server: 未知 Host 兜底 404, 不落到业务
+server {
+    listen 80 default_server;
+    server_name _;
+    return 404;
+}
+
+server {
+    listen 80;
+    server_name forum.yourtj.de;
+
+    client_max_body_size 50m;
+
+    location / {
+        set $backend main:5234;
+        proxy_pass http://$backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen 80;
+    server_name dev.yourtj.de;
+
+    client_max_body_size 50m;
+
+    location / {
+        set $backend dev:5234;
+        proxy_pass http://$backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -18,7 +18,6 @@ ROOT="${YOURTJ_ROOT:-/opt/yourtj}"
 ENV_FILE="$ROOT/.env"
 COMPOSE_FILE="$ROOT/docker-compose.yaml"
 TAG_VAR="$([ "$INSTANCE" = "main" ] && echo MAIN_TAG || echo DEV_TAG)"
-IMAGE="${IMAGE_REPO:-ghcr.io/yourtongji/yourtj-hub}"
 
 log() { echo "[deploy:$INSTANCE] $*"; }
 
@@ -62,6 +61,11 @@ prune_old_images() {
 
 [ -f "$ENV_FILE" ] || { log "FATAL: $ENV_FILE missing (run init-server.sh first)"; exit 1; }
 [ -f "$COMPOSE_FILE" ] || { log "FATAL: $COMPOSE_FILE missing (run init-server.sh first)"; exit 1; }
+
+# IMAGE_REPO 优先取 .env(与 compose 一致), 未设置时用默认 GHCR 公开仓库
+IMAGE="$(grep -E '^IMAGE_REPO=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- || true)"
+IMAGE="${IMAGE:-ghcr.io/yourtongji/yourtj-hub}"
+log "image repo: $IMAGE"
 
 # 1. 记录当前 tag 用于回滚
 OLD_TAG="$(grep -E "^$TAG_VAR=" "$ENV_FILE" | cut -d= -f2 || true)"

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1,28 +1,28 @@
 #!/usr/bin/env bash
-# deploy.sh — 容器版部署: 构建镜像 → compose 更新 → 健康检查 → 失败回滚。
+# deploy.sh — GHCR 镜像流部署: 拉取镜像 → compose 更新 → 健康检查 → 失败回滚。
 #   compose up 带 --remove-orphans: 不在当前 compose 文件中定义的服务容器
 #   (如旧 VitePress wiki 的 yourtj-wiki-main/-dev) 会被停止并移除。
-#   部署成功后自动清理本实例前缀的旧镜像与构建缓存, 防止磁盘无限膨胀。
-# usage: deploy.sh <instance> <new-binary> <image-tag> [health-port]
+#   部署成功后自动清理本实例前缀的旧镜像, 防止磁盘无限膨胀。
+# usage: deploy.sh <instance> <image-tag> [health-port]
 #   instance: main 或 dev
-# 环境变量: IMAGE_KEEP_N — 每个实例前缀保留的镜像 tag 数(含当前), 默认 5
+# 环境变量:
+#   IMAGE_REPO   — 镜像仓库(默认 ghcr.io/yourtongji/yourtj-hub, 公开镜像匿名 pull)
+#   IMAGE_KEEP_N — 每个实例前缀保留的镜像 tag 数(含当前), 默认 5
 set -euo pipefail
 
-INSTANCE="${1:?usage: deploy.sh <instance> <new-binary> <image-tag> [health-port]}"
-NEW_BINARY="${2:?usage: deploy.sh <instance> <new-binary> <image-tag> [health-port]}"
-IMAGE_TAG="${3:?usage: deploy.sh <instance> <new-binary> <image-tag> [health-port]}"
-PORT="${4:-5234}"
+INSTANCE="${1:?usage: deploy.sh <instance> <image-tag> [health-port]}"
+IMAGE_TAG="${2:?usage: deploy.sh <instance> <image-tag> [health-port]}"
+PORT="${3:-5234}"
 
 ROOT="${YOURTJ_ROOT:-/opt/yourtj}"
-BUILD_DIR="$ROOT/build"
 ENV_FILE="$ROOT/.env"
 COMPOSE_FILE="$ROOT/docker-compose.yaml"
 TAG_VAR="$([ "$INSTANCE" = "main" ] && echo MAIN_TAG || echo DEV_TAG)"
-IMAGE="yourtj-hub"
+IMAGE="${IMAGE_REPO:-ghcr.io/yourtongji/yourtj-hub}"
 
 log() { echo "[deploy:$INSTANCE] $*"; }
 
-# 清理旧镜像与构建缓存, 防止磁盘无限膨胀:
+# 清理旧镜像, 防止磁盘无限膨胀:
 #   - 保留该实例前缀(dev-*/main-*)最近 IMAGE_KEEP_N 个 tag(含当前) + prev 回滚 tag
 #   - 清理 dangling images 与构建缓存
 prune_old_images() {
@@ -52,7 +52,7 @@ prune_old_images() {
       | grep "^${instance_prefix}" \
       | sort -t'|' -k2 -r)
 
-  # 清理 dangling 镜像(构建残留)与不再使用的构建缓存, 失败不影响部署结果
+  # 清理 dangling 镜像(拉取/重打标签残留)与不再使用的构建缓存, 失败不影响部署结果
   dangling_before="$(docker images -q -f dangling=true 2>/dev/null | wc -l | tr -d ' ' || true)"
   docker image prune -f >/dev/null 2>&1 || true
   docker builder prune -f --filter "until=72h" >/dev/null 2>&1 || true
@@ -60,10 +60,8 @@ prune_old_images() {
   log "prune done: removed $removed image tag(s); dangling $dangling_before -> $dangling_after"
 }
 
-[ -f "$NEW_BINARY" ] || { log "FATAL: new binary not found: $NEW_BINARY"; exit 1; }
 [ -f "$ENV_FILE" ] || { log "FATAL: $ENV_FILE missing (run init-server.sh first)"; exit 1; }
 [ -f "$COMPOSE_FILE" ] || { log "FATAL: $COMPOSE_FILE missing (run init-server.sh first)"; exit 1; }
-[ -f "$BUILD_DIR/Dockerfile" ] || { log "FATAL: $BUILD_DIR/Dockerfile missing (run init-server.sh first)"; exit 1; }
 
 # 1. 记录当前 tag 用于回滚
 OLD_TAG="$(grep -E "^$TAG_VAR=" "$ENV_FILE" | cut -d= -f2 || true)"
@@ -72,15 +70,21 @@ if [ -n "$OLD_TAG" ] && docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; 
   log "saved previous image tag: $OLD_TAG"
 fi
 
-# 2. 安装新二进制并构建镜像
-install -m 0755 "$NEW_BINARY" "$BUILD_DIR/yourtj-hub"
-docker build -q -t "$IMAGE:$IMAGE_TAG" "$BUILD_DIR"
-log "built image $IMAGE:$IMAGE_TAG"
+# 2. 拉取新镜像(GHCR 公开镜像, 匿名 pull)
+docker pull "$IMAGE:$IMAGE_TAG"
+log "pulled image $IMAGE:$IMAGE_TAG"
 
-# 3. 更新 .env tag 并启动实例
+# 3. 更新 .env tag 并启动实例。
+#    nginx 反代若在当前 compose 中定义则一并 up(新机首个实例部署时拉起;
+#    旧机 compose 无 nginx 服务时不传, 保持向后兼容)
 sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$IMAGE_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
-log "compose up $INSTANCE with $IMAGE_TAG (--remove-orphans)"
+SERVICES="$INSTANCE"
+if docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" config --services 2>/dev/null | grep -qx nginx; then
+  SERVICES="$SERVICES nginx"
+fi
+# shellcheck disable=SC2086
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans $SERVICES
+log "compose up $SERVICES with $IMAGE_TAG (--remove-orphans)"
 
 # 4. 健康检查(覆盖启动 + AutoMigrate 大库迁移)
 for ((i = 1; i <= 60; i++)); do

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -67,11 +67,17 @@ IMAGE="$(grep -E '^IMAGE_REPO=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2-
 IMAGE="${IMAGE:-ghcr.io/yourtongji/yourtj-hub}"
 log "image repo: $IMAGE"
 
-# 1. 记录当前 tag 用于回滚
+# 1. 记录当前 tag 用于回滚。
+#    prev 仅代表"本脚本最近一次成功部署的镜像": 先清掉旧的 prev 引用,
+#    避免首次部署/镜像被 prune 后, 失败回滚时 prev 指向无关或已不存在的镜像;
+#    没有可回滚的 prev 时回滚步骤自然跳过(只改 .env, 容器保持旧镜像)。
 OLD_TAG="$(grep -E "^$TAG_VAR=" "$ENV_FILE" | cut -d= -f2 || true)"
 if [ -n "$OLD_TAG" ] && docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; then
+  docker image rm "$IMAGE:prev" >/dev/null 2>&1 || true
   docker tag "$IMAGE:$OLD_TAG" "$IMAGE:prev" >/dev/null 2>&1 || true
-  log "saved previous image tag: $OLD_TAG"
+  log "saved previous image tag: $OLD_TAG (as prev)"
+else
+  log "no previous local image for $OLD_TAG; rollback will only revert .env tag"
 fi
 
 # 2. 拉取新镜像(GHCR 公开镜像, 匿名 pull)
@@ -101,11 +107,17 @@ for ((i = 1; i <= 60; i++)); do
   sleep 3
 done
 
-# 5. 失败: 回滚到旧 tag
+# 5. 失败: 回滚到旧 tag(prev 不可用时仅改 .env, 容器保持旧镜像)
 log "FATAL: health check failed, rolling back"
 if [ -n "$OLD_TAG" ]; then
-  sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$OLD_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
-  log "rolled back to $OLD_TAG"
+  if docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; then
+    sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$OLD_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
+    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
+    log "rolled back to $OLD_TAG"
+  else
+    log "WARNING: $IMAGE:$OLD_TAG not present locally, cannot roll back container; .env still points at new tag $IMAGE_TAG"
+  fi
+else
+  log "WARNING: no previous tag recorded, cannot roll back"
 fi
 exit 1

--- a/deploy/scripts/init-server.sh
+++ b/deploy/scripts/init-server.sh
@@ -16,16 +16,16 @@ if ! command -v sqlite3 >/dev/null 2>&1; then
 fi
 
 # 2. 目录结构
-mkdir -p "$ROOT"/{build,scripts,snapshots,main/storage,dev/storage}
+mkdir -p "$ROOT"/{scripts,snapshots,nginx,main/storage,dev/storage}
 
-# 3. 复制 Dockerfile / compose / 配置模板 / 脚本(源=目标时跳过)
+# 3. 复制 compose / nginx 反代配置 / 配置模板 / 脚本(源=目标时跳过)
 copy_if_diff() {
   local src="$1" dst="$2"
   [ "$(realpath "$src")" = "$(realpath "$dst")" ] && return 0
   cp "$src" "$dst"
 }
-copy_if_diff "$SCRIPT_DIR/../Dockerfile" "$ROOT/build/Dockerfile"
 copy_if_diff "$SCRIPT_DIR/../docker-compose.yaml" "$ROOT/docker-compose.yaml"
+copy_if_diff "$SCRIPT_DIR/../nginx/yourtj.conf" "$ROOT/nginx/yourtj.conf"
 copy_if_diff "$SCRIPT_DIR/../config.toml.example" "$ROOT/config.toml.example"
 for f in "$SCRIPT_DIR"/*.sh; do
   copy_if_diff "$f" "$ROOT/scripts/$(basename "$f")"
@@ -36,15 +36,18 @@ chmod +x "$ROOT/scripts/"*.sh
 #    - 已存在(存量服务器)时逐条追加缺失的 POSTGRES_* 变量, 保证已有部署
 #      POSTGRES_PASSWORD 由 init 生成随机值(compose 要求非空; 部署默认 PG 主库)
 PG_PASS="$(openssl rand -hex 16)"
+MEILI_KEY="$(openssl rand -hex 16)"
 if [ ! -f "$ROOT/.env" ]; then
   cat > "$ROOT/.env" <<EOF
 MAIN_PORT=5234
 DEV_PORT=5235
 MAIN_TAG=latest
 DEV_TAG=latest
+IMAGE_REPO=ghcr.io/yourtongji/yourtj-hub
 POSTGRES_USER=yourtj
 POSTGRES_PASSWORD=$PG_PASS
 POSTGRES_DB=postgres
+MEILI_MASTER_KEY=$MEILI_KEY
 EOF
   echo "init: $ROOT/.env created"
 else
@@ -59,6 +62,8 @@ else
   append_if_missing DEV_PORT 5235
   append_if_missing MAIN_TAG latest
   append_if_missing DEV_TAG latest
+  append_if_missing IMAGE_REPO ghcr.io/yourtongji/yourtj-hub
+  append_if_missing MEILI_MASTER_KEY "$MEILI_KEY"
   append_if_missing POSTGRES_USER yourtj
   if grep -q "^POSTGRES_PASSWORD=" "$ROOT/.env" && [ -z "$(grep '^POSTGRES_PASSWORD=' "$ROOT/.env" | cut -d= -f2-)" ]; then
     sed -i.bak -E "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$PG_PASS/" "$ROOT/.env" && rm -f "$ROOT/.env.bak"
@@ -74,6 +79,7 @@ fi
 GEN_KEY="$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)"
 PG_USER="$(grep '^POSTGRES_USER=' "$ROOT/.env" | cut -d= -f2-)"
 PG_PASS="$(grep '^POSTGRES_PASSWORD=' "$ROOT/.env" | cut -d= -f2-)"
+MEILI_KEY="$(grep '^MEILI_MASTER_KEY=' "$ROOT/.env" | cut -d= -f2-)"
 for inst in main dev; do
   if [ ! -f "$ROOT/$inst/config.toml" ]; then
     domain="$MAIN_DOMAIN"
@@ -82,6 +88,7 @@ for inst in main dev; do
     sed -e "s|REPLACE_SIGNING_KEY|$GEN_KEY|" \
         -e "s|REPLACE_SERVER_URL|$domain|" \
         -e "s|REPLACE_POSTGRES_DSN|$pg_dsn|" \
+        -e "s|REPLACE_MEILI_KEY|$MEILI_KEY|" \
       "$ROOT/config.toml.example" > "$ROOT/$inst/config.toml"
     echo "init: $ROOT/$inst/config.toml created (domain: $domain, db: yourtj_$inst)"
   fi
@@ -89,7 +96,7 @@ done
 
 # 5.5 启动 postgres 容器并创建实例数据库(main/dev 隔离, 幂等; 供部署默认 PG 主库使用)
 PG_USER="$(grep '^POSTGRES_USER=' "$ROOT/.env" | cut -d= -f2-)"
-docker compose --env-file "$ROOT/.env" -f "$ROOT/docker-compose.yaml" up -d postgres
+docker compose --env-file "$ROOT/.env" -f "$ROOT/docker-compose.yaml" up -d postgres meilisearch
 for _ in $(seq 1 30); do
   docker exec yourtj-postgres pg_isready -U "$PG_USER" >/dev/null 2>&1 && break
   sleep 2

--- a/deploy/scripts/init-server.sh
+++ b/deploy/scripts/init-server.sh
@@ -27,6 +27,15 @@ copy_if_diff() {
 copy_if_diff "$SCRIPT_DIR/../docker-compose.yaml" "$ROOT/docker-compose.yaml"
 copy_if_diff "$SCRIPT_DIR/../nginx/yourtj.conf" "$ROOT/nginx/yourtj.conf"
 copy_if_diff "$SCRIPT_DIR/../config.toml.example" "$ROOT/config.toml.example"
+
+# nginx server_name 参数化: 从传入域名提取 host 并替换默认值
+MAIN_HOST="$(echo "$MAIN_DOMAIN" | sed -E 's|^https?://||; s|/.*$||')"
+DEV_HOST="$(echo "$DEV_DOMAIN" | sed -E 's|^https?://||; s|/.*$||')"
+sed -i.bak -E \
+  -e "s|server_name forum\.yourtj\.de;|server_name $MAIN_HOST;|" \
+  -e "s|server_name dev\.yourtj\.de;|server_name $DEV_HOST;|" \
+  "$ROOT/nginx/yourtj.conf" && rm -f "$ROOT/nginx/yourtj.conf.bak"
+echo "init: nginx server_name -> $MAIN_HOST / $DEV_HOST"
 for f in "$SCRIPT_DIR"/*.sh; do
   copy_if_diff "$f" "$ROOT/scripts/$(basename "$f")"
 done
@@ -91,6 +100,15 @@ for inst in main dev; do
         -e "s|REPLACE_MEILI_KEY|$MEILI_KEY|" \
       "$ROOT/config.toml.example" > "$ROOT/$inst/config.toml"
     echo "init: $ROOT/$inst/config.toml created (domain: $domain, db: yourtj_$inst)"
+  fi
+done
+
+# 5.2 存量 config 同步 MEILI key: init 为 .env 补 MEILI_MASTER_KEY 后,
+#     旧 config 的 masterkey 若为空/占位符, 搜索会 401; 仅替换空/占位符值
+for inst in main dev; do
+  if [ -f "$ROOT/$inst/config.toml" ] && grep -qE '^\s*masterkey\s*=\s*""|^\s*masterkey\s*=\s*"REPLACE_MEILI_KEY"' "$ROOT/$inst/config.toml"; then
+    sed -i.bak -E "s|^(\s*masterkey\s*=\s*)\"\"|\1\"$MEILI_KEY\"|; s|^(\s*masterkey\s*=\s*)\"REPLACE_MEILI_KEY\"|\1\"$MEILI_KEY\"|" "$ROOT/$inst/config.toml" && rm -f "$ROOT/$inst/config.toml.bak"
+    echo "init: $ROOT/$inst/config.toml masterkey 已同步 .env 的 MEILI_MASTER_KEY"
   fi
 done
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -16,14 +16,19 @@
   `[db.default] connection = "postgres"`); SQLite is the local development/test default; the file
   database `[db.file]` stays SQLite; MySQL is **not supported**; optional Meilisearch; optional
   built-in OIDC Provider ([oidc] in config.toml).
-- **Reverse proxy + SSL by 1Panel** (openresty): `forum.yourtj.de` → `127.0.0.1:5234` (main),
-  `dev.yourtj.de` → `127.0.0.1:5235` (dev). Both behind Cloudflare (proxied, origin IP hidden).
-- Backend containers bind `127.0.0.1` only; nothing else is exposed publicly.
+- **Image pipeline**: CI builds the single binary and packages it into an OCI image pushed to GHCR
+  (`ghcr.io/yourtongji/yourtj-hub:<instance>-<sha>`; repo is public, so servers pull anonymously —
+  no registry credentials on the server).
+- **Reverse proxy**: a self-managed `nginx` container (`deploy/nginx/yourtj.conf`, mounted into the
+  compose `nginx` service) terminates Cloudflare origin traffic on `:80` and proxies
+  `forum.yourtj.de` → `main:5234`, `dev.yourtj.de` → `dev:5234`. Backend addressing uses a variable +
+  Docker DNS resolver so nginx never blocks on backend startup. Backend containers bind
+  `127.0.0.1` only; only nginx (and SSH) is exposed publicly.
 - **Trusted proxies**: the binary only trusts `127.0.0.1`/`::1` reverse proxies by default
-  (`engine.SetTrustedProxies`). If an additional proxy sits in front of the binary, add it to
-  `server.trusted_proxies` in `config.toml` so rate-limit IP attribution cannot be bypassed via
-  a forged `X-Forwarded-For` header.
-- **Two instances on one VM** (Ubuntu 24.04, ssh alias `yourtj`), managed as one compose project:
+  (`engine.SetTrustedProxies`). With the compose nginx container in front, `server.trusted_proxies`
+  must include the docker network (`deploy/config.toml.example` defaults to `["172.16.0.0/12"]`) so
+  rate-limit IP attribution cannot be bypassed via a forged `X-Forwarded-For` header.
+- **Two instances on one VM** (Debian 12, ssh `root`), managed as one compose project:
   - `main` — production, `/opt/yourtj/main`
   - `dev` — test line, `/opt/yourtj/dev`
   - DB sync is one-way: dev gets a consistent snapshot of main on each deploy (below).
@@ -60,24 +65,23 @@
 4. 重建期间旧站可继续在线（只读），全部内容迁移完成、新站 `/wiki` 导航树
    核对无误后再按上方步骤退役旧容器与路由。
 
-## Server layout (1Panel container orchestration)
+## Server layout (Docker Compose)
 
 ```
 /opt/yourtj/
-  .env                    # MAIN_PORT/DEV_PORT/MAIN_TAG/DEV_TAG + POSTGRES_USER/POSTGRES_PASSWORD/MEILI_MASTER_KEY (created by init-server.sh)
-  docker-compose.yaml     # main + dev + meili services (created by init-server.sh)
+  .env                    # MAIN_PORT/DEV_PORT/MAIN_TAG/DEV_TAG/IMAGE_REPO + POSTGRES_*/MEILI_MASTER_KEY (created by init-server.sh)
+  docker-compose.yaml     # main + dev + nginx + postgres + meilisearch services (created by init-server.sh)
   config.toml.example     # template with REPLACE_* placeholders
-  build/
-    Dockerfile            # alpine + binary
+  nginx/
+    yourtj.conf           # reverse proxy config (mounted into the nginx container)
   scripts/                # snapshot-db.sh, sync-db-from-main.sh, backup-db.sh, deploy.sh, pgdsn.sh
   main/
     config.toml           # production config (signingKey, db path) — never in git
-    storage/              # sqlite.db + file.db + logs (uid 1000) — PG 部署时 sqlite.db 不产生
+    storage/              # file.db + logs (uid 1000); PG 部署时 sqlite.db 不产生
   dev/
     config.toml           # dev config
     storage/
   snapshots/
-    main/sqlite-*.db      # pre-deploy backups (keep 7) — SQLite 部署
     main/pg-*.sql         # pre-deploy pg_dump backups (keep 7) — PostgreSQL 部署
 ```
 
@@ -85,19 +89,19 @@
 
 - `dev` is the default branch and the main development line; merges to `dev` trigger
   `.github/workflows/deploy-dev.yml`:
-  1. Build single binary (frontend + go build) on GitHub Actions.
-  2. Upload binary via scp; SSH: `sync-db-from-main.sh` (auto-detects mode: SQLite `.backup` snapshot
+  1. Build single binary (frontend + go build) and push GHCR image `dev-<sha>` on GitHub Actions.
+  2. SSH: `sync-db-from-main.sh` (auto-detects mode: SQLite `.backup` snapshot
      or PG `pg_dump|psql` rebuild of dev db).
-  3. SSH: `deploy.sh dev <binary> dev-<sha> 5235` → build image, compose up, health check, rollback;
+  3. SSH: `deploy.sh dev dev-<sha> 5235` → pull image, compose up, health check, rollback;
      after a successful deploy the script prunes old images (keeps the newest
      `IMAGE_KEEP_N` tags of the instance prefix including the current one, plus the `prev`
-     rollback tag) and build cache older than 72h.
+     rollback tag).
      The dev workflow sets `IMAGE_KEEP_N=3` because dev deploys frequently.
 - `main` is the production site; merges to `main` trigger `.github/workflows/deploy-main.yml`:
-  1. Build single binary on GitHub Actions.
+  1. Build single binary and push GHCR image `main-<sha>` on GitHub Actions.
   2. SSH: `backup-db.sh main` (pre-deploy consistent snapshot, keep 7).
-  3. SSH: `deploy.sh main <binary> main-<sha> 5234` → build image, compose up, health check,
-     auto-rollback to previous image tag on failure; same post-deploy image/cache pruning as dev
+  3. SSH: `deploy.sh main main-<sha> 5234` → pull image, compose up, health check,
+     auto-rollback to previous image tag on failure; same post-deploy image pruning as dev
      (`IMAGE_KEEP_N=5`, keeps more rollback candidates for production).
 - **Release gate**: `.github/workflows/release-to-main.yml` (manual `workflow_dispatch`) merges `dev` →
   `main`, bumps the version (`patch` / `minor` / `major`, computed from the latest `vX.Y.Z` tag, first
@@ -122,9 +126,10 @@
 
 | Secret | Value |
 |---|---|
-| `VM_HOST` | server public IP or hostname (`20.205.27.178`) |
-| `VM_USER` | SSH user (e.g. `yourtj`) |
-| `VM_SSH_KEY` | private key for that user (full PEM, including `-----BEGIN ...` lines) |
+| `VM_HOST` | server public IP or hostname (`43.108.84.213`) |
+| `VM_USER` | SSH user (`root`) |
+| `VM_SSH_KEY` | PEM private key for that user (full PEM, including `-----BEGIN ...` lines; e.g. `YourTJ_Korean.pem`) |
+| `VM_SSH_PORT` | SSH port (default 22) |
 
 Deploy workflows use `appleboy/scp-action` + `appleboy/ssh-action` with these secrets.
 
@@ -136,8 +141,9 @@ sudo bash /opt/yourtj/scripts/init-server.sh \
   https://forum.yourtj.de https://dev.yourtj.de
 ```
 
-This creates `/opt/yourtj/{.env,build,docker-compose.yaml,main,dev}` with randomized signing keys.
-The script itself is deployed to the server by the first CI run (or copy `deploy/` manually).
+This creates `/opt/yourtj/{.env,docker-compose.yaml,nginx,main,dev}` with randomized signing keys,
+PG/Meili passwords, starts `postgres` + `meilisearch`, and creates the `yourtj_main`/`yourtj_dev`
+databases. The script itself is deployed to the server by the first CI run (or copy `deploy/` manually).
 
 ## Build (local)
 
@@ -160,9 +166,8 @@ make build     # cd apps/gooseforum/resource && pnpm build → cd apps/gooseforu
   surfacing as runtime API failures (the original issue #8 login/register outage). It also means a
   deploy with an incompatible schema change will roll back — rehearse on dev (which syncs main's db)
   before main.
-- Rollback: `deploy.sh` tags the previous image `yourtj-hub:prev` and re-points the instance on
-  health-check failure; forward-compatible migrations mean an older binary can still start.
-- Pre-deploy snapshot in `snapshots/main/` is the data-level restore point (SQLite).
+- Rollback: `deploy.sh` tags the previous image `ghcr.io/yourtongji/yourtj-hub:prev` and re-points
+  the instance on health-check failure; forward-compatible migrations mean an older binary can still start.
 
 ### Upgrade note: `app.signingKey` is now mandatory and fail-closed
 
@@ -389,6 +394,94 @@ instance:
   进程崩溃后若需立即重跑，可等待窗口过期或手动清掉该学期 `pk_fetch_log`。
 - 注意：`app.signingKey` 轮换会使管理端已存的一系统 Cookie 密文失效（与 TOTP 相同），
   需到管理端重新保存。
+
+## 服务器迁移 runbook（旧机 → 新机）
+
+旧生产服务器（20.205.27.178, 1Panel）迁移到新机（43.108.84.213, Docker Compose + GHCR）的完整步骤。
+**原则：signingKey 必须原样复制，绝不重新生成**（否则全部会话 / TOTP / 重置链接失效，fail-closed）。
+
+### 0. 前置
+
+- 新机已装 Docker Engine + Compose + 2G swap（`deploy/scripts/init-server.sh` 会在 CI 首次部署时下发，
+  也可手动拷贝 `deploy/` 后在服务器执行）。
+- 仓库侧 GHCR 镜像流 PR 已合并；GHCR 镜像为公开（repo 公开），服务器匿名 pull。
+- 备份密钥：`~/Documents/YourTJ_Korean.pem`（新机 SSH PEM）。
+
+### 1. 新机初始化
+
+```bash
+ssh -i ~/Documents/YourTJ_Korean.pem root@43.108.84.213
+mkdir -p /opt/yourtj && cd /opt/yourtj
+# 从仓库拷贝 deploy/ 目录后:
+sudo bash deploy/scripts/init-server.sh https://forum.yourtj.de https://dev.yourtj.de
+```
+
+这会生成 `/opt/yourtj/{.env,docker-compose.yaml,nginx,main/config.toml,dev/config.toml}`，
+启动 postgres + meilisearch，创建 `yourtj_main` / `yourtj_dev` 数据库。
+
+### 2. 数据迁移（main + dev）
+
+在旧机（1Panel 部署）上导出，再导入新机。**旧机 / 新机 PostgreSQL 版本一致（16）**。
+
+```bash
+# 旧机: 导出主库(在 postgres 容器内)
+docker compose exec postgres sh -c \
+  'pg_dump -U yourtj -d yourtj_main > /tmp/yourtj_main.sql'
+docker compose exec postgres sh -c \
+  'pg_dump -U yourtj -d yourtj_dev > /tmp/yourtj_dev.sql'
+scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/tmp/yourtj_*.sql /tmp/
+
+# 新机: 导入(在 postgres 容器内)
+docker compose exec -T postgres sh -c 'psql -U yourtj -d yourtj_main' < /tmp/yourtj_main.sql
+docker compose exec -T postgres sh -c 'psql -U yourtj -d yourtj_dev' < /tmp/yourtj_dev.sql
+```
+
+文件库 `file.db`（SQLite，附件 BLOB）直接拷贝：
+
+```bash
+# 旧机
+scp -i ~/Documents/YourTJ_Korean.pem -r root@<旧机>:/opt/yourtj/main/storage/file.db /tmp/main-file.db
+scp -i ~/Documents/YourTJ_Korean.pem -r root@<旧机>:/opt/yourtj/dev/storage/file.db /tmp/dev-file.db
+# 新机
+install -m 0664 /tmp/main-file.db /opt/yourtj/main/storage/file.db
+install -m 0664 /tmp/dev-file.db /opt/yourtj/dev/storage/file.db
+```
+
+### 3. signingKey / 配置复制（关键！）
+
+```bash
+# 旧机: 读取两个 config.toml 的 signingKey
+ssh root@<旧机> 'grep signingKey /opt/yourtj/main/config.toml /opt/yourtj/dev/config.toml'
+# 新机: 把相同的 signingKey 写入 main/config.toml 与 dev/config.toml
+#   同时确保 server.trusted_proxies 含 docker 网段(模板已默认 ["172.16.0.0/12"])
+#   server.url 保持 https://forum.yourtj.de / https://dev.yourtj.de
+```
+
+### 4. 首次部署 + 健康检查
+
+```bash
+# 手动拉取并启动(等价于 CI deploy.sh main main-<sha> 5234)
+cd /opt/yourtj
+IMAGE_KEEP_N=5 bash scripts/deploy.sh main main-<latest-sha> 5234
+IMAGE_KEEP_N=3 bash scripts/deploy.sh dev dev-<latest-sha> 5235
+# 验证
+curl -fsS http://127.0.0.1:5234/health && echo MAIN_OK
+curl -fsS http://127.0.0.1:5235/health && echo DEV_OK
+curl -fsS -H "Host: forum.yourtj.de" http://127.0.0.1/ | head -5   # 经 nginx
+```
+
+### 5. DNS 切换 + 收尾
+
+1. Cloudflare DNS：`forum.yourtj.de` / `dev.yourtj.de` 的 A 记录从旧机 IP（20.205.27.178）改为新机 IP（43.108.84.213）。
+2. 等 TTL 过后从外网验证 `https://forum.yourtj.de` 与 `https://dev.yourtj.de` 可达、登录/发帖/附件/搜索 spot-check。
+3. **观察期（≥7 天）内旧机保持运行**；确认稳定后退役旧机（`docker compose down`，保留数据快照）。
+4. 更新 GitHub Secrets `VM_HOST` → 新机 IP；旧机从 CI 摘除。
+
+### 风险与回滚
+
+- 迁移窗口内的新写入不会进入 dump；**切换前在旧机再跑一次 `backup-db.sh main`** 生成最新快照，接受分钟级数据窗口。
+- 若新机异常：Cloudflare A 记录切回旧机 IP（旧机仍运行）即可回滚，数据无损。
+- Meilisearch 索引不迁移，首次启动后由 `rebuild-search-index` 重建（ADR-003：索引是可重建投影）。
 
 ## Runbooks to write
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -427,6 +427,11 @@ sudo bash deploy/scripts/init-server.sh https://forum.yourtj.de https://dev.your
 
 在旧机（1Panel 部署）上导出，再导入新机。**旧机 / 新机 PostgreSQL 版本一致（16）**。
 
+> **⚠️ 旧机是 1Panel 管理**：下列命令假设 compose 项目在 `/opt/yourtj`（与仓库约定一致）。
+> 实际路径以旧机 1Panel 配置为准（1Panel 项目目录可能是 `/opt/1panel/apps/...` 或自定义），
+> 执行前先 `ls` 确认。`docker compose` 命令在 1Panel 的 compose 项目目录下执行；
+> 1Panel 的 compose 版本若为 v1（无 `exec -T` 的 `-T` 参数），去掉 `-T`。
+
 ```bash
 # 旧机: 导出主库到宿主机 /tmp(exec -T 流式输出, 重定向在宿主机执行;
 #       若在容器内重定向, 文件落在容器 /tmp, 宿主机 scp 找不到)
@@ -446,13 +451,20 @@ docker compose exec -T postgres sh -c 'psql -U yourtj -d yourtj_dev' < /tmp/your
 `storage/database/file.db`**（见 config.toml `[db.file].path`）：
 
 ```bash
-# 旧机: 拷贝文件库
-scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/main/storage/database/file.db /tmp/main-file.db
-scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/dev/storage/database/file.db /tmp/dev-file.db
-# 新机
+# 旧机: 用 sqlite3 .backup 做一致性快照(实例仍在运行, 直接 scp 活库会拿到 torn copy;
+#       与 backup-db.sh 相同做法; 旧机已装 sqlite3, init-server.sh 也会装)
+sqlite3 /opt/yourtj/main/storage/database/file.db ".backup '/tmp/main-file.db'"
+sqlite3 /opt/yourtj/dev/storage/database/file.db ".backup '/tmp/dev-file.db'"
+# 或直接复用旧机已有的 backup-db.sh(它已做一致性快照):
+#   /opt/yourtj/scripts/backup-db.sh main && scp ... root@<旧机>:/opt/yourtj/snapshots/main/file-*.db /tmp/main-file.db
+
+# 旧机 → 新机
+scp -i ~/Documents/YourTJ_Korean.pem /tmp/main-file.db /tmp/dev-file.db \
+  root@43.108.84.213:/tmp/
+
+# 新机: 安装 + 属主必须是容器内 app uid(1000), 否则附件写入报权限错误
 install -m 0664 /tmp/main-file.db /opt/yourtj/main/storage/database/file.db
 install -m 0664 /tmp/dev-file.db /opt/yourtj/dev/storage/database/file.db
-# 属主必须是容器内 app uid(1000), 否则附件写入报权限错误
 chown 1000:1000 /opt/yourtj/main/storage/database/file.db /opt/yourtj/dev/storage/database/file.db
 ```
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -404,7 +404,11 @@ instance:
 
 - 新机已装 Docker Engine + Compose + 2G swap（`deploy/scripts/init-server.sh` 会在 CI 首次部署时下发，
   也可手动拷贝 `deploy/` 后在服务器执行）。
-- 仓库侧 GHCR 镜像流 PR 已合并；GHCR 镜像为公开（repo 公开），服务器匿名 pull。
+- 仓库侧 GHCR 镜像流 PR 已合并；**合并后先更新 GitHub Secrets（`VM_HOST` → 新机 IP、
+  `VM_USER` → `root`、`VM_SSH_KEY` → PEM 内容）再触发 dev 部署**；若 dev 在更新前自动部署到旧机，
+  会因 :80 被 1Panel openresty 占用导致 nginx 容器启动失败（部署报错，旧服务不受影响，重跑即可）。
+- **GHCR 包可见性**：首次 build-image 推送后，GitHub Packages → `yourtj-hub` → Settings →
+  Change visibility → **Public**（默认 private，服务器匿名 pull 会 401）。
 - 备份密钥：`~/Documents/YourTJ_Korean.pem`（新机 SSH PEM）。
 
 ### 1. 新机初始化
@@ -424,37 +428,52 @@ sudo bash deploy/scripts/init-server.sh https://forum.yourtj.de https://dev.your
 在旧机（1Panel 部署）上导出，再导入新机。**旧机 / 新机 PostgreSQL 版本一致（16）**。
 
 ```bash
-# 旧机: 导出主库(在 postgres 容器内)
-docker compose exec postgres sh -c \
-  'pg_dump -U yourtj -d yourtj_main > /tmp/yourtj_main.sql'
-docker compose exec postgres sh -c \
-  'pg_dump -U yourtj -d yourtj_dev > /tmp/yourtj_dev.sql'
-scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/tmp/yourtj_*.sql /tmp/
+# 旧机: 导出主库到宿主机 /tmp(exec -T 流式输出, 重定向在宿主机执行;
+#       若在容器内重定向, 文件落在容器 /tmp, 宿主机 scp 找不到)
+docker compose exec -T postgres sh -c 'pg_dump -U yourtj -d yourtj_main' > /tmp/yourtj_main.sql
+docker compose exec -T postgres sh -c 'pg_dump -U yourtj -d yourtj_dev' > /tmp/yourtj_dev.sql
+
+# 旧机 → 新机: 直传
+scp -i ~/Documents/YourTJ_Korean.pem /tmp/yourtj_main.sql /tmp/yourtj_dev.sql \
+  root@43.108.84.213:/tmp/
 
 # 新机: 导入(在 postgres 容器内)
 docker compose exec -T postgres sh -c 'psql -U yourtj -d yourtj_main' < /tmp/yourtj_main.sql
 docker compose exec -T postgres sh -c 'psql -U yourtj -d yourtj_dev' < /tmp/yourtj_dev.sql
 ```
 
-文件库 `file.db`（SQLite，附件 BLOB）直接拷贝：
+文件库 `file.db`（SQLite，附件 BLOB）直接拷贝。**注意实际路径是
+`storage/database/file.db`**（见 config.toml `[db.file].path`）：
 
 ```bash
-# 旧机
-scp -i ~/Documents/YourTJ_Korean.pem -r root@<旧机>:/opt/yourtj/main/storage/file.db /tmp/main-file.db
-scp -i ~/Documents/YourTJ_Korean.pem -r root@<旧机>:/opt/yourtj/dev/storage/file.db /tmp/dev-file.db
+# 旧机: 拷贝文件库
+scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/main/storage/database/file.db /tmp/main-file.db
+scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/dev/storage/database/file.db /tmp/dev-file.db
 # 新机
-install -m 0664 /tmp/main-file.db /opt/yourtj/main/storage/file.db
-install -m 0664 /tmp/dev-file.db /opt/yourtj/dev/storage/file.db
+install -m 0664 /tmp/main-file.db /opt/yourtj/main/storage/database/file.db
+install -m 0664 /tmp/dev-file.db /opt/yourtj/dev/storage/database/file.db
+# 属主必须是容器内 app uid(1000), 否则附件写入报权限错误
+chown 1000:1000 /opt/yourtj/main/storage/database/file.db /opt/yourtj/dev/storage/database/file.db
 ```
 
-### 3. signingKey / 配置复制（关键！）
+### 3. 配置迁移（完整拷贝 + reconcile，关键！）
+
+**不要只复制 signingKey**：`config.toml` 还包含 GitHub OAuth `client_id`/`client_secret`、
+OIDC 设置（含 signing_key_file PEM）、一系统同步 Cookie 密文等，全部需要原样迁移：
 
 ```bash
-# 旧机: 读取两个 config.toml 的 signingKey
-ssh root@<旧机> 'grep signingKey /opt/yourtj/main/config.toml /opt/yourtj/dev/config.toml'
-# 新机: 把相同的 signingKey 写入 main/config.toml 与 dev/config.toml
-#   同时确保 server.trusted_proxies 含 docker 网段(模板已默认 ["172.16.0.0/12"])
-#   server.url 保持 https://forum.yourtj.de / https://dev.yourtj.de
+# 旧机: 完整拷贝两个 config.toml 与 OIDC 密钥文件
+scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/main/config.toml /tmp/main-config.toml
+scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/dev/config.toml /tmp/dev-config.toml
+# 若 [oidc] signing_key_file 启用, 一并拷贝对应 PEM
+
+# 新机: 用旧配置覆盖, 然后 reconcile 以下部署相关键:
+#   - [db.default] url: host 改为 postgres(compose 服务名), 不要沿用旧机 127.0.0.1
+#   - [server] trusted_proxies: 包含 docker 网段 ["172.16.0.0/12"]
+#   - [meilisearch] masterkey: 与 /opt/yourtj/.env 的 MEILI_MASTER_KEY 一致
+#   - [server] url: 保持 https://forum.yourtj.de / https://dev.yourtj.de
+install -m 0644 /tmp/main-config.toml /opt/yourtj/main/config.toml
+install -m 0644 /tmp/dev-config.toml /opt/yourtj/dev/config.toml
 ```
 
 ### 4. 首次部署 + 健康检查
@@ -470,17 +489,34 @@ curl -fsS http://127.0.0.1:5235/health && echo DEV_OK
 curl -fsS -H "Host: forum.yourtj.de" http://127.0.0.1/ | head -5   # 经 nginx
 ```
 
-### 5. DNS 切换 + 收尾
+### 5. Cloudflare SSL 模式 + DNS 切换
 
-1. Cloudflare DNS：`forum.yourtj.de` / `dev.yourtj.de` 的 A 记录从旧机 IP（20.205.27.178）改为新机 IP（43.108.84.213）。
-2. 等 TTL 过后从外网验证 `https://forum.yourtj.de` 与 `https://dev.yourtj.de` 可达、登录/发帖/附件/搜索 spot-check。
-3. **观察期（≥7 天）内旧机保持运行**；确认稳定后退役旧机（`docker compose down`，保留数据快照）。
-4. 更新 GitHub Secrets `VM_HOST` → 新机 IP；旧机从 CI 摘除。
+**先改 SSL/TLS 模式，再切 DNS**（否则切换瞬间 521/525）：
+
+1. **Cloudflare SSL/TLS 模式**：旧机由 1Panel 提供 origin 证书，当前模式很可能是
+   Full (strict)（Cloudflare → origin 走 HTTPS:443）。新机 nginx 只监听 :80，
+   切换前把 `SSL/TLS → Overview → SSL/TLS encryption mode` 改为 **Flexible**
+   （Cloudflare → origin 走 HTTP:80）。若必须保持端到端加密，需在新机 nginx
+   配置 443 监听 + Cloudflare origin 证书（本仓库 compose 默认只暴露 80）。
+2. **DNS**：`forum.yourtj.de` / `dev.yourtj.de` 的 A 记录从旧机 IP（20.205.27.178）
+   改为新机 IP（43.108.84.213）。
+3. 等 TTL 过后从外网验证 `https://forum.yourtj.de` 与 `https://dev.yourtj.de` 可达、
+   登录/发帖/附件/搜索 spot-check。
+4. **观察期（≥7 天）内旧机保持运行**；确认稳定后退役旧机（`docker compose down`，保留数据快照）。
+5. 更新 GitHub Secrets `VM_HOST` → 新机 IP；旧机从 CI 摘除。
 
 ### 风险与回滚
 
-- 迁移窗口内的新写入不会进入 dump；**切换前在旧机再跑一次 `backup-db.sh main`** 生成最新快照，接受分钟级数据窗口。
-- 若新机异常：Cloudflare A 记录切回旧机 IP（旧机仍运行）即可回滚，数据无损。
+- 迁移窗口内的新写入不会进入 dump；**切换前在旧机再跑一次 `backup-db.sh main`** 生成最新快照，
+  接受分钟级数据窗口。
+- **回滚不是简单的 DNS 切回**：DNS 切换到新机后，新机接受了新的发帖/注册/附件写入。
+  若此时切回旧机，这些新写入会丢失。因此回滚前必须**反向同步**：
+  1. 停写：临时把 Cloudflare 页面规则或新机 nginx 置为维护模式（或直接切 DNS 前先接受
+     "最近写入可能丢失" 的窗口）；
+  2. 从新机 `pg_dump yourtj_main/yourtj_dev` 回灌旧机对应库（与 §2 相同方式反向）；
+  3. 把新机 `storage/database/file.db` 拷回旧机对应路径并 `chown 1000:1000`；
+  4. 再切 DNS 回旧机。
+  - 若回滚发生在切换后很短时间内且写入量可忽略，可接受不回灌，但文档不承诺"数据无损"。
 - Meilisearch 索引不迁移，首次启动后由 `rebuild-search-index` 重建（ADR-003：索引是可重建投影）。
 
 ## Runbooks to write


### PR DESCRIPTION
## Summary

将自动化部署从「CI scp 二进制 → 服务器本地 docker build」迁移为 **GHCR 镜像流 + 服务器 pull**，并为新生产服务器准备自管 nginx 反代。这是「迁移到新机并规范化部署」的 Phase 1（仓库侧）。

### 镜像管线
- `deploy-{dev,main}.yml` 新增 `build-image` job：用 `docker/build-push-action@v6` 构建并推送到 `ghcr.io/yourtongji/yourtj-hub:<instance>-<sha>`（`GITHUB_TOKEN`，`packages: write`）
- 仓库是 **public** → GHCR 镜像公开，服务器**匿名 pull，零凭证**
- `deploy.sh` 改为 `docker pull + compose up`，保留健康检查回滚与镜像清理；兼容旧机（compose 无 nginx 服务时不传）

### 自管 nginx 反代（替代 1Panel openresty）
- `deploy/nginx/yourtj.conf`：`forum.yourtj.de → main:5234`、`dev.yourtj.de → dev:5234`，变量 + Docker DNS resolver（不阻塞后端启动），`X-Forwarded-Proto https`，`/healthz` 探针
- compose 新增 `nginx` 服务（仅暴露 :80，后端容器仍只绑 127.0.0.1）
- `config.toml.example` 加 `server.trusted_proxies = ["172.16.0.0/12"]`（nginx 容器从 bridge 网段访问，必须信任才能正确解析 X-Forwarded-For）

### 初始化
- `init-server.sh`：移除本地 build 目录，改下发 nginx 配置；生成 `IMAGE_REPO` / `MEILI_MASTER_KEY`；启动 postgres + meilisearch
- `config.toml.example` meilisearch url 改 compose 服务名 `http://meilisearch:7700`

### 文档
- `docs/operations/deployment.md`：Deployment shape / Server layout / CI/CD / secrets（PEM + 新机 IP）/ 首次初始化全部更新，新增「服务器迁移 runbook」（含 signingKey 原样复制关键步骤）

## 兼容性
- 旧服务器（1Panel，无 nginx 服务）在迁移窗口内仍可被部署：`deploy.sh` 检测 compose 是否有 nginx 服务，无则不启动
- `release-to-main` → `deploy-main` 链路不变
- required status check 不变

## 验证
- `bash -n` 全部脚本通过（deploy/init/backup/sync）
- YAML（所有 workflow + compose）解析通过
- config.toml.example TOML 解析通过
- `git diff --check` 通过

## 服务器侧（Phase 2，本 PR 不包含）
- 新机 Docker Engine + Compose + 2G swap 已手动装好
- 数据迁移（pg_dump + file.db + signingKey）、DNS 切换、GitHub Secrets 更新按 runbook 执行