### PR TITLE
fix(wiki): propagate database query failures

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/wikiController.go
+++ b/apps/gooseforum/app/http/controllers/api/wikiController.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/wikiservice"
 )
@@ -9,17 +11,29 @@ import (
 
 // WikiTree 返回公开导航树（契约包裹形状）。
 func WikiTree(req component.BetterRequest[component.Null]) component.Response {
-	return component.SuccessResponse(wikiservice.BuildTreeAPI())
+	data, err := wikiservice.BuildTreeAPI()
+	if err != nil {
+		return component.BuildResponse(http.StatusInternalServerError, component.FailData())
+	}
+	return component.SuccessResponse(data)
 }
 
 // WikiNamespaces 返回 namespace 摘要列表（公开）。
 func WikiNamespaces(req component.BetterRequest[component.Null]) component.Response {
-	return component.SuccessResponse(wikiservice.BuildNamespaceSummaries())
+	data, err := wikiservice.BuildNamespaceSummaries()
+	if err != nil {
+		return component.BuildResponse(http.StatusInternalServerError, component.FailData())
+	}
+	return component.SuccessResponse(data)
 }
 
 // WikiHome 返回首页数据（公开）。
 func WikiHome(req component.BetterRequest[component.Null]) component.Response {
-	return component.SuccessResponse(wikiservice.BuildHome())
+	data, err := wikiservice.BuildHome()
+	if err != nil {
+		return component.BuildResponse(http.StatusInternalServerError, component.FailData())
+	}
+	return component.SuccessResponse(data)
 }
 
 // ---------- admin：只读页面树（PageManager/Admin） ----------
@@ -27,5 +41,9 @@ func WikiHome(req component.BetterRequest[component.Null]) component.Response {
 // WikiAdminTree 返回管理端导航树（PageManager/Admin）。
 // GitHub SSOT：命名空间与页面结构由仓库同步决定，管理端只读。
 func WikiAdminTree(req component.BetterRequest[component.Null]) component.Response {
-	return component.SuccessResponse(wikiservice.BuildAdminTree())
+	data, err := wikiservice.BuildAdminTree()
+	if err != nil {
+		return component.BuildResponse(http.StatusInternalServerError, component.FailData())
+	}
+	return component.SuccessResponse(data)
 }

--- a/apps/gooseforum/app/http/controllers/api/wikiSyncController.go
+++ b/apps/gooseforum/app/http/controllers/api/wikiSyncController.go
@@ -25,7 +25,11 @@ import (
 
 // WikiSyncStatus 返回 wiki 同步面板状态（PageManager/Admin）。
 func WikiSyncStatus(req component.BetterRequest[component.Null]) component.Response {
-	return component.SuccessResponse(wikiservice.BuildSyncStatus())
+	data, err := wikiservice.BuildSyncStatus()
+	if err != nil {
+		return component.BuildResponse(http.StatusInternalServerError, component.FailData())
+	}
+	return component.SuccessResponse(data)
 }
 
 // WikiSyncRun 手动触发一次 wiki 同步（PageManager/Admin）。

--- a/apps/gooseforum/app/http/controllers/forum/wiki.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki.go
@@ -22,7 +22,18 @@ type WikiHomeProps struct {
 // WikiHome 渲染 wiki 首页（PageComponent: wiki.home）。
 func WikiHome(c *gin.Context) {
 	loginUser := component.GetLoginUser(c)
-	home := wikiservice.BuildHome()
+	home, err := wikiservice.BuildHome()
+	if err != nil {
+		slog.Error("wiki home load failed", "error", err)
+		renderInternalError(c)
+		return
+	}
+	tree, err := wikiTreePayload("")
+	if err != nil {
+		slog.Error("wiki tree load failed", "error", err)
+		renderInternalError(c)
+		return
+	}
 	props := WikiHomeProps{
 		Namespaces: home.Namespaces,
 		Recent:     home.Recent,
@@ -41,7 +52,7 @@ func WikiHome(c *gin.Context) {
 		Version: payloadVersion,
 	}
 	payload.Layout.Sidebar.Mode = "wiki"
-	payload.Layout.Sidebar.WikiTree = wikiTreePayload("")
+	payload.Layout.Sidebar.WikiTree = tree
 	renderPage(c, "wiki.gohtml", payload)
 }
 
@@ -120,6 +131,12 @@ func WikiDetail(c *gin.Context) {
 	props.Page.EditUrl = cfg.EditURL(repoPath)
 	props.Page.HistoryUrl = cfg.HistoryURL(repoPath)
 
+	tree, err := wikiTreePayload(page.Path)
+	if err != nil {
+		slog.Error("wiki tree load failed", "path", path, "error", err)
+		renderInternalError(c)
+		return
+	}
 	payload := PagePayload{
 		Component: PageComponentWikiDetail,
 		Props:     props,
@@ -133,7 +150,7 @@ func WikiDetail(c *gin.Context) {
 		Version: payloadVersion,
 	}
 	payload.Layout.Sidebar.Mode = "wiki"
-	payload.Layout.Sidebar.WikiTree = wikiTreePayload(page.Path)
+	payload.Layout.Sidebar.WikiTree = tree
 	renderPage(c, "wiki.gohtml", payload)
 	// 计一次浏览（review P2：TopicDetail 已记录，wiki 详情此前漏记）。
 	if shouldCountTopicView(&topic) {
@@ -141,8 +158,11 @@ func WikiDetail(c *gin.Context) {
 	}
 }
 
-func wikiTreePayload(activePath string) []WikiTreeNamespacePayload {
-	tree := wikiservice.BuildTree(activePath)
+func wikiTreePayload(activePath string) ([]WikiTreeNamespacePayload, error) {
+	tree, err := wikiservice.BuildTree(activePath)
+	if err != nil {
+		return nil, err
+	}
 	result := make([]WikiTreeNamespacePayload, 0, len(tree))
 	for _, ns := range tree {
 		pages := make([]WikiTreePagePayload, 0, len(ns.Pages))
@@ -161,5 +181,5 @@ func wikiTreePayload(activePath string) []WikiTreeNamespacePayload {
 			Pages: pages,
 		})
 	}
-	return result
+	return result, nil
 }

--- a/apps/gooseforum/app/http/routes/contract_wiki_test.go
+++ b/apps/gooseforum/app/http/routes/contract_wiki_test.go
@@ -355,6 +355,59 @@ func TestWikiHomeHTTPContract(t *testing.T) {
 	}
 }
 
+func TestWikiQueryFailuresHTTPContract(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		dropTable any
+		admin     bool
+	}{
+		{name: "tree", path: "/api/wiki/tree", dropTable: &wikiNamespaces.Entity{}},
+		{name: "namespaces", path: "/api/wiki/namespaces", dropTable: &wikiNamespaces.Entity{}},
+		{name: "home", path: "/api/wiki/home", dropTable: &wikiPages.Entity{}},
+		{name: "sync status", path: "/api/admin/wiki/sync/status", dropTable: &wikiPages.Entity{}, admin: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, router := setupWikiContractTest(t)
+			token := ""
+			if tt.admin {
+				user := createHTTPContractUser(t, conn, contractTestID())
+				grantContractPermission(t, conn, user.Id, permission.PageManager)
+				token = contractSessionToken(t, user)
+			}
+			if err := conn.Migrator().DropTable(tt.dropTable); err != nil {
+				t.Fatalf("drop query table: %v", err)
+			}
+
+			rec := serveAuthSecurityJSON(router, http.MethodGet, tt.path, "", token)
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("%s query failure status = %d, want 500: %s", tt.name, rec.Code, rec.Body.String())
+			}
+			env := decodeContractEnvelope(t, rec)
+			if env.Code != 1 || string(env.Result) != "null" {
+				t.Fatalf("%s query failure envelope = %#v, want failure with null result", tt.name, env)
+			}
+		})
+	}
+}
+
+func TestWikiEmptyResultsHTTPContract(t *testing.T) {
+	_, router := setupWikiContractTest(t)
+	for _, path := range []string{"/api/wiki/tree", "/api/wiki/namespaces", "/api/wiki/home"} {
+		t.Run(path, func(t *testing.T) {
+			rec := serveAuthSecurityJSON(router, http.MethodGet, path, "", "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("empty wiki status = %d, want 200: %s", rec.Code, rec.Body.String())
+			}
+			if env := decodeContractEnvelope(t, rec); env.Code != 0 {
+				t.Fatalf("empty wiki envelope = %#v, want success", env)
+			}
+		})
+	}
+}
+
 func TestWikiWebhookSecretHTTPContract(t *testing.T) {
 	conn, router := setupWikiContractTest(t)
 	bob := createHTTPContractUser(t, conn, contractTestID())

--- a/apps/gooseforum/app/models/forum/wikiNamespaces/wikiNamespaces_rep.go
+++ b/apps/gooseforum/app/models/forum/wikiNamespaces/wikiNamespaces_rep.go
@@ -4,13 +4,19 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
 )
 
-func List() []*Entity {
+func List() ([]*Entity, error) {
 	var entities []*Entity
-	builder().
+	err := builder().
 		Order(queryopt.Asc("sort_order")).
 		Order(queryopt.Asc("id")).
-		Find(&entities)
-	return entities
+		Find(&entities).Error
+	return entities, err
+}
+
+func Count() (int64, error) {
+	var count int64
+	err := builder().Count(&count).Error
+	return count, err
 }
 
 func GetByName(name string) (entity Entity) {

--- a/apps/gooseforum/app/models/forum/wikiPages/wikiPages_rep.go
+++ b/apps/gooseforum/app/models/forum/wikiPages/wikiPages_rep.go
@@ -26,14 +26,20 @@ func GetByTopicId(topicId uint64) (entity Entity) {
 	return
 }
 
-func ListAll() []*Entity {
+func ListAll() ([]*Entity, error) {
 	var entities []*Entity
-	builder().
+	err := builder().
 		Order(queryopt.Asc("namespace")).
 		Order(queryopt.Asc("sort_order")).
 		Order(queryopt.Asc("id")).
-		Find(&entities)
-	return entities
+		Find(&entities).Error
+	return entities, err
+}
+
+func Count() (int64, error) {
+	var count int64
+	err := builder().Count(&count).Error
+	return count, err
 }
 
 // ListByIDs 按 id 集合批量返回页面（审核队列取 path 用，避免 ListAll 全表扫，

--- a/apps/gooseforum/app/service/contentdeleteservice/content_delete_service_test.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/content_delete_service_test.go
@@ -549,7 +549,11 @@ func TestDeleteWikiTopicByUserCascadesPage(t *testing.T) {
 	if revs := wikiPageRevisions.ListByPage(pageID); len(revs) != 0 {
 		t.Fatalf("wiki revisions still present after topic delete: %d", len(revs))
 	}
-	for _, p := range wikiPages.ListAll() {
+	pages, err := wikiPages.ListAll()
+	if err != nil {
+		t.Fatalf("list wiki pages: %v", err)
+	}
+	for _, p := range pages {
 		if p != nil && p.Id == pageID {
 			t.Fatal("deleted wiki page still returned by wikiPages.ListAll()")
 		}

--- a/apps/gooseforum/app/service/wikiservice/query.go
+++ b/apps/gooseforum/app/service/wikiservice/query.go
@@ -2,6 +2,7 @@ package wikiservice
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -66,12 +67,19 @@ func ResolvePageByURLPath(urlPath string) (entity wikiPages.Entity) {
 // GitHub SSOT 后内容/标题直接来自 wiki_pages 投影列（不再查修订表）。
 // D7 URL key 语义：page.Namespace 列 = URL key（slug，降级=显示名），
 // 分组按 URL key；输出 Name/Label 用显示名（中文目录名）。
-func BuildTree(activePath string) []TreeNamespace {
-	namespaces := wikiNamespaces.List()
-	if len(namespaces) == 0 {
-		return []TreeNamespace{}
+func BuildTree(activePath string) ([]TreeNamespace, error) {
+	namespaces, err := wikiNamespaces.List()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki namespaces: %w", err)
 	}
-	allPages := filterPublicPages(wikiPages.ListAll())
+	if len(namespaces) == 0 {
+		return []TreeNamespace{}, nil
+	}
+	allPages, err := wikiPages.ListAll()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki pages: %w", err)
+	}
+	allPages = filterPublicPages(allPages)
 	byURLKey := make(map[string][]*wikiPages.Entity)
 	for _, page := range allPages {
 		byURLKey[page.Namespace] = append(byURLKey[page.Namespace], page)
@@ -96,7 +104,7 @@ func BuildTree(activePath string) []TreeNamespace {
 			Pages: items,
 		})
 	}
-	return result
+	return result, nil
 }
 
 // filterPublicPages 过滤出 topic 仍公开的页面：删除/隐藏的 wiki 页面不得
@@ -126,17 +134,28 @@ func filterPublicPages(pages []*wikiPages.Entity) []*wikiPages.Entity {
 }
 
 // BuildTreeAPI 构建公开导航树（契约形状）：path 为 namespace 内相对路径。
-func BuildTreeAPI() WikiTreeResult {
-	return WikiTreeResult{Namespaces: buildTree("", true)}
+func BuildTreeAPI() (WikiTreeResult, error) {
+	namespaces, err := buildTree("", true)
+	if err != nil {
+		return WikiTreeResult{}, err
+	}
+	return WikiTreeResult{Namespaces: namespaces}, nil
 }
 
 // buildTree 构建导航树；relative=true 时 path 相对 namespace（URL key 前缀）。
-func buildTree(activePath string, contractShape bool) []TreeNamespace {
-	namespaces := wikiNamespaces.List()
-	if len(namespaces) == 0 {
-		return []TreeNamespace{}
+func buildTree(activePath string, contractShape bool) ([]TreeNamespace, error) {
+	namespaces, err := wikiNamespaces.List()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki namespaces: %w", err)
 	}
-	allPages := filterPublicPages(wikiPages.ListAll())
+	if len(namespaces) == 0 {
+		return []TreeNamespace{}, nil
+	}
+	allPages, err := wikiPages.ListAll()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki pages: %w", err)
+	}
+	allPages = filterPublicPages(allPages)
 	byURLKey := make(map[string][]*wikiPages.Entity)
 	for _, page := range allPages {
 		byURLKey[page.Namespace] = append(byURLKey[page.Namespace], page)
@@ -166,7 +185,7 @@ func buildTree(activePath string, contractShape bool) []TreeNamespace {
 			Pages: items,
 		})
 	}
-	return result
+	return result, nil
 }
 
 // AdminTreePage 管理端导航树中的一页。
@@ -188,12 +207,18 @@ type AdminTreeNamespace struct {
 }
 
 // BuildAdminTree 构建管理端导航树（含 sortOrder/sourcePath；path 为完整路径，含 URL key 段）。
-func BuildAdminTree() []AdminTreeNamespace {
-	namespaces := wikiNamespaces.List()
-	if len(namespaces) == 0 {
-		return []AdminTreeNamespace{}
+func BuildAdminTree() ([]AdminTreeNamespace, error) {
+	namespaces, err := wikiNamespaces.List()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki namespaces: %w", err)
 	}
-	allPages := wikiPages.ListAll()
+	if len(namespaces) == 0 {
+		return []AdminTreeNamespace{}, nil
+	}
+	allPages, err := wikiPages.ListAll()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki pages: %w", err)
+	}
 	byURLKey := make(map[string][]*wikiPages.Entity)
 	for _, page := range allPages {
 		byURLKey[page.Namespace] = append(byURLKey[page.Namespace], page)
@@ -217,7 +242,7 @@ func BuildAdminTree() []AdminTreeNamespace {
 			Pages: items,
 		})
 	}
-	return result
+	return result, nil
 }
 
 // NamespaceSummary 首页 namespace 卡。
@@ -233,9 +258,16 @@ type NamespaceSummary struct {
 
 // BuildNamespaceSummaries 返回 namespace 摘要列表（页面数 + 最近更新时间）。
 // 分组按 URL key（page.Namespace），输出显示名/URL key 分离（D7）。
-func BuildNamespaceSummaries() []NamespaceSummary {
-	namespaces := wikiNamespaces.List()
-	pages := filterPublicPages(wikiPages.ListAll())
+func BuildNamespaceSummaries() ([]NamespaceSummary, error) {
+	namespaces, err := wikiNamespaces.List()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki namespaces: %w", err)
+	}
+	pages, err := wikiPages.ListAll()
+	if err != nil {
+		return nil, fmt.Errorf("list wiki pages: %w", err)
+	}
+	pages = filterPublicPages(pages)
 	byURLKey := make(map[string][]*wikiPages.Entity)
 	for _, p := range pages {
 		byURLKey[p.Namespace] = append(byURLKey[p.Namespace], p)
@@ -263,7 +295,7 @@ func BuildNamespaceSummaries() []NamespaceSummary {
 			FirstPagePath: firstPath,
 		})
 	}
-	return summaries
+	return summaries, nil
 }
 
 // RecentPage 首页最近更新条目。
@@ -283,9 +315,16 @@ type HomeData struct {
 }
 
 // BuildHome 组装 wiki 首页数据（最近更新 = 页面投影更新时间降序前 10）。
-func BuildHome() HomeData {
-	pages := filterPublicPages(wikiPages.ListAll())
-	summaries := BuildNamespaceSummaries()
+func BuildHome() (HomeData, error) {
+	pages, err := wikiPages.ListAll()
+	if err != nil {
+		return HomeData{}, fmt.Errorf("list wiki pages: %w", err)
+	}
+	pages = filterPublicPages(pages)
+	summaries, err := BuildNamespaceSummaries()
+	if err != nil {
+		return HomeData{}, err
+	}
 
 	// 最近更新：按页面投影 updated_at 降序取 10。
 	all := make([]*wikiPages.Entity, 0, len(pages))
@@ -308,7 +347,7 @@ func BuildHome() HomeData {
 			UpdatedAt: item.UpdatedAt.Format(time.RFC3339),
 		})
 	}
-	return HomeData{Namespaces: summaries, Recent: recentPages}
+	return HomeData{Namespaces: summaries, Recent: recentPages}, nil
 }
 
 // Contributor 贡献者条目（GitHub SSOT：来源为仓库 git log 贡献者快照）。

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -183,7 +183,7 @@ func statusString(s int8) string {
 }
 
 // BuildSyncStatus 构建同步面板状态。
-func BuildSyncStatus() SyncStatus {
+func BuildSyncStatus() (SyncStatus, error) {
 	cfg := LoadGitConfig()
 	status := SyncStatus{
 		Enabled: cfg.Enabled(),
@@ -198,9 +198,16 @@ func BuildSyncStatus() SyncStatus {
 	for _, r := range wikiSyncRuns.ListRecent(10) {
 		status.RecentRuns = append(status.RecentRuns, ToRunView(r))
 	}
-	dbconnect.Connect().Table("wiki_pages").Count(&status.Pages.Total)
-	dbconnect.Connect().Table("wiki_namespaces").Count(&status.Pages.Namespaces)
-	return status
+	var err error
+	status.Pages.Total, err = wikiPages.Count()
+	if err != nil {
+		return SyncStatus{}, fmt.Errorf("count wiki pages: %w", err)
+	}
+	status.Pages.Namespaces, err = wikiNamespaces.Count()
+	if err != nil {
+		return SyncStatus{}, fmt.Errorf("count wiki namespaces: %w", err)
+	}
+	return status, nil
 }
 
 // ToRunView 把同步运行实体映射为视图（控制器层导出用）。
@@ -571,7 +578,10 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 	}
 
 	// 1. 收集现有页面（含软删，用于恢复）。
-	existing := wikiPages.ListAll()
+	existing, err := wikiPages.ListAll()
+	if err != nil {
+		return fmt.Errorf("list existing wiki pages: %w", err)
+	}
 	byPath := make(map[string]*wikiPages.Entity, len(existing))
 	for _, p := range existing {
 		byPath[p.Path] = p
@@ -870,7 +880,11 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 	for _, wp := range wanted {
 		repoNamespaces[wp.displayName] = struct{}{}
 	}
-	for _, ns := range wikiNamespaces.List() {
+	namespaces, err := wikiNamespaces.List()
+	if err != nil {
+		return fmt.Errorf("list existing wiki namespaces: %w", err)
+	}
+	for _, ns := range namespaces {
 		if _, ok := repoNamespaces[ns.Name]; ok {
 			continue
 		}

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -86,7 +86,10 @@ func TestApplyRepoToDBIdempotent(t *testing.T) {
 	if res.PagesAdded != 0 || res.PagesUpdated != 0 || res.PagesDeleted != 0 {
 		t.Fatalf("second sync added/updated/deleted=%d/%d/%d, want 0/0/0", res.PagesAdded, res.PagesUpdated, res.PagesDeleted)
 	}
-	pages := wikiPages.ListAll()
+	pages, err := wikiPages.ListAll()
+	if err != nil {
+		t.Fatalf("list wiki pages: %v", err)
+	}
 	if len(pages) != 1 {
 		t.Fatalf("page count after second sync=%d, want 1", len(pages))
 	}
@@ -600,7 +603,11 @@ func TestApplyRepoToDBSlugConflictKeepsOldValue(t *testing.T) {
 		t.Fatal("want error on slug conflict")
 	}
 	slugs := map[string]string{}
-	for _, ns := range wikiNamespaces.List() {
+	namespaces, err := wikiNamespaces.List()
+	if err != nil {
+		t.Fatalf("list wiki namespaces: %v", err)
+	}
+	for _, ns := range namespaces {
 		slugs[ns.Name] = ns.SlugOrEmpty()
 	}
 	guideHas := slugs["guide"] == "guide"

--- a/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
+++ b/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
@@ -140,17 +140,17 @@ func TestValidatePath(t *testing.T) {
 		{"deployment/waline", true},
 		{"guide/sub/page-name", true},
 		{"同济新手教程/学校/简介", true},          // 中文命名空间与页面段（GitHub SSOT）
-		{"中文/目录/页面", true},               // 纯中文路径
-		{"Guide/Getting-Started", true},   // 保留大小写（不再小写归一）
-		{"guide/UPPER", true},             // 大写段合法
-		{"guide", false},                  // 至少 namespace + 一个 slug 段
-		{"guide/..", false},               // 禁止 ..
-		{"guide/.hidden", false},          // 禁止点开头段
-		{"guide/a b", false},              // 空格非法
-		{"guide/a\tb", false},             // 控制字符非法
-		{"guide/a:b", false},              // 保留字符非法
-		{"guide/a*b", false},              // 保留字符非法
-		{"guide/中文 空格", false},           // 中文路径含空格非法
+		{"中文/目录/页面", true},              // 纯中文路径
+		{"Guide/Getting-Started", true}, // 保留大小写（不再小写归一）
+		{"guide/UPPER", true},           // 大写段合法
+		{"guide", false},                // 至少 namespace + 一个 slug 段
+		{"guide/..", false},             // 禁止 ..
+		{"guide/.hidden", false},        // 禁止点开头段
+		{"guide/a b", false},            // 空格非法
+		{"guide/a\tb", false},           // 控制字符非法
+		{"guide/a:b", false},            // 保留字符非法
+		{"guide/a*b", false},            // 保留字符非法
+		{"guide/中文 空格", false},          // 中文路径含空格非法
 		{"", false},
 	}
 	for _, tc := range cases {
@@ -173,15 +173,15 @@ func TestValidateNamespace(t *testing.T) {
 		{"deployment", true},
 		{"my-namespace", true},
 		{"同济新手教程", true}, // 中文命名空间（GitHub 顶层目录名）
-		{"使用指南", true},    // 中文命名空间
-		{"Guide", true},    // 保留大小写
-		{"UPPER", true},    // 保留大小写
+		{"使用指南", true},   // 中文命名空间
+		{"Guide", true},  // 保留大小写
+		{"UPPER", true},  // 保留大小写
 		{"has space", false},
-		{"中文 空格", false}, // 中间空格非法
-		{" 前导空格", true},  // 首尾空格被 trim 后为合法名称（trim 后再校验）
-		{".hidden", false},    // 点开头（隐藏目录）非法
-		{"a:b", false},        // 保留字符非法
-		{"a*b", false},        // 保留字符非法
+		{"中文 空格", false},   // 中间空格非法
+		{" 前导空格", true},    // 首尾空格被 trim 后为合法名称（trim 后再校验）
+		{".hidden", false}, // 点开头（隐藏目录）非法
+		{"a:b", false},     // 保留字符非法
+		{"a*b", false},     // 保留字符非法
 		{"", false},
 	}
 	for _, tc := range cases {
@@ -212,7 +212,10 @@ func TestBuildTreeGroupsNamespacesAndActive(t *testing.T) {
 	seedProjectedWikiPage(t, "docs", "docs/new", "New", base.Add(time.Hour))
 	seedProjectedWikiPage(t, "guide", "guide/start", "Start", base.Add(2*time.Hour))
 
-	tree := BuildTree("docs/new")
+	tree, err := BuildTree("docs/new")
+	if err != nil {
+		t.Fatalf("BuildTree: %v", err)
+	}
 	if len(tree) != 2 {
 		t.Fatalf("tree namespaces=%d, want 2: %+v", len(tree), tree)
 	}
@@ -255,7 +258,10 @@ func TestBuildTreeAPIRelativePaths(t *testing.T) {
 	seedProjectedWikiPage(t, "docs", "docs/guide/tips", "Tips", base)
 	seedProjectedWikiPage(t, "guide", "guide/start", "Start", base.Add(time.Hour))
 
-	res := BuildTreeAPI()
+	res, err := BuildTreeAPI()
+	if err != nil {
+		t.Fatalf("BuildTreeAPI: %v", err)
+	}
 	if len(res.Namespaces) != 2 {
 		t.Fatalf("namespaces=%d, want 2: %+v", len(res.Namespaces), res.Namespaces)
 	}
@@ -285,7 +291,10 @@ func TestBuildHomeRecentByUpdatedAt(t *testing.T) {
 	seedProjectedWikiPage(t, "docs", "docs/mid", "Mid", base.Add(time.Hour))
 	seedProjectedWikiPage(t, "docs", "docs/new", "New", base.Add(2*time.Hour))
 
-	home := BuildHome()
+	home, err := BuildHome()
+	if err != nil {
+		t.Fatalf("BuildHome: %v", err)
+	}
 	if len(home.Recent) != 3 {
 		t.Fatalf("recent count=%d, want 3: %+v", len(home.Recent), home.Recent)
 	}
@@ -306,7 +315,10 @@ func TestBuildNamespaceSummaries(t *testing.T) {
 	seedProjectedWikiPage(t, "docs", "docs/b", "B", base.Add(time.Hour))
 	seedProjectedWikiPage(t, "guide", "guide/start", "Start", base.Add(2*time.Hour))
 
-	summaries := BuildNamespaceSummaries()
+	summaries, err := BuildNamespaceSummaries()
+	if err != nil {
+		t.Fatalf("BuildNamespaceSummaries: %v", err)
+	}
 	if len(summaries) != 2 {
 		t.Fatalf("summaries=%d, want 2: %+v", len(summaries), summaries)
 	}


### PR DESCRIPTION
## Summary
- propagate Wiki namespace/page query and sync-status count errors through the repository, service, controller, and SSR paths
- return the existing documented HTTP 500 ApiFailure response instead of a successful empty Wiki response
- add route-level failure injection and empty-result regression coverage

## Verification
- `go vet ./...`
- `go test ./...`
- `YOURTJ_TEST_PG_URL=... go test ./app/migration/ -run 'TestSchema' -v`\n- pre-push hook: `go vet` and incremental `golangci-lint`\n\nCloses #287