### PR TITLE
fix(wiki): 移除 wiki 侧边栏顶部 pb-2 首页块

### DIFF
--- a/apps/gooseforum/resource/src/site/components/WikiSidebar.vue
+++ b/apps/gooseforum/resource/src/site/components/WikiSidebar.vue
@@ -16,10 +16,6 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 const collapsed = ref<Set<string>>(new Set())
-const isHome = computed(() => {
-  if (typeof window === 'undefined') return false
-  return window.location.pathname === '/wiki' || window.location.pathname === '/wiki/'
-})
 
 const groups = computed(() => props.tree || [])
 
@@ -38,17 +34,6 @@ function toggleCollapse(name: string) {
 
 <template>
   <nav class="py-3" aria-label="Wiki sidebar">
-    <div class="pb-2">
-      <a
-        href="/wiki"
-        class="flex h-8 items-center gap-2 rounded-md px-2 text-[13px] font-semibold transition-colors duration-150"
-        :class="isHome ? 'bg-info/10 text-primary' : 'text-base-content/75 hover:bg-base-300 hover:text-base-content'"
-        @click="emit('navigate')"
-      >
-        {{ t('wiki.home') }}
-      </a>
-    </div>
-
     <div v-if="!groups.length" class="px-2 py-3 text-xs text-base-content/55">
       {{ t('wiki.sidebarEmpty') }}
     </div>

--- a/apps/gooseforum/resource/test/wiki-mobile-nav.test.ts
+++ b/apps/gooseforum/resource/test/wiki-mobile-nav.test.ts
@@ -71,15 +71,6 @@ function makeLayout(mode: 'forum' | 'wiki'): LayoutPayload {
 const stubs = { Motion: MotionStub, AnimatePresence: AnimatePresenceStub }
 
 describe('WikiSidebar 导航事件', () => {
-  test('点击 wiki 首页链接发出 navigate 事件（供抽屉关闭）', async () => {
-    const wrapper = mount(WikiSidebar, {
-      props: { tree: wikiTree },
-      global: { plugins: [i18n] },
-    })
-    await wrapper.get('a[href="/wiki"]').trigger('click')
-    expect(wrapper.emitted('navigate')).toHaveLength(1)
-  })
-
   test('点击页面链接发出 navigate 事件，且中文路径按段编码', async () => {
     const wrapper = mount(WikiSidebar, {
       props: { tree: wikiTree },
@@ -113,14 +104,15 @@ describe('MobileDrawer wiki 模式', () => {
     })
   }
 
-  test('wiki 模式下渲染 wiki 首页 + 命名空间 + 页面树', () => {
+  test('wiki 模式下渲染命名空间 + 页面树（侧边栏已无 wiki 首页块）', () => {
     const wrapper = mountDrawer({ wikiMode: true, wikiTree })
     const drawer = wrapper.get('[role="dialog"]')
     expect(drawer.text()).toContain('同济新手教程')
     expect(drawer.text()).toContain('使用指南')
     expect(drawer.text()).toContain('学校简介')
     expect(drawer.text()).toContain('快速开始')
-    expect(drawer.get('a[href="/wiki"]').text()).toBe('Wiki')
+    // 需求：wiki 侧边栏移除顶部 pb-2 首页块 → 抽屉内不再有 /wiki 首页链接。
+    expect(drawer.find('a[href="/wiki"]').exists()).toBe(false)
   })
 
   test('活动页面保持高亮（与桌面侧栏一致）', () => {


### PR DESCRIPTION
## 动机

用户需求：wiki 布局的侧边栏不再需要顶部那个展示「wiki 首页/活跃高亮」的 pb-2 区块。

## 改动

- `apps/gooseforum/resource/src/site/components/WikiSidebar.vue`：
  - 移除顶部 `<div class="pb-2">` 首页链接块（`/wiki` + `t('wiki.home')` + isHome 高亮）；
  - 清理因此不再使用的 `isHome` computed；
  - 保留空态（`wiki.sidebarEmpty`）与命名空间分组列表，不受影响。
- `apps/gooseforum/resource/test/wiki-mobile-nav.test.ts`：
  - 移除「点击 wiki 首页链接发出 navigate 事件」用例（home 链接已不存在）；
  - 「wiki 模式渲染」用例改为断言抽屉内不再有 `a[href="/wiki"]`（回归需求）。

## 验证

```text
cd apps/gooseforum/resource
pnpm typecheck   → OK
pnpm test        → 31 files / 221 tests passed
pnpm build       → OK (built in 2.98s)
```

## 说明

- `wiki.home` 在 `WikiPage.vue:89`（面包屑首页链接）与 `WikiHome.vue` 页面标题仍有独立使用，不在本次移除范围；
- `AppShell.vue:585` 的 `pb-2` 属于论坛模式（非 wiki）侧边栏，与本次需求无关。