### PR TITLE
fix: 修复 Wiki 仓库目录导航层级

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/payload.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload.go
@@ -211,15 +211,17 @@ type WikiTreeNamespacePayload struct {
 	Name  string                `json:"name"`
 	Label string                `json:"label"`
 	Slug  string                `json:"slug"`
-	Pages []WikiTreePagePayload `json:"pages"`
+	Nodes []WikiTreeNodePayload `json:"nodes"`
 }
 
-// WikiTreePagePayload wiki 导航树的一页。
-type WikiTreePagePayload struct {
-	PageId uint64 `json:"pageId"`
-	Path   string `json:"path"`
-	Title  string `json:"title"`
-	Active bool   `json:"active"`
+// WikiTreeNodePayload wiki 导航树的递归节点。
+type WikiTreeNodePayload struct {
+	Kind     string                `json:"kind"`
+	PageId   uint64                `json:"pageId"`
+	Path     string                `json:"path"`
+	Title    string                `json:"title"`
+	Active   bool                  `json:"active"`
+	Children []WikiTreeNodePayload `json:"children"`
 }
 
 type FooterPayload struct {

--- a/apps/gooseforum/app/http/controllers/forum/wiki.go
+++ b/apps/gooseforum/app/http/controllers/forum/wiki.go
@@ -145,20 +145,22 @@ func wikiTreePayload(activePath string) []WikiTreeNamespacePayload {
 	tree := wikiservice.BuildTree(activePath)
 	result := make([]WikiTreeNamespacePayload, 0, len(tree))
 	for _, ns := range tree {
-		pages := make([]WikiTreePagePayload, 0, len(ns.Pages))
-		for _, p := range ns.Pages {
-			pages = append(pages, WikiTreePagePayload{
-				PageId: p.PageId,
-				Path:   p.Path,
-				Title:  p.Title,
-				Active: p.Active,
-			})
-		}
 		result = append(result, WikiTreeNamespacePayload{
 			Name:  ns.Name,
 			Label: ns.Label,
 			Slug:  ns.Slug,
-			Pages: pages,
+			Nodes: wikiTreeNodesPayload(ns.Nodes),
+		})
+	}
+	return result
+}
+
+func wikiTreeNodesPayload(nodes []wikiservice.TreeNode) []WikiTreeNodePayload {
+	result := make([]WikiTreeNodePayload, 0, len(nodes))
+	for _, node := range nodes {
+		result = append(result, WikiTreeNodePayload{
+			Kind: node.Kind, PageId: node.PageId, Path: node.Path, Title: node.Title,
+			Active: node.Active, Children: wikiTreeNodesPayload(node.Children),
 		})
 	}
 	return result

--- a/apps/gooseforum/app/service/wikiservice/query.go
+++ b/apps/gooseforum/app/service/wikiservice/query.go
@@ -11,12 +11,22 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
 )
 
-// TreePage 导航树中的一页。
-type TreePage struct {
-	PageId uint64 `json:"pageId"`
-	Path   string `json:"path"`
-	Title  string `json:"title"`
-	Active bool   `json:"active"`
+const (
+	// WikiTreeNodePage is a Markdown page from the content repository.
+	WikiTreeNodePage = "page"
+	// WikiTreeNodeDirectory is a non-clickable repository directory. Directories
+	// do not require an index.md page to retain their navigation hierarchy.
+	WikiTreeNodeDirectory = "directory"
+)
+
+// TreeNode is a recursive navigation node. Directory nodes have pageId 0.
+type TreeNode struct {
+	Kind     string     `json:"kind"`
+	PageId   uint64     `json:"pageId"`
+	Path     string     `json:"path"`
+	Title    string     `json:"title"`
+	Active   bool       `json:"active"`
+	Children []TreeNode `json:"children"`
 }
 
 // TreeNamespace 导航树中的一个 namespace 分组。
@@ -26,7 +36,7 @@ type TreeNamespace struct {
 	Name  string     `json:"name"`
 	Label string     `json:"label"`
 	Slug  string     `json:"slug"`
-	Pages []TreePage `json:"pages"`
+	Nodes []TreeNode `json:"nodes"`
 }
 
 // WikiTreeResult 公开导航树响应（契约包裹层）。
@@ -80,20 +90,11 @@ func BuildTree(activePath string) []TreeNamespace {
 	result := make([]TreeNamespace, 0, len(namespaces))
 	for _, ns := range namespaces {
 		pages := byURLKey[namespaceURLKey(ns)]
-		items := make([]TreePage, 0, len(pages))
-		for _, page := range pages {
-			items = append(items, TreePage{
-				PageId: page.Id,
-				Path:   page.Path,
-				Title:  page.Title,
-				Active: page.Path == activePath,
-			})
-		}
 		result = append(result, TreeNamespace{
 			Name:  ns.Name,
 			Label: ns.Name,
 			Slug:  namespaceURLKey(ns),
-			Pages: items,
+			Nodes: buildTreeNodes(pages, namespaceURLKey(ns), activePath, false),
 		})
 	}
 	return result
@@ -146,45 +147,117 @@ func buildTree(activePath string, contractShape bool) []TreeNamespace {
 	for _, ns := range namespaces {
 		urlKey := namespaceURLKey(ns)
 		pages := byURLKey[urlKey]
-		items := make([]TreePage, 0, len(pages))
-		for _, page := range pages {
-			path := page.Path
-			if contractShape {
-				path = strings.TrimPrefix(path, urlKey+"/")
-			}
-			items = append(items, TreePage{
-				PageId: page.Id,
-				Path:   path,
-				Title:  page.Title,
-				Active: page.Path == activePath,
-			})
-		}
 		result = append(result, TreeNamespace{
 			Name:  ns.Name,
 			Label: ns.Name,
 			Slug:  urlKey,
-			Pages: items,
+			Nodes: buildTreeNodes(pages, urlKey, activePath, contractShape),
 		})
 	}
 	return result
 }
 
-// AdminTreePage 管理端导航树中的一页。
+type treeNodeBuilder struct {
+	node      TreeNode
+	sortOrder int
+	children  map[string]*treeNodeBuilder
+}
+
+func newDirectoryNode(path, title string, sortOrder int) *treeNodeBuilder {
+	return &treeNodeBuilder{
+		node:      TreeNode{Kind: WikiTreeNodeDirectory, Path: path, Title: title, Children: []TreeNode{}},
+		sortOrder: sortOrder,
+		children:  make(map[string]*treeNodeBuilder),
+	}
+}
+
+// buildTreeNodes projects directory segments from paths. It deliberately does
+// not depend on parent_id: a valid repository directory may have no index.md.
+func buildTreeNodes(pages []*wikiPages.Entity, urlKey, activePath string, relative bool) []TreeNode {
+	root := newDirectoryNode("", "", 0)
+	directoryOrder := make(map[string]int)
+	for _, page := range pages {
+		rel := strings.TrimPrefix(page.Path, urlKey+"/")
+		parts := strings.Split(rel, "/")
+		for i := 1; i < len(parts); i++ {
+			dirPath := strings.Join(parts[:i], "/")
+			if current, ok := directoryOrder[dirPath]; !ok || page.SortOrder < current {
+				directoryOrder[dirPath] = page.SortOrder
+			}
+		}
+		if len(parts) > 1 && parts[len(parts)-1] == "index" {
+			directoryOrder[strings.Join(parts[:len(parts)-1], "/")] = page.SortOrder
+		}
+	}
+	for _, page := range pages {
+		rel := strings.TrimPrefix(page.Path, urlKey+"/")
+		parts := strings.Split(rel, "/")
+		cursor := root
+		for i := 0; i < len(parts)-1; i++ {
+			dirPath := strings.Join(parts[:i+1], "/")
+			child, ok := cursor.children[dirPath]
+			if !ok {
+				outputPath := dirPath
+				if !relative {
+					outputPath = urlKey + "/" + dirPath
+				}
+				child = newDirectoryNode(outputPath, parts[i], directoryOrder[dirPath])
+				cursor.children[dirPath] = child
+			}
+			cursor = child
+		}
+		path := page.Path
+		if relative {
+			path = rel
+		}
+		cursor.children["page:"+rel] = &treeNodeBuilder{
+			node: TreeNode{Kind: WikiTreeNodePage, PageId: page.Id, Path: path, Title: page.Title,
+				Active: page.Path == activePath, Children: []TreeNode{}},
+			sortOrder: page.SortOrder,
+			children:  make(map[string]*treeNodeBuilder),
+		}
+	}
+	return flattenTreeChildren(root)
+}
+
+func flattenTreeChildren(parent *treeNodeBuilder) []TreeNode {
+	items := make([]*treeNodeBuilder, 0, len(parent.children))
+	for _, child := range parent.children {
+		items = append(items, child)
+	}
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && (items[j].sortOrder < items[j-1].sortOrder ||
+			(items[j].sortOrder == items[j-1].sortOrder && items[j].node.Path < items[j-1].node.Path)); j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
+	result := make([]TreeNode, 0, len(items))
+	for _, item := range items {
+		item.node.Children = flattenTreeChildren(item)
+		result = append(result, item.node)
+	}
+	return result
+}
+
+// AdminTreeNode 管理端导航树节点。directory 节点没有 GitHub 文件，pageId
+// 为零且 sourcePath 为空；page 节点保留 GitHub 外链所需的 sourcePath。
 // Path 首段 = URL key（slug，降级=显示名）；SourcePath = 仓库真实路径
 // （GitHub 编辑/历史外链拼接用，与 URL 解耦，D7）。
-type AdminTreePage struct {
-	PageId     uint64 `json:"pageId"`
-	Path       string `json:"path"`
-	SourcePath string `json:"sourcePath"`
-	Title      string `json:"title"`
-	SortOrder  int    `json:"sortOrder"`
+type AdminTreeNode struct {
+	Kind       string          `json:"kind"`
+	PageId     uint64          `json:"pageId"`
+	Path       string          `json:"path"`
+	SourcePath string          `json:"sourcePath"`
+	Title      string          `json:"title"`
+	SortOrder  int             `json:"sortOrder"`
+	Children   []AdminTreeNode `json:"children"`
 }
 
 // AdminTreeNamespace 管理端导航树中的一个 namespace 分组。
 type AdminTreeNamespace struct {
 	Name  string          `json:"name"`
 	Label string          `json:"label"`
-	Pages []AdminTreePage `json:"pages"`
+	Nodes []AdminTreeNode `json:"nodes"`
 }
 
 // BuildAdminTree 构建管理端导航树（含 sortOrder/sourcePath；path 为完整路径，含 URL key 段）。
@@ -201,21 +274,76 @@ func BuildAdminTree() []AdminTreeNamespace {
 	result := make([]AdminTreeNamespace, 0, len(namespaces))
 	for _, ns := range namespaces {
 		pages := byURLKey[namespaceURLKey(ns)]
-		items := make([]AdminTreePage, 0, len(pages))
-		for _, page := range pages {
-			items = append(items, AdminTreePage{
-				PageId:     page.Id,
-				Path:       page.Path,
-				SourcePath: page.SourcePath,
-				Title:      page.Title,
-				SortOrder:  page.SortOrder,
-			})
-		}
 		result = append(result, AdminTreeNamespace{
 			Name:  ns.Name,
 			Label: ns.Name,
-			Pages: items,
+			Nodes: buildAdminTreeNodes(pages, namespaceURLKey(ns)),
 		})
+	}
+	return result
+}
+
+type adminTreeNodeBuilder struct {
+	node     AdminTreeNode
+	children map[string]*adminTreeNodeBuilder
+}
+
+func buildAdminTreeNodes(pages []*wikiPages.Entity, urlKey string) []AdminTreeNode {
+	root := &adminTreeNodeBuilder{children: make(map[string]*adminTreeNodeBuilder)}
+	directoryOrder := make(map[string]int)
+	for _, page := range pages {
+		rel := strings.TrimPrefix(page.Path, urlKey+"/")
+		parts := strings.Split(rel, "/")
+		for i := 1; i < len(parts); i++ {
+			dirPath := strings.Join(parts[:i], "/")
+			if current, ok := directoryOrder[dirPath]; !ok || page.SortOrder < current {
+				directoryOrder[dirPath] = page.SortOrder
+			}
+		}
+		if len(parts) > 1 && parts[len(parts)-1] == "index" {
+			directoryOrder[strings.Join(parts[:len(parts)-1], "/")] = page.SortOrder
+		}
+	}
+	for _, page := range pages {
+		rel := strings.TrimPrefix(page.Path, urlKey+"/")
+		parts := strings.Split(rel, "/")
+		cursor := root
+		for i := 0; i < len(parts)-1; i++ {
+			dirRel := strings.Join(parts[:i+1], "/")
+			key := "dir:" + dirRel
+			child, ok := cursor.children[key]
+			if !ok {
+				child = &adminTreeNodeBuilder{node: AdminTreeNode{
+					Kind: WikiTreeNodeDirectory, Path: urlKey + "/" + dirRel, Title: parts[i],
+					SortOrder: directoryOrder[dirRel], Children: []AdminTreeNode{},
+				}, children: make(map[string]*adminTreeNodeBuilder)}
+				cursor.children[key] = child
+			}
+			cursor = child
+		}
+		cursor.children["page:"+rel] = &adminTreeNodeBuilder{node: AdminTreeNode{
+			Kind: WikiTreeNodePage, PageId: page.Id, Path: page.Path, SourcePath: page.SourcePath,
+			Title: page.Title, SortOrder: page.SortOrder, Children: []AdminTreeNode{},
+		}, children: make(map[string]*adminTreeNodeBuilder)}
+	}
+	return flattenAdminTreeChildren(root)
+}
+
+func flattenAdminTreeChildren(parent *adminTreeNodeBuilder) []AdminTreeNode {
+	items := make([]*adminTreeNodeBuilder, 0, len(parent.children))
+	for _, child := range parent.children {
+		items = append(items, child)
+	}
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && (items[j].node.SortOrder < items[j-1].node.SortOrder ||
+			(items[j].node.SortOrder == items[j-1].node.SortOrder && items[j].node.Path < items[j-1].node.Path)); j-- {
+			items[j], items[j-1] = items[j-1], items[j]
+		}
+	}
+	result := make([]AdminTreeNode, 0, len(items))
+	for _, item := range items {
+		item.node.Children = flattenAdminTreeChildren(item)
+		result = append(result, item.node)
 	}
 	return result
 }

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -830,6 +830,13 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 		result.PagesDeleted++
 	}
 
+	// 4.5 Rebuild page-to-index links after every create/update/delete pass.
+	// Navigation itself is path-derived so directories without index.md remain
+	// valid; parent_id is a reconciled cache for pages with an ancestor index.
+	if err := reconcileWikiPageParents(); err != nil {
+		errs = append(errs, fmt.Sprintf("reconcile wiki page parents: %v", err))
+	}
+
 	// 5. 命名空间元数据同步（D4/D7）：按 2.6 定稿的 plans 应用
 	//    description/order（仅 index.md 携带时）+ slug 列。
 	//    幂等：描述/排序/slug 都未变时跳过（CompareAndSwap 语义）。
@@ -901,6 +908,44 @@ func applyRepoToDB(cfg GitConfig, result *SyncResult) error {
 	return nil
 }
 
+// reconcileWikiPageParents rebuilds parent_id from the nearest ancestor index
+// page. Root index pages and pages below directories without index.md attach to
+// the namespace root (0). Derived parent paths are always shorter, so a
+// successful reconciliation removes stale links and cannot create a cycle.
+func reconcileWikiPageParents() error {
+	pages := wikiPages.ListAll()
+	byPath := make(map[string]*wikiPages.Entity, len(pages))
+	for _, page := range pages {
+		byPath[page.Path] = page
+	}
+	return dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
+		for _, page := range pages {
+			parentID := parentIndexID(page, byPath)
+			if page.ParentId == parentID {
+				continue
+			}
+			if err := tx.Table("wiki_pages").Where("id = ?", page.Id).Update("parent_id", parentID).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func parentIndexID(page *wikiPages.Entity, byPath map[string]*wikiPages.Entity) uint64 {
+	parts := strings.Split(page.Path, "/")
+	for end := len(parts) - 1; end >= 1; end-- {
+		candidate := strings.Join(parts[:end], "/") + "/index"
+		if candidate == page.Path {
+			continue
+		}
+		if parent, ok := byPath[candidate]; ok {
+			return parent.Id
+		}
+	}
+	return 0
+}
+
 // listAllUnscoped 返回全部页面（含软删，供恢复检测）。
 func listAllUnscoped() []*wikiPages.Entity {
 	var entities []*wikiPages.Entity
@@ -924,15 +969,6 @@ func createPageFromRepo(cfg GitConfig, wp wantedPage) error {
 	if wp.displayName == "" {
 		return fmt.Errorf("empty display name for path %s", wp.path)
 	}
-	// 嵌套路径：parent_id 关联父页面。
-	parentID := uint64(0)
-	if segments := strings.Split(wp.path, "/"); len(segments) > 2 {
-		parentPath := strings.Join(segments[:len(segments)-1], "/")
-		if parent := wikiPages.GetByPath(parentPath); parent.Id != 0 {
-			parentID = parent.Id
-		}
-	}
-
 	rendered := markdown2html.PostMarkdownToHTML(wp.body)
 	toc := encodeTOCOrEmpty(markdown2html.ExtractHeadings(wp.body))
 
@@ -974,11 +1010,14 @@ func createPageFromRepo(cfg GitConfig, wp wantedPage) error {
 			return err
 		}
 		page = wikiPages.Entity{
-			TopicId:             topic.Id,
-			Namespace:           ns,
-			Path:                wp.path,
-			SourcePath:          wp.sourcePath,
-			ParentId:            parentID,
+			TopicId:    topic.Id,
+			Namespace:  ns,
+			Path:       wp.path,
+			SourcePath: wp.sourcePath,
+			// parent_id is rebuilt after the complete repository projection. A
+			// single upsert cannot safely derive it when ancestors appear later,
+			// move, delete, or restore in the same sync.
+			ParentId:            0,
 			SortOrder:           wp.order,
 			Title:               wp.title,
 			Content:             wp.body,

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -69,6 +69,56 @@ func TestApplyRepoToDBFirstSync(t *testing.T) {
 	}
 }
 
+// TestApplyRepoToDBReconcilesParentsAfterTreeChanges verifies that parent_id is a
+// derived cache of the nearest ancestor index page. Reconciliation happens after
+// all files are upserted, so repository ordering, moves, deletes, and restores
+// cannot leave a stale relationship behind.
+func TestApplyRepoToDBReconcilesParentsAfterTreeChanges(t *testing.T) {
+	setupWikiTestDB(t)
+	repo := t.TempDir()
+	cfg := GitConfig{CloneDir: repo}
+
+	// Deliberately create the leaf before either ancestor index. scanRepoFiles
+	// sorts paths, but the reconciliation pass must be correct independently of
+	// create order.
+	writeRepoFile(t, repo, "guide/admission/process.md", "---\ntitle: 流程\n---\n\n# 流程")
+	writeRepoFile(t, repo, "guide/index.md", "---\ntitle: 指南\n---\n\n# 指南")
+	writeRepoFile(t, repo, "guide/admission/index.md", "---\ntitle: 入学\n---\n\n# 入学")
+	if err := applyRepoToDB(cfg, &SyncResult{}); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	root := wikiPages.GetByPath("guide/index")
+	admission := wikiPages.GetByPath("guide/admission/index")
+	process := wikiPages.GetByPath("guide/admission/process")
+	if root.ParentId != 0 || admission.ParentId != root.Id || process.ParentId != admission.Id {
+		t.Fatalf("initial parent chain root/admission/process=%d/%d/%d, want 0/%d/%d", root.ParentId, admission.ParentId, process.ParentId, root.Id, admission.Id)
+	}
+
+	// Removing the directory index leaves the page visible under a synthetic
+	// directory node and falls back to the next ancestor index rather than
+	// retaining the deleted page id.
+	if err := os.Remove(filepath.Join(repo, "guide/admission/index.md")); err != nil {
+		t.Fatal(err)
+	}
+	if err := applyRepoToDB(cfg, &SyncResult{}); err != nil {
+		t.Fatalf("delete index sync: %v", err)
+	}
+	if process = wikiPages.GetByPath("guide/admission/process"); process.ParentId != root.Id {
+		t.Fatalf("process parent after deleting index=%d, want root %d", process.ParentId, root.Id)
+	}
+
+	// Restoring the index must reconnect the unchanged child to its restored row.
+	writeRepoFile(t, repo, "guide/admission/index.md", "---\ntitle: 入学\n---\n\n# 入学")
+	if err := applyRepoToDB(cfg, &SyncResult{}); err != nil {
+		t.Fatalf("restore index sync: %v", err)
+	}
+	admission = wikiPages.GetByPath("guide/admission/index")
+	process = wikiPages.GetByPath("guide/admission/process")
+	if process.ParentId != admission.Id {
+		t.Fatalf("process parent after restoring index=%d, want %d", process.ParentId, admission.Id)
+	}
+}
+
 // TestApplyRepoToDBIdempotent 幂等：内容未变时重复同步零变更，不重复建行。
 func TestApplyRepoToDBIdempotent(t *testing.T) {
 	setupWikiTestDB(t)

--- a/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
+++ b/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
@@ -140,17 +140,17 @@ func TestValidatePath(t *testing.T) {
 		{"deployment/waline", true},
 		{"guide/sub/page-name", true},
 		{"同济新手教程/学校/简介", true},          // 中文命名空间与页面段（GitHub SSOT）
-		{"中文/目录/页面", true},               // 纯中文路径
-		{"Guide/Getting-Started", true},   // 保留大小写（不再小写归一）
-		{"guide/UPPER", true},             // 大写段合法
-		{"guide", false},                  // 至少 namespace + 一个 slug 段
-		{"guide/..", false},               // 禁止 ..
-		{"guide/.hidden", false},          // 禁止点开头段
-		{"guide/a b", false},              // 空格非法
-		{"guide/a\tb", false},             // 控制字符非法
-		{"guide/a:b", false},              // 保留字符非法
-		{"guide/a*b", false},              // 保留字符非法
-		{"guide/中文 空格", false},           // 中文路径含空格非法
+		{"中文/目录/页面", true},              // 纯中文路径
+		{"Guide/Getting-Started", true}, // 保留大小写（不再小写归一）
+		{"guide/UPPER", true},           // 大写段合法
+		{"guide", false},                // 至少 namespace + 一个 slug 段
+		{"guide/..", false},             // 禁止 ..
+		{"guide/.hidden", false},        // 禁止点开头段
+		{"guide/a b", false},            // 空格非法
+		{"guide/a\tb", false},           // 控制字符非法
+		{"guide/a:b", false},            // 保留字符非法
+		{"guide/a*b", false},            // 保留字符非法
+		{"guide/中文 空格", false},          // 中文路径含空格非法
 		{"", false},
 	}
 	for _, tc := range cases {
@@ -173,15 +173,15 @@ func TestValidateNamespace(t *testing.T) {
 		{"deployment", true},
 		{"my-namespace", true},
 		{"同济新手教程", true}, // 中文命名空间（GitHub 顶层目录名）
-		{"使用指南", true},    // 中文命名空间
-		{"Guide", true},    // 保留大小写
-		{"UPPER", true},    // 保留大小写
+		{"使用指南", true},   // 中文命名空间
+		{"Guide", true},  // 保留大小写
+		{"UPPER", true},  // 保留大小写
 		{"has space", false},
-		{"中文 空格", false}, // 中间空格非法
-		{" 前导空格", true},  // 首尾空格被 trim 后为合法名称（trim 后再校验）
-		{".hidden", false},    // 点开头（隐藏目录）非法
-		{"a:b", false},        // 保留字符非法
-		{"a*b", false},        // 保留字符非法
+		{"中文 空格", false},   // 中间空格非法
+		{" 前导空格", true},    // 首尾空格被 trim 后为合法名称（trim 后再校验）
+		{".hidden", false}, // 点开头（隐藏目录）非法
+		{"a:b", false},     // 保留字符非法
+		{"a*b", false},     // 保留字符非法
 		{"", false},
 	}
 	for _, tc := range cases {
@@ -226,12 +226,12 @@ func TestBuildTreeGroupsNamespacesAndActive(t *testing.T) {
 	if docs == nil {
 		t.Fatal("tree missing docs namespace")
 	}
-	if len(docs.Pages) != 2 {
-		t.Fatalf("docs pages=%d, want 2: %+v", len(docs.Pages), docs.Pages)
+	if len(docs.Nodes) != 2 {
+		t.Fatalf("docs nodes=%d, want 2: %+v", len(docs.Nodes), docs.Nodes)
 	}
 	paths := map[string]bool{}
 	activeCount := 0
-	for _, p := range docs.Pages {
+	for _, p := range docs.Nodes {
 		paths[p.Path] = true
 		if p.Active {
 			activeCount++
@@ -266,14 +266,62 @@ func TestBuildTreeAPIRelativePaths(t *testing.T) {
 			break
 		}
 	}
-	if docs == nil || len(docs.Pages) != 1 {
+	if docs == nil || len(docs.Nodes) != 1 {
 		t.Fatalf("docs tree: %+v", res.Namespaces)
 	}
-	if docs.Pages[0].Path != "guide/tips" {
-		t.Fatalf("API tree path=%q, want relative guide/tips", docs.Pages[0].Path)
+	if docs.Nodes[0].Kind != WikiTreeNodeDirectory || len(docs.Nodes[0].Children) != 1 || docs.Nodes[0].Children[0].Path != "guide/tips" {
+		t.Fatalf("API tree nodes=%+v, want guide directory with relative guide/tips", docs.Nodes)
 	}
-	if docs.Pages[0].Active {
+	if docs.Nodes[0].Children[0].Active {
 		t.Fatal("API tree page should not be active (no active path)")
+	}
+}
+
+// TestBuildTreePreservesRepositoryDirectories verifies that directory segments are
+// emitted as tree nodes even when the directory has no index.md page. The content
+// repository treats directories as hierarchy, not as a requirement for a parent
+// markdown file.
+func TestBuildTreePreservesRepositoryDirectories(t *testing.T) {
+	setupWikiTestDB(t)
+	base := time.Now().Add(-24 * time.Hour)
+	index := seedProjectedWikiPage(t, "guide", "guide/index", "指南首页", base)
+	admissionIndex := seedProjectedWikiPage(t, "guide", "guide/admission/index", "入学", base.Add(time.Minute))
+	process := seedProjectedWikiPage(t, "guide", "guide/admission/process", "流程", base.Add(2*time.Minute))
+	faq := seedProjectedWikiPage(t, "guide", "guide/faq/common", "常见问题", base.Add(3*time.Minute))
+	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", admissionIndex.Id).Update("sort_order", 2).Error; err != nil {
+		t.Fatalf("set admission order: %v", err)
+	}
+	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", process.Id).Update("sort_order", 1).Error; err != nil {
+		t.Fatalf("set process order: %v", err)
+	}
+
+	tree := BuildTree("guide/admission/process")
+	if len(tree) != 1 {
+		t.Fatalf("namespaces=%d, want 1: %+v", len(tree), tree)
+	}
+	// Root index remains a page. admission has an index.md page and faq has no
+	// index.md, but both directories must retain their descendants.
+	nodes := tree[0].Nodes
+	if len(nodes) != 3 {
+		t.Fatalf("root nodes=%d, want index + admission + faq: %+v", len(nodes), nodes)
+	}
+	byPath := make(map[string]TreeNode, len(nodes))
+	for _, node := range nodes {
+		byPath[node.Path] = node
+	}
+	if node := byPath["guide/index"]; node.Kind != WikiTreeNodePage || node.PageId != index.Id {
+		t.Fatalf("root index node=%+v", node)
+	}
+	admissionNode := byPath["guide/admission"]
+	if admissionNode.Kind != WikiTreeNodeDirectory || len(admissionNode.Children) != 2 {
+		t.Fatalf("admission directory=%+v", admissionNode)
+	}
+	if admissionNode.Children[0].PageId != process.Id || !admissionNode.Children[0].Active || admissionNode.Children[1].PageId != admissionIndex.Id {
+		t.Fatalf("admission children=%+v, want process then index by sibling order", admissionNode.Children)
+	}
+	faqNode := byPath["guide/faq"]
+	if faqNode.Kind != WikiTreeNodeDirectory || len(faqNode.Children) != 1 || faqNode.Children[0].PageId != faq.Id {
+		t.Fatalf("faq directory=%+v", faqNode)
 	}
 }
 

--- a/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
+++ b/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
@@ -263,11 +263,14 @@ export interface SidebarPayload {
   wikiTree?: WikiTreeNamespace[]
 }
 
-export interface WikiTreePage {
+export interface WikiTreeNode {
+  /** A Markdown page or a non-clickable repository directory. */
+  kind: 'page' | 'directory'
   pageId: number
   path: string
   title: string
   active: boolean
+  children: WikiTreeNode[]
 }
 
 export interface WikiTreeNamespace {
@@ -275,7 +278,7 @@ export interface WikiTreeNamespace {
   label: string
   /** 有效 URL key（slug，未分配时降级=显示名）；拼 /wiki/{slug}/{page.path} 用。 */
   slug: string
-  pages: WikiTreePage[]
+  nodes: WikiTreeNode[]
 }
 
 export interface FooterPayload {

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -784,7 +784,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Public wiki page tree across namespaces */
+        /** Public hierarchical wiki tree across namespaces */
         get: operations["getWikiTree"];
         put?: never;
         post?: never;
@@ -835,7 +835,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Admin wiki page tree with sort order (PageManager or Admin only) */
+        /** Admin hierarchical wiki tree with sort order (PageManager or Admin only) */
         get: operations["getAdminWikiTree"];
         put?: never;
         post?: never;
@@ -2189,14 +2189,23 @@ export interface components {
             /** @description True for the session that carries the current token. */
             isCurrent: boolean;
         };
-        WikiTreePage: {
-            /** Format: uint64 */
+        WikiTreeNode: {
+            /**
+             * @description page is a Markdown file; directory is a non-clickable repository directory container.
+             * @enum {string}
+             */
+            kind: "page" | "directory";
+            /**
+             * Format: uint64
+             * @description Non-zero for page nodes and zero for directory nodes.
+             */
             pageId: number;
-            /** @description Canonical page path within the namespace (slash-separated). */
+            /** @description Stable repository-relative page or directory path within the namespace (slash-separated). */
             path: string;
             title: string;
-            /** @description True when the page has at least one approved revision; pages with only pending revisions are drafts. */
+            /** @description True when this page is the active SSR route; always false for directory nodes. */
             active: boolean;
+            children: components["schemas"]["WikiTreeNode"][];
         };
         WikiTreeNamespace: {
             /** @description Display name (top-level directory name; may contain Unicode such as Chinese). */
@@ -2205,7 +2214,7 @@ export interface components {
             label: string;
             /** @description Effective URL key for this namespace (index.md frontmatter `slug`, or directory name when pure ASCII; falls back to display name when unassigned). Consumers build hrefs as /wiki/{slug}/{page.path}. */
             slug: string;
-            pages: components["schemas"]["WikiTreePage"][];
+            nodes: components["schemas"]["WikiTreeNode"][];
         };
         WikiTreeResult: {
             namespaces: components["schemas"]["WikiTreeNamespace"][];
@@ -2256,8 +2265,13 @@ export interface components {
         WikiHomeResponse: (components["schemas"]["ApiSuccess"] & {
             result: components["schemas"]["WikiHomeResult"];
         }) | components["schemas"]["ApiFailure"];
-        WikiAdminTreePage: {
-            /** Format: uint64 */
+        WikiAdminTreeNode: {
+            /** @enum {string} */
+            kind: "page" | "directory";
+            /**
+             * Format: uint64
+             * @description Non-zero for page nodes and zero for directory nodes.
+             */
             pageId: number;
             /** @description Canonical page path with URL key as first segment (slug, or display name as fallback when slug is unassigned). */
             path: string;
@@ -2265,11 +2279,12 @@ export interface components {
             sourcePath: string;
             title: string;
             sortOrder: number;
+            children: components["schemas"]["WikiAdminTreeNode"][];
         };
         WikiAdminTreeNamespace: {
             name: string;
             label: string;
-            pages: components["schemas"]["WikiAdminTreePage"][];
+            nodes: components["schemas"]["WikiAdminTreeNode"][];
         };
         /** @description The raw namespace tree array; an empty listing is an empty array, never null. */
         WikiAdminTreeResult: components["schemas"]["WikiAdminTreeNamespace"][];
@@ -4409,7 +4424,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Namespace-labeled page tree with an active-page flag for each page. */
+            /** @description Namespace-labeled recursive directory/page tree with active-page flags. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -4496,7 +4511,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Namespace-labeled page tree including sort order for admin editing. */
+            /** @description Namespace-labeled recursive directory/page tree including sort order for admin editing. */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/apps/gooseforum/resource/src/admin/components/WikiTreeNode.vue
+++ b/apps/gooseforum/resource/src/admin/components/WikiTreeNode.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { ExternalLink, FileText, Folder } from '@lucide/vue'
+import type { WikiTreeNode } from '@/admin/types'
+
+defineOptions({ name: 'WikiTreeNode' })
+
+const props = defineProps<{
+  node: WikiTreeNode
+  depth: number
+  editUrlFor: (node: WikiTreeNode) => string
+  editTitle: string
+  viewTitle: string
+}>()
+
+function wikiHref(path: string) {
+  return `/wiki/${path.split('/').map((segment) => encodeURIComponent(segment)).join('/')}`
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 px-3 py-2" :style="{ paddingLeft: `${24 + depth * 18}px` }">
+      <Folder v-if="node.kind === 'directory'" class="size-4 shrink-0 text-muted-foreground" />
+      <FileText v-else class="size-4 shrink-0 text-muted-foreground" />
+      <div class="min-w-0 flex-1">
+        <div class="truncate text-sm font-medium">{{ node.title || node.path }}</div>
+        <div class="truncate font-mono text-xs text-muted-foreground">{{ node.path }}</div>
+      </div>
+      <div v-if="node.kind === 'page'" class="flex shrink-0 items-center gap-1">
+        <a
+          v-if="editUrlFor(node)"
+          :href="editUrlFor(node)"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="grid size-8 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          :title="editTitle"
+        >
+          <ExternalLink class="size-3.5" />
+        </a>
+        <a
+          :href="wikiHref(node.path)"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="grid size-8 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          :title="viewTitle"
+        >
+          <ExternalLink class="size-3.5" />
+        </a>
+      </div>
+    </div>
+    <div v-if="node.children.length" class="divide-y">
+      <WikiTreeNode
+        v-for="child in node.children"
+        :key="`${child.kind}:${child.path}`"
+        :node="child"
+        :depth="depth + 1"
+        :edit-url-for="editUrlFor"
+        :edit-title="editTitle"
+        :view-title="viewTitle"
+      />
+    </div>
+  </div>
+</template>

--- a/apps/gooseforum/resource/src/admin/pages/WikiManage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/WikiManage.vue
@@ -5,14 +5,13 @@ import { computed, onMounted, ref } from 'vue'
 import {
   BookOpen,
   Clock,
-  ExternalLink,
-  FileText,
   History,
   KeyRound,
   RefreshCw,
 } from '@lucide/vue'
 import AdminSection from '@/admin/components/AdminSection.vue'
 import AdminToolbar from '@/admin/components/AdminToolbar.vue'
+import WikiTreeNode from '@/admin/components/WikiTreeNode.vue'
 import { BasicPage } from '@/admin/components/global-layout'
 import { Badge } from '@/admin/components/ui/badge'
 import { Button } from '@/admin/components/ui/button'
@@ -48,7 +47,7 @@ import type {
   ManageHomeProps,
   WikiNamespace,
   WikiNamespaceTree,
-  WikiPageNode,
+  WikiTreeNode as WikiTreeNodeData,
 } from '@/admin/types'
 
 defineProps<{
@@ -127,7 +126,7 @@ function repoEditBase() {
   return path.includes('/') ? path : ''
 }
 
-function editUrlFor(page: WikiPageNode) {
+function editUrlFor(page: WikiTreeNodeData) {
   const base = repoEditBase()
   if (!base) return ''
   const branch = syncStatus.value?.branch || 'main'
@@ -155,10 +154,6 @@ async function loadNamespaces() {
 }
 
 // ---------- Page tree（只读：GitHub SSOT，结构由仓库决定） ----------
-function sortedPages(group: WikiNamespaceTree) {
-  return [...(group.pages || [])].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-}
-
 async function loadTree() {
   treeLoading.value = true
   treeError.value = ''
@@ -335,39 +330,20 @@ onMounted(() => {
                   <div class="flex min-w-0 items-center gap-2">
                     <BookOpen class="size-4 shrink-0 text-muted-foreground" />
                     <span class="truncate text-sm font-medium">{{ group.label || group.name }}</span>
-                    <span class="shrink-0 text-xs text-muted-foreground">{{ group.pages.length }}</span>
+                    <span class="shrink-0 text-xs text-muted-foreground">{{ group.nodes.length }}</span>
                   </div>
                 </div>
-                <div v-if="!group.pages.length" class="px-4 py-6 text-center text-sm text-muted-foreground">{{ adminText('k00ny') }}</div>
+                <div v-if="!group.nodes.length" class="px-4 py-6 text-center text-sm text-muted-foreground">{{ adminText('k00ny') }}</div>
                 <div v-else class="divide-y">
-                  <div v-for="page in sortedPages(group)" :key="page.pageId" class="flex items-center gap-2 px-3 py-2 pl-6">
-                    <FileText class="size-4 shrink-0 text-muted-foreground" />
-                    <div class="min-w-0 flex-1">
-                      <div class="truncate text-sm font-medium">{{ page.title || page.path }}</div>
-                      <div class="truncate font-mono text-xs text-muted-foreground">{{ page.path }}</div>
-                    </div>
-                    <div class="flex shrink-0 items-center gap-1">
-                      <a
-                        v-if="editUrlFor(page)"
-                        :href="editUrlFor(page)"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="grid size-8 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                        :title="adminText('k00q3')"
-                      >
-                        <ExternalLink class="size-3.5" />
-                      </a>
-                      <a
-                        :href="`/wiki/${page.path.split('/').map((seg) => encodeURIComponent(seg)).join('/')}`"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="grid size-8 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                        :title="adminText('k00nv')"
-                      >
-                        <ExternalLink class="size-3.5" />
-                      </a>
-                    </div>
-                  </div>
+                  <WikiTreeNode
+                    v-for="node in group.nodes"
+                    :key="`${node.kind}:${node.path}`"
+                    :node="node"
+                    :depth="0"
+                    :edit-url-for="editUrlFor"
+                    :edit-title="adminText('k00q3')"
+                    :view-title="adminText('k00nv')"
+                  />
                 </div>
               </div>
             </template>

--- a/apps/gooseforum/resource/src/admin/types.ts
+++ b/apps/gooseforum/resource/src/admin/types.ts
@@ -443,16 +443,18 @@ export interface WikiNamespace {
   updatedAt: string
 }
 
-export interface WikiPageNode {
+export interface WikiTreeNode {
+  kind: 'page' | 'directory'
   pageId: number
   path: string
   sourcePath: string
   title: string
   sortOrder: number
+  children: WikiTreeNode[]
 }
 
 export interface WikiNamespaceTree {
   name: string
   label: string
-  pages: WikiPageNode[]
+  nodes: WikiTreeNode[]
 }

--- a/apps/gooseforum/resource/src/site/components/WikiSidebar.vue
+++ b/apps/gooseforum/resource/src/site/components/WikiSidebar.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 import { ChevronDown, ChevronRight } from '@lucide/vue'
 import { useI18n } from 'vue-i18n'
 import type { WikiTreeNamespace } from '@gooseforum/client'
+import WikiSidebarNode from './WikiSidebarNode.vue'
 
 const props = defineProps<{
   tree: WikiTreeNamespace[]
@@ -28,10 +29,6 @@ function toggleCollapse(name: string) {
   collapsed.value = next
 }
 
-// GitHub SSOT：路径保留中文等 Unicode（不再小写归一），URL 按段编码。
-function wikiHref(path: string): string {
-  return '/wiki/' + path.split('/').map((seg) => encodeURIComponent(seg)).join('/')
-}
 </script>
 
 <template>
@@ -66,15 +63,12 @@ function wikiHref(path: string): string {
         <span class="truncate">{{ group.label }}</span>
       </button>
       <div v-if="!isCollapsed(group.name)" class="space-y-px">
-        <a
-          v-for="page in group.pages"
-          :key="page.pageId"
-          :href="wikiHref(page.path)"
-          class="flex h-7 items-center gap-2 rounded-md px-2 text-[13px] font-medium transition-colors duration-150"
-          :class="page.active ? 'bg-info/10 text-primary' : 'text-base-content/75 hover:bg-base-300 hover:text-base-content'"
-        >
-          <span class="truncate">{{ page.title }}</span>
-        </a>
+        <WikiSidebarNode
+          v-for="node in group.nodes"
+          :key="`${node.kind}:${node.path}`"
+          :node="node"
+          :depth="0"
+        />
       </div>
     </div>
   </nav>

--- a/apps/gooseforum/resource/src/site/components/WikiSidebarNode.vue
+++ b/apps/gooseforum/resource/src/site/components/WikiSidebarNode.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { ChevronDown, ChevronRight, FileText, Folder } from '@lucide/vue'
+import type { WikiTreeNode } from '@gooseforum/client'
+
+defineOptions({ name: 'WikiSidebarNode' })
+
+const props = defineProps<{
+  node: WikiTreeNode
+  depth: number
+}>()
+
+const collapsed = ref(false)
+const isDirectory = computed(() => props.node.kind === 'directory')
+
+function wikiHref(path: string): string {
+  return '/wiki/' + path.split('/').map((segment) => encodeURIComponent(segment)).join('/')
+}
+</script>
+
+<template>
+  <div>
+    <button
+      v-if="isDirectory"
+      type="button"
+      class="flex h-7 w-full items-center gap-1 rounded-md pr-2 text-left text-[13px] font-medium text-base-content/70 transition-colors duration-150 hover:bg-base-300 hover:text-base-content"
+      :style="{ paddingLeft: `${8 + depth * 12}px` }"
+      :aria-expanded="!collapsed"
+      @click="collapsed = !collapsed"
+    >
+      <ChevronDown v-if="!collapsed" class="h-3.5 w-3.5 shrink-0" />
+      <ChevronRight v-else class="h-3.5 w-3.5 shrink-0" />
+      <Folder class="h-3.5 w-3.5 shrink-0" />
+      <span class="truncate">{{ node.title }}</span>
+    </button>
+    <a
+      v-else
+      :href="wikiHref(node.path)"
+      class="flex h-7 items-center gap-2 rounded-md pr-2 text-[13px] font-medium transition-colors duration-150"
+      :style="{ paddingLeft: `${20 + depth * 12}px` }"
+      :class="node.active ? 'bg-info/10 text-primary' : 'text-base-content/75 hover:bg-base-300 hover:text-base-content'"
+    >
+      <FileText class="h-3.5 w-3.5 shrink-0 opacity-70" />
+      <span class="truncate">{{ node.title }}</span>
+    </a>
+    <div v-if="isDirectory && !collapsed" class="space-y-px">
+      <WikiSidebarNode
+        v-for="child in node.children"
+        :key="`${child.kind}:${child.path}`"
+        :node="child"
+        :depth="depth + 1"
+      />
+    </div>
+  </div>
+</template>

--- a/apps/gooseforum/resource/test/wiki-sidebar-node.test.ts
+++ b/apps/gooseforum/resource/test/wiki-sidebar-node.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, test } from 'vitest'
+import WikiSidebarNode from '../src/site/components/WikiSidebarNode.vue'
+
+describe('WikiSidebarNode', () => {
+  test('renders nested directories, exposes the active page, and collapses descendants', async () => {
+    const wrapper = mount(WikiSidebarNode, {
+      props: {
+        depth: 0,
+        node: {
+          kind: 'directory',
+          pageId: 0,
+          path: 'admission',
+          title: 'admission',
+          active: false,
+          children: [
+            {
+              kind: 'page',
+              pageId: 12,
+              path: 'guide/admission/process',
+              title: '流程',
+              active: true,
+              children: [],
+            },
+          ],
+        },
+      },
+    })
+
+    expect(wrapper.get('button').attributes('aria-expanded')).toBe('true')
+    expect(wrapper.get('a').attributes('href')).toBe('/wiki/guide/admission/process')
+    expect(wrapper.get('a').classes()).toContain('text-primary')
+
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.get('button').attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('a').exists()).toBe(false)
+  })
+})

--- a/apps/mobile/packages/core/lib/src/gen/wiki.dart
+++ b/apps/mobile/packages/core/lib/src/gen/wiki.dart
@@ -56,31 +56,46 @@ class WikiNamespace {
   }
 }
 
-/// 导航树中的一页（公开 `GET /api/wiki/tree`）。
-class WikiTreePage {
-  const WikiTreePage({
+/// 导航树节点（公开 `GET /api/wiki/tree`）。目录节点没有对应页面，pageId 为 0。
+class WikiTreeNode {
+  const WikiTreeNode({
+    required this.kind,
     required this.pageId,
     required this.path,
     required this.title,
     required this.active,
+    required this.children,
   });
 
+  final String kind;
   final int pageId;
   final String path;
   final String title;
   final bool active;
+  final List<WikiTreeNode> children;
 
-  factory WikiTreePage.fromJson(Map<String, dynamic> json) {
-    return WikiTreePage(
+  factory WikiTreeNode.fromJson(Map<String, dynamic> json) {
+    return WikiTreeNode(
+      kind: json['kind'] as String? ?? 'page',
       pageId: (json['pageId'] as num?)?.toInt() ?? 0,
       path: json['path'] as String? ?? '',
       title: json['title'] as String? ?? '',
       active: json['active'] as bool? ?? false,
+      children: (json['children'] as List<dynamic>? ?? const [])
+          .map((item) => WikiTreeNode.fromJson(item as Map<String, dynamic>))
+          .toList(),
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {'pageId': pageId, 'path': path, 'title': title, 'active': active};
+    return {
+      'kind': kind,
+      'pageId': pageId,
+      'path': path,
+      'title': title,
+      'active': active,
+      'children': children.map((node) => node.toJson()).toList(),
+    };
   }
 }
 
@@ -90,7 +105,7 @@ class WikiTreeNamespace {
     required this.name,
     required this.label,
     required this.slug,
-    required this.pages,
+    required this.nodes,
   });
 
   final String name;
@@ -99,15 +114,15 @@ class WikiTreeNamespace {
   /// 有效 URL key（slug，未分配时降级=显示名）；消费方拼
   /// `/wiki/{slug}/{page.path}` href 用。
   final String slug;
-  final List<WikiTreePage> pages;
+  final List<WikiTreeNode> nodes;
 
   factory WikiTreeNamespace.fromJson(Map<String, dynamic> json) {
     return WikiTreeNamespace(
       name: json['name'] as String? ?? '',
       label: json['label'] as String? ?? '',
       slug: json['slug'] as String? ?? '',
-      pages: (json['pages'] as List<dynamic>? ?? const [])
-          .map((item) => WikiTreePage.fromJson(item as Map<String, dynamic>))
+      nodes: (json['nodes'] as List<dynamic>? ?? const [])
+          .map((item) => WikiTreeNode.fromJson(item as Map<String, dynamic>))
           .toList(),
     );
   }
@@ -117,7 +132,7 @@ class WikiTreeNamespace {
       'name': name,
       'label': label,
       'slug': slug,
-      'pages': pages.map((page) => page.toJson()).toList(),
+      'nodes': nodes.map((node) => node.toJson()).toList(),
     };
   }
 }
@@ -319,16 +334,19 @@ class WikiTocItem {
   }
 }
 
-/// 管理端树中的一页（`GET /api/admin/wiki/tree`）。
-class WikiAdminTreePage {
-  const WikiAdminTreePage({
+/// 管理端树节点（`GET /api/admin/wiki/tree`）。目录节点没有对应页面。
+class WikiAdminTreeNode {
+  const WikiAdminTreeNode({
+    required this.kind,
     required this.pageId,
     required this.path,
     required this.sourcePath,
     required this.title,
     required this.sortOrder,
+    required this.children,
   });
 
+  final String kind;
   final int pageId;
 
   /// URL 友好路径（首段 = slug，降级 = 显示名）。
@@ -338,24 +356,31 @@ class WikiAdminTreePage {
   final String sourcePath;
   final String title;
   final int sortOrder;
+  final List<WikiAdminTreeNode> children;
 
-  factory WikiAdminTreePage.fromJson(Map<String, dynamic> json) {
-    return WikiAdminTreePage(
+  factory WikiAdminTreeNode.fromJson(Map<String, dynamic> json) {
+    return WikiAdminTreeNode(
+      kind: json['kind'] as String? ?? 'page',
       pageId: (json['pageId'] as num?)?.toInt() ?? 0,
       path: json['path'] as String? ?? '',
       sourcePath: json['sourcePath'] as String? ?? '',
       title: json['title'] as String? ?? '',
       sortOrder: (json['sortOrder'] as num?)?.toInt() ?? 0,
+      children: (json['children'] as List<dynamic>? ?? const [])
+          .map((item) => WikiAdminTreeNode.fromJson(item as Map<String, dynamic>))
+          .toList(),
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
+      'kind': kind,
       'pageId': pageId,
       'path': path,
       'sourcePath': sourcePath,
       'title': title,
       'sortOrder': sortOrder,
+      'children': children.map((node) => node.toJson()).toList(),
     };
   }
 }
@@ -365,20 +390,20 @@ class WikiAdminTreeNamespace {
   const WikiAdminTreeNamespace({
     required this.name,
     required this.label,
-    required this.pages,
+    required this.nodes,
   });
 
   final String name;
   final String label;
-  final List<WikiAdminTreePage> pages;
+  final List<WikiAdminTreeNode> nodes;
 
   factory WikiAdminTreeNamespace.fromJson(Map<String, dynamic> json) {
     return WikiAdminTreeNamespace(
       name: json['name'] as String? ?? '',
       label: json['label'] as String? ?? '',
-      pages: (json['pages'] as List<dynamic>? ?? const [])
+      nodes: (json['nodes'] as List<dynamic>? ?? const [])
           .map(
-            (item) => WikiAdminTreePage.fromJson(item as Map<String, dynamic>),
+            (item) => WikiAdminTreeNode.fromJson(item as Map<String, dynamic>),
           )
           .toList(),
     );
@@ -388,7 +413,7 @@ class WikiAdminTreeNamespace {
     return {
       'name': name,
       'label': label,
-      'pages': pages.map((page) => page.toJson()).toList(),
+      'nodes': nodes.map((node) => node.toJson()).toList(),
     };
   }
 }

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -47,8 +47,9 @@ The contract capability is **Partial**. The controlled OpenAPI 3.1 entry point i
   （GitHub push 事件，HMAC-SHA256 验签，触发即时同步）；**URL 语义 = slug**：页面
   `path` 首段与 `namespace` 列存 URL key（frontmatter `slug` 优先，目录名纯 ASCII 时
   默认 slug=目录名，中文目录无 slug 时降级=显示名），显示名从 `wiki_namespaces.name`
-  取，`source_path` 恒存仓库真实路径（GitHub 外链用，与 URL 解耦）；管理端树
-  `WikiAdminTreePage` 带 `sourcePath` 字段；生成 TS 类型 + 手写 Dart mirror
+  取，`source_path` 恒存仓库真实路径（GitHub 外链用，与 URL 解耦）；公开与管理端树均返回递归
+  `nodes`：`page` 节点对应 Markdown，`directory` 节点由路径投影且 `pageId=0`，完整路径在每层
+  保持稳定；管理端页面节点带 `sourcePath` 字段；生成 TS 类型 + 手写 Dart mirror
   （`apps/mobile/packages/core/lib/src/gen/wiki.dart`）。
 
 Paths are split per domain under `packages/api-contract/paths/` (for example `auth.yaml`,

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -94,7 +94,8 @@ Wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作�
 - **后端分层**: `app/models/forum/wikiNamespaces` / `wikiPages` / `wikiSyncRuns` →
   `app/service/wikiservice`（同步引擎 `sync.go`：`clone --depth=1` + `fetch` + `reset --hard`、
   frontmatter 解析、sha256 幂等 diff、upsert/软删/恢复、贡献者快照；查询 `query.go`：
-  BuildTree/BuildHome/贡献者；管理：命名空间 CRUD + 只读树）→ controllers：
+  BuildTree/BuildHome/贡献者；树以仓库路径递归投影目录节点（目录可无 `index.md`），同步结束后
+  将 `parent_id` 重算为最近祖先 `index.md` 页面；管理：命名空间 CRUD + 只读树）→ controllers：
   `app/http/controllers/forum/wiki.go`（SSR，PageComponent `wiki.home`/`wiki.detail`）+
   `app/http/controllers/api/wikiController.go`（公开读 + `/api/admin/wiki/*` 管理端）+
   `wikiSyncController.go`（`/api/wiki/webhook` + `/api/admin/wiki/sync*`）。
@@ -108,7 +109,7 @@ Wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作�
   `sync` / `sync/runs`）。站内写/回滚/diff/编辑者/版本历史端点已退役。
 - **前端**: site 区 `WikiHome.vue` / `WikiPage.vue` + `WikiSidebar` / `WikiToc` /
   `WikiPageActions`（编辑/历史按钮外链 GitHub），AppShell 侧栏 wiki 模式；admin 区
-  `WikiManage.vue`（`/admin/wiki`，PageManager：命名空间 + 只读页面树 + 同步面板）。
+  `WikiManage.vue`（`/admin/wiki`，PageManager：命名空间 + 递归只读页面树 + 同步面板）。
 - **隔离与通知**: `topics.topic_type`（0=论坛 1=wiki）隔离 feed 与搜索——默认论坛搜索/feed/RSS/
   sitemap 排除 wiki 话题（TopicSearchDocument 带 topicType）；同步更新后向订阅者发
   `wiki_updated` 通知（`notifications.templates.wikiUpdated`，同页面 10 分钟节流）。

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -84,7 +84,9 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
 - **命名空间/页面来源**：命名空间 = 仓库顶层目录名（支持中文等 Unicode 字符，目录
   消失自动删除命名空间）；页面 = 目录内 `.md` 文件（路径去 `.md` 后缀；frontmatter
   `title`/`order`/`description` 驱动页面标题/排序与命名空间描述，`index.md` 的
-  description/order 写入命名空间元数据）。
+  description/order 写入命名空间元数据）。任意子目录都会在导航树中保留为可折叠目录节点，
+  不要求 `index.md`；`index.md` 存在时仍是该目录下可直接访问的页面。同步完成后会重算页面
+  到最近祖先索引页的 `parent_id`，所以目录新增、移动、删除或恢复不会保留已删除的父引用。
 - **GitHub webhook 配置**（仓库 Settings → Webhooks → Add webhook）：
   - Payload URL：`https://forum.yourtj.de/api/wiki/webhook`（dev 实例用 `https://dev.yourtj.de/api/wiki/webhook`）
   - Content type：`application/json`；Secret：与 webhook 验签密钥一致

--- a/docs/product/current-state.md
+++ b/docs/product/current-state.md
@@ -23,7 +23,8 @@
   （wiki.home/wiki.detail）与公开 API（tree/namespaces/home）；同步触发 = 每日定时（默认
   03:00，可配）+ 管理端手动 + GitHub webhook（push 事件，PR merge 后即时）；站内无写路径
   （编辑/历史按钮外链 GitHub）；topics.topic_type 隔离论坛 feed 与搜索；`wiki_sync_runs`
-  记录每次同步（running/success/failed + 变更计数）。
+  记录每次同步（running/success/failed + 变更计数）。仓库目录逐级投影为可折叠导航：目录
+  不要求 `index.md`，`index.md` 是该目录下的普通可点击页面，同级节点按 `order` 排序。
 - **Built-in OIDC Provider**: the forum issues standard OIDC tokens (authorization code + PKCE S256,
   RS256 id_token, opaque access tokens) for first-party clients; `sub` is always the numeric users.id.
 - Monorepo structure (apps/packages/services/deploy/docs) + CI (server/web/contract workflows).

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -2578,27 +2578,36 @@ ResetPasswordResponse:
   oneOf:
     - $ref: '#/ResetPasswordSuccess'
     - $ref: '#/ApiFailure'
-WikiTreePage:
+WikiTreeNode:
   type: object
-  required: [pageId, path, title, active]
+  required: [kind, pageId, path, title, active, children]
   properties:
+    kind:
+      type: string
+      enum: [page, directory]
+      description: page is a Markdown file; directory is a non-clickable repository directory container.
     pageId:
       type: integer
       format: uint64
-      minimum: 1
+      minimum: 0
+      description: Non-zero for page nodes and zero for directory nodes.
     path:
       type: string
-      description: Canonical page path within the namespace (slash-separated).
+      description: Stable repository-relative page or directory path within the namespace (slash-separated).
     title:
       type: string
     active:
       type: boolean
-      description: True when the page has at least one approved revision; pages with only pending revisions are drafts.
+      description: True when this page is the active SSR route; always false for directory nodes.
+    children:
+      type: array
+      items:
+        $ref: '#/WikiTreeNode'
   additionalProperties: false
 
 WikiTreeNamespace:
   type: object
-  required: [name, label, slug, pages]
+  required: [name, label, slug, nodes]
   properties:
     name:
       type: string
@@ -2609,10 +2618,10 @@ WikiTreeNamespace:
     slug:
       type: string
       description: Effective URL key for this namespace (index.md frontmatter `slug`, or directory name when pure ASCII; falls back to display name when unassigned). Consumers build hrefs as /wiki/{slug}/{page.path}.
-    pages:
+    nodes:
       type: array
       items:
-        $ref: '#/WikiTreePage'
+        $ref: '#/WikiTreeNode'
   additionalProperties: false
 
 WikiTreeResult:
@@ -2735,14 +2744,18 @@ WikiHomeResponse:
 
 
 
-WikiAdminTreePage:
+WikiAdminTreeNode:
   type: object
-  required: [pageId, path, sourcePath, title, sortOrder]
+  required: [kind, pageId, path, sourcePath, title, sortOrder, children]
   properties:
+    kind:
+      type: string
+      enum: [page, directory]
     pageId:
       type: integer
       format: uint64
-      minimum: 1
+      minimum: 0
+      description: Non-zero for page nodes and zero for directory nodes.
     path:
       type: string
       description: Canonical page path with URL key as first segment (slug, or display name as fallback when slug is unassigned).
@@ -2753,20 +2766,24 @@ WikiAdminTreePage:
       type: string
     sortOrder:
       type: integer
+    children:
+      type: array
+      items:
+        $ref: '#/WikiAdminTreeNode'
   additionalProperties: false
 
 WikiAdminTreeNamespace:
   type: object
-  required: [name, label, pages]
+  required: [name, label, nodes]
   properties:
     name:
       type: string
     label:
       type: string
-    pages:
+    nodes:
       type: array
       items:
-        $ref: '#/WikiAdminTreePage'
+        $ref: '#/WikiAdminTreeNode'
   additionalProperties: false
 
 WikiAdminTreeResult:

--- a/packages/api-contract/fixtures/wiki-admin-tree-success.json
+++ b/packages/api-contract/fixtures/wiki-admin-tree-success.json
@@ -3,27 +3,43 @@
     {
       "name": "guide",
       "label": "guide",
-      "pages": [
+      "nodes": [
         {
+          "kind": "page",
           "pageId": 1001,
           "path": "guide/getting-started",
           "title": "快速开始",
           "sortOrder": 1,
-          "sourcePath": "guide/getting-started"
+          "sourcePath": "guide/getting-started",
+          "children": []
         },
         {
+          "kind": "page",
           "pageId": 1002,
           "path": "guide/content",
           "title": "内容规范",
           "sortOrder": 2,
-          "sourcePath": "guide/content"
+          "sourcePath": "guide/content",
+          "children": []
         },
         {
-          "pageId": 1003,
-          "path": "guide/draft/ideas",
-          "title": "草稿想法",
+          "kind": "directory",
+          "pageId": 0,
+          "path": "guide/draft",
+          "sourcePath": "",
+          "title": "draft",
           "sortOrder": 3,
-          "sourcePath": "guide/draft/ideas"
+          "children": [
+            {
+              "kind": "page",
+              "pageId": 1003,
+              "path": "guide/draft/ideas",
+              "title": "草稿想法",
+              "sortOrder": 3,
+              "sourcePath": "guide/draft/ideas",
+              "children": []
+            }
+          ]
         }
       ]
     }

--- a/packages/api-contract/fixtures/wiki-tree-success.json
+++ b/packages/api-contract/fixtures/wiki-tree-success.json
@@ -4,24 +4,39 @@
       {
         "name": "guide",
         "label": "guide",
-        "pages": [
+        "nodes": [
           {
+            "kind": "page",
             "pageId": 1001,
             "path": "getting-started",
             "title": "快速开始",
-            "active": false
+            "active": false,
+            "children": []
           },
           {
+            "kind": "page",
             "pageId": 1002,
             "path": "content",
             "title": "内容规范",
-            "active": false
+            "active": false,
+            "children": []
           },
           {
-            "pageId": 1003,
-            "path": "draft/ideas",
-            "title": "草稿想法",
-            "active": false
+            "kind": "directory",
+            "pageId": 0,
+            "path": "draft",
+            "title": "draft",
+            "active": false,
+            "children": [
+              {
+                "kind": "page",
+                "pageId": 1003,
+                "path": "draft/ideas",
+                "title": "草稿想法",
+                "active": false,
+                "children": []
+              }
+            ]
           }
         ],
         "slug": "guide"

--- a/packages/api-contract/openapi.yaml
+++ b/packages/api-contract/openapi.yaml
@@ -442,8 +442,8 @@ components:
       $ref: ./components/schemas.yaml#/SessionMessageSuccess
     UserSession:
       $ref: ./components/schemas.yaml#/UserSession
-    WikiTreePage:
-      $ref: ./components/schemas.yaml#/WikiTreePage
+    WikiTreeNode:
+      $ref: ./components/schemas.yaml#/WikiTreeNode
     WikiTreeNamespace:
       $ref: ./components/schemas.yaml#/WikiTreeNamespace
     WikiTreeResult:
@@ -462,8 +462,8 @@ components:
       $ref: ./components/schemas.yaml#/WikiHomeResult
     WikiHomeResponse:
       $ref: ./components/schemas.yaml#/WikiHomeResponse
-    WikiAdminTreePage:
-      $ref: ./components/schemas.yaml#/WikiAdminTreePage
+    WikiAdminTreeNode:
+      $ref: ./components/schemas.yaml#/WikiAdminTreeNode
     WikiAdminTreeNamespace:
       $ref: ./components/schemas.yaml#/WikiAdminTreeNamespace
     WikiAdminTreeResult:

--- a/packages/api-contract/paths/wiki.yaml
+++ b/packages/api-contract/paths/wiki.yaml
@@ -1,12 +1,12 @@
 getWikiTree:
   get:
     tags: [Wiki]
-    summary: Public wiki page tree across namespaces
+    summary: Public hierarchical wiki tree across namespaces
     security: []
     operationId: getWikiTree
     responses:
       '200':
-        description: Namespace-labeled page tree with an active-page flag for each page.
+        description: Namespace-labeled recursive directory/page tree with active-page flags.
         content:
           application/json:
             schema:
@@ -70,14 +70,14 @@ getWikiHome:
 getAdminWikiTree:
   get:
     tags: [Wiki Admin]
-    summary: Admin wiki page tree with sort order (PageManager or Admin only)
+    summary: Admin hierarchical wiki tree with sort order (PageManager or Admin only)
     operationId: getAdminWikiTree
     security:
       - bearerAuth: []
       - accessTokenCookie: []
     responses:
       '200':
-        description: Namespace-labeled page tree including sort order for admin editing.
+        description: Namespace-labeled recursive directory/page tree including sort order for admin editing.
         content:
           application/json:
             schema:

--- a/packages/api-contract/scripts/validate-fixtures.mjs
+++ b/packages/api-contract/scripts/validate-fixtures.mjs
@@ -37,24 +37,30 @@ function resolveRef(doc, ref) {
 // Fully dereference a schema subtree so ajv can compile it standalone
 // (the bundle keeps internal $refs; ajv cannot resolve them from an
 // extracted schema object without the full document registered).
-function deref(doc, node, seen = new Set()) {
-  if (Array.isArray(node)) return node.map((n) => deref(doc, n, seen));
+// Recursive schemas (e.g. WikiTreeNode.children → WikiTreeNode, PR #303)
+// cannot be expanded into a finite object; fixtures are finite and shallow,
+// so $ref expansion is depth-capped and anything below the cap matches the
+// empty schema. Every reachable fixture level still validates against the
+// real schema.
+const maxDerefDepth = 50;
+
+function deref(doc, node, depth = 0) {
+  if (Array.isArray(node)) return node.map((n) => deref(doc, n, depth));
   if (!node || typeof node !== "object") return node;
   const out = {};
   for (const [key, value] of Object.entries(node)) {
     if (key === "$ref" && typeof value === "string") {
-      if (seen.has(value)) {
-        throw new Error(`circular $ref "${value}" cannot be dereferenced for fixture validation`);
+      if (depth >= maxDerefDepth) {
+        // Recursion cap reached: emit the empty schema for this ref.
+        continue;
       }
-      seen.add(value);
-      const target = deref(doc, resolveRef(doc, value), seen);
-      seen.delete(value);
+      const target = deref(doc, resolveRef(doc, value), depth + 1);
       for (const [tk, tv] of Object.entries(target)) {
         if (!(tk in out)) out[tk] = tv;
       }
       continue;
     }
-    out[key] = deref(doc, value, seen);
+    out[key] = deref(doc, value, depth);
   }
   return out;
 }


### PR DESCRIPTION
Fixes #289

- 以递归目录节点重建 Wiki 公共、SSR 和管理端导航树，支持没有 `index.md` 的目录。
- 全量同步后重新推导页面 `parent_id`，处理目录索引的新增、删除与恢复。
- 同步 OpenAPI、Web/Dart 契约镜像、夹具、文档和回归测试。

验证：
- `cd apps/gooseforum && go vet ./... && go test ./...`
- `cd apps/gooseforum/resource && pnpm typecheck && pnpm test && pnpm build`
- `cd packages/api-contract && pnpm run check`
- 推送钩子：`go vet`、增量 `golangci-lint`、前端类型检查

未运行 Flutter 契约夹具测试：本机缺少 Dart SDK（`dart: command not found`）。