### PR TITLE
fix: support wiki relative links and assets

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/wiki.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki.go
@@ -218,7 +218,7 @@ func wikiAsset(c *gin.Context, assetPath string) {
 		renderNotFound(c)
 		return
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	contentType, safe := wikiAssetType(info.Name())
 	if !safe {
 		// 未知/危险类型：强制下载，绝不内联（nosniff + CSP sandbox 双保险）。

--- a/apps/gooseforum/app/http/controllers/forum/wiki.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki.go
@@ -2,9 +2,14 @@ package forum
 
 import (
 	"log/slog"
+	"math"
 	"net/http"
+	"path"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/ratelimit"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserAction"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
@@ -146,12 +151,65 @@ func WikiDetail(c *gin.Context) {
 	}
 }
 
+// wikiAssetType 资源扩展名 → Content-Type 白名单（review H1）：
+// 只允许惰性内容类型；HTML/SVG/XML/JS/WASM/无扩展名等可执行文档一律拒绝
+// 内联渲染（否则公开 PR 合并一个 .html/.svg 即成为论坛同源脚本执行原语）。
+// 返回 (contentType, ok)；ok=false 时调用方以 octet-stream + attachment 兜底。
+func wikiAssetType(name string) (string, bool) {
+	ext := strings.ToLower(path.Ext(name))
+	switch ext {
+	case ".jpg", ".jpeg":
+		return "image/jpeg", true
+	case ".png":
+		return "image/png", true
+	case ".gif":
+		return "image/gif", true
+	case ".webp":
+		return "image/webp", true
+	case ".avif":
+		return "image/avif", true
+	case ".bmp":
+		return "image/bmp", true
+	case ".ico":
+		return "image/x-icon", true
+	case ".pdf":
+		return "application/pdf", true
+	case ".doc", ".docx":
+		return "application/msword", true
+	case ".xls", ".xlsx":
+		return "application/vnd.ms-excel", true
+	case ".ppt", ".pptx":
+		return "application/vnd.ms-powerpoint", true
+	case ".zip", ".gz", ".7z", ".rar", ".tar":
+		return "application/octet-stream", true
+	case ".txt", ".csv":
+		return "text/plain", true
+	case ".md", ".markdown", ".mdown", ".mkd":
+		return "", false // Markdown 源文件不得作为资产提供
+	default:
+		return "", false
+	}
+}
+
 // wikiAsset serves a validated repository asset through the existing Wiki
 // catch-all route, which avoids introducing a conflicting Gin wildcard route.
+// 安全（review H1）：仅白名单类型内联渲染；其余一律
+// application/octet-stream + Content-Disposition: attachment 下载，并加
+// Content-Security-Policy: sandbox 兜底（即使类型绕过也无法执行脚本）。
 func wikiAsset(c *gin.Context, assetPath string) {
 	cfg := wikiservice.LoadGitConfig()
 	if !cfg.Enabled() {
 		renderNotFound(c)
+		return
+	}
+	// review F3：匿名文件端点限流（per-IP 固定配额，60s 窗口 120 次）。
+	// 资产是公开只读端点，不需要配置化；防止未认证调用方反复拉大文件
+	// 造成带宽/磁盘 I/O 耗尽。wiki 页面浏览不受影响（限流只在资产分派内）。
+	store := ratelimit.Default()
+	key := "wiki.asset:ip:" + c.ClientIP()
+	if ok, retryAfter, _ := store.Allow(key, 120, time.Minute); !ok {
+		c.Header("Retry-After", strconv.Itoa(int(math.Ceil(retryAfter.Seconds()))))
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate limited"})
 		return
 	}
 	file, info, err := wikiservice.OpenWikiAsset(cfg.CloneDir, assetPath)
@@ -161,8 +219,17 @@ func wikiAsset(c *gin.Context, assetPath string) {
 		return
 	}
 	defer file.Close()
+	contentType, safe := wikiAssetType(info.Name())
+	if !safe {
+		// 未知/危险类型：强制下载，绝不内联（nosniff + CSP sandbox 双保险）。
+		contentType = "application/octet-stream"
+		c.Header("Content-Disposition", "attachment; filename=\""+strings.ReplaceAll(info.Name(), `"`, "")+"\"")
+	}
 	c.Header("Cache-Control", "no-cache")
 	c.Header("X-Content-Type-Options", "nosniff")
+	// CSP sandbox：即使类型/内容被绕过，文档上下文内也不执行脚本。
+	c.Header("Content-Security-Policy", "sandbox")
+	c.Header("Content-Type", contentType)
 	http.ServeContent(c.Writer, c.Request, info.Name(), info.ModTime(), file)
 }
 

--- a/apps/gooseforum/app/http/controllers/forum/wiki.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki.go
@@ -2,6 +2,7 @@ package forum
 
 import (
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
@@ -60,6 +61,10 @@ func WikiDetail(c *gin.Context) {
 	}
 	path = strings.TrimPrefix(path, "/")
 	path = strings.TrimSuffix(path, "/")
+	if assetPath, ok := strings.CutPrefix(path, "_assets/"); ok {
+		wikiAsset(c, assetPath)
+		return
+	}
 	// D7 URL 语义（URL 用 slug）：path 首段 = URL key（slug，降级=显示名）。
 	// ResolvePageByURLPath 先直查 slug 路径，未命中时回退按显示名解析重建
 	// （兼容中文目录声明 slug 前的旧链接 / 直接访问中文显示名 URL）。
@@ -139,6 +144,26 @@ func WikiDetail(c *gin.Context) {
 	if shouldCountTopicView(&topic) {
 		topicviewservice.RecordView(topic.Id)
 	}
+}
+
+// wikiAsset serves a validated repository asset through the existing Wiki
+// catch-all route, which avoids introducing a conflicting Gin wildcard route.
+func wikiAsset(c *gin.Context, assetPath string) {
+	cfg := wikiservice.LoadGitConfig()
+	if !cfg.Enabled() {
+		renderNotFound(c)
+		return
+	}
+	file, info, err := wikiservice.OpenWikiAsset(cfg.CloneDir, assetPath)
+	if err != nil {
+		slog.Warn("wiki asset unavailable", "path", assetPath, "error", err)
+		renderNotFound(c)
+		return
+	}
+	defer file.Close()
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Content-Type-Options", "nosniff")
+	http.ServeContent(c.Writer, c.Request, info.Name(), info.ModTime(), file)
 }
 
 func wikiTreePayload(activePath string) []WikiTreeNamespacePayload {

--- a/apps/gooseforum/app/http/controllers/forum/wiki_asset_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki_asset_test.go
@@ -1,0 +1,48 @@
+package forum
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
+	"github.com/gin-gonic/gin"
+)
+
+func TestWikiDetailServesRepositoryAsset(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := t.TempDir()
+	asset := filepath.Join(repo, "assets", "guide.pdf")
+	if err := os.MkdirAll(filepath.Dir(asset), 0o755); err != nil {
+		t.Fatalf("create asset directory: %v", err)
+	}
+	if err := os.WriteFile(asset, []byte("PDF"), 0o644); err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+	previousRepo := preferences.GetString("wiki.git.repo", "")
+	previousCloneDir := preferences.GetString("wiki.git.clone_dir", "")
+	preferences.Set("wiki.git.repo", "https://github.com/YourTongji/YourTJ-Wiki.git")
+	preferences.Set("wiki.git.clone_dir", repo)
+	t.Cleanup(func() {
+		preferences.Set("wiki.git.repo", previousRepo)
+		preferences.Set("wiki.git.clone_dir", previousCloneDir)
+	})
+
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodGet, "/wiki/_assets/assets/guide.pdf", nil)
+	context.Params = gin.Params{{Key: "path", Value: "/_assets/assets/guide.pdf"}}
+	WikiDetail(context)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("asset status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if recorder.Body.String() != "PDF" {
+		t.Fatalf("asset body = %q, want PDF", recorder.Body.String())
+	}
+	if recorder.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", recorder.Header().Get("X-Content-Type-Options"))
+	}
+}

--- a/apps/gooseforum/app/http/controllers/forum/wiki_asset_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki_asset_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
@@ -44,5 +45,84 @@ func TestWikiDetailServesRepositoryAsset(t *testing.T) {
 	}
 	if recorder.Header().Get("X-Content-Type-Options") != "nosniff" {
 		t.Fatalf("X-Content-Type-Options = %q, want nosniff", recorder.Header().Get("X-Content-Type-Options"))
+	}
+}
+
+// TestWikiAssetTypeAllowlist review H1：白名单类型内联渲染，危险/未知类型
+// 一律拒绝内联（返回 ok=false → octet-stream + attachment）。
+func TestWikiAssetTypeAllowlist(t *testing.T) {
+	cases := []struct {
+		name   string
+		file   string
+		wantOK bool
+		wantCT string
+	}{
+		{"png", "a.png", true, "image/png"},
+		{"jpeg", "a.jpg", true, "image/jpeg"},
+		{"webp", "a.webp", true, "image/webp"},
+		{"pdf", "a.pdf", true, "application/pdf"},
+		{"docx", "a.docx", true, "application/msword"},
+		{"zip", "a.zip", true, "application/octet-stream"},
+		{"txt", "a.txt", true, "text/plain"},
+		{"html rejected", "a.html", false, ""},
+		{"svg rejected", "a.svg", false, ""},
+		{"js rejected", "a.js", false, ""},
+		{"wasm rejected", "a.wasm", false, ""},
+		{"md rejected", "a.md", false, ""},
+		{"markdown rejected", "a.markdown", false, ""},
+		{"extensionless rejected", "README", false, ""},
+		{"unknown ext rejected", "a.xyz", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ct, ok := wikiAssetType(tc.file)
+			if ok != tc.wantOK {
+				t.Fatalf("wikiAssetType(%q) ok=%v, want %v", tc.file, ok, tc.wantOK)
+			}
+			if ok && ct != tc.wantCT {
+				t.Fatalf("wikiAssetType(%q) ct=%q, want %q", tc.file, ct, tc.wantCT)
+			}
+		})
+	}
+}
+
+// TestWikiDetailServesHtmlAsAttachment review H1：即使仓库里有 .html 文件，
+// 服务端也必须以 octet-stream + attachment 返回，绝不内联渲染（防同源 XSS）。
+func TestWikiDetailServesHtmlAsAttachment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := t.TempDir()
+	asset := filepath.Join(repo, "assets", "evil.html")
+	if err := os.MkdirAll(filepath.Dir(asset), 0o755); err != nil {
+		t.Fatalf("create asset directory: %v", err)
+	}
+	if err := os.WriteFile(asset, []byte("<script>alert(1)</script>"), 0o644); err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+	previousRepo := preferences.GetString("wiki.git.repo", "")
+	previousCloneDir := preferences.GetString("wiki.git.clone_dir", "")
+	preferences.Set("wiki.git.repo", "https://github.com/YourTongji/YourTJ-Wiki.git")
+	preferences.Set("wiki.git.clone_dir", repo)
+	t.Cleanup(func() {
+		preferences.Set("wiki.git.repo", previousRepo)
+		preferences.Set("wiki.git.clone_dir", previousCloneDir)
+	})
+
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	context.Request = httptest.NewRequest(http.MethodGet, "/wiki/_assets/assets/evil.html", nil)
+	context.Params = gin.Params{{Key: "path", Value: "/_assets/assets/evil.html"}}
+	WikiDetail(context)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("asset status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+	}
+	if ct := recorder.Header().Get("Content-Type"); ct != "application/octet-stream" {
+		t.Fatalf("Content-Type = %q, want application/octet-stream", ct)
+	}
+	if cd := recorder.Header().Get("Content-Disposition"); !strings.Contains(cd, "attachment") {
+		t.Fatalf("Content-Disposition = %q, want attachment", cd)
+	}
+	if csp := recorder.Header().Get("Content-Security-Policy"); csp != "sandbox" {
+		t.Fatalf("Content-Security-Policy = %q, want sandbox", csp)
 	}
 }

--- a/apps/gooseforum/app/service/wikiservice/path.go
+++ b/apps/gooseforum/app/service/wikiservice/path.go
@@ -23,7 +23,10 @@ const (
 )
 
 // reservedPathChars 文件系统保留字符（Windows 保留，跨平台目录名安全）。
-const reservedPathChars = `/ \ : * ? " < > |`
+// 额外拒绝 % 与 #（review M2）：Markdown URL 语法无法可靠表示——`%` 是
+// 转义前缀（`100%done.md` 无法被 url.Parse 解析），`#` 开启 fragment
+// （`a#b.md` 被截断为 `a`）；GitHub 外链拼接同样受影响。
+const reservedPathChars = `/ \ : * ? " < > | % #`
 
 // validSegment 校验单个路径段（命名空间或 slug）是否合法。
 func validSegment(seg string) bool {

--- a/apps/gooseforum/app/service/wikiservice/relative_urls.go
+++ b/apps/gooseforum/app/service/wikiservice/relative_urls.go
@@ -1,0 +1,248 @@
+package wikiservice
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/markdown2html"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+	nethtml "golang.org/x/net/html"
+)
+
+const wikiAssetRoutePrefix = "/wiki/_assets/"
+
+// wikiReferenceResolver turns repository-relative Markdown destinations into
+// public Wiki page or asset URLs. Source Markdown remains unchanged in the DB.
+type wikiReferenceResolver struct {
+	cloneDir          string
+	pagesBySourcePath map[string]string
+}
+
+func newWikiReferenceResolver(cloneDir string, pages []wantedPage) *wikiReferenceResolver {
+	pagesBySourcePath := make(map[string]string, len(pages))
+	for _, page := range pages {
+		pagesBySourcePath[page.sourcePath] = page.path
+	}
+	return &wikiReferenceResolver{cloneDir: cloneDir, pagesBySourcePath: pagesBySourcePath}
+}
+
+// Validate checks every rendered Markdown link and image before the sync mutates page rows.
+func (r *wikiReferenceResolver) Validate(page wantedPage) error {
+	reader := text.NewReader([]byte(page.body))
+	doc := markdown2html.GetParser().Parser().Parse(reader)
+	var validationErr error
+	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if validationErr != nil {
+			return ast.WalkStop, nil
+		}
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch node := node.(type) {
+		case *ast.Link:
+			_, validationErr = r.resolve(page.sourcePath+".md", string(node.Destination))
+		case *ast.Image:
+			_, validationErr = r.resolve(page.sourcePath+".md", string(node.Destination))
+		}
+		return ast.WalkContinue, nil
+	})
+	if validationErr != nil {
+		return fmt.Errorf("wiki source %s.md: %w", page.sourcePath, validationErr)
+	}
+	return nil
+}
+
+func (r *wikiReferenceResolver) Render(page wantedPage) (string, error) {
+	raw := markdown2html.PostMarkdownToHTML(page.body)
+	root, err := nethtml.Parse(strings.NewReader("<div>" + raw + "</div>"))
+	if err != nil {
+		return "", fmt.Errorf("parse rendered HTML: %w", err)
+	}
+
+	var rewriteErr error
+	var walk func(*nethtml.Node)
+	walk = func(node *nethtml.Node) {
+		if rewriteErr != nil {
+			return
+		}
+		if node.Type == nethtml.ElementNode {
+			var key string
+			switch node.Data {
+			case "a":
+				key = "href"
+			case "img":
+				key = "src"
+			}
+			if key != "" {
+				for i := range node.Attr {
+					if node.Attr[i].Key != key {
+						continue
+					}
+					rewritten, err := r.resolve(page.sourcePath+".md", node.Attr[i].Val)
+					if err != nil {
+						rewriteErr = fmt.Errorf("wiki source %s.md: %w", page.sourcePath, err)
+						return
+					}
+					node.Attr[i].Val = rewritten
+				}
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			walk(child)
+		}
+	}
+	walk(root)
+	if rewriteErr != nil {
+		return "", rewriteErr
+	}
+
+	container := findWikiHTMLElement(root, "div")
+	if container == nil {
+		return "", fmt.Errorf("rendered HTML missing container")
+	}
+	var output bytes.Buffer
+	for child := container.FirstChild; child != nil; child = child.NextSibling {
+		if err := nethtml.Render(&output, child); err != nil {
+			return "", fmt.Errorf("render rewritten HTML: %w", err)
+		}
+	}
+	return output.String(), nil
+}
+
+func (r *wikiReferenceResolver) resolve(sourceFile, destination string) (string, error) {
+	trimmed := strings.TrimSpace(destination)
+	if trimmed == "" {
+		return destination, nil
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL %q: %w", destination, err)
+	}
+	// Absolute, protocol-relative, anchor-only, query-only, and site-root URLs
+	// deliberately retain their author-provided meaning.
+	if parsed.IsAbs() || parsed.Host != "" || strings.HasPrefix(trimmed, "//") || parsed.Path == "" || strings.HasPrefix(parsed.Path, "/") {
+		return destination, nil
+	}
+
+	repoPath, err := resolveWikiRelativePath(sourceFile, parsed.EscapedPath())
+	if err != nil {
+		return "", fmt.Errorf("relative URL %q: %w", destination, err)
+	}
+	if strings.EqualFold(path.Ext(repoPath), ".md") {
+		wikiPath, ok := r.pagesBySourcePath[strings.TrimSuffix(repoPath, ".md")]
+		if !ok {
+			return "", fmt.Errorf("linked page %q does not exist", repoPath)
+		}
+		parsed.Path = "/wiki/" + wikiPath
+		parsed.RawPath = ""
+		return parsed.String(), nil
+	}
+	if _, _, err := resolveWikiAssetFile(r.cloneDir, repoPath); err != nil {
+		return "", fmt.Errorf("asset %q: %w", repoPath, err)
+	}
+	parsed.Path = wikiAssetRoutePrefix + repoPath
+	parsed.RawPath = ""
+	return parsed.String(), nil
+}
+
+func resolveWikiRelativePath(sourceFile, encodedPath string) (string, error) {
+	decoded, err := url.PathUnescape(encodedPath)
+	if err != nil {
+		return "", fmt.Errorf("invalid path encoding: %w", err)
+	}
+	if strings.ContainsRune(decoded, '\x00') || strings.ContainsRune(decoded, '\\') {
+		return "", fmt.Errorf("invalid repository path")
+	}
+	resolved := path.Clean(path.Join(path.Dir(sourceFile), decoded))
+	if resolved == "." || resolved == ".." || strings.HasPrefix(resolved, "../") {
+		return "", fmt.Errorf("escapes repository root")
+	}
+	if err := validateWikiAssetPath(resolved, false); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// OpenWikiAsset opens a non-Markdown repository file after resolving symlinks
+// and verifying that the result remains inside the configured clone directory.
+func OpenWikiAsset(cloneDir, repoPath string) (*os.File, os.FileInfo, error) {
+	assetPath, info, err := resolveWikiAssetFile(cloneDir, repoPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	file, err := os.Open(assetPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open asset: %w", err)
+	}
+	return file, info, nil
+}
+
+func resolveWikiAssetFile(cloneDir, repoPath string) (string, os.FileInfo, error) {
+	if err := validateWikiAssetPath(repoPath, true); err != nil {
+		return "", nil, err
+	}
+	rootAbs, err := filepath.Abs(cloneDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve clone directory: %w", err)
+	}
+	root, err := filepath.EvalSymlinks(rootAbs)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve clone directory: %w", err)
+	}
+	asset, err := filepath.EvalSymlinks(filepath.Join(root, filepath.FromSlash(repoPath)))
+	if err != nil {
+		return "", nil, fmt.Errorf("asset not found")
+	}
+	if !isPathWithin(root, asset) {
+		return "", nil, fmt.Errorf("asset resolves outside repository")
+	}
+	info, err := os.Stat(asset)
+	if err != nil {
+		return "", nil, fmt.Errorf("inspect asset: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, fmt.Errorf("asset is not a regular file")
+	}
+	return asset, info, nil
+}
+
+func validateWikiAssetPath(repoPath string, rejectMarkdown bool) error {
+	if repoPath == "" || strings.HasPrefix(repoPath, "/") || path.Clean(repoPath) != repoPath {
+		return fmt.Errorf("invalid repository path")
+	}
+	for _, segment := range strings.Split(repoPath, "/") {
+		if segment == "" || segment == "." || segment == ".." || strings.HasPrefix(segment, ".") || strings.ContainsRune(segment, '\\') {
+			return fmt.Errorf("invalid repository path")
+		}
+	}
+	if rejectMarkdown && strings.EqualFold(path.Ext(repoPath), ".md") {
+		return fmt.Errorf("Markdown source files are not assets")
+	}
+	return nil
+}
+
+func isPathWithin(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}
+
+func findWikiHTMLElement(node *nethtml.Node, tag string) *nethtml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Type == nethtml.ElementNode && node.Data == tag {
+		return node
+	}
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		if found := findWikiHTMLElement(child, tag); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/apps/gooseforum/app/service/wikiservice/relative_urls.go
+++ b/apps/gooseforum/app/service/wikiservice/relative_urls.go
@@ -46,7 +46,7 @@ func (r *wikiReferenceResolver) Validate(page wantedPage) error {
 	var validationErr error
 	_ = ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if validationErr != nil {
-			return ast.WalkStop, nil
+			return ast.WalkStop, validationErr
 		}
 		if !entering {
 			return ast.WalkContinue, nil
@@ -252,7 +252,7 @@ func validateWikiAssetPath(repoPath string, rejectMarkdown bool) error {
 		}
 	}
 	if rejectMarkdown && isMarkdownPath(repoPath) {
-		return fmt.Errorf("Markdown source files are not assets")
+		return fmt.Errorf("markdown source files are not assets")
 	}
 	return nil
 }

--- a/apps/gooseforum/app/service/wikiservice/relative_urls.go
+++ b/apps/gooseforum/app/service/wikiservice/relative_urls.go
@@ -2,6 +2,7 @@ package wikiservice
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -16,6 +17,12 @@ import (
 )
 
 const wikiAssetRoutePrefix = "/wiki/_assets/"
+
+// errWikiRefEscapesRepo 标记引用解析中的安全类错误（路径逃逸/符号链接越界）：
+// 这类错误必须整体失败（sync 停止），不允许 per-page 降级——否则恶意仓库
+// 可通过「坏链接页跳过」绕过安全校验。普通内容错误（链接的页面/资产不存在、
+// 图片引用 .md 等）降级为单页跳过并聚合告警。
+var errWikiRefEscapesRepo = errors.New("wiki reference escapes repository")
 
 // wikiReferenceResolver turns repository-relative Markdown destinations into
 // public Wiki page or asset URLs. Source Markdown remains unchanged in the DB.
@@ -46,9 +53,11 @@ func (r *wikiReferenceResolver) Validate(page wantedPage) error {
 		}
 		switch node := node.(type) {
 		case *ast.Link:
-			_, validationErr = r.resolve(page.sourcePath+".md", string(node.Destination))
+			_, validationErr = r.resolve(page.sourcePath+".md", string(node.Destination), false)
 		case *ast.Image:
-			_, validationErr = r.resolve(page.sourcePath+".md", string(node.Destination))
+			// review M3：图片指向 Markdown 页面会渲染成永久坏图（浏览器把
+			// HTML 当图片加载），直接拒绝并给出可操作错误。
+			_, validationErr = r.resolve(page.sourcePath+".md", string(node.Destination), true)
 		}
 		return ast.WalkContinue, nil
 	})
@@ -71,26 +80,26 @@ func (r *wikiReferenceResolver) Render(page wantedPage) (string, error) {
 		if rewriteErr != nil {
 			return
 		}
-		if node.Type == nethtml.ElementNode {
-			var key string
-			switch node.Data {
-			case "a":
-				key = "href"
-			case "img":
-				key = "src"
-			}
-			if key != "" {
-				for i := range node.Attr {
-					if node.Attr[i].Key != key {
-						continue
-					}
-					rewritten, err := r.resolve(page.sourcePath+".md", node.Attr[i].Val)
-					if err != nil {
-						rewriteErr = fmt.Errorf("wiki source %s.md: %w", page.sourcePath, err)
-						return
-					}
-					node.Attr[i].Val = rewritten
+		var key string
+		isImage := false
+		switch node.Data {
+		case "a":
+			key = "href"
+		case "img":
+			key = "src"
+			isImage = true
+		}
+		if key != "" {
+			for i := range node.Attr {
+				if node.Attr[i].Key != key {
+					continue
 				}
+				rewritten, err := r.resolve(page.sourcePath+".md", node.Attr[i].Val, isImage)
+				if err != nil {
+					rewriteErr = fmt.Errorf("wiki source %s.md: %w", page.sourcePath, err)
+					return
+				}
+				node.Attr[i].Val = rewritten
 			}
 		}
 		for child := node.FirstChild; child != nil; child = child.NextSibling {
@@ -115,7 +124,7 @@ func (r *wikiReferenceResolver) Render(page wantedPage) (string, error) {
 	return output.String(), nil
 }
 
-func (r *wikiReferenceResolver) resolve(sourceFile, destination string) (string, error) {
+func (r *wikiReferenceResolver) resolve(sourceFile, destination string, isImage bool) (string, error) {
 	trimmed := strings.TrimSpace(destination)
 	if trimmed == "" {
 		return destination, nil
@@ -134,8 +143,14 @@ func (r *wikiReferenceResolver) resolve(sourceFile, destination string) (string,
 	if err != nil {
 		return "", fmt.Errorf("relative URL %q: %w", destination, err)
 	}
-	if strings.EqualFold(path.Ext(repoPath), ".md") {
-		wikiPath, ok := r.pagesBySourcePath[strings.TrimSuffix(repoPath, ".md")]
+	if isMarkdownPath(repoPath) {
+		if isImage {
+			return "", fmt.Errorf("image cannot reference a Markdown page %q", repoPath)
+		}
+		// review M4：扩展名大小写不敏感（.MD/.md 同义），但 TrimSuffix 必须
+		// 用精确的 ext（path.Ext 保留大小写）切掉，map 查找才一致。
+		key := strings.TrimSuffix(repoPath, path.Ext(repoPath))
+		wikiPath, ok := r.pagesBySourcePath[key]
 		if !ok {
 			return "", fmt.Errorf("linked page %q does not exist", repoPath)
 		}
@@ -151,6 +166,19 @@ func (r *wikiReferenceResolver) resolve(sourceFile, destination string) (string,
 	return parsed.String(), nil
 }
 
+// isMarkdownPath 判断仓库相对路径是否为 Markdown 源文件（.md 家族，大小写不敏感）。
+// 与 scanRepoFiles 只投影 `.md` 一致：仅 `.md` 是页面；.markdown/.mdown/.mkd
+// 既不是页面也不得作为资产（F4：防止「不是页面的 Markdown」被原样吐给浏览器）。
+func isMarkdownPath(repoPath string) bool {
+	lower := strings.ToLower(repoPath)
+	for _, ext := range []string{".md", ".markdown", ".mdown", ".mkd"} {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
 func resolveWikiRelativePath(sourceFile, encodedPath string) (string, error) {
 	decoded, err := url.PathUnescape(encodedPath)
 	if err != nil {
@@ -161,7 +189,8 @@ func resolveWikiRelativePath(sourceFile, encodedPath string) (string, error) {
 	}
 	resolved := path.Clean(path.Join(path.Dir(sourceFile), decoded))
 	if resolved == "." || resolved == ".." || strings.HasPrefix(resolved, "../") {
-		return "", fmt.Errorf("escapes repository root")
+		// 安全类错误：仓库根逃逸必须致命（恶意链接不得降级跳过）。
+		return "", fmt.Errorf("escapes repository root: %w", errWikiRefEscapesRepo)
 	}
 	if err := validateWikiAssetPath(resolved, false); err != nil {
 		return "", err
@@ -200,7 +229,8 @@ func resolveWikiAssetFile(cloneDir, repoPath string) (string, os.FileInfo, error
 		return "", nil, fmt.Errorf("asset not found")
 	}
 	if !isPathWithin(root, asset) {
-		return "", nil, fmt.Errorf("asset resolves outside repository")
+		// 安全类错误：符号链接越界必须致命。
+		return "", nil, fmt.Errorf("asset resolves outside repository: %w", errWikiRefEscapesRepo)
 	}
 	info, err := os.Stat(asset)
 	if err != nil {
@@ -221,7 +251,7 @@ func validateWikiAssetPath(repoPath string, rejectMarkdown bool) error {
 			return fmt.Errorf("invalid repository path")
 		}
 	}
-	if rejectMarkdown && strings.EqualFold(path.Ext(repoPath), ".md") {
+	if rejectMarkdown && isMarkdownPath(repoPath) {
 		return fmt.Errorf("Markdown source files are not assets")
 	}
 	return nil

--- a/apps/gooseforum/app/service/wikiservice/relative_urls_test.go
+++ b/apps/gooseforum/app/service/wikiservice/relative_urls_test.go
@@ -1,0 +1,47 @@
+package wikiservice
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOpenWikiAsset(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "assets/guide.pdf", "PDF")
+
+	file, info, err := OpenWikiAsset(repo, "assets/guide.pdf")
+	if err != nil {
+		t.Fatalf("open asset: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+	if info.Name() != "guide.pdf" {
+		t.Fatalf("asset name = %q, want guide.pdf", info.Name())
+	}
+	body, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatalf("read asset: %v", err)
+	}
+	if string(body) != "PDF" {
+		t.Fatalf("asset body = %q, want PDF", body)
+	}
+
+	for _, path := range []string{"../outside.txt", "assets/guide.md", "assets/missing.pdf"} {
+		if _, _, err := OpenWikiAsset(repo, path); err == nil {
+			t.Fatalf("OpenWikiAsset(%q) succeeded, want rejection", path)
+		}
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.pdf")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatalf("write outside asset: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, "assets", "outside.pdf")); err != nil {
+		t.Fatalf("create asset symlink: %v", err)
+	}
+	if _, _, err := OpenWikiAsset(repo, "assets/outside.pdf"); err == nil || !strings.Contains(err.Error(), "outside repository") {
+		t.Fatalf("symlink escape error = %v, want outside-repository rejection", err)
+	}
+}

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -516,13 +516,14 @@ func syncOnce(cfg GitConfig, trigger string) (*SyncResult, error) {
 // 可中文）；namespace = URL key（wiki_pages.namespace 列）；sourcePath = 仓库
 // 真实相对路径（GitHub 外链拼接用，与 URL 解耦）。
 type wantedPage struct {
-	path        string
-	sourcePath  string
-	namespace   string
-	displayName string
-	title       string
-	order       int
-	body        string
+	path         string
+	sourcePath   string
+	namespace    string
+	displayName  string
+	title        string
+	order        int
+	body         string
+	renderedHTML string
 }
 
 // nsSlugPlan slug 定稿结果（D7：URL 用 slug，显示名与 URL key 分离）。
@@ -689,6 +690,9 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 			continue
 		}
 		dir := NamespaceOf(norm)
+		if dir == "_assets" {
+			return fmt.Errorf("wiki namespace %q is reserved for repository assets", dir)
+		}
 		urlKey := plans[dir].urlKey
 		title, order, _, _, body := parseMarkdownFile(f)
 		wp := wantedPage{
@@ -702,6 +706,18 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 		}
 		wanted = append(wanted, wp)
 		wantedByPath[wp.path] = wp
+	}
+	resolver := newWikiReferenceResolver(cfg.CloneDir, wanted)
+	for i := range wanted {
+		wp := &wanted[i]
+		if err := resolver.Validate(*wp); err != nil {
+			return err
+		}
+		rendered, err := resolver.Render(*wp)
+		if err != nil {
+			return err
+		}
+		wp.renderedHTML = rendered
 	}
 
 	// 2.7 既有页面 path 迁移：URL key 变化（slug 变更/首回填）时，把该命名空间
@@ -804,6 +820,7 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 			existingPage.Title == wp.title &&
 			existingPage.SortOrder == wp.order &&
 			existingPage.SourcePath == wp.sourcePath &&
+			existingPage.RenderedHTML == wp.renderedHTML &&
 			!restored {
 			continue
 		}
@@ -933,7 +950,7 @@ func createPageFromRepo(cfg GitConfig, wp wantedPage) error {
 		}
 	}
 
-	rendered := markdown2html.PostMarkdownToHTML(wp.body)
+	rendered := wp.renderedHTML
 	toc := encodeTOCOrEmpty(markdown2html.ExtractHeadings(wp.body))
 
 	topic := topics.Entity{
@@ -1004,7 +1021,7 @@ func createPageFromRepo(cfg GitConfig, wp wantedPage) error {
 
 // updatePageFromRepo 更新已存在页面的投影（内容/标题/渲染/哈希 + topic/post 物化）。
 func updatePageFromRepo(cfg GitConfig, page *wikiPages.Entity, wp wantedPage, curHash string) error {
-	rendered := markdown2html.PostMarkdownToHTML(wp.body)
+	rendered := wp.renderedHTML
 	toc := encodeTOCOrEmpty(markdown2html.ExtractHeadings(wp.body))
 
 	topic := topics.UnscopedGet(page.TopicId)

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -320,7 +320,14 @@ type repoFile struct {
 	Hash    string // sha256(content)
 }
 
+// maxWikiPageBytes 单页源文件大小上限（review F2）：仓库恶意/意外的大文件
+// （如符号链接指向 /dev/zero）会撑爆内存并卡死同步，超限直接报错。
+const maxWikiPageBytes = 4 << 20 // 4 MiB
+
 // scanRepoFiles 递归扫描 clone 目录下的 .md 文件（排除 .git、隐藏目录）。
+// 只接受普通文件（lstat IsRegular）：Git 克隆会把仓库符号链接物化为 symlink，
+// 若跟随读取可把服务器任意文件（如 ../../config.toml）投影为公开 wiki 页
+// （review F2），或读 /dev/zero 类目标永久阻塞同步。符号链接一律拒绝。
 func scanRepoFiles(cloneDir string) ([]repoFile, error) {
 	var files []repoFile
 	err := filepath.Walk(cloneDir, func(path string, info os.FileInfo, err error) error {
@@ -336,6 +343,16 @@ func scanRepoFiles(cloneDir string) ([]repoFile, error) {
 		}
 		if !strings.HasSuffix(info.Name(), ".md") {
 			return nil
+		}
+		// review F2：拒绝符号链接（lstat 语义，不跟随）。
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("wiki page %s is a symlink (not allowed)", path)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("wiki page %s is not a regular file", path)
+		}
+		if info.Size() > maxWikiPageBytes {
+			return fmt.Errorf("wiki page %s exceeds %d bytes", path, maxWikiPageBytes)
 		}
 		rel, err := filepath.Rel(cloneDir, path)
 		if err != nil {
@@ -614,6 +631,8 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 	// 默认 slug=guide，另一目录 frontmatter 声明 slug: guide）→ 后处理方
 	// 报错并降级为显示名（唯一索引保护；两行都尚不存在时 DB 冲突检测不可用）。
 	var errs []string
+	// review M1：引用校验/渲染失败的页面跳过（保留旧版本），聚合为 run 错误。
+	skipWanted := make(map[string]bool, 0)
 	repoDisplayNames := make(map[string]struct{}, len(files))
 	for _, f := range files {
 		rel := strings.TrimSuffix(f.Path, ".md")
@@ -708,14 +727,27 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 		wantedByPath[wp.path] = wp
 	}
 	resolver := newWikiReferenceResolver(cfg.CloneDir, wanted)
+	// review M1：单页引用校验/渲染失败 → 跳过该页并聚合告警（其余页面继续），
+	// 避免一个坏链接冻结整个 wiki 的更新与删除。但安全类错误（仓库根逃逸/
+	// 符号链接越界）必须整体失败：恶意链接不允许通过「坏页跳过」绕过校验。
 	for i := range wanted {
 		wp := &wanted[i]
 		if err := resolver.Validate(*wp); err != nil {
-			return err
+			if errors.Is(err, errWikiRefEscapesRepo) {
+				return err
+			}
+			errs = append(errs, fmt.Sprintf("skip %s: %v", wp.path, err))
+			skipWanted[wp.path] = true
+			continue
 		}
 		rendered, err := resolver.Render(*wp)
 		if err != nil {
-			return err
+			if errors.Is(err, errWikiRefEscapesRepo) {
+				return err
+			}
+			errs = append(errs, fmt.Sprintf("skip %s: %v", wp.path, err))
+			skipWanted[wp.path] = true
+			continue
 		}
 		wp.renderedHTML = rendered
 	}
@@ -757,6 +789,11 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 	// 3. 逐页 upsert（每页独立事务）。单页失败聚合为整体失败：DB 与仓库
 	//    部分偏离时 run 必须标记 failed，而不是向运维报告 success。
 	for _, wp := range wanted {
+		if skipWanted[wp.path] {
+			// review M1：引用校验/渲染失败的页面保留 DB 旧版本（不写空
+			// renderedHTML 覆盖），仅聚合告警；其余页面正常 upsert。
+			continue
+		}
 		// 仓库顶层目录 = namespace 显示名；不存在则自动创建（名字=显示名，
 		// 与 URL key 解耦）。放在 upsert 循环内，覆盖「目录曾被 D5 删除、
 		// 页面重新出现走恢复路径」的场景（恢复路径不经过 createPageFromRepo，

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -3,6 +3,7 @@ package wikiservice
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -12,6 +13,104 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiNamespaces"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
 )
+
+func TestApplyRepoToDBRewritesRelativeReferences(t *testing.T) {
+	setupWikiTestDB(t)
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "同济指南/index.md", "---\ntitle: 指南\nslug: guide\n---\n\n# 指南")
+	writeRepoFile(t, repo, "同济指南/other.md", "# 下一页")
+	writeRepoFile(t, repo, "同济指南/nested/start.md", `# 开始
+
+[下一页](../other.md?tab=2#section)
+![图片](../../assets/a%20b.png?raw=1#preview)
+[附件](../../assets/handout.pdf)
+[外部](https://example.com/guide)
+[根路径](/static/logo.svg)`)
+	writeRepoFile(t, repo, "assets/a b.png", "png")
+	writeRepoFile(t, repo, "assets/handout.pdf", "pdf")
+
+	if err := applyRepoToDB(GitConfig{CloneDir: repo}, &SyncResult{}); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	page := wikiPages.GetByPath("guide/nested/start")
+	if page.Id == 0 {
+		t.Fatal("nested page missing after sync")
+	}
+	for _, want := range []string{
+		`href="/wiki/guide/other?tab=2#section"`,
+		`src="/wiki/_assets/assets/a%20b.png?raw=1#preview"`,
+		`href="/wiki/_assets/assets/handout.pdf"`,
+		`href="https://example.com/guide"`,
+		`href="/static/logo.svg"`,
+	} {
+		if !strings.Contains(page.RenderedHTML, want) {
+			t.Fatalf("rendered HTML missing %s: %s", want, page.RenderedHTML)
+		}
+	}
+}
+
+func TestApplyRepoToDBRejectsBrokenRelativeReferences(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "escapes repository",
+			content: "# 开始\n\n![图片](../../outside.png)",
+			want:    "escapes repository root",
+		},
+		{
+			name:    "missing page",
+			content: "# 开始\n\n[下一页](missing.md)",
+			want:    `linked page "guide/missing.md" does not exist`,
+		},
+		{
+			name:    "missing asset",
+			content: "# 开始\n\n![图片](missing.png)",
+			want:    `asset "guide/missing.png": asset not found`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setupWikiTestDB(t)
+			repo := t.TempDir()
+			writeRepoFile(t, repo, "guide/start.md", tc.content)
+
+			err := applyRepoToDB(GitConfig{CloneDir: repo}, &SyncResult{})
+			if err == nil || !strings.Contains(err.Error(), "wiki source guide/start.md") || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("sync error = %v, want actionable error containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyRepoToDBRefreshesRelativeLinksAfterSlugChange(t *testing.T) {
+	setupWikiTestDB(t)
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "指南/index.md", "---\nslug: guide\n---\n\n# 指南")
+	writeRepoFile(t, repo, "指南/start.md", "# 开始\n\n[下一页](../文档/other.md)")
+	writeRepoFile(t, repo, "文档/index.md", "---\nslug: docs\n---\n\n# 文档")
+	writeRepoFile(t, repo, "文档/other.md", "# 下一页")
+	cfg := GitConfig{CloneDir: repo}
+
+	if err := applyRepoToDB(cfg, &SyncResult{}); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	start := wikiPages.GetByPath("guide/start")
+	if !strings.Contains(start.RenderedHTML, `href="/wiki/docs/other"`) {
+		t.Fatalf("first rendered link = %s, want /wiki/docs/other", start.RenderedHTML)
+	}
+
+	writeRepoFile(t, repo, "文档/index.md", "---\nslug: handbook\n---\n\n# 文档")
+	if err := applyRepoToDB(cfg, &SyncResult{}); err != nil {
+		t.Fatalf("sync after slug change: %v", err)
+	}
+	start = wikiPages.GetByPath("guide/start")
+	if !strings.Contains(start.RenderedHTML, `href="/wiki/handbook/other"`) {
+		t.Fatalf("refreshed rendered link = %s, want /wiki/handbook/other", start.RenderedHTML)
+	}
+}
 
 // writeRepoFile 在临时仓库目录下写一个 md 文件（自动建父目录）。
 func writeRepoFile(t *testing.T, root, rel string, content string) {

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -85,6 +85,52 @@ func TestApplyRepoToDBRejectsBrokenRelativeReferences(t *testing.T) {
 	}
 }
 
+// TestApplyRepoToDBDegradesPerPageOnBrokenReferences review M1：
+// 单个页面坏引用（missing 类）→ 该页跳过（保留 DB 旧版本）+ 聚合告警，
+// 其余页面正常 upsert；只有安全类错误（仓库根逃逸）才整体失败。
+func TestApplyRepoToDBDegradesPerPageOnBrokenReferences(t *testing.T) {
+	setupWikiTestDB(t)
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "guide/broken.md", "# 坏页\n\n[下一页](missing.md)")
+	writeRepoFile(t, repo, "guide/good.md", "# 好页\n\n[下一页](broken.md)")
+	writeRepoFile(t, repo, "guide/index.md", "---\ntitle: 指南\nslug: guide\n---\n\n# 指南")
+
+	cfg := GitConfig{CloneDir: repo}
+	res := &SyncResult{}
+	err := applyRepoToDB(cfg, res)
+	if err == nil {
+		t.Fatal("sync error = nil, want aggregated per-page failure")
+	}
+	if !strings.Contains(err.Error(), "skip guide/broken") {
+		t.Fatalf("sync error = %v, want skip guide/broken", err)
+	}
+	// 好页仍被创建；被跳过页不存在（首次同步，无旧版本可保留）。
+	if page := wikiPages.GetByPath("guide/good"); page.Id == 0 {
+		t.Fatal("good page missing after degraded sync")
+	}
+	if page := wikiPages.GetByPath("guide/broken"); page.Id != 0 {
+		t.Fatalf("broken page should not be created, got id=%d", page.Id)
+	}
+}
+
+// TestApplyRepoToDBKeepsEscapeFatal review M1：仓库根逃逸是安全类错误，
+// 不允许 per-page 降级，必须整体失败（恶意链接不得通过「坏页跳过」绕过）。
+func TestApplyRepoToDBKeepsEscapeFatal(t *testing.T) {
+	setupWikiTestDB(t)
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "guide/start.md", "# 开始\n\n![图片](../../outside.png)")
+	writeRepoFile(t, repo, "guide/good.md", "# 好页")
+
+	err := applyRepoToDB(GitConfig{CloneDir: repo}, &SyncResult{})
+	if err == nil || !strings.Contains(err.Error(), "escapes repository root") {
+		t.Fatalf("sync error = %v, want fatal escape error", err)
+	}
+	// 逃逸致命：整体失败，好页也不创建。
+	if page := wikiPages.GetByPath("guide/good"); page.Id != 0 {
+		t.Fatal("good page should not be created when sync fails fatally")
+	}
+}
+
 func TestApplyRepoToDBRefreshesRelativeLinksAfterSlugChange(t *testing.T) {
 	setupWikiTestDB(t)
 	repo := t.TempDir()
@@ -490,6 +536,39 @@ func TestScanRepoFilesSkipsNonMarkdown(t *testing.T) {
 		if files[i].Path != want {
 			t.Fatalf("scan[%d]=%q, want %q (all=%v)", i, files[i].Path, want, wantPaths)
 		}
+	}
+}
+
+// TestScanRepoFilesRejectsSymlinks review F2：Git 克隆会把仓库符号链接物化为
+// symlink，若跟随读取可把服务器任意文件投影为公开 wiki 页（任意文件泄露）
+// 或读 /dev/zero 类目标永久阻塞同步。扫描必须 lstat 拒绝符号链接。
+func TestScanRepoFilesRejectsSymlinks(t *testing.T) {
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "docs/ok.md", "# OK")
+	writeRepoFile(t, repo, "docs/target.md", "# 目标")
+	if err := os.Symlink(filepath.Join(repo, "docs/target.md"), filepath.Join(repo, "docs/link.md")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	_, err := scanRepoFiles(repo)
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("scan error = %v, want symlink rejection", err)
+	}
+}
+
+// TestScanRepoFilesRejectsOversize review F2：超大 .md（超 4MiB）拒绝，
+// 防止恶意仓库撑爆内存。
+func TestScanRepoFilesRejectsOversize(t *testing.T) {
+	repo := t.TempDir()
+	big := make([]byte, maxWikiPageBytes+1)
+	for i := range big {
+		big[i] = 'a'
+	}
+	writeRepoFile(t, repo, "docs/big.md", string(big))
+
+	_, err := scanRepoFiles(repo)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("scan error = %v, want size rejection", err)
 	}
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ status. Do not use PR-relative "shipped this / later" labels as long-term status
 
 - [Vision & principles](product/vision-and-principles.md)
 - [Current state & gaps](product/current-state.md)
+- [Wiki authoring](product/wiki-authoring.md)
 - [Identity, login & account lifecycle](product/identity-and-access.md)
 - [Points & cross-platform settlement](product/credit-and-escrow.md)
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -102,7 +102,8 @@ Wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作�
   `/admin/wiki` 同步面板手动触发 + GitHub webhook（`POST /api/wiki/webhook`，HMAC-SHA256
   验签，push 事件，仅默认分支）。同步运行写入 `wiki_sync_runs`
   （trigger/status/head_sha/变更计数/错误）。
-- **路由**: `GET /wiki`、`GET /wiki/*path`（SSR 服务端渲染）；公开 API
+- **路由**: `GET /wiki`、`GET /wiki/*path`（SSR 服务端渲染）；`/wiki/_assets/*path`
+  由同一 catch-all 分派并仅从当前仓库 clone 提供已验证的非 Markdown 资源；公开 API
   `GET /api/wiki/{tree,namespaces,home}` + `POST /api/wiki/webhook`；管理端
   `/api/admin/wiki/*`（PageManager：namespaces CRUD、只读树、`sync/status` /
   `sync` / `sync/runs`）。站内写/回滚/diff/编辑者/版本历史端点已退役。

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -57,8 +57,11 @@
 1. 旧 VitePress 站点仓库的 `docs/`（Markdown 源文件）按新仓库结构整理：
    顶层目录 = namespace，文件 = 页面，front-matter 的 `title` 作为页面标题
    （旧站路径映射为 `<namespace>/<slug>.md`）。
-2. 旧站的静态资源（图片/附件）随文件一并提交到仓库（同步器只投影 `.md`；
-   图片等资源从 GitHub raw 引用，或移入仓库后改写为相对路径）。
+2. 旧站的静态资源（图片/附件）随文件一并提交到仓库。同步器只将 `.md` 作为页面投影，
+   但会把页面中的仓库相对资源引用重写为论坛二进制提供的受控
+   `/wiki/_assets/<repository-path>` 路由；不需要 GitHub raw URL。相对页面链接保留 `.md`
+   源文件后缀，投影后会变为无后缀的 `/wiki/...` 路由。作者语义与路径限制见
+   [Wiki authoring](../product/wiki-authoring.md)。
 3. 旧站评论区（Waline）数据不迁移；如确有保留价值，导出 Waline 评论 JSON
    后以人工方式并入对应页面的论坛回复流（wiki 无评论表，评论走回复流）。
 4. 内容提交、PR 合并后，在管理端 `/admin/wiki` → GitHub 同步面板触发一次

--- a/docs/product/wiki-authoring.md
+++ b/docs/product/wiki-authoring.md
@@ -34,8 +34,35 @@ Absolute URLs, protocol-relative URLs, site-root URLs such as `/static/logo.svg`
 query-only links are left unchanged. Do not use relative links without a file extension for pages: page
 targets must name their `.md` source file.
 
+### Asset serving policy
+
+`/wiki/_assets/` serves only a small allowlist of inert content types: images (PNG/JPEG/GIF/WebP/AVIF/
+BMP/ICO), PDF, Office documents, archives, and plain text. Everything else — including HTML, SVG, XML,
+JavaScript, and extension-less files — is forced to `application/octet-stream` with
+`Content-Disposition: attachment`, so a repository file can never be rendered as same-origin executable
+content. All asset responses carry `Content-Security-Policy: sandbox` and `X-Content-Type-Options:
+nosniff` as defense in depth, and the endpoint is rate-limited per IP.
+
+### Failure semantics
+
 Every relative target must remain inside the repository. A linked Markdown page must be projected by the
-same sync; an asset must exist as a regular, non-Markdown file. Hidden paths, path traversal, and assets
-whose symlinks resolve outside the repository are rejected. The sync run fails with the source Markdown
-path and invalid target so it can be corrected before retrying. The top-level namespace `_assets` is
-reserved for the controlled asset route.
+same sync; an asset must exist as a regular, non-Markdown file. Hidden paths and path traversal are
+rejected. Failures are split into two classes:
+
+- **Security-class errors** (target escapes the repository root, or an asset symlink resolves outside
+  the clone directory) abort the whole sync — they must never be bypassed by a per-page skip.
+- **Content-class errors** (linked page or asset missing, image pointing at a `.md` page, unlinkable
+  hidden page) skip only the offending page — it keeps its previous rendered version — while the rest
+  of the repository syncs normally. The sync run records the skipped page and target so it can be
+  corrected before the next run.
+
+Repository hygiene requirements:
+
+- Pages are regular files: symlinked `.md` files are rejected at scan time (a merged symlink would
+  otherwise be followed to arbitrary server paths).
+- Individual page sources are capped at 4 MiB.
+- Page and asset filenames must not contain `%`, `#`, `?`, or the filesystem-reserved characters
+  (`/ \ : * ? " < > |`): `%` is the URL-escape prefix and `#` opens a fragment, so Markdown link
+  syntax cannot represent them reliably.
+
+The top-level namespace `_assets` is reserved for the controlled asset route.

--- a/docs/product/wiki-authoring.md
+++ b/docs/product/wiki-authoring.md
@@ -1,0 +1,41 @@
+# Wiki Authoring
+
+> Doc type: product guide
+>
+> Status: Active
+>
+> Owner: Wiki maintainers
+>
+> Last verified: 2026-08-16
+
+Wiki content is authored in the public `YourTongji/YourTJ-Wiki` Git repository. The forum is a
+read-only projection: merge changes through GitHub, then wait for the scheduled sync or trigger the
+admin Wiki sync. Pages are Markdown files beneath a top-level namespace directory; page URLs omit the
+`.md` suffix and use the namespace slug where one is declared.
+
+## Links And Assets
+
+Repository-relative links are supported as `Current` behavior. Author page links with their repository
+path and `.md` suffix, and author images or attachments with their repository-relative file path:
+
+```markdown
+[下一页](other.md?tab=2#section)
+![示意图](../assets/a%20b.png?raw=1#preview)
+[下载讲义](../assets/guide.pdf)
+```
+
+During sync, page links are resolved from the source Markdown file and rendered as normalized
+`/wiki/<namespace-slug>/...` URLs without `.md`. Images and non-Markdown attachments are served by the
+single forum binary through `/wiki/_assets/<repository-path>`. Query strings, fragments, URL encoding,
+and nested paths are preserved. This lets an author keep links valid when a namespace directory has a
+display name different from its URL slug.
+
+Absolute URLs, protocol-relative URLs, site-root URLs such as `/static/logo.svg`, and anchor-only or
+query-only links are left unchanged. Do not use relative links without a file extension for pages: page
+targets must name their `.md` source file.
+
+Every relative target must remain inside the repository. A linked Markdown page must be projected by the
+same sync; an asset must exist as a regular, non-Markdown file. Hidden paths, path traversal, and assets
+whose symlinks resolve outside the repository are rejected. The sync run fails with the source Markdown
+path and invalid target so it can be corrected before retrying. The top-level namespace `_assets` is
+reserved for the controlled asset route.


### PR DESCRIPTION
Fixes #284

## Summary
- Rewrite repository-relative Markdown page links to normalized Wiki routes.
- Serve validated repository images and attachments through the controlled /wiki/_assets route.
- Reject missing, escaping, hidden, Markdown, and symlink-escaping asset paths during sync or serving.
- Document Wiki authoring and deployment behavior.

## Verification
- git diff --check
- go test ./app/service/wikiservice ./app/http/controllers/forum -count=1
- go vet ./...
- go test ./...