### PR TITLE
feat(wiki): safe v21 projection migration (#259)

### DIFF
--- a/apps/gooseforum/app/console/cmd/wikiExport.go
+++ b/apps/gooseforum/app/console/cmd/wikiExport.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/markdown2html"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPageRevisions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
+	"github.com/spf13/cobra"
+	"go.yaml.in/yaml/v3"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "wiki-export <output-dir>",
+		Short: "Export wiki pages to a hierarchical markdown tree (seed for the git repo, reverse of wiki-import)",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runWikiExport,
+		// Export reads the compatibility revision table directly and must not run
+		// unrelated startup migrations before validating its data source.
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	}
+	cmd.Flags().Bool("dry-run", false, "validate and print what would be exported, do not write")
+	cmd.Flags().Bool("with-frontmatter", true, "write YAML frontmatter (title/order/description/draft) per wiki-markdown-format.md")
+	appendCommand(cmd)
+}
+
+// ---------------------------------------------------------------------------
+// wiki-export：把兼容期 wiki_page_revisions 导出为 git 仓库种子。
+// 方向与 wiki-import 相反：从 DB 读 wiki_pages + 最新 approved 修订，
+// 导出为 git 仓库规范的 markdown 文件树 <namespace>/<path>.md，每页带
+// frontmatter（docs/product/wiki-markdown-format.md）。生成的内容即为
+// 新仓库 YourTongji/YourTJ-Wiki 的种子。
+// 表已缺失时 hard fail，绝不静默空导出。
+// ---------------------------------------------------------------------------
+
+func runWikiExport(cmd *cobra.Command, args []string) error {
+	outDir := args[0]
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	withFrontmatter, _ := cmd.Flags().GetBool("with-frontmatter")
+
+	// 数据源表缺失时必须失败，避免 0 页导出掩盖异常 schema。
+	if !dbconnect.Connect().Migrator().HasTable("wiki_page_revisions") {
+		return fmt.Errorf("wiki_page_revisions table does not exist; cannot export wiki source data")
+	}
+
+	pages := wikiPages.ListAll()
+	if len(pages) == 0 {
+		return fmt.Errorf("wiki-export found no wiki pages; refusing to produce an empty seed")
+	}
+	type exportItem struct {
+		page *wikiPages.Entity
+		rev  wikiPageRevisions.Entity
+	}
+	items := make([]exportItem, 0, len(pages))
+	missing := make([]string, 0)
+	for _, page := range pages {
+		rev := wikiPageRevisions.GetLatestApproved(page.Id)
+		if rev.Id == 0 {
+			missing = append(missing, page.Path+".md")
+			continue
+		}
+		items = append(items, exportItem{page: page, rev: rev})
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("wiki-export cannot produce a complete seed: %d page(s) have no approved revision: %s", len(missing), strings.Join(missing, ", "))
+	}
+	if !dryRun {
+		if err := prepareWikiExportDir(outDir); err != nil {
+			return err
+		}
+	}
+
+	var written int
+	var errs []string
+	for _, item := range items {
+		page, rev := item.page, item.rev
+		relPath := page.Path + ".md"
+		if dryRun {
+			fmt.Printf("[dry-run] would write %-48s title=%q content=%dB\n", relPath, rev.Title, len(rev.Content))
+			written++
+			continue
+		}
+		content, err := renderWikiExportContent(rev.Title, page, rev.Content, withFrontmatter)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("frontmatter %s: %v", relPath, err))
+			continue
+		}
+		// review LOW：防御路径穿越——path 段经 ValidatePath 校验（^[a-z0-9]+(-[a-z0-9]+)*$）
+		// 不含 ".."，仅历史脏数据/手工改库有风险；Clean 后断言仍在 outDir 内，越界即失败。
+		target := filepath.Join(outDir, filepath.FromSlash(relPath))
+		cleaned := filepath.Clean(target)
+		if !strings.HasPrefix(cleaned, filepath.Clean(outDir)+string(os.PathSeparator)) {
+			errs = append(errs, fmt.Sprintf("path escape blocked: %s", relPath))
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(cleaned), 0o755); err != nil {
+			errs = append(errs, fmt.Sprintf("mkdir %s: %v", filepath.Dir(cleaned), err))
+			continue
+		}
+		if err := os.WriteFile(cleaned, []byte(content), 0o644); err != nil {
+			errs = append(errs, fmt.Sprintf("write %s: %v", relPath, err))
+			continue
+		}
+		written++
+		fmt.Printf("  wrote %-48s title=%q\n", relPath, rev.Title)
+	}
+
+	fmt.Printf("wiki-export: output=%s dryRun=%v frontmatter=%v\n", outDir, dryRun, withFrontmatter)
+	fmt.Printf("  total=%d written=%d errors=%d\n", len(items), written, len(errs))
+	for _, e := range errs {
+		fmt.Printf("  [error] %s\n", e)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("wiki-export finished with %d error(s)", len(errs))
+	}
+	return nil
+}
+
+func prepareWikiExportDir(outDir string) error {
+	entries, err := os.ReadDir(outDir)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			return fmt.Errorf("create output dir: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read output dir: %w", err)
+	}
+	if len(entries) != 0 {
+		return fmt.Errorf("wiki-export output dir must be empty: %s", outDir)
+	}
+	return nil
+}
+
+func renderWikiExportContent(title string, page *wikiPages.Entity, revisionContent string, withFrontmatter bool) (string, error) {
+	_, body := markdown2html.SplitFrontmatter(revisionContent)
+	if !withFrontmatter {
+		return body, nil
+	}
+	fm, err := renderWikiFrontmatter(title, page, body)
+	if err != nil {
+		return "", err
+	}
+	return fm + "\n" + body, nil
+}
+
+// renderWikiFrontmatter 按 wiki-markdown-format.md §2 生成 YAML frontmatter。
+// title 必填；description 取 topics.Excerpt（为空则省略，由 ExtractDescription 兜底）；
+// order 映射 sort_order；draft 恒为 false（导出即发布）。yaml.v3 对 map 键排序，
+// 输出稳定。
+func renderWikiFrontmatter(title string, page *wikiPages.Entity, content string) (string, error) {
+	fm := map[string]any{
+		"title": title,
+		"order": page.SortOrder,
+		"draft": false,
+	}
+	desc := excerptOf(page.TopicId)
+	if strings.TrimSpace(desc) == "" {
+		desc = deriveExcerpt(content)
+	}
+	if desc != "" {
+		fm["description"] = desc
+	}
+	data, err := yaml.Marshal(fm)
+	if err != nil {
+		return "", err
+	}
+	return "---\n" + string(data) + "---", nil
+}
+
+// excerptOf 返回页面 topic 的物化摘要（写路径已用 ExtractDescription 同步）。
+func excerptOf(topicID uint64) string {
+	if topicID == 0 {
+		return ""
+	}
+	return topics.Get(topicID).Excerpt
+}
+
+// deriveExcerpt 当 topic 无摘要时从修订正文提取（与写路径 ExtractDescription 对齐的
+// 轻量回退；不引 markdown2html，避免导出命令拉入渲染依赖）。
+// description 为单行摘要语义：先把连续空白/换行压缩为单空格，再按 rune 截断到 200。
+func deriveExcerpt(content string) string {
+	clean := strings.Join(strings.Fields(content), " ")
+	r := []rune(clean)
+	if len(r) <= 200 {
+		return clean
+	}
+	return string(r[:200])
+}

--- a/apps/gooseforum/app/console/cmd/wikiExport_test.go
+++ b/apps/gooseforum/app/console/cmd/wikiExport_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
+)
+
+func TestRenderWikiFrontmatter(t *testing.T) {
+	page := &wikiPages.Entity{TopicId: 0, SortOrder: 3}
+	fm, err := renderWikiFrontmatter("学校简介", page, "学校始于1907年。\n\n详见正文。")
+	if err != nil {
+		t.Fatalf("renderWikiFrontmatter: %v", err)
+	}
+	for _, frag := range []string{
+		"---\n",
+		"title: 学校简介",
+		"order: 3",
+		"draft: false",
+		"description: 学校始于1907年。",
+	} {
+		if !strings.Contains(fm, frag) {
+			t.Errorf("frontmatter missing %q:\n%s", frag, fm)
+		}
+	}
+}
+
+// TestRenderWikiFrontmatterEscapesYAMLScalar 标题/摘要含 YAML 特殊字符必须正确转义
+// （冒号、引号、列表标记），否则生成的种子 markdown 无法被后续 frontmatter 解析。
+func TestRenderWikiFrontmatterEscapesYAMLScalar(t *testing.T) {
+	page := &wikiPages.Entity{TopicId: 0, SortOrder: 0}
+	fm, err := renderWikiFrontmatter(`标题: 带冒号 "and quotes"`, page, "正文")
+	if err != nil {
+		t.Fatalf("renderWikiFrontmatter: %v", err)
+	}
+	// yaml.v3 会把含特殊字符的标量加引号包裹。
+	if !strings.Contains(fm, `"`) {
+		t.Errorf("frontmatter should quote a scalar containing colon/quote:\n%s", fm)
+	}
+	if !strings.Contains(fm, "标题") {
+		t.Errorf("frontmatter should preserve title text:\n%s", fm)
+	}
+}
+
+func TestRenderWikiFrontmatterOmitsEmptyDescription(t *testing.T) {
+	page := &wikiPages.Entity{TopicId: 0, SortOrder: 1}
+	fm, err := renderWikiFrontmatter("空白页", page, "")
+	if err != nil {
+		t.Fatalf("renderWikiFrontmatter: %v", err)
+	}
+	if strings.Contains(fm, "description") {
+		t.Errorf("frontmatter should omit empty description:\n%s", fm)
+	}
+}
+
+func TestDeriveExcerpt(t *testing.T) {
+	long := strings.Repeat("字", 300)
+	got := deriveExcerpt(long)
+	// 按 rune 截断到 200。
+	if len([]rune(got)) != 200 {
+		t.Errorf("deriveExcerpt long = %d runes, want 200", len([]rune(got)))
+	}
+	if got := deriveExcerpt(""); got != "" {
+		t.Errorf("deriveExcerpt empty = %q, want empty", got)
+	}
+	if got := deriveExcerpt("短文本"); got != "短文本" {
+		t.Errorf("deriveExcerpt short = %q, want short text", got)
+	}
+	medium := strings.Repeat("字", 100)
+	if got := deriveExcerpt(medium); got != medium {
+		t.Errorf("deriveExcerpt medium multibyte text changed: got %d runes", len([]rune(got)))
+	}
+}
+
+func TestPrepareWikiExportDirRejectsStaleFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "stale.md"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := prepareWikiExportDir(dir); err == nil {
+		t.Fatal("prepareWikiExportDir accepted a non-empty output directory")
+	}
+}
+
+func TestPrepareWikiExportDirCreatesMissingDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "wiki-seed")
+	if err := prepareWikiExportDir(dir); err != nil {
+		t.Fatalf("prepareWikiExportDir: %v", err)
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		t.Fatalf("output directory was not created: info=%v err=%v", info, err)
+	}
+}
+
+func TestRenderWikiExportContentNormalizesFrontmatter(t *testing.T) {
+	page := &wikiPages.Entity{SortOrder: 2}
+	revision := "---\ntitle: 旧标题\ndraft: true\n---\n\n# 正文"
+	content, err := renderWikiExportContent("新标题", page, revision, true)
+	if err != nil {
+		t.Fatalf("renderWikiExportContent: %v", err)
+	}
+	if strings.Count(content, "---\n") != 2 {
+		t.Fatalf("frontmatter delimiter count = %d, want 2:\n%s", strings.Count(content, "---\n"), content)
+	}
+	if strings.Contains(content, "旧标题") || strings.Contains(content, "draft: true") {
+		t.Fatalf("legacy frontmatter leaked into export:\n%s", content)
+	}
+	if !strings.Contains(content, "title: 新标题") || !strings.HasSuffix(content, "# 正文") {
+		t.Fatalf("normalized export missing title/body:\n%s", content)
+	}
+}

--- a/apps/gooseforum/app/migration/app_migration.go
+++ b/apps/gooseforum/app/migration/app_migration.go
@@ -211,11 +211,8 @@ func runVersionedDataMigrations() {
 		currentVersion = 18
 	}
 	if currentVersion < 19 {
-		// 单一事件源架构（wiki 写即发布 + 版本指针 + 物化水印）：
-		// 为存量 wiki 页面回填 published_revision_no（= 最新 approved revision_no），
-		// 并初始化 topics/posts 的 wiki_synced_revision_no 水印（当前内容即最新版）。
-		// 幂等：指针已 >0 的页面跳过。部署前已存在的 wiki 页面（发布即通过）
-		// 不先回填指针，CAS 编辑将永远无法匹配 published_revision_no=0 的基线。
+		// Preserve the v19 bridge for instances upgrading directly from <=18:
+		// v21 adds git projection columns, but v19 owns the topic/post revision watermarks.
 		singleSourceResult := datamigration.BackfillWikiSingleSource()
 		slog.Info("app migration wiki single source backfill done",
 			"pages", singleSourceResult.PagesSeeded,
@@ -254,6 +251,24 @@ func runVersionedDataMigrations() {
 		}
 		pageConfig.SyncMigrationVersion(20)
 		currentVersion = 20
+	}
+	if currentVersion < 21 {
+		// wiki_pages 加渲染/溯源列 + wiki_sync_runs 建表并回填旧 revision/editors 数据。
+		// 旧表仍服务过渡期读写 API；物理删除与 #262 消费者切换同批完成。
+		wikiV21 := datamigration.MigrateWikiProjectionV21()
+		slog.Info("app migration wiki projection v21 done",
+			"pagesBackfilled", wikiV21.PagesBackfilled,
+			"pagesSkipped", wikiV21.PagesSkipped,
+			"editorsMigrated", wikiV21.EditorsMigrated,
+			"editorsSkipped", wikiV21.EditorsSkipped,
+			"failed", wikiV21.Failed,
+			"lastFailed", wikiV21.LastFailed)
+		if wikiV21.Failed > 0 {
+			slog.Error("app migration wiki projection v21 has failures", "failed", wikiV21.Failed, "lastFailed", wikiV21.LastFailed)
+			return
+		}
+		pageConfig.SyncMigrationVersion(21)
+		currentVersion = 21
 	}
 	slog.Info("app migration end", "version", currentVersion)
 }

--- a/apps/gooseforum/app/migration/migration.go
+++ b/apps/gooseforum/app/migration/migration.go
@@ -60,6 +60,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiNamespaces"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPageRevisions"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiSyncRuns"
 	"gorm.io/gorm"
 )
 
@@ -83,8 +84,8 @@ func migrateSchema() {
 		slog.Error("dbconnect course_review legacy upgrade failed", "err", err)
 		os.Exit(1)
 	}
-	if err = dedupeWikiRevisionNumbers(db); err != nil {
-		slog.Error("dbconnect wiki revision dedupe failed", "err", err)
+	if err = upgradeWikiPagesProjectionColumns(db); err != nil {
+		slog.Error("dbconnect wiki_pages projection columns upgrade failed", "err", err)
 		os.Exit(1)
 	}
 	if err = upgradeImportRunCompositeIndex(db); err != nil {
@@ -223,10 +224,11 @@ func SchemaModels() []any {
 		&topicCategoryIndex.Entity{},
 		&topicUserAction.Entity{},
 		&postUserAction.Entity{},
-		&wikiNamespaces.Entity{},
 		&wikiNamespaceEditors.Entity{},
-		&wikiPages.Entity{},
+		&wikiNamespaces.Entity{},
 		&wikiPageRevisions.Entity{},
+		&wikiPages.Entity{},
+		&wikiSyncRuns.Entity{},
 		&topicUserStat.Entity{},
 		&contentDeleteEvent.Entity{},
 		&role.Entity{},
@@ -389,49 +391,41 @@ func upgradeCourseReviewLegacySchema(db *gorm.DB) error {
 
 const courseReviewTableName = "course_review"
 
-// dedupeWikiRevisionNumbers 在 AutoMigrate 创建 uniq_wiki_rev_page_no 唯一索引前，
-// 清理存量 wiki_page_revisions 中 (page_id, revision_no) 重复的行（旧版并发写入
-// 或回滚残留可能产生同号修订；唯一索引不区分 deleted_at，软删行同样占用索引槽，
-// 因此对全部行含软删去重）。每组保留 id 最大（最新写入）的一行，其余物理删除。
-func dedupeWikiRevisionNumbers(db *gorm.DB) error {
-	if !db.Migrator().HasTable("wiki_page_revisions") {
-		return nil
+// upgradeWikiPagesProjectionColumns 为存量 wiki_pages 表补上迁移 v21 的 6 个投影/溯源列。
+//
+// PostgreSQL：AutoMigrate 对加列走 ALTER COLUMN ADD COLUMN，不重建表、不丢数据，
+// 无需干预（由 PG 迁移测试覆盖），此处直接返回。
+// SQLite：GORM 的整表重建（temp 表 + INSERT SELECT）只复制"列变化检测"涉及的列，
+// 实测存量行数据丢失（与 upgradeImportRunCompositeIndex 同源坑，issue #183）。因此
+// 在 AutoMigrate 之前显式 ALTER TABLE ADD COLUMN（带默认值，保留存量数据），加完列后
+// AutoMigrate 无差异可检，不再重建。仅检测列缺失时执行；全新库/已升级库跳过。
+func upgradeWikiPagesProjectionColumns(db *gorm.DB) error {
+	if db.Dialector.Name() != "sqlite" {
+		return nil // PG 由 AutoMigrate ALTER COLUMN 处理
 	}
-	var dups []struct {
-		PageId     uint64
-		RevisionNo int
-		Cnt        int64
+	if !db.Migrator().HasTable("wiki_pages") {
+		return nil // 全新库，AutoMigrate 直接建全表
 	}
-	if err := db.Table("wiki_page_revisions").Unscoped().
-		Select("page_id, revision_no, COUNT(*) AS cnt").
-		Group("page_id, revision_no").
-		Having("COUNT(*) > 1").
-		Scan(&dups).Error; err != nil {
-		return fmt.Errorf("inspect duplicate wiki revisions: %w", err)
+	// SQLite ADD COLUMN 约束：NOT NULL 列必须带常量默认值；时间列可空不加默认。
+	columns := []struct {
+		name string
+		ddl  string
+	}{
+		{"content_hash", `ALTER TABLE wiki_pages ADD COLUMN content_hash varchar(64) NOT NULL DEFAULT ''`},
+		{"last_commit_sha", `ALTER TABLE wiki_pages ADD COLUMN last_commit_sha varchar(40) NOT NULL DEFAULT ''`},
+		{"last_commit_at", `ALTER TABLE wiki_pages ADD COLUMN last_commit_at datetime`},
+		{"rendered_html", `ALTER TABLE wiki_pages ADD COLUMN rendered_html text`},
+		{"toc", `ALTER TABLE wiki_pages ADD COLUMN toc text`},
+		{"contributors_json", `ALTER TABLE wiki_pages ADD COLUMN contributors_json text`},
 	}
-	if len(dups) == 0 {
-		return nil
-	}
-	slog.Warn("migration: found duplicate wiki revision numbers", "groups", len(dups))
-	for _, d := range dups {
-		var keepID uint64
-		if err := db.Table("wiki_page_revisions").Unscoped().
-			Where("page_id = ?", d.PageId).
-			Where("revision_no = ?", d.RevisionNo).
-			Order("id DESC").
-			Limit(1).
-			Pluck("id", &keepID).Error; err != nil {
-			return fmt.Errorf("find keep wiki revision: %w", err)
+	for _, col := range columns {
+		if db.Migrator().HasColumn(&wikiPages.Entity{}, col.name) {
+			continue
 		}
-		// Unscoped + Delete = 物理删除：软删行仍占用唯一索引，必须真正删除。
-		if err := db.Table("wiki_page_revisions").Unscoped().
-			Where("page_id = ?", d.PageId).
-			Where("revision_no = ?", d.RevisionNo).
-			Where("id <> ?", keepID).
-			Delete(&wikiPageRevisions.Entity{}).Error; err != nil {
-			return fmt.Errorf("dedupe wiki revisions (page=%d rev=%d): %w", d.PageId, d.RevisionNo, err)
+		if err := db.Exec(col.ddl).Error; err != nil {
+			return fmt.Errorf("add wiki_pages.%s column: %w", col.name, err)
 		}
+		slog.Info("dbconnect wiki_pages." + col.name + " column added (SQLite explicit ALTER)")
 	}
-	slog.Info("migration: wiki revision dedupe done", "groups", len(dups))
 	return nil
 }

--- a/apps/gooseforum/app/migration/migration_pg_test.go
+++ b/apps/gooseforum/app/migration/migration_pg_test.go
@@ -84,6 +84,7 @@ func TestSchemaMigratesOnPostgreSQL(t *testing.T) {
 	}
 	assertPkFetchLogLeaseSchema(t, db)
 	assertPointsSourceKeySchema(t, db)
+	assertWikiProjectionSchema(t, db)
 }
 
 // TestSchemaUpgradeCreatesNewTablesOnPostgreSQL 模拟存量实例升级场景：

--- a/apps/gooseforum/app/migration/wiki_projection_upgrade_test.go
+++ b/apps/gooseforum/app/migration/wiki_projection_upgrade_test.go
@@ -1,0 +1,228 @@
+package migration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiNamespaceEditors"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPageRevisions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/datamigration"
+	"github.com/glebarez/sqlite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// legacyWikiPageEntity 旧版 wiki_pages 模型（迁移 v21 前）：无 content_hash /
+// last_commit_sha / last_commit_at / rendered_html / toc / contributors_json 列。
+// 用它 AutoMigrate 建出与真实存量库一致的旧表（列类型/索引均由旧版 GORM 生成）。
+type legacyWikiPageEntity struct {
+	Id                  uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+	TopicId             uint64         `gorm:"column:topic_id;not null;default:0;uniqueIndex:uniq_wiki_page_topic,priority:1;" json:"topicId"`
+	Namespace           string         `gorm:"column:namespace;type:varchar(64);not null;default:'';index:idx_wiki_page_namespace,priority:1;" json:"namespace"`
+	Path                string         `gorm:"column:path;type:varchar(255);not null;default:'';uniqueIndex:uniq_wiki_page_path,priority:1;" json:"path"`
+	ParentId            uint64         `gorm:"column:parent_id;not null;default:0;" json:"parentId"`
+	SortOrder           int            `gorm:"column:sort_order;type:int;not null;default:0;" json:"sortOrder"`
+	PublishedRevisionNo int            `gorm:"column:published_revision_no;type:int;not null;default:0;" json:"publishedRevisionNo"`
+	DeletedAt           gorm.DeletedAt `gorm:"column:deleted_at;" json:"-"`
+	CreatedAt           time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt           time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+}
+
+func (legacyWikiPageEntity) TableName() string { return "wiki_pages" }
+
+// exerciseWikiProjectionUpgrade 在给定连接上执行完整升级路径并断言结果：
+// 旧表（wiki_pages 无新列 + revisions + editors 有存量数据）→ upgradeWikiPagesProjectionColumns
+// （SQLite 显式 ADD COLUMN 保留数据；PG no-op 交给 AutoMigrate）→ AutoMigrate 全表
+// → MigrateWikiProjectionV21（回填投影/溯源 + editors 种子迁移并保留兼容表）。
+func exerciseWikiProjectionUpgrade(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	// 1) 旧 schema + 存量数据。
+	if err := db.AutoMigrate(&legacyWikiPageEntity{}, &wikiPageRevisions.Entity{}, &wikiNamespaceEditors.Entity{}); err != nil {
+		t.Fatalf("migrate legacy wiki schema: %v", err)
+	}
+	page1 := legacyWikiPageEntity{TopicId: 1, Namespace: "school", Path: "school/intro", SortOrder: 1, PublishedRevisionNo: 2}
+	if err := db.Create(&page1).Error; err != nil {
+		t.Fatalf("seed page1: %v", err)
+	}
+	// v19 未跑过的页面（published_revision_no=0）：v21 需补回填指针。
+	page2 := legacyWikiPageEntity{TopicId: 2, Namespace: "school", Path: "school/history", SortOrder: 2}
+	if err := db.Create(&page2).Error; err != nil {
+		t.Fatalf("seed page2: %v", err)
+	}
+	revisions := []wikiPageRevisions.Entity{
+		{PageId: page1.Id, RevisionNo: 1, Title: "简介", Content: "旧内容", RenderedHTML: "<p>旧内容</p>", Toc: "[]", Status: wikiPageRevisions.StatusApproved, EditorId: 100},
+		{PageId: page1.Id, RevisionNo: 2, Title: "简介v2", Content: "---\ntitle: 简介v2\n---\n\n# 新内容", RenderedHTML: "<h1>新内容</h1>", Toc: `[{"level":1,"id":"new-content","text":"新内容"}]`, Status: wikiPageRevisions.StatusApproved, EditorId: 100},
+		{PageId: page2.Id, RevisionNo: 1, Title: "历史", Content: "历史内容", RenderedHTML: "<p>历史内容</p>", Toc: "[]", Status: wikiPageRevisions.StatusApproved, EditorId: 200},
+	}
+	for _, rev := range revisions {
+		if err := db.Create(&rev).Error; err != nil {
+			t.Fatalf("seed revision: %v", err)
+		}
+	}
+	if err := db.Create(&wikiNamespaceEditors.Entity{Namespace: "school", UserId: 100, AddedBy: 1}).Error; err != nil {
+		t.Fatalf("seed namespace editor: %v", err)
+	}
+
+	// 2) 升级：显式加列（SQLite）+ AutoMigrate 全表。
+	if err := upgradeWikiPagesProjectionColumns(db); err != nil {
+		t.Fatalf("upgrade wiki pages columns: %v", err)
+	}
+	if err := db.AutoMigrate(SchemaModels()...); err != nil {
+		t.Fatalf("automigrate full schema: %v", err)
+	}
+	// 前置：AutoMigrate 不删表，v21 数据迁移前旧表必须仍在（回填数据源）。
+	if !db.Migrator().HasTable("wiki_page_revisions") || !db.Migrator().HasTable("wiki_namespace_editors") {
+		t.Fatal("precondition failed: legacy tables must still exist before v21 data migration")
+	}
+
+	// 3) v21 数据迁移：回填 + 种子；旧表留给 #262 前的兼容 API。
+	result := datamigration.MigrateWikiProjectionV21WithDB(db)
+	if result.Failed > 0 {
+		t.Fatalf("wiki projection v21 migration failed: %s", result.LastFailed)
+	}
+
+	// 4) 断言。
+	assertWikiProjectionSchema(t, db)
+	assertWikiProjectionBackfill(t, db, page1.Id, page2.Id)
+}
+
+// assertWikiProjectionSchema 断言新列/新表存在、兼容期旧表仍保留。
+func assertWikiProjectionSchema(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	for _, col := range []string{"content_hash", "last_commit_sha", "last_commit_at", "rendered_html", "toc", "contributors_json"} {
+		if !db.Migrator().HasColumn(&wikiPages.Entity{}, col) {
+			t.Errorf("wiki_pages.%s column missing after upgrade", col)
+		}
+	}
+	if !db.Migrator().HasTable("wiki_sync_runs") {
+		t.Error("wiki_sync_runs table missing after upgrade")
+	}
+	if !db.Migrator().HasTable("wiki_page_revisions") {
+		t.Error("wiki_page_revisions must remain until #262 switches all consumers")
+	}
+	if !db.Migrator().HasTable("wiki_namespace_editors") {
+		t.Error("wiki_namespace_editors must remain until #262 switches all consumers")
+	}
+}
+
+// assertWikiProjectionBackfill 断言回填正确：rendered_html/toc 取最新 approved 修订、
+// content_hash 为最新 markdown 的 sha256、<19 页面指针补回填、editors 种子入 contributors_json。
+func assertWikiProjectionBackfill(t *testing.T, db *gorm.DB, page1ID, page2ID uint64) {
+	t.Helper()
+	var page1 wikiPages.Entity
+	if err := db.First(&page1, "id = ?", page1ID).Error; err != nil {
+		t.Fatalf("load page1: %v", err)
+	}
+	if page1.RenderedHTML != "<h1>新内容</h1>" {
+		t.Errorf("page1 rendered_html = %q, want latest approved revision", page1.RenderedHTML)
+	}
+	if !strings.Contains(page1.Toc, "new-content") {
+		t.Errorf("page1 toc = %q, want backfilled from latest approved revision", page1.Toc)
+	}
+	if want := sha256HexForTest("\n# 新内容"); page1.ContentHash != want {
+		t.Errorf("page1 content_hash = %q, want %q", page1.ContentHash, want)
+	}
+	if page1.LastCommitAt == nil {
+		t.Error("page1 last_commit_at nil, want backfilled from latest approved revision")
+	}
+	if page1.PublishedRevisionNo != 2 {
+		t.Errorf("page1 published_revision_no = %d, want 2 (already set)", page1.PublishedRevisionNo)
+	}
+	var page2 wikiPages.Entity
+	if err := db.First(&page2, "id = ?", page2ID).Error; err != nil {
+		t.Fatalf("load page2: %v", err)
+	}
+	if page2.PublishedRevisionNo != 1 {
+		t.Errorf("page2 published_revision_no = %d, want 1 (backfilled for <19 instance)", page2.PublishedRevisionNo)
+	}
+	var contributors string
+	if err := db.Table("wiki_pages").Select("contributors_json").Where("id = ?", page1ID).Scan(&contributors).Error; err != nil {
+		t.Fatalf("load contributors_json: %v", err)
+	}
+	if !strings.Contains(contributors, `"userId":100`) {
+		t.Errorf("page1 contributors_json = %q, want seed migrated from wiki_namespace_editors", contributors)
+	}
+	// 同一 namespace 下的 page2 也应带种子贡献者。
+	var contributors2 string
+	if err := db.Table("wiki_pages").Select("contributors_json").Where("id = ?", page2ID).Scan(&contributors2).Error; err != nil {
+		t.Fatalf("load page2 contributors_json: %v", err)
+	}
+	if !strings.Contains(contributors2, `"userId":100`) {
+		t.Errorf("page2 contributors_json = %q, want same namespace seed", contributors2)
+	}
+}
+
+func sha256HexForTest(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// TestWikiProjectionUpgradeFromLegacySchema 迁移 v21（issue #259）升级路径（SQLite）：
+// 存量库无新列 + 两旧表有数据 → 显式加列保留数据 → v21 回填投影/溯源 → 种子迁移 editors
+// → 保留两张兼容表。核心断言：存量数据不丢、回填取最新 approved 修订、旧读写链仍可用。
+func TestWikiProjectionUpgradeFromLegacySchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	exerciseWikiProjectionUpgrade(t, db)
+}
+
+// TestWikiProjectionV21NoopOnFreshDB 全新库路径：revision/editors 表都不存在时，
+// 迁移必须 no-op 成功（Failed=0），不报错、不推进失败（review LOW #10d）。
+func TestWikiProjectionV21NoopOnFreshDB(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	result := datamigration.MigrateWikiProjectionV21WithDB(db)
+	if result.Failed > 0 {
+		t.Fatalf("fresh-db migration failed: %s", result.LastFailed)
+	}
+}
+
+// TestWikiProjectionV21PreservesLegacyTables verifies the compatibility bridge:
+// #262 has not switched every reader/writer yet, so v21 must not drop either table.
+func TestWikiProjectionV21PreservesLegacyTables(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&wikiNamespaceEditors.Entity{}, &wikiPageRevisions.Entity{}); err != nil {
+		t.Fatalf("migrate legacy tables: %v", err)
+	}
+	if err := db.Create(&wikiNamespaceEditors.Entity{Namespace: "school", UserId: 100, AddedBy: 1}).Error; err != nil {
+		t.Fatalf("seed editor: %v", err)
+	}
+	result := datamigration.MigrateWikiProjectionV21WithDB(db)
+	if result.Failed > 0 {
+		t.Fatalf("migration failed: %s", result.LastFailed)
+	}
+	if !db.Migrator().HasTable("wiki_page_revisions") || !db.Migrator().HasTable("wiki_namespace_editors") {
+		t.Error("v21 must preserve both legacy tables until #262")
+	}
+}
+
+// TestSchemaWikiProjectionUpgradeOnPostgreSQL 同上，PostgreSQL 版（PG 走 AutoMigrate ALTER
+// COLUMN 加列，不重建表不丢数据）。依赖 YOURTJ_TEST_PG_URL，未设置时跳过。
+func TestSchemaWikiProjectionUpgradeOnPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL wiki projection upgrade test")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{TranslateError: true, Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	// 清理共享测试库（与 migration_pg_test 共用）。
+	if err := db.Exec(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;`).Error; err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	exerciseWikiProjectionUpgrade(t, db)
+}

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
@@ -39,7 +39,7 @@ func GetConfigByPageType[T any](pageType string, defaultValue T) T {
 	return defaultValue
 }
 
-const AppMigrationVersion uint32 = 20
+const AppMigrationVersion uint32 = 21
 
 func GetMigrationVersion() uint32 {
 	configEntity := GetByPageType(Migration)

--- a/apps/gooseforum/app/models/forum/wikiPages/wikiPages.go
+++ b/apps/gooseforum/app/models/forum/wikiPages/wikiPages.go
@@ -22,6 +22,20 @@ type Entity struct {
 	DeletedAt           gorm.DeletedAt `gorm:"column:deleted_at;" json:"-"`
 	CreatedAt           time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt           time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+	// Git 溯源 + 渲染投影列（迁移 v21，GitHub 仓库为唯一真源后由同步引擎写入）：
+	//   content_hash     sha256(剥离 frontmatter 后的 markdown body) 十六进制——同步引擎
+	//                    必须先剥 frontmatter 再 hash（#258），口径与 v21 回填一致
+	//                    （多页可同内容，不建唯一索引）
+	//   last_commit_sha 投影对应的 git commit SHA-1 hex；last_commit_at 对应提交时间
+	//   rendered_html    剥离 frontmatter 后的 goldmark 渲染快照
+	//   toc              目录 JSON 字符串（与 wikiPageRevisions.Toc 同构，读侧 json.Unmarshal）
+	//   contributors_json 贡献者列表 JSON（同步引擎从 git 历史聚合；迁移 v21 由 wiki_namespace_editors 种子迁移）
+	ContentHash      string     `gorm:"column:content_hash;type:varchar(64);not null;default:'';" json:"contentHash"`
+	LastCommitSha    string     `gorm:"column:last_commit_sha;type:varchar(40);not null;default:'';" json:"lastCommitSha"`
+	LastCommitAt     *time.Time `gorm:"column:last_commit_at;" json:"lastCommitAt"`
+	RenderedHTML     string     `gorm:"column:rendered_html;type:text;" json:"renderedHTML"`
+	Toc              string     `gorm:"column:toc;type:text;" json:"toc"`
+	ContributorsJson string     `gorm:"column:contributors_json;type:text;" json:"contributorsJson"`
 }
 
 func (itself *Entity) TableName() string {

--- a/apps/gooseforum/app/models/forum/wikiSyncRuns/wikiSyncRuns.go
+++ b/apps/gooseforum/app/models/forum/wikiSyncRuns/wikiSyncRuns.go
@@ -1,0 +1,45 @@
+package wikiSyncRuns
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+const tableName = "wiki_sync_runs"
+
+// 同步状态。
+const (
+	StatusRunning = "running" // 同步进行中
+	StatusSuccess = "success" // 成功
+	StatusFailed  = "failed"  // 失败（错误详情见 Error）
+)
+
+// 触发源。
+const (
+	TriggerWebhook = "webhook" // GitHub webhook 即时触发
+	TriggerTicker  = "ticker"  // 每日定时
+	TriggerManual  = "manual"  // 管理端手动「立即同步」
+)
+
+// Entity wiki 同步运行日志（迁移 v21 新建，同步引擎后端落库）。
+type Entity struct {
+	Id            uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
+	HeadSha       string         `gorm:"column:head_sha;type:varchar(40);not null;default:'';" json:"headSha"`
+	InsertedCount int            `gorm:"column:inserted_count;type:int;not null;default:0;" json:"insertedCount"`
+	UpdatedCount  int            `gorm:"column:updated_count;type:int;not null;default:0;" json:"updatedCount"`
+	DeletedCount  int            `gorm:"column:deleted_count;type:int;not null;default:0;" json:"deletedCount"`
+	Status        string         `gorm:"column:status;type:varchar(16);not null;default:'';" json:"status"`
+	Error         string         `gorm:"column:error;type:text;" json:"error"`
+	DurationMs    int64          `gorm:"column:duration_ms;type:bigint;not null;default:0;" json:"durationMs"`
+	TriggerSource string         `gorm:"column:trigger_source;type:varchar(16);not null;default:'';" json:"triggerSource"`
+	StartedAt     *time.Time     `gorm:"column:started_at;" json:"startedAt"`
+	FinishedAt    *time.Time     `gorm:"column:finished_at;" json:"finishedAt"`
+	DeletedAt     gorm.DeletedAt `gorm:"column:deleted_at;" json:"-"`
+	CreatedAt     time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
+	UpdatedAt     time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`
+}
+
+func (itself *Entity) TableName() string {
+	return tableName
+}

--- a/apps/gooseforum/app/models/forum/wikiSyncRuns/wikiSyncRuns_connect.go
+++ b/apps/gooseforum/app/models/forum/wikiSyncRuns/wikiSyncRuns_connect.go
@@ -1,0 +1,10 @@
+package wikiSyncRuns
+
+import (
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"gorm.io/gorm"
+)
+
+func builder() *gorm.DB {
+	return db.Connect().Table(tableName)
+}

--- a/apps/gooseforum/app/models/forum/wikiSyncRuns/wikiSyncRuns_rep.go
+++ b/apps/gooseforum/app/models/forum/wikiSyncRuns/wikiSyncRuns_rep.go
@@ -1,0 +1,61 @@
+package wikiSyncRuns
+
+import (
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
+	"gorm.io/gorm"
+)
+
+func Get(id uint64) (entity Entity) {
+	builder().First(&entity, id)
+	return
+}
+
+// GetLatest 返回最近一次同步运行（按创建时间降序首条；无则零值）。
+// 管理端「同步状态」面板用：head_sha / 上次同步时间 / 最近一次结果。
+func GetLatest() (entity Entity) {
+	builder().Order(queryopt.Desc("id")).First(&entity)
+	return
+}
+
+// ListRecent 分页返回同步运行日志（降序；pageSize+1 探测 hasNext，与
+// wikiPageRevisions.ListRecent 同模式，避免额外 COUNT）。
+func ListRecent(page, pageSize int) ([]*Entity, bool) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize <= 0 || pageSize > 100 {
+		pageSize = 20
+	}
+	var entities []*Entity
+	builder().
+		Order(queryopt.Desc("id")).
+		Offset((page - 1) * pageSize).
+		Limit(pageSize + 1).
+		Find(&entities)
+	hasNext := len(entities) > pageSize
+	if hasNext {
+		entities = entities[:pageSize]
+	}
+	return entities, hasNext
+}
+
+func Create(entity *Entity) error {
+	return builder().Create(entity).Error
+}
+
+func CreateTx(tx *gorm.DB, entity *Entity) error {
+	return tx.Table(tableName).Create(entity).Error
+}
+
+func Save(entity *Entity) error {
+	return builder().Save(entity).Error
+}
+
+func SaveTx(tx *gorm.DB, entity *Entity) error {
+	return tx.Table(tableName).Save(entity).Error
+}
+
+// DeleteOlderThan 清理某时间点之前的运行日志（保留窗口，防止日志无限增长）。
+func DeleteOlderThan(before string) error {
+	return builder().Where("created_at < ?", before).Delete(&Entity{}).Error
+}

--- a/apps/gooseforum/app/service/datamigration/wiki_projection_v21.go
+++ b/apps/gooseforum/app/service/datamigration/wiki_projection_v21.go
@@ -1,0 +1,208 @@
+package datamigration
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/markdown2html"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiNamespaceEditors"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPageRevisions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
+	"gorm.io/gorm"
+)
+
+// WikiProjectionV21Result 迁移 v21（issue #259）执行结果。
+type WikiProjectionV21Result struct {
+	PagesBackfilled int
+	PagesSkipped    int
+	EditorsMigrated int
+	EditorsSkipped  int
+	Failed          int
+	LastFailed      string
+}
+
+// contributorSeed 迁移 v21 写入 contributors_json 的种子条目（与 wikiservice.Contributor
+// 同构；同步引擎上线后用 git 历史重写该列）。
+type contributorSeed struct {
+	UserId       uint64    `json:"userId"`
+	Username     string    `json:"username"`
+	AvatarUrl    string    `json:"avatarUrl"`
+	Count        int       `json:"count"`
+	LastEditedAt time.Time `json:"lastEditedAt"`
+}
+
+// MigrateWikiProjectionV21 迁移 v21：wiki_pages 加渲染/溯源列并回填旧内容。
+//
+// 从兼容期旧表回填：
+//  1. rendered_html/toc ← 各页最新 approved 修订（revision 表仍是唯一正文源时读它）
+//  2. content_hash ← sha256(最新 approved 修订 markdown)；last_commit_at ← 修订创建时间
+//  3. published_revision_no 仍为 0 的页面补回填（覆盖 v19 未跑过的 <19 升级实例）
+//  4. wiki_namespace_editors 数据种子迁移到该 namespace 下各页 contributors_json
+//
+// 旧 revision/editors 表仍被 #262 之前的公开详情与写/回滚接口读取，必须保留到
+// 消费者和 OpenAPI/Web/mobile 同步切换后，再由后续迁移物理删除。
+func MigrateWikiProjectionV21() WikiProjectionV21Result {
+	return MigrateWikiProjectionV21WithDB(dbconnect.Connect())
+}
+
+func MigrateWikiProjectionV21WithDB(conn *gorm.DB) WikiProjectionV21Result {
+	result := WikiProjectionV21Result{}
+	// 回填仅在数据源表存在时执行（revision 是投影回填的数据源，editors 是种子数据源）。
+	if conn.Migrator().HasTable(&wikiPages.Entity{}) && conn.Migrator().HasTable("wiki_page_revisions") {
+		if !backfillPageProjections(conn, &result) {
+			return result
+		}
+		if conn.Migrator().HasTable("wiki_namespace_editors") {
+			migrateNamespaceEditors(conn, &result)
+		}
+		if result.Failed > 0 {
+			return result
+		}
+	}
+	return result
+}
+
+// backfillPageProjections 逐页回填投影列；失败返回 false，迁移版本不会推进。
+func backfillPageProjections(conn *gorm.DB, result *WikiProjectionV21Result) bool {
+	const batchSize = 200
+	var cursor uint64
+	for {
+		var batch []wikiPages.Entity
+		err := conn.Model(&wikiPages.Entity{}).
+			Select("id", "topic_id", "published_revision_no").
+			Where("id > ?", cursor).
+			Order("id ASC").
+			Limit(batchSize).
+			Find(&batch).Error
+		if err != nil {
+			result.Failed++
+			result.LastFailed = "pages_scan:" + err.Error()
+			return false
+		}
+		for i := range batch {
+			page := &batch[i]
+			cursor = page.Id
+			if err := backfillOnePage(conn, page, result); err != nil {
+				result.Failed++
+				result.LastFailed = "page:" + err.Error()
+				return false
+			}
+		}
+		if len(batch) < batchSize {
+			return true
+		}
+	}
+}
+
+func backfillOnePage(conn *gorm.DB, page *wikiPages.Entity, result *WikiProjectionV21Result) error {
+	var latest wikiPageRevisions.Entity
+	err := conn.Model(&wikiPageRevisions.Entity{}).
+		Where("page_id = ?", page.Id).
+		Where("status = ?", wikiPageRevisions.StatusApproved).
+		Order("revision_no DESC").
+		Order("id DESC").
+		First(&latest).Error
+	if err == gorm.ErrRecordNotFound {
+		// 无 approved 修订（异常态页面）：跳过，保留原列值。
+		result.PagesSkipped++
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// #258 之后 revision.Content 可含完整 frontmatter；hash 和 git 同步统一只取剥离后的 body。
+	_, body := markdown2html.SplitFrontmatter(latest.Content)
+	updates := map[string]any{
+		"rendered_html":  latest.RenderedHTML,
+		"toc":            latest.Toc,
+		"content_hash":   sha256Hex(body),
+		"last_commit_at": latest.CreatedAt,
+	}
+	if page.PublishedRevisionNo == 0 && latest.RevisionNo > 0 {
+		updates["published_revision_no"] = latest.RevisionNo
+	}
+	if err := conn.Model(&wikiPages.Entity{}).
+		Where("id = ?", page.Id).
+		Updates(updates).Error; err != nil {
+		return err
+	}
+	result.PagesBackfilled++
+	return nil
+}
+
+// sha256Hex 计算字符串的 sha256 十六进制（content_hash 语义：页面 markdown）。
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// migrateNamespaceEditors 把 wiki_namespace_editors 数据种子迁移到 contributors_json。
+// 「如需保留」语义：表为空则整体跳过；每个有编辑者的 namespace 把其编辑者列表写入该
+// namespace 下全部页面的 contributors_json（粒度从 namespace 级落到页面级，由同步引擎
+// 后续用 git 历史精确重写）。
+func migrateNamespaceEditors(conn *gorm.DB, result *WikiProjectionV21Result) {
+	if !conn.Migrator().HasTable("wiki_namespace_editors") {
+		return
+	}
+	var editors []wikiNamespaceEditors.Entity
+	if err := conn.Model(&wikiNamespaceEditors.Entity{}).Find(&editors).Error; err != nil {
+		result.Failed++
+		result.LastFailed = "editors_scan:" + err.Error()
+		return
+	}
+	if len(editors) == 0 {
+		result.EditorsSkipped++
+		return
+	}
+	byNS := make(map[string][]*wikiNamespaceEditors.Entity)
+	for i := range editors {
+		e := &editors[i]
+		if e.Namespace == "" {
+			continue
+		}
+		byNS[e.Namespace] = append(byNS[e.Namespace], e)
+	}
+	for ns, list := range byNS {
+		if err := writeNamespaceContributors(conn, ns, list); err != nil {
+			result.Failed++
+			result.LastFailed = "contributors:" + err.Error()
+			return
+		}
+		result.EditorsMigrated++
+	}
+}
+
+func writeNamespaceContributors(conn *gorm.DB, namespace string, editors []*wikiNamespaceEditors.Entity) error {
+	userIDs := make([]uint64, 0, len(editors))
+	for _, e := range editors {
+		userIDs = append(userIDs, e.UserId)
+	}
+	userMap := users.GetMapByIds(userIDs)
+	contributors := make([]contributorSeed, 0, len(editors))
+	for _, e := range editors {
+		entry := contributorSeed{
+			UserId:       e.UserId,
+			Count:        1,
+			LastEditedAt: e.CreatedAt,
+		}
+		if u, ok := userMap[e.UserId]; ok && u != nil {
+			entry.Username = u.Username
+			entry.AvatarUrl = u.GetWebAvatarUrl()
+		}
+		contributors = append(contributors, entry)
+	}
+	// review LOW：按 userId 稳定排序（byNS map 迭代顺序不确定），保证迁移幂等输出稳定。
+	sort.Slice(contributors, func(i, j int) bool { return contributors[i].UserId < contributors[j].UserId })
+	data, err := json.Marshal(contributors)
+	if err != nil {
+		return err
+	}
+	return conn.Model(&wikiPages.Entity{}).
+		Where("namespace = ?", namespace).
+		Update("contributors_json", string(data)).Error
+}

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -98,6 +98,10 @@ than a hand-maintained duplicate baseline.
 - Migrations: upstream `app/migration` (Go migrations, run at startup/CLI); PostgreSQL is the
   default deployment database and SQLite the local development/test default; MySQL is not
   supported; the file db stays SQLite.
+- Wiki git projection migration v21 is an expand step: it adds the rendered/provenance columns and
+  `wiki_sync_runs`, then backfills them from approved revisions and namespace editors. The legacy
+  revision/editor tables remain registered while the current HTTP readers and writers still consume
+  them; their physical removal belongs to the #262 contract step after those consumers switch.
 - Post content revisions: `post_revisions` is an append-only snapshot table (post_id, version,
   editor_id, content, rendered_html, process_status, created_at). Every content edit — first post
   (post_no = 1) and replies alike, by the author — appends a new version inside the edit


### PR DESCRIPTION
## Summary
- add the six git projection columns to `wiki_pages` and register `wiki_sync_runs`
- backfill rendered content, body hashes, revision pointers, and contributor seeds on SQLite and PostgreSQL
- add a fail-closed `wiki-export` command that normalizes frontmatter and rejects incomplete or stale output
- keep `wiki_page_revisions` and `wiki_namespace_editors` through the compatibility window; physical removal moves to #262 when all runtime consumers switch

## Stack
- base: #269 / #258 (frontmatter parsing)
- this PR contains only #259 migration/model/export work
- #260 will be submitted separately on top of this PR

## Verification
- `go vet ./...`
- `go test ./...`
- `YOURTJ_TEST_PG_URL=... go test ./app/migration/ -run TestSchema -count=1 -v` against an isolated local PostgreSQL instance
- `git diff --check`

Closes #259