### PR TITLE
docs(deploy): Wiki GitHub 唯一真实源同步部署文档与配置样例

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,9 @@ be changed, but the "Go + Vue in one binary, frontend go:embed into the binary" 
   mobile OIDC exchange, session management (list/revoke/revoke-all), topic writing, account
   registration/password recovery (`/api/register`, `/api/forgot-password`, `/api/reset-password`),
   the six-operation Agent forum API, course catalog reads + review write/moderation, the Wiki domain
-  (16 ops: public tree/namespaces/home/revisions, login page writes with write-publish + CAS, admin
-  `/api/admin/wiki/*` incl. version history + rollback + diff), and the PK scheduler (14 ops:
+  (public tree/namespaces/home + admin sync/status|sync|sync/runs + webhook; the legacy in-forum
+  write/revision/rollback/diff/editor endpoints were retired with the GitHub-SSoT model — PR #270),
+  and the PK scheduler (14 ops:
   courses-by-major/optional-types/courses-by-nature/course-details/course-search/courses-by-time/
   latest-update/course-info-sync/course-review-brief),
   with lint/bundle, generated TypeScript types, fixtures, and route-level HTTP tests;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ be changed, but the "Go + Vue in one binary, frontend go:embed into the binary" 
   registration/password recovery (`/api/register`, `/api/forgot-password`, `/api/reset-password`),
   the six-operation Agent forum API, course catalog reads + review write/moderation, the Wiki domain
   (public tree/namespaces/home + admin sync/status|sync|sync/runs + webhook; the legacy in-forum
-  write/revision/rollback/diff/editor endpoints were retired with the GitHub-SSoT model — PR #270),
+  write/revision/rollback/diff/editor endpoints were retired with the GitHub-SSoT model),
   and the PK scheduler (14 ops:
   courses-by-major/optional-types/courses-by-nature/course-details/course-search/courses-by-time/
   latest-update/course-info-sync/course-review-brief),

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,7 @@
 # yourtj-hub 单二进制运行镜像(前端已 go:embed 进二进制)
 FROM alpine:3.20
 
-RUN apk add --no-cache ca-certificates tzdata \
+RUN apk add --no-cache ca-certificates tzdata git \
     && adduser -D -u 1000 app
 
 WORKDIR /app

--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -53,6 +53,18 @@ maxLifeSeconds = 300
 url = "http://meilisearch:7700"
 masterkey = "REPLACE_MEILI_KEY"
 
+# Wiki GitHub 唯一真实源（可选）：配置后 wiki 内容由仓库同步（只读投影），
+# 编辑/审核/历史/贡献者全部走 GitHub PR。repo 留空 = 不启用。
+[wiki.git]
+repo = "https://github.com/YourTongji/YourTJ-Wiki.git"
+branch = "main"
+clone_dir = "./storage/wiki-repo"
+# 每日定时同步 cron spec（默认每日 03:00）
+schedule = "0 3 * * *"
+# GitHub webhook 验签密钥（GitHub 仓库 Settings → Webhooks 配置；
+# 留空 = webhook 端点 403 拒绝）
+webhook_secret = ""
+
 [log]
 type = "file"
 path = "./storage/logs/run.log"

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -41,7 +41,7 @@ The contract capability is **Partial**. The controlled OpenAPI 3.1 entry point i
   `POST /api/forum/moderation/course-review-reveal`.
 - Wiki 域（`paths/wiki.yaml`，GitHub 唯一真实源模型）：公开读
   `GET /api/wiki/{tree,namespaces,home}` + 写即发布/CAS/版本历史/回滚/diff/编辑者等站内写
-  端点已随 PR #270 **退役**（编辑/审核/历史/贡献者走 GitHub PR）；保留管理端
+  端点已**退役**（编辑/审核/历史/贡献者走 GitHub PR）；保留管理端
   `/api/admin/wiki/*`（PageManager：命名空间 CRUD + 只读树 + `sync/status` /
   `sync` / `sync/runs`）与公开 `POST /api/wiki/webhook`（GitHub push 事件，HMAC-SHA256
   验签，触发即时同步）；生成 TS 类型 + 手写 Dart mirror

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -39,10 +39,12 @@ The contract capability is **Partial**. The controlled OpenAPI 3.1 entry point i
 - `POST /api/forum/moderation/course-review-status`,
   `POST /api/forum/moderation/course-review-reports`, and
   `POST /api/forum/moderation/course-review-reveal`.
-- Wiki 域（16 操作，`paths/wiki.yaml`）：`GET /api/wiki/{tree,namespaces,home,revisions}`
-  公开读、`POST /api/wiki/pages` / `PUT /api/wiki/pages/{pageId}`（写即发布，
-  `baseRevisionNo` 乐观锁 CAS）、`/api/admin/wiki/*` 管理端（PageManager：命名空间/编辑者/树、
-  版本历史、`rollback`（不可撤销）、`diff`（任意两版本对比））；生成 TS 类型 + 手写 Dart mirror
+- Wiki 域（`paths/wiki.yaml`，GitHub 唯一真实源模型）：公开读
+  `GET /api/wiki/{tree,namespaces,home}` + 写即发布/CAS/版本历史/回滚/diff/编辑者等站内写
+  端点已随 PR #270 **退役**（编辑/审核/历史/贡献者走 GitHub PR）；保留管理端
+  `/api/admin/wiki/*`（PageManager：命名空间 CRUD + 只读树 + `sync/status` /
+  `sync` / `sync/runs`）与公开 `POST /api/wiki/webhook`（GitHub push 事件，HMAC-SHA256
+  验签，触发即时同步）；生成 TS 类型 + 手写 Dart mirror
   （`apps/mobile/packages/core/lib/src/gen/wiki.dart`）。
 
 Paths are split per domain under `packages/api-contract/paths/` (for example `auth.yaml`,

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -88,26 +88,33 @@
 
 ### Wiki 分站 (Current)
 
-Wiki 已原生化进论坛单二进制（同二进制内嵌视图，不再是独立 VitePress 静态站；旧 wiki 站点与部署已废弃）。
+Wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作编辑/审核/历史/贡献者），
+论坛为只读投影（GitHub 唯一真实源，SSOT）。旧 VitePress 静态站与站内写模型已废弃。
 
-- **后端分层**: `app/models/forum/wikiNamespaces` / `wikiNamespaceEditors` / `wikiPages` /
-  `wikiPageRevisions` → `app/service/wikiservice`（Create/Edit 写即发布 + CAS 编辑锁、Rollback/Diff、
-  BuildTree/BuildHome/ListRevisions、贡献者；admin 树操作/命名空间管理/编辑者管理）→ controllers：
+- **后端分层**: `app/models/forum/wikiNamespaces` / `wikiPages` / `wikiSyncRuns` →
+  `app/service/wikiservice`（同步引擎 `sync.go`：`clone --depth=1` + `fetch` + `reset --hard`、
+  frontmatter 解析、sha256 幂等 diff、upsert/软删/恢复、贡献者快照；查询 `query.go`：
+  BuildTree/BuildHome/贡献者；管理：命名空间 CRUD + 只读树）→ controllers：
   `app/http/controllers/forum/wiki.go`（SSR，PageComponent `wiki.home`/`wiki.detail`）+
-  `app/http/controllers/api/wikiController.go`（公开 API + `/api/admin/wiki/*` 管理端）。
+  `app/http/controllers/api/wikiController.go`（公开读 + `/api/admin/wiki/*` 管理端）+
+  `wikiSyncController.go`（`/api/wiki/webhook` + `/api/admin/wiki/sync*`）。
+- **同步触发**: 每日定时（`[wiki.git].schedule`，默认 `0 3 * * *`）+ 管理端
+  `/admin/wiki` 同步面板手动触发 + GitHub webhook（`POST /api/wiki/webhook`，HMAC-SHA256
+  验签，push 事件，仅默认分支）。同步运行写入 `wiki_sync_runs`
+  （trigger/status/head_sha/变更计数/错误）。
 - **路由**: `GET /wiki`、`GET /wiki/*path`（SSR 服务端渲染）；公开 API
-  `GET /api/wiki/{tree,namespaces,home,revisions}`；登录写
-  `POST /api/wiki/pages`、`PUT /api/wiki/pages/:pageId`（写即发布，`baseRevisionNo` CAS 冲突 409）；
-  管理端 `/api/admin/wiki/*`（PageManager 权限：namespaces CRUD、editors、tree、tree ops、
-  revisions 版本历史、rollback（不可撤销硬删后续修订）、diff（任意两版本对比））。
-- **前端**: site 区 `WikiHome.vue` / `WikiPage.vue` + `WikiSidebar` / `WikiToc` / `WikiPageActions`
-  组件（`PostStream` 从 TopicPage 抽取共享），AppShell 侧栏 wiki 模式；admin 区 `WikiManage.vue`
-  （`/admin/wiki`，PageManager）。
+  `GET /api/wiki/{tree,namespaces,home}` + `POST /api/wiki/webhook`；管理端
+  `/api/admin/wiki/*`（PageManager：namespaces CRUD、只读树、`sync/status` /
+  `sync` / `sync/runs`）。站内写/回滚/diff/编辑者/版本历史端点已退役。
+- **前端**: site 区 `WikiHome.vue` / `WikiPage.vue` + `WikiSidebar` / `WikiToc` /
+  `WikiPageActions`（编辑/历史按钮外链 GitHub），AppShell 侧栏 wiki 模式；admin 区
+  `WikiManage.vue`（`/admin/wiki`，PageManager：命名空间 + 只读页面树 + 同步面板）。
 - **隔离与通知**: `topics.topic_type`（0=论坛 1=wiki）隔离 feed 与搜索——默认论坛搜索/feed/RSS/
-  sitemap 排除 wiki 话题（TopicSearchDocument 带 topicType）；编辑/回滚后向订阅者发
+  sitemap 排除 wiki 话题（TopicSearchDocument 带 topicType）；同步更新后向订阅者发
   `wiki_updated` 通知（`notifications.templates.wikiUpdated`，同页面 10 分钟节流）。
-- **契约**: OpenAPI wiki 域已覆盖（16 操作，`paths/wiki.yaml`），生成 TS
-  类型 + 手写 Dart mirror（`apps/mobile/packages/core/lib/src/gen/wiki.dart`）。
+- **契约**: OpenAPI wiki 域覆盖公开读 + 管理同步端点 + webhook（`paths/wiki.yaml` +
+  `paths/wiki-sync.yaml`），生成 TS 类型 + 手写 Dart mirror
+  （`apps/mobile/packages/core/lib/src/gen/wiki.dart`）。
 
 ### Points (phase 2)
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -65,6 +65,33 @@
 4. 重建期间旧站可继续在线（只读），全部内容迁移完成、新站 `/wiki` 导航树
    核对无误后再按上方步骤退役旧容器与路由。
 
+### Wiki GitHub 唯一真实源同步（PR #270 后）
+
+wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作编辑/审核/历史/贡献者），
+论坛只保留只读投影。配置 `[wiki.git]` 后启用（见 `deploy/config.toml.example`）：
+
+```toml
+[wiki.git]
+repo = "https://github.com/YourTongji/YourTJ-Wiki.git"
+branch = "main"
+clone_dir = "./storage/wiki-repo"
+schedule = "0 3 * * *"      # 每日定时同步（默认 03:00）
+webhook_secret = ""         # GitHub webhook 验签密钥；留空 = webhook 端点 403
+```
+
+- **同步触发**：每日定时（`[wiki.git].schedule`，默认 `0 3 * * *`）+ 管理端
+  `/admin/wiki` → GitHub 同步面板「立即同步」+ GitHub webhook（PR merge = push 事件）。
+- **GitHub webhook 配置**（仓库 Settings → Webhooks → Add webhook）：
+  - Payload URL：`https://forum.yourtj.de/api/wiki/webhook`（dev 实例用 `https://dev.yourtj.de/api/wiki/webhook`）
+  - Content type：`application/json`；Secret：与 `webhook_secret` 一致
+  - Events：仅 `push`（PR merge 触发）
+  - 验签：`X-Hub-Signature-256` = HMAC-SHA256(webhook_secret, body)，验签失败/未配置返回 403/401。
+- **运行要求**：服务器需可出站访问 `github.com`（:443）；容器镜像需含 `git` 二进制
+  （同步用 `clone --depth=1` + `fetch` + `reset --hard`，**不使用 pull**）。
+- **本地 clone**：默认 `./storage/wiki-repo`（`main`/`dev` 实例各自独立），可被 `[wiki.git].clone_dir` 覆盖。
+- **同步记录**：每次同步写入 `wiki_sync_runs`（trigger/status/变更计数/错误），管理端可查最近 20 条；
+  同步幂等（正文 sha256 比对），重复同步零变更；软删页面在仓库重新出现时自动恢复（含 topic 生命周期）。
+
 ## Server layout (Docker Compose)
 
 ```

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -48,24 +48,23 @@
     （`deploy.sh` 的镜像清理只保留 `yourtj-hub` 前缀 tag，不含 `yourtj-wiki:*`）。
   - 若反向代理仍把旧 wiki 域名指到 127.0.0.1:5284/5285，退役后需同步摘除路由。
 
-### 旧 VitePress wiki 内容重建（PR #219 后）
+### 旧 VitePress wiki 内容迁移（GitHub 唯一真实源）
 
-论坛内嵌 wiki 是全新实现，**没有**自动导入旧 VitePress 静态站（`wiki-dist`/`deploy-wiki.sh`）
-内容的迁移通道。旧站内容如需保留，需手动重建：
+论坛 wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作编辑），
+论坛侧只读投影。旧 VitePress 静态站（`wiki-dist`/`deploy-wiki.sh`）内容如需
+保留，迁移到 GitHub 仓库后由同步器自动投影：
 
-1. 旧 VitePress 站点仓库仍保留 `docs/`（Markdown 源文件）。按
-   `docs/product/current-state.md` 的 wiki 使用说明，在管理端创建 namespace，
-   然后把每个 Markdown 文件作为新页面手动发布（正文粘贴原 Markdown，标题取
-   front-matter 的 `title`；旧站路径映射为 `<namespace>/<slug>`）。
-2. 旧站的静态资源（图片/附件）若在仓库内，随正文重新上传；若引用旧域名
-   （如 `https://wiki.example.com/...`），需先下载到本地再上传，或改写为
-   相对路径后上传到新站附件。
+1. 旧 VitePress 站点仓库的 `docs/`（Markdown 源文件）按新仓库结构整理：
+   顶层目录 = namespace，文件 = 页面，front-matter 的 `title` 作为页面标题
+   （旧站路径映射为 `<namespace>/<slug>.md`）。
+2. 旧站的静态资源（图片/附件）随文件一并提交到仓库（同步器只投影 `.md`；
+   图片等资源从 GitHub raw 引用，或移入仓库后改写为相对路径）。
 3. 旧站评论区（Waline）数据不迁移；如确有保留价值，导出 Waline 评论 JSON
-   后以人工方式并入对应新页面（wiki 无评论表，评论仍走论坛回复流）。
-4. 重建期间旧站可继续在线（只读），全部内容迁移完成、新站 `/wiki` 导航树
-   核对无误后再按上方步骤退役旧容器与路由。
+   后以人工方式并入对应页面的论坛回复流（wiki 无评论表，评论走回复流）。
+4. 内容提交、PR 合并后，在管理端 `/admin/wiki` → GitHub 同步面板触发一次
+   同步，`/wiki` 导航树核对无误后再退役旧容器与路由（见上文 VitePress 退役）。
 
-### Wiki GitHub 唯一真实源同步（PR #270 后）
+### Wiki GitHub 唯一真实源同步
 
 wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作编辑/审核/历史/贡献者），
 论坛只保留只读投影。配置 `[wiki.git]` 后启用（见 `deploy/config.toml.example`）：

--- a/docs/product/current-state.md
+++ b/docs/product/current-state.md
@@ -18,10 +18,12 @@
   import/export, pluggable file storage (SQLite BLOB / S3-compatible), admin-managed bot personas
   (Agents) with unique bearer tokens and webhook endpoints, and configurable AI-readable public-content
   exports (`/llms.txt`, `/llms-full.txt`, `/p/posts/{id}.md`).
-- **Wiki 分站（论坛内嵌）**: wiki 已原生化进论坛单二进制（不再是独立 VitePress 静态站）——SSR
-  `/wiki` 与 `/wiki/*path`（wiki.home/wiki.detail）、写即发布（L1 编辑直接发布，无审核流）+
-  管理员回滚（不可撤销，硬删后续修订）与任意版本 diff、管理端 `/admin/wiki`；topics.topic_type
-  隔离论坛 feed 与搜索；编辑/回滚后向订阅者发 `wiki_updated` 通知（10 分钟节流）。
+- **Wiki 分站（GitHub 唯一真实源）**: wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护
+  （PR 协作编辑、审核、历史、贡献者），论坛为只读投影——SSR `/wiki` + `/wiki/*path`
+  （wiki.home/wiki.detail）与公开 API（tree/namespaces/home）；同步触发 = 每日定时（默认
+  03:00，可配）+ 管理端手动 + GitHub webhook（push 事件，PR merge 后即时）；站内无写路径
+  （编辑/历史按钮外链 GitHub）；topics.topic_type 隔离论坛 feed 与搜索；`wiki_sync_runs`
+  记录每次同步（running/success/failed + 变更计数）。
 - **Built-in OIDC Provider**: the forum issues standard OIDC tokens (authorization code + PKCE S256,
   RS256 id_token, opaque access tokens) for first-party clients; `sub` is always the numeric users.id.
 - Monorepo structure (apps/packages/services/deploy/docs) + CI (server/web/contract workflows).
@@ -31,7 +33,7 @@
 | Domain | Status | Note |
 |---|---|---|
 | Forum itself | `Current` | Upstream features complete and runnable; `make build` single binary verified locally (2026-08-06: go vet/test, pnpm typecheck/build, smoke all green) |
-| Wiki 分站 | `Current` | 论坛内嵌视图（同二进制）：SSR `/wiki` + `/wiki/*path`（wiki.home/wiki.detail）、公开 API（tree/namespaces/home/revisions）、登录写页面（写即发布，L1 编辑直接发布，无审核）+ 管理员回滚（不可撤销硬删后续修订）/版本历史/任意两版本 diff、管理端 `/admin/wiki`（PageManager 权限：命名空间/编辑者/树/版本历史/回滚/diff）；topics.topic_type 隔离 feed/搜索（默认论坛搜索/feed/RSS/sitemap 排除 wiki）；编辑/回滚后发 `wiki_updated` 通知（10 分钟节流）；OpenAPI wiki 域 16 操作已覆盖（TS 类型 + 手写 Dart mirror） |
+| Wiki 分站 | `Current` | GitHub 仓库为唯一真实源（`YourTongji/YourTJ-Wiki`，公开，PR 协作编辑）：SSR `/wiki` + `/wiki/*path`（wiki.home/wiki.detail）、公开 API（tree/namespaces/home）、管理端 `/admin/wiki`（PageManager：命名空间 CRUD + 只读页面树 + GitHub 同步面板：状态/手动同步/运行记录）；同步触发 = 每日定时（默认 03:00，可配）+ 手动 + webhook（HMAC-SHA256 验签，push 事件）；站内无写/回滚/diff/编辑者 API（编辑/历史/贡献者走 GitHub）；topics.topic_type 隔离 feed/搜索；`wiki_sync_runs` 记录同步（running/success/failed + 变更计数）；OpenAPI wiki 域覆盖公开读 + 管理同步端点（TS 类型 + 手写 Dart mirror） |
 | Database | `Current` | PostgreSQL is the default deployment database (`deploy/config.toml.example`); SQLite stays the local development/test default; file db stays SQLite; MySQL is not supported; data migration from SQLite→PG is manual |
 | Search | `Partial` | Aggregate search landed (issue #22): one search box covers topics, users and categories with grouped sections and scope tabs; pinyin/initials matching for users and categories; index sync via topic/user/category events + migration v13 rebuild; per-scope partial degradation; unavailable-state UI fallback |
 | Course reviews (课评) | `Partial` | Cross-dialect course catalog schema (course/alias/term/offering/instructor/offering-instructor/import-run/source-ref), offline `course-import` CLI with manifest checksum + dry-run + quarantine + idempotent retry (`catalog` + `reviews` subcommands; reviews gated on manifest `rights_approval_ref`), PG read service with keyword/teacher/term/campus filters, SSR `/courses` + `/courses/:courseId` and JSON `GET /api/forum/courses(/{courseId})` (OpenAPI-covered, route contract tests green); Meilisearch `courses` scope with persistent transaction-bound outbox worker + `rebuild-course-search`/`reconcile-course-search`; native review write/update/delete/helpful/report with anonymous zero-leak DTO, CourseManager moderation (hide/show + report queue) and Admin-only audited identity reveal, `rebuild-course-stats` CLI; **PK 排课器 14 端点** (`/api/pk/*`，统一 `{code,msg,data}` 信封，OpenAPI 契约 + route contract tests green，含 teacher_timeslots 懒构建/降级)；一系统在线同步管线 `course-pk-sync <学期>` (issue #186): PK 域表（pk_calendar/pk_language/pk_course_nature(+_by_calendar)/pk_assessment/pk_campus/pk_faculty/pk_major/pk_major_course/pk_course_detail/pk_teacher/pk_teacher_timeslot/pk_fetch_log），分页抓取 200/页 + 500 行/批事务写入 + `PkFetchLog` 断点续跑（崩溃从失败批次续）+ `teacher_timeslots` 重建 + 可选 `--materialize` 物化课程目录；凭证经 `--onesystem-cookie` / `ONESYSTEM_COOKIE` env / 管理端设置（securestore 加密落库，`onesystem-settings` admin API）；Vue3 排课器 (`/schedule`) 仍 `Planned`；30-day deletion isolation window (B3 privacy, issue #175): `course-review-cleanup` job (daily cron enqueue + background worker + manual CLI) anonymizes expired deleted rows — content cleared, author released via NULL, unique slot freed, row kept for audit — with migration v17 backfilling legacy `deleted_at` anchors; mobile course UI remains `Planned`; in-course review-body search is recorded as **Won't** (issue #184: review body stays out of the `courses` index and no separate `course_reviews` index will be added, per PRD §5.1 B5 / RICE 0.35) |


### PR DESCRIPTION
## Summary

配合后端同步引擎（PR #270）补齐部署与文档面：

- **`deploy/config.toml.example` + `config.templ.toml`**：新增 `[wiki.git]` 段（`repo` / `branch` / `clone_dir` / `schedule` / `webhook_secret`；`repo` 空 = 禁用）
- **`deploy/Dockerfile`**：镜像增加 `git` 二进制（同步引擎运行要求）
- **`docs/operations/deployment.md`**：新增「Wiki GitHub 唯一真实源同步」章节（配置、GitHub webhook 注册步骤、运行要求——出站 443 + git 二进制、同步记录 `wiki_sync_runs` 语义）
- **`docs/product/current-state.md` / `docs/architecture/contracts-and-data.md` / `AGENTS.md`**：wiki 域状态词与契约描述更新为 GitHub-SSoT 模型（站内写/回滚/diff/编辑者端点已退役）

## Verification

- `git diff --check` 干净
- 文档状态词遵循 `Current`/`Partial`/`Planned`/`Decision needed` 规范
- 无代码改动（纯文档 + 配置样例 + Dockerfile 一行依赖）