### PR TITLE
fix(deploy): upload compose file separately to survive strip_components

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -67,6 +67,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+      # 上传到 run-specific 路径, 避免与 deploy-main 并发部署时
+      # 互相覆盖 /tmp 下的同名文件(见 PR review #1)
       - name: Upload deploy scripts to dev host
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -75,20 +77,12 @@ jobs:
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh,deploy/nginx/yourtj.conf"
-          target: "/tmp"
+          target: "/tmp/yourtj-deploy-${{ github.run_id }}"
           strip_components: 2
-      # docker-compose.yaml 只有两层路径, strip_components: 2 会把它剥没
-      # (scp-action 丢弃空路径), 必须单独上传不 strip
-      - name: Upload compose file to dev host
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.VM_HOST }}
-          username: ${{ secrets.VM_USER }}
-          key: ${{ secrets.VM_SSH_KEY }}
-          port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/docker-compose.yaml"
-          target: "/tmp"
-          strip_components: 1
+      # compose 由 init-server.sh 一次性安装到服务器, dev 部署不更新它:
+      #   - dev 分支的 compose 变更不应影响共享的生产 nginx 服务(PR review #3)
+      #   - 避免覆盖含未迁移 wiki 服务的现有 compose(PR review #2)
+      # 部署只需 pull 镜像 + up 已有 compose 中的服务
       - name: Deploy to dev (sync db from main + pull image + restart + smoke)
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -101,13 +95,10 @@ jobs:
             # 0. 同步仓库最新脚本到服务器(install 保证可执行位)。
             #    sync-db-from-main.sh source pgdsn.sh, 必须一并下发, 否则
             #    set -e 下 source 失败阻断部署(review W2)。
-            install -m 0755 /tmp/deploy.sh /opt/yourtj/scripts/deploy.sh
-            install -m 0755 /tmp/sync-db-from-main.sh /opt/yourtj/scripts/sync-db-from-main.sh
-            install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
-            # 0.5 同步新 compose + nginx 反代配置(存量服务器升级 GHCR 流必需,
-            #     旧 compose 引用本地镜像 yourtj-hub:* 与 pull 流不兼容)
-            install -m 0644 /tmp/docker-compose.yaml /opt/yourtj/docker-compose.yaml
-            install -D -m 0644 /tmp/yourtj.conf /opt/yourtj/nginx/yourtj.conf
+            install -m 0755 /tmp/yourtj-deploy-${{ github.run_id }}/deploy.sh /opt/yourtj/scripts/deploy.sh
+            install -m 0755 /tmp/yourtj-deploy-${{ github.run_id }}/sync-db-from-main.sh /opt/yourtj/scripts/sync-db-from-main.sh
+            install -m 0755 /tmp/yourtj-deploy-${{ github.run_id }}/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
+            install -D -m 0644 /tmp/yourtj-deploy-${{ github.run_id }}/yourtj.conf /opt/yourtj/nginx/yourtj.conf
             # 1. 同步 main 数据库一致性快照(dev 用 main 真实数据预演迁移)
             /opt/yourtj/scripts/sync-db-from-main.sh
             # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), dev 对外端口 5235

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -74,9 +74,21 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh,deploy/docker-compose.yaml,deploy/nginx/yourtj.conf"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh,deploy/nginx/yourtj.conf"
           target: "/tmp"
           strip_components: 2
+      # docker-compose.yaml 只有两层路径, strip_components: 2 会把它剥没
+      # (scp-action 丢弃空路径), 必须单独上传不 strip
+      - name: Upload compose file to dev host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          source: "deploy/docker-compose.yaml"
+          target: "/tmp"
+          strip_components: 1
       - name: Deploy to dev (sync db from main + pull image + restart + smoke)
         uses: appleboy/ssh-action@v1.2.0
         with:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -53,6 +53,8 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
+      # 上传到 run-specific 路径, 避免与 deploy-dev 并发部署时
+      # 互相覆盖 /tmp 下的同名文件(见 PR review #1)
       - name: Upload deploy scripts to prod host
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -60,8 +62,8 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh,deploy/nginx/yourtj.conf"
-          target: "/tmp"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh,deploy/scripts/merge-wiki-services.sh,deploy/nginx/yourtj.conf"
+          target: "/tmp/yourtj-deploy-${{ github.run_id }}"
           strip_components: 2
       # docker-compose.yaml 只有两层路径, strip_components: 2 会把它剥没
       # (scp-action 丢弃空路径), 必须单独上传不 strip
@@ -73,7 +75,7 @@ jobs:
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "deploy/docker-compose.yaml"
-          target: "/tmp"
+          target: "/tmp/yourtj-deploy-${{ github.run_id }}"
           strip_components: 1
       - name: Deploy to main (backup db + pull image + restart + smoke + rollback)
         uses: appleboy/ssh-action@v1.2.0
@@ -84,18 +86,31 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
+            RUN_DIR=/tmp/yourtj-deploy-${{ github.run_id }}
             # 0. 同步仓库最新脚本到服务器(install 保证可执行位)。
             #    backup-db.sh source pgdsn.sh, 必须一并下发, 否则 set -e 下
             #    source 失败阻断部署(review W2)。
-            install -m 0755 /tmp/deploy.sh /opt/yourtj/scripts/deploy.sh
-            install -m 0755 /tmp/backup-db.sh /opt/yourtj/scripts/backup-db.sh
-            install -m 0755 /tmp/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
-            # 0.5 同步新 compose + nginx 反代配置(存量服务器升级 GHCR 流必需,
-            #     旧 compose 引用本地镜像 yourtj-hub:* 与 pull 流不兼容)
-            install -m 0644 /tmp/docker-compose.yaml /opt/yourtj/docker-compose.yaml
-            install -D -m 0644 /tmp/yourtj.conf /opt/yourtj/nginx/yourtj.conf
+            install -m 0755 "$RUN_DIR/deploy.sh" /opt/yourtj/scripts/deploy.sh
+            install -m 0755 "$RUN_DIR/backup-db.sh" /opt/yourtj/scripts/backup-db.sh
+            install -m 0755 "$RUN_DIR/pgdsn.sh" /opt/yourtj/scripts/pgdsn.sh
+            install -m 0755 "$RUN_DIR/merge-wiki-services.sh" /opt/yourtj/scripts/merge-wiki-services.sh
+            install -D -m 0644 "$RUN_DIR/yourtj.conf" /opt/yourtj/nginx/yourtj.conf
+            # 0.5 更新 compose(仅 main 部署更新共享 compose, 生产为权威):
+            #   - 先备份现有 compose, 部署失败时由 deploy.sh 恢复(PR review #4)
+            #   - 若现有 compose 含未迁移的 wiki 服务, 保留 wiki 服务块,
+            #     避免 --remove-orphans 把未迁移内容带下线(PR review #2)
+            if [ -f /opt/yourtj/docker-compose.yaml ]; then
+              cp -f /opt/yourtj/docker-compose.yaml /opt/yourtj/docker-compose.yaml.prev
+              echo "main: backed up existing compose to docker-compose.yaml.prev"
+            fi
+            install -m 0644 "$RUN_DIR/docker-compose.yaml" /opt/yourtj/docker-compose.yaml
+            /opt/yourtj/scripts/merge-wiki-services.sh \
+              /opt/yourtj/docker-compose.yaml.prev \
+              /opt/yourtj/docker-compose.yaml
             # 1. 部署前一致性备份(保留最近 7 份)
             /opt/yourtj/scripts/backup-db.sh main
             # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), main 对外端口 5234
             #    生产保留更多回滚候选, 镜像保留最近 5 个(含当前) + prev
             IMAGE_KEEP_N=5 /opt/yourtj/scripts/deploy.sh main main-${{ github.sha }} 5234
+            # 3. 部署成功后清理备份(失败时 deploy.sh 已恢复 compose)
+            rm -f /opt/yourtj/docker-compose.yaml.prev

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -60,9 +60,21 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh,deploy/docker-compose.yaml,deploy/nginx/yourtj.conf"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh,deploy/nginx/yourtj.conf"
           target: "/tmp"
           strip_components: 2
+      # docker-compose.yaml 只有两层路径, strip_components: 2 会把它剥没
+      # (scp-action 丢弃空路径), 必须单独上传不 strip
+      - name: Upload compose file to prod host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          source: "deploy/docker-compose.yaml"
+          target: "/tmp"
+          strip_components: 1
       - name: Deploy to main (backup db + pull image + restart + smoke + rollback)
         uses: appleboy/ssh-action@v1.2.0
         with:

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -109,6 +109,14 @@ done
 
 # 5. 失败: 回滚到旧 tag(prev 不可用时仅改 .env, 容器保持旧镜像)
 log "FATAL: health check failed, rolling back"
+
+# 5.1 若 main 部署前备份了 compose(main workflow 更新共享 compose 时),
+#     一并恢复旧 compose, 避免新的 mounts/env/网络配置残留(PR review #4)
+if [ -f "$ROOT/docker-compose.yaml.prev" ]; then
+  cp -f "$ROOT/docker-compose.yaml.prev" "$ROOT/docker-compose.yaml"
+  log "restored previous compose file from docker-compose.yaml.prev"
+fi
+
 if [ -n "$OLD_TAG" ]; then
   if docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; then
     sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$OLD_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"

--- a/deploy/scripts/merge-wiki-services.sh
+++ b/deploy/scripts/merge-wiki-services.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# merge-wiki-services.sh — 把旧 compose 中未迁移的 wiki 服务块并入新 compose。
+# 目的: 存量服务器(PR #219 前初始化)的 compose 仍定义 wiki-main/wiki-dev,
+#       直接换成新 compose 后 deploy.sh 的 --remove-orphans 会把 wiki 容器
+#       带下线。本脚本在 main 部署更新 compose 时保留这些服务块, 直到
+#       wiki 内容迁移完成后再手动移除(见 docs/operations/deployment.md)。
+# usage: merge-wiki-services.sh <old-compose> <new-compose>
+set -euo pipefail
+
+OLD="${1:?usage: merge-wiki-services.sh <old-compose> <new-compose>}"
+NEW="${2:?usage: merge-wiki-services.sh <old-compose> <new-compose>}"
+
+[ -f "$OLD" ] || { echo "merge-wiki: $OLD not found, skip"; exit 0; }
+[ -f "$NEW" ] || { echo "merge-wiki: $NEW not found, skip"; exit 0; }
+
+# 新 compose 已含 wiki 服务则无需合并
+if grep -qE '^\s{2}wiki-(main|dev):' "$NEW"; then
+  echo "merge-wiki: new compose already has wiki services, skip"
+  exit 0
+fi
+
+# 旧 compose 无 wiki 服务也无需合并
+if ! grep -qE '^\s{2}wiki-(main|dev):' "$OLD"; then
+  echo "merge-wiki: old compose has no wiki services, skip"
+  exit 0
+fi
+
+python3 - "$OLD" "$NEW" <<'PYEOF'
+import re, sys
+old_path, new_path = sys.argv[1], sys.argv[2]
+old = open(old_path).read()
+new = open(new_path).read()
+
+blocks = []
+for svc in ('wiki-main', 'wiki-dev'):
+    m = re.search(rf'^(\s{{2}}{svc}:\n(?:\s{{4,}}.*\n|\s*\n)*)', old, re.M)
+    if m:
+        blocks.append(m.group(1))
+
+if blocks and 'wiki-' not in new:
+    new = re.sub(r'^(services:\n)', r'\1' + ''.join(blocks), new, count=1, flags=re.M)
+    open(new_path, 'w').write(new)
+    print(f'merge-wiki: merged {len(blocks)} legacy wiki service block(s) into {new_path}')
+else:
+    print('merge-wiki: nothing to merge')
+PYEOF


### PR DESCRIPTION
## Summary

`appleboy/scp-action` 的 `strip_components: 2` 会静默丢弃两层路径的文件：
`deploy/docker-compose.yaml`（2 层）被剥成空路径，不会上传到 `/tmp`。
导致部署脚本 `install /tmp/docker-compose.yaml` 失败，`set -e` 中止整个部署。

**修复**：把 `docker-compose.yaml` 拆成独立 scp 步骤（`strip_components: 1`），
与脚本/nginx.conf（3 层路径）分开上传。

## 影响

- 这是 dev 自动部署失败的根因（Deploy / dev 在 `install: cannot stat '/tmp/docker-compose.yaml'` 处失败）
- 修复后 CI 会正常上传 compose → install → sync db → pull 镜像 → 健康检查

## 验证

- YAML 解析通过
- `git diff --check` 通过
- cherry-pick 自 `feat/deploy-ghcr` 的最新修复 commit