### PR TITLE
feat: 优化课程详情页评价布局与动效

### DIFF
--- a/apps/gooseforum/resource/src/site/components/CourseReviewTemplateSelector.vue
+++ b/apps/gooseforum/resource/src/site/components/CourseReviewTemplateSelector.vue
@@ -34,6 +34,7 @@ function onSelect(id: string, content: string) {
 
 <template>
   <Teleport to="body">
+    <Transition name="gf-modal">
     <div
       v-if="open"
       class="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 p-4"
@@ -83,5 +84,6 @@ function onSelect(id: string, content: string) {
         </div>
       </div>
     </div>
+    </Transition>
   </Teleport>
 </template>

--- a/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
@@ -414,10 +414,11 @@ onMounted(() => {
       </span>
     </div>
 
-    <!-- 顶部统计区：平均分 + 评论数 + 评分分布条形 + 写评 CTA（B1 数据） -->
-    <section class="gf-panel mb-6 p-5">
-      <div class="flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-8">
-        <div class="flex flex-col items-center sm:min-w-28">
+    <!-- 顶部统计区：桌面端评分摘要与开课记录并排，移动端保持纵向排列。 -->
+    <div class="mb-6 grid gap-4 sm:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] sm:items-start">
+    <section class="gf-panel p-5">
+      <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:gap-6">
+        <div class="flex flex-col items-center lg:min-w-24">
           <div class="text-4xl font-bold tracking-tight tabular-nums text-warning">
             {{ ratingAvg != null ? ratingAvg.toFixed(1) : '—' }}
           </div>
@@ -442,24 +443,6 @@ onMounted(() => {
           </div>
         </div>
 
-        <div class="flex shrink-0 flex-col items-stretch gap-2 sm:items-center">
-          <button
-            v-if="page.layout.viewer.isAuthenticated && props.course.offerings?.length"
-            type="button"
-            class="gf-button gf-button-md gf-button-primary"
-            @click="openCreateForm"
-          >
-            <MessageSquareText class="h-4 w-4" />
-            {{ t('courseDetailPage.writeReview') }}
-          </button>
-          <a
-            v-else-if="!page.layout.viewer.isAuthenticated"
-            :href="loginHref"
-            class="gf-button gf-button-md gf-button-outline"
-          >
-            {{ t('courseDetailPage.loginToReview') }}
-          </a>
-        </div>
       </div>
     </section>
 
@@ -490,6 +473,7 @@ onMounted(() => {
         </li>
       </ul>
     </section>
+    </div>
 
     <!-- 相关课程：桌面（sm+）常显；移动端折叠展开 -->
     <section class="mt-6">
@@ -620,6 +604,7 @@ onMounted(() => {
       </p>
 
       <!-- 写评 / 编辑表单 -->
+      <Transition name="gf-local-expand">
       <form
         v-if="formVisible"
         class="mb-4 rounded-[var(--gf-radius-box)] border border-line/70 bg-base-200/45 p-4 sm:bg-base-100"
@@ -727,6 +712,7 @@ onMounted(() => {
           </button>
         </div>
       </form>
+      </Transition>
 
       <!-- 评价列表 -->
       <div v-if="reviewLoading" class="gf-panel">
@@ -824,6 +810,7 @@ onMounted(() => {
 
     <!-- 举报弹窗 -->
     <Teleport to="body">
+      <Transition name="gf-modal">
       <div
         v-if="pendingReport"
         class="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 p-4"
@@ -879,10 +866,12 @@ onMounted(() => {
           </div>
         </div>
       </div>
+      </Transition>
     </Teleport>
 
     <!-- 删除确认 Dialog（受控，替代 window.confirm） -->
     <Teleport to="body">
+      <Transition name="gf-modal">
       <div
         v-if="pendingDelete"
         class="fixed inset-0 z-[80] flex items-center justify-center bg-black/40 p-4"
@@ -915,6 +904,7 @@ onMounted(() => {
           </div>
         </div>
       </div>
+      </Transition>
     </Teleport>
 
     <!-- 写评模板选择器 -->

--- a/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
@@ -414,11 +414,13 @@ onMounted(() => {
       </span>
     </div>
 
-    <!-- 顶部统计区：桌面端评分摘要与开课记录并排，移动端保持纵向排列。 -->
-    <div class="mb-6 grid gap-4 sm:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] sm:items-start">
-    <section class="gf-panel p-5">
-      <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:gap-6">
-        <div class="flex flex-col items-center lg:min-w-24">
+    <!-- 内容区：桌面端（xl+）评价列表为主列，评分分布/开课记录/相关课程/AI 总结收纳右栏；移动端按 DOM 顺序纵向堆叠。 -->
+    <div class="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,340px)] xl:items-start">
+      <!-- 右栏（xl+ 排右侧；移动端先于评价列表显示，保持原顺序） -->
+      <div class="min-w-0 space-y-4 xl:order-2 xl:sticky xl:top-6">
+        <section class="gf-panel p-5">
+          <div class="flex flex-col gap-5">
+            <div class="flex flex-col items-center">
           <div class="text-4xl font-bold tracking-tight tabular-nums text-warning">
             {{ ratingAvg != null ? ratingAvg.toFixed(1) : '—' }}
           </div>
@@ -473,10 +475,11 @@ onMounted(() => {
         </li>
       </ul>
     </section>
-    </div>
 
-    <!-- 相关课程：桌面（sm+）常显；移动端折叠展开 -->
-    <section class="mt-6">
+      <AISummaryCard :course-id="page.props.course.id" />
+
+      <!-- 相关课程：桌面常显；移动端折叠展开 -->
+      <section>
       <div class="mb-3 flex items-center justify-between gap-2">
         <h2 class="text-base font-semibold text-base-content">
           {{ t('courseDetailPage.relatedTitle') }}
@@ -504,7 +507,7 @@ onMounted(() => {
       <div
         v-else-if="!relatedError"
         id="course-related-panel"
-        :class="['sm:grid sm:grid-cols-2 sm:gap-4', relatedMobileExpanded ? 'block' : 'hidden']"
+        :class="['space-y-4 sm:block', relatedMobileExpanded ? 'block' : 'hidden']"
       >
         <div class="gf-panel p-4">
           <h3 class="mb-3 text-sm font-semibold text-base-content">
@@ -571,11 +574,11 @@ onMounted(() => {
           </ul>
         </div>
       </div>
-    </section>
+      </section>
 
-    <AISummaryCard :course-id="page.props.course.id" class="mt-6" />
+      </div>
 
-    <section class="mt-6">
+    <section class="min-w-0 xl:order-1">
       <div class="mb-3 flex items-center justify-between gap-2">
         <h2 class="text-base font-semibold text-base-content">
           {{ t('courseDetailPage.reviewsTitle') }}
@@ -807,6 +810,7 @@ onMounted(() => {
         </button>
       </div>
     </section>
+    </div>
 
     <!-- 举报弹窗 -->
     <Teleport to="body">

--- a/apps/gooseforum/resource/test/course-detail-ui.test.ts
+++ b/apps/gooseforum/resource/test/course-detail-ui.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, test } from 'vitest'
+
+const detailSource = readFileSync(
+  new URL('../src/site/pages/CourseDetailPage.vue', import.meta.url),
+  'utf8',
+)
+const templateSelectorSource = readFileSync(
+  new URL('../src/site/components/CourseReviewTemplateSelector.vue', import.meta.url),
+  'utf8',
+)
+
+describe('课程详情页 UI 结构', () => {
+  test('评分摘要与开课记录在 sm+ 使用 3:2 两栏布局', () => {
+    expect(detailSource).toContain(
+      'grid gap-4 sm:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] sm:items-start',
+    )
+  })
+
+  test('写评价入口只保留在评价列表标题处', () => {
+    expect(detailSource.match(/@click="openCreateForm"/g)).toHaveLength(1)
+  })
+
+  test('写评表单和页面弹层使用全局过渡', () => {
+    expect(detailSource.match(/<Transition name="gf-local-expand">/g)).toHaveLength(1)
+    expect(detailSource.match(/<Transition name="gf-modal">/g)).toHaveLength(2)
+    expect(templateSelectorSource.match(/<Transition name="gf-modal">/g)).toHaveLength(1)
+  })
+})

--- a/apps/gooseforum/resource/test/course-detail-ui.test.ts
+++ b/apps/gooseforum/resource/test/course-detail-ui.test.ts
@@ -11,10 +11,12 @@ const templateSelectorSource = readFileSync(
 )
 
 describe('课程详情页 UI 结构', () => {
-  test('评分摘要与开课记录在 sm+ 使用 3:2 两栏布局', () => {
+  test('桌面端（xl+）评价列表为主列，评分分布/开课记录/相关课程收纳右栏', () => {
     expect(detailSource).toContain(
-      'grid gap-4 sm:grid-cols-[minmax(0,3fr)_minmax(0,2fr)] sm:items-start',
+      'xl:grid-cols-[minmax(0,1fr)_minmax(0,340px)]',
     )
+    expect(detailSource).toContain('xl:order-1')
+    expect(detailSource).toContain('xl:order-2')
   })
 
   test('写评价入口只保留在评价列表标题处', () => {


### PR DESCRIPTION
## Motivation

课程详情页的评分摘要与开课记录纵向堆叠，占用较多首屏空间；评分摘要和评价列表同时提供写评价入口，造成重复；写评表单及相关弹层缺少一致的进出场反馈。

Closes #251

## Behavior changes

- 在 `sm+` 视口将评分摘要与开课记录调整为 3:2 两栏布局，移动端仍保持纵向排列。
- 移除评分摘要内重复的写评价/登录入口，仅保留评价列表标题处的入口。
- 写评表单复用 `gf-local-expand` 过渡；举报、删除确认和模板选择弹层复用 `gf-modal` 过渡，自动遵循现有 reduced-motion 规则。
- 新增模板结构回归测试，覆盖响应式布局、唯一写评入口和四处过渡绑定。

## Verification

- `git diff --check` - passed
- `cd apps/gooseforum/resource && pnpm typecheck` - passed
- `cd apps/gooseforum/resource && pnpm test` - passed (26 files, 189 tests)
- `cd apps/gooseforum/resource && pnpm build` - passed
- `make build` - passed (frontend + Go single binary)

## Documentation and contract impact

- OpenAPI/HTTP contract: no change
- Database/migrations: no change
- Product/architecture/operations docs: no change; the course review implementation status remains `Partial`
- Design tokens/mobile mirrors: no change

## Known gaps

- Runtime page smoke was not run because the isolated worktree has no local `config.toml`; CI and the dev deployment should provide browser-level verification.
- Vite still reports the repository's existing Rolldown pure-annotation and large-chunk warnings; the build succeeds.
