### PR TITLE
fix(forum): 课评审核/课程管理页 sidebar activeKey 硬编码 courses 改为 courseReviews/courseManage（issue #236）

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/course_manage.go
+++ b/apps/gooseforum/app/http/controllers/forum/course_manage.go
@@ -248,7 +248,7 @@ func CourseManagement(c *gin.Context) {
 			Title:       pageTitle(i18n.T(requestLang(c), "meta.courseManagement")),
 			Description: i18n.T(requestLang(c), "meta.courseManagementDesc"),
 		},
-		Layout:  buildLayout(c, "courses"),
+		Layout:  buildLayout(c, "courseManage"),
 		URL:     buildPageURL(c),
 		Version: payloadVersion,
 	}

--- a/apps/gooseforum/app/http/controllers/forum/course_review.go
+++ b/apps/gooseforum/app/http/controllers/forum/course_review.go
@@ -331,7 +331,7 @@ func CourseReviewModeration(c *gin.Context) {
 			Title:       pageTitle(i18n.T(requestLang(c), "meta.courseReviewModeration")),
 			Description: i18n.T(requestLang(c), "meta.courseReviewModerationDesc"),
 		},
-		Layout:  buildLayout(c, "courses"),
+		Layout:  buildLayout(c, "courseReviews"),
 		URL:     buildPageURL(c),
 		Version: payloadVersion,
 	}


### PR DESCRIPTION
Closes #236

## 问题
`/moderation/course-reviews`（课评审核）和 `/moderation/courses`（课程管理）两页 sidebar 高亮错误显示为「课程」。根因是后端给这两个管理页硬编码传了 `"courses"` 作为 activeKey，与前端 sidebar 项 key（`courseReviews`/`courseManage`）不匹配。

## 改动
| 文件 | 改动 |
|---|---|
| `apps/gooseforum/app/http/controllers/forum/course_review.go` L334 | `buildLayout(c, "courses")` → `buildLayout(c, "courseReviews")` |
| `apps/gooseforum/app/http/controllers/forum/course_manage.go` L251 | `buildLayout(c, "courses")` → `buildLayout(c, "courseManage")` |

## 验证
- ✅ `go build ./...` 通过
- ✅ `go vet ./app/http/controllers/forum/` 通过
- ✅ 前端 `AppShell.vue` sidebar key（`courses`/`courseReviews`/`courseManage`）与后端修复完全匹配

## 回归测试计划
- [ ] CourseManager 账号进「课评审核」→ 高亮「课评审核」；进「课程管理」→ 高亮「课程管理」
- [ ] 普通用户访问 `/courses` → 高亮「课程」不变
- [ ] 无权限用户访问管理页 → 404 不变