### PR TITLE
fix(wiki): serialize pending sync reruns

### DIFF
--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -250,6 +250,10 @@ var syncPending bool
 // Production always uses syncOnce.
 var syncOnceFn = syncOnce
 
+// syncLifecycleReleasedHook is used only by tests to deterministically place a
+// successor lifecycle between normal completion and deferred panic cleanup.
+var syncLifecycleReleasedHook func()
+
 // ErrSyncAlreadyRunning 同步已在运行（webhook/定时/手动并发时）。
 var ErrSyncAlreadyRunning = errors.New("wiki sync already running")
 
@@ -281,12 +285,17 @@ func ReleaseSyncLock() {
 // ends the lifecycle.
 func consumePendingOrRelease() bool {
 	syncMu.Lock()
-	defer syncMu.Unlock()
 	if syncPending {
 		syncPending = false
+		syncMu.Unlock()
 		return true
 	}
 	syncRunning = false
+	hook := syncLifecycleReleasedHook
+	syncMu.Unlock()
+	if hook != nil {
+		hook()
+	}
 	return false
 }
 
@@ -582,11 +591,17 @@ func SyncWithConfig(cfg GitConfig, trigger string) (*SyncResult, error) {
 	markAbandonedRuns()
 	// Preserve cleanup if the initial sync panics. The normal path releases in
 	// consumePendingOrRelease so the final pending check and release are atomic.
-	defer ReleaseSyncLock()
+	completedNormally := false
+	defer func() {
+		if !completedNormally {
+			ReleaseSyncLock()
+		}
+	}()
 	result, err := syncOnceFn(cfg, trigger)
 	for consumePendingOrRelease() {
 		runPendingSync(cfg)
 	}
+	completedNormally = true
 	return result, err
 }
 

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -236,19 +235,59 @@ var syncMu sync.Mutex
 
 // syncPending 运行期间到达的 webhook push 合并标记：锁释放后补跑一次，
 // 避免投影停留在旧 head（并发丢弃 push 会 stale 到下次定时同步）。
-var syncPending atomic.Bool
+// syncRunning stays true across the initial sync and every pending rerun.
+// It must only be read or written while syncMu is held.
+var syncRunning bool
+
+// syncReconciling prevents a status read from being treated as a live sync.
+var syncReconciling bool
+
+// syncPending is coalesced under syncMu to prevent a trigger from being lost
+// between the final rerun and lifecycle release.
+var syncPending bool
+
+// syncOnceFn keeps contention tests independent from Git and database I/O.
+// Production always uses syncOnce.
+var syncOnceFn = syncOnce
 
 // ErrSyncAlreadyRunning 同步已在运行（webhook/定时/手动并发时）。
 var ErrSyncAlreadyRunning = errors.New("wiki sync already running")
 
-// TryAcquireSyncLock 尝试获取同步锁（防重入；webhook/定时/手动并发时只跑一个）。
+// TryAcquireSyncLock 尝试开始一个同步生命周期。若已有同步在运行，当前
+// 触发会被合并为一次 pending rerun。
 func TryAcquireSyncLock() bool {
-	return syncMu.TryLock()
+	syncMu.Lock()
+	defer syncMu.Unlock()
+	if syncRunning {
+		syncPending = true
+		return false
+	}
+	if syncReconciling {
+		return false
+	}
+	syncRunning = true
+	return true
 }
 
-// ReleaseSyncLock 释放同步锁。
+// ReleaseSyncLock 结束同步生命周期。它主要是 panic 清理路径；正常路径在
+// 确认没有 pending 触发时会在同一临界区内结束生命周期。
 func ReleaseSyncLock() {
+	syncMu.Lock()
+	syncRunning = false
 	syncMu.Unlock()
+}
+
+// consumePendingOrRelease atomically either consumes one coalesced trigger or
+// ends the lifecycle.
+func consumePendingOrRelease() bool {
+	syncMu.Lock()
+	defer syncMu.Unlock()
+	if syncPending {
+		syncPending = false
+		return true
+	}
+	syncRunning = false
+	return false
 }
 
 // abandonedRunErrMsg 崩溃/重启遗留 running 行的回收标记文案（issue #290）。
@@ -275,10 +314,18 @@ func markAbandonedRuns() int64 {
 // 让管理端 lastRun 呈现可恢复状态（手动同步按钮不再被永久禁用）。锁被占用
 // （同步真在运行）时跳过，避免误杀在途同步。供状态读取与进程启动时调用。
 func ReconcileStaleRuns() {
-	if !TryAcquireSyncLock() {
-		return // 锁被占用 = 同步真在运行，running 行是活的，不得回收
+	syncMu.Lock()
+	if syncRunning || syncReconciling {
+		syncMu.Unlock()
+		return
 	}
-	defer ReleaseSyncLock()
+	syncReconciling = true
+	syncMu.Unlock()
+	defer func() {
+		syncMu.Lock()
+		syncReconciling = false
+		syncMu.Unlock()
+	}()
 	markAbandonedRuns()
 }
 
@@ -526,7 +573,6 @@ func SyncWithConfig(cfg GitConfig, trigger string) (*SyncResult, error) {
 		return nil, fmt.Errorf("wiki git sync not configured ([wiki.git].repo empty)")
 	}
 	if !TryAcquireSyncLock() {
-		syncPending.Store(true)
 		return nil, ErrSyncAlreadyRunning
 	}
 	// 崩溃恢复（issue #290）：此刻锁空闲刚被本调用持有 = 本进程无其他在途
@@ -534,26 +580,21 @@ func SyncWithConfig(cfg GitConfig, trigger string) (*SyncResult, error) {
 	// 避免管理端 lastRun.status=running 永久禁用手动同步。锁已持有，
 	// markAbandonedRuns 不再重入锁（不调用 ReconcileStaleRuns）。
 	markAbandonedRuns()
-	defer func() {
-		ReleaseSyncLock()
-		// 运行期间到达的 webhook push 合并补跑一次（只补一次，避免链式同步）。
-		if syncPending.CompareAndSwap(true, false) {
-			// review MEDIUM：补跑在调用方 goroutine 内执行，panic 同样会终止
-			// 进程（webhook/manual 外层已有 Recover，此处再兜底，覆盖
-			// startup/cron 之外的直接调用方）。
-			defer recovery.Recover("wiki_sync_pending_rerun")
-			// 补跑同样持锁（issue #290）：保持「running 行存在 ⇒ 同步锁被持有」
-			// 不变量，状态读取时的遗留行回收才不会误杀在途同步。抢锁失败 =
-			// 另一同步已在进行，其完成后投影即最新 head，补跑可安全丢弃。
-			if TryAcquireSyncLock() {
-				defer ReleaseSyncLock()
-				if _, err := syncOnce(cfg, "webhook"); err != nil {
-					slog.Warn("wiki sync: pending rerun failed", "error", err)
-				}
-			}
-		}
-	}()
-	return syncOnce(cfg, trigger)
+	// Preserve cleanup if the initial sync panics. The normal path releases in
+	// consumePendingOrRelease so the final pending check and release are atomic.
+	defer ReleaseSyncLock()
+	result, err := syncOnceFn(cfg, trigger)
+	for consumePendingOrRelease() {
+		runPendingSync(cfg)
+	}
+	return result, err
+}
+
+func runPendingSync(cfg GitConfig) {
+	defer recovery.Recover("wiki_sync_pending_rerun")
+	if _, err := syncOnceFn(cfg, "webhook"); err != nil {
+		slog.Warn("wiki sync: pending rerun failed", "error", err)
+	}
 }
 
 // syncOnce 执行一次同步主体（调用方持有同步锁；不重入锁）。

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -1,12 +1,14 @@
 package wikiservice
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
@@ -274,6 +276,129 @@ func TestSyncWithConfigSerializesPendingReruns(t *testing.T) {
 	if got := maxActive.Load(); got != 1 {
 		t.Fatalf("max concurrent sync bodies=%d, want 1", got)
 	}
+}
+
+// TestSyncWithConfigDoesNotReleaseSuccessorAfterNormalCompletion verifies that
+// the panic cleanup deferred by an earlier lifecycle cannot clear a successor
+// which acquires immediately after the normal completion release.
+func TestSyncWithConfigDoesNotReleaseSuccessorAfterNormalCompletion(t *testing.T) {
+	syncMu.Lock()
+	syncRunning = false
+	syncPending = false
+	syncMu.Unlock()
+
+	originalSyncOnce := syncOnceFn
+	originalHook := syncLifecycleReleasedHook
+	t.Cleanup(func() {
+		syncOnceFn = originalSyncOnce
+		syncLifecycleReleasedHook = originalHook
+		syncMu.Lock()
+		syncRunning = false
+		syncPending = false
+		syncMu.Unlock()
+	})
+
+	secondStarted := make(chan struct{})
+	allowSecond := make(chan struct{})
+	secondDone := make(chan error, 1)
+	var calls atomic.Int32
+	var hookCalls atomic.Int32
+	syncOnceFn = func(_ GitConfig, trigger string) (*SyncResult, error) {
+		switch calls.Add(1) {
+		case 1:
+			return &SyncResult{}, nil
+		case 2:
+			close(secondStarted)
+			<-allowSecond
+			return &SyncResult{}, nil
+		case 3:
+			if trigger != "webhook" {
+				t.Fatal("successor lifecycle was released by stale cleanup")
+			}
+			return &SyncResult{}, nil
+		default:
+			t.Fatalf("unexpected sync invocation %d", calls.Load())
+		}
+		return nil, nil
+	}
+	syncLifecycleReleasedHook = func() {
+		if hookCalls.Add(1) != 1 {
+			return
+		}
+		go func() {
+			_, err := SyncWithConfig(GitConfig{Repo: "test"}, "webhook")
+			secondDone <- err
+		}()
+		select {
+		case <-secondStarted:
+		case <-time.After(time.Second):
+			t.Fatal("successor sync did not start")
+		}
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := SyncWithConfig(GitConfig{Repo: "test"}, "manual")
+		firstDone <- err
+	}()
+
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("first sync: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first sync did not finish")
+	}
+
+	if _, err := SyncWithConfig(GitConfig{Repo: "test"}, "cron"); !errors.Is(err, ErrSyncAlreadyRunning) {
+		t.Fatalf("third trigger error=%v, want ErrSyncAlreadyRunning", err)
+	}
+	close(allowSecond)
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatalf("successor sync: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("successor sync did not finish")
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("sync body calls=%d, want 3", got)
+	}
+}
+
+func TestSyncWithConfigReleasesLockAfterPanic(t *testing.T) {
+	syncMu.Lock()
+	syncRunning = false
+	syncPending = false
+	syncMu.Unlock()
+
+	originalSyncOnce := syncOnceFn
+	t.Cleanup(func() {
+		syncOnceFn = originalSyncOnce
+		syncMu.Lock()
+		syncRunning = false
+		syncPending = false
+		syncMu.Unlock()
+	})
+	syncOnceFn = func(_ GitConfig, _ string) (*SyncResult, error) {
+		panic("sync panic")
+	}
+
+	func() {
+		defer func() {
+			if recovered := recover(); recovered == nil {
+				t.Fatal("SyncWithConfig did not propagate panic")
+			}
+		}()
+		_, _ = SyncWithConfig(GitConfig{Repo: "test"}, "manual")
+	}()
+
+	if !TryAcquireSyncLock() {
+		t.Fatal("sync lock remained held after panic")
+	}
+	ReleaseSyncLock()
 }
 
 // writeRepoFile 在临时仓库目录下写一个 md 文件（自动建父目录）。

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -157,6 +158,121 @@ func TestApplyRepoToDBRefreshesRelativeLinksAfterSlugChange(t *testing.T) {
 	start = wikiPages.GetByPath("guide/start")
 	if !strings.Contains(start.RenderedHTML, `href="/wiki/handbook/other"`) {
 		t.Fatalf("refreshed rendered link = %s, want /wiki/handbook/other", start.RenderedHTML)
+	}
+}
+
+// TestSyncWithConfigSerializesPendingReruns reproduces three overlapping
+// triggers: A runs, B is coalesced into a pending rerun, and C arrives while
+// that rerun is active. Every invocation of the sync body must remain serial
+// and C must cause a third run rather than being lost.
+func TestSyncWithConfigSerializesPendingReruns(t *testing.T) {
+	syncMu.Lock()
+	syncRunning = false
+	syncPending = false
+	syncMu.Unlock()
+
+	originalSyncOnce := syncOnceFn
+	t.Cleanup(func() {
+		syncOnceFn = originalSyncOnce
+		syncMu.Lock()
+		syncRunning = false
+		syncPending = false
+		syncMu.Unlock()
+	})
+
+	firstStarted := make(chan struct{})
+	allowFirst := make(chan struct{})
+	pendingStarted := make(chan struct{})
+	allowPending := make(chan struct{})
+	finalStarted := make(chan struct{})
+	allowFinal := make(chan struct{})
+	var calls atomic.Int32
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	syncOnceFn = func(_ GitConfig, _ string) (*SyncResult, error) {
+		current := active.Add(1)
+		for previous := maxActive.Load(); current > previous && !maxActive.CompareAndSwap(previous, current); previous = maxActive.Load() {
+		}
+		defer active.Add(-1)
+
+		switch calls.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-allowFirst
+		case 2:
+			close(pendingStarted)
+			<-allowPending
+		case 3:
+			close(finalStarted)
+			<-allowFinal
+		default:
+			t.Fatalf("unexpected sync invocation")
+		}
+		return &SyncResult{}, nil
+	}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := SyncWithConfig(GitConfig{Repo: "test"}, "manual")
+		firstDone <- err
+	}()
+	<-firstStarted
+
+	if _, err := SyncWithConfig(GitConfig{Repo: "test"}, "webhook"); !errors.Is(err, ErrSyncAlreadyRunning) {
+		t.Fatalf("second trigger error=%v, want ErrSyncAlreadyRunning", err)
+	}
+	close(allowFirst)
+	<-pendingStarted
+
+	thirdDone := make(chan error, 1)
+	go func() {
+		_, err := SyncWithConfig(GitConfig{Repo: "test"}, "cron")
+		thirdDone <- err
+	}()
+	thirdReturned := false
+	finalAlreadyStarted := false
+	select {
+	case err := <-thirdDone:
+		thirdReturned = true
+		if !errors.Is(err, ErrSyncAlreadyRunning) {
+			t.Fatalf("third trigger error=%v, want ErrSyncAlreadyRunning", err)
+		}
+	case <-finalStarted:
+		// The old implementation releases before the pending rerun, allowing
+		// the third trigger to enter the sync body concurrently.
+		finalAlreadyStarted = true
+	case <-time.After(time.Second):
+		t.Fatal("third trigger neither returned nor started a sync body")
+	}
+	close(allowPending)
+	if !finalAlreadyStarted {
+		<-finalStarted
+	}
+	close(allowFinal)
+
+	select {
+	case err := <-firstDone:
+		if err != nil {
+			t.Fatalf("first trigger error=%v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first trigger did not finish")
+	}
+	if !thirdReturned {
+		select {
+		case err := <-thirdDone:
+			if !errors.Is(err, ErrSyncAlreadyRunning) {
+				t.Fatalf("third trigger error=%v, want ErrSyncAlreadyRunning", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("third trigger did not finish")
+		}
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("sync body calls=%d, want 3", got)
+	}
+	if got := maxActive.Load(); got != 1 {
+		t.Fatalf("max concurrent sync bodies=%d, want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation
Fixes #285. A pending wiki sync rerun previously released its lock before executing, allowing a third trigger to start concurrent clone/projection work.

## Changes
- Keep one synchronization lifecycle across the initial run and all coalesced reruns.
- Atomically consume a pending trigger or end the lifecycle, so tail triggers are neither concurrent nor lost.
- Add a deterministic three-trigger contention regression test.

## Verification
- `go vet ./app/service/wikiservice`
- `go test -race ./app/service/wikiservice`
- `go test -race ./app/service/wikiservice -run TestSyncWithConfigSerializesPendingReruns -count=20`
- `git diff --check`
- pre-push hook: go vet, golangci-lint, pnpm typecheck

## Contract and docs
No HTTP, OpenAPI, migration, frontend, or user-visible documentation change.