### PR TITLE
feat(wiki): 贡献者区块显示 GitHub 头像与主页外链

### DIFF
--- a/apps/gooseforum/app/service/wikiservice/query.go
+++ b/apps/gooseforum/app/service/wikiservice/query.go
@@ -482,16 +482,19 @@ func BuildHome() (HomeData, error) {
 }
 
 // Contributor 贡献者条目（GitHub SSOT：来源为仓库 git log 贡献者快照）。
+// GitHub 贡献者无论坛账号：userId 恒 0；username 由 noreply 邮箱解析时
+// avatarUrl/githubUrl 可用，自定义邮箱贡献者三者皆空（前端降级占位）。
 type Contributor struct {
 	UserId       uint64    `json:"userId"`
 	Username     string    `json:"username"`
 	AvatarUrl    string    `json:"avatarUrl"`
+	GithubUrl    string    `json:"githubUrl,omitempty"`
 	Count        int       `json:"count"`
 	LastEditedAt time.Time `json:"lastEditedAt"`
 }
 
 // BuildContributors 返回页面贡献者（读 wiki_pages.contributors_json 缓存；
-// 由同步器从 git log 生成，GitHub 贡献者无论坛账号，userId/avatarUrl 为空）。
+// 由同步器从 git log 生成，GitHub 贡献者无论坛账号，userId 恒为空）。
 func BuildContributors(pageId uint64) []Contributor {
 	page := wikiPages.Get(pageId)
 	if page.Id == 0 || page.ContributorsJSON == "" {
@@ -507,11 +510,16 @@ func BuildContributors(pageId uint64) []Contributor {
 	}
 	result := make([]Contributor, 0, len(raw))
 	for _, c := range raw {
-		result = append(result, Contributor{
+		item := Contributor{
 			Username:     c.Name,
 			Count:        c.Count,
 			LastEditedAt: lastEdited,
-		})
+		}
+		if c.Username != "" {
+			item.AvatarUrl = githubAvatarURL(c.Username)
+			item.GithubUrl = githubProfileURL(c.Username)
+		}
+		result = append(result, item)
 	}
 	return result
 }

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -341,10 +341,10 @@ func ensureClone(cfg GitConfig) (head string, unshallowed bool, err error) {
 			unshallowed = true
 		}
 		if out, err := runGit(cfg.CloneDir, "fetch", "origin", cfg.Branch); err != nil {
-			return "", unshallowed, fmt.Errorf("git fetch: %v: %s", err, out)
+			return "", unshallowed, fmt.Errorf("git fetch: %w: %s", err, out)
 		}
 		if out, err := runGit(cfg.CloneDir, "reset", "--hard", "origin/"+cfg.Branch); err != nil {
-			return "", unshallowed, fmt.Errorf("git reset: %v: %s", err, out)
+			return "", unshallowed, fmt.Errorf("git reset: %w: %s", err, out)
 		}
 	} else {
 		if err := os.MkdirAll(cfg.CloneDir, 0o755); err != nil {
@@ -353,12 +353,12 @@ func ensureClone(cfg GitConfig) (head string, unshallowed bool, err error) {
 		// 全量 clone（不用 --depth=1，贡献者统计依赖完整 git log 历史）+
 		// --single-branch（只取配置分支，避免拉取无关长驻分支的冗余对象）。
 		if out, err := runGit("", "clone", "--single-branch", "--branch", cfg.Branch, cfg.Repo, cfg.CloneDir); err != nil {
-			return "", false, fmt.Errorf("git clone: %v: %s", err, out)
+			return "", false, fmt.Errorf("git clone: %w: %s", err, out)
 		}
 	}
 	out, err := runGit(cfg.CloneDir, "rev-parse", "HEAD")
 	if err != nil {
-		return "", unshallowed, fmt.Errorf("git rev-parse: %v: %s", err, out)
+		return "", unshallowed, fmt.Errorf("git rev-parse: %w: %s", err, out)
 	}
 	return strings.TrimSpace(out), unshallowed, nil
 }

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -309,11 +309,13 @@ func ReconcileStaleRuns() {
 // ---------- git 操作 ----------
 
 // ensureClone 确保本地 clone 存在且 remote 与配置一致（无则 clone，有则 fetch + reset --hard）。
-// 返回当前 head SHA。本地工作区永不手动修改，reset --hard 比 pull 更确定。
+// 返回当前 head SHA，以及本次是否发生了浅克隆→全量升级（unshallowed：调用方需要
+// 据此重建全部页面的 git 溯源缓存——存量 depth-1 缓存只有最后一位作者）。
+// 本地工作区永不手动修改，reset --hard 比 pull 更确定。
 // 配置变更（repo 换源）时丢弃缓存 clone 重建，避免投影到错误仓库。
-func ensureClone(cfg GitConfig) (string, error) {
+func ensureClone(cfg GitConfig) (head string, unshallowed bool, err error) {
 	if cfg.Repo == "" {
-		return "", fmt.Errorf("wiki git repo not configured")
+		return "", false, fmt.Errorf("wiki git repo not configured")
 	}
 	if cfg.CloneDir == "" {
 		cfg.CloneDir = "./storage/wiki-repo"
@@ -324,38 +326,41 @@ func ensureClone(cfg GitConfig) (string, error) {
 				slog.Warn("wiki sync: cached clone remote mismatch, recloning",
 					"cached", strings.TrimSpace(out), "configured", cfg.Repo)
 				if err := os.RemoveAll(cfg.CloneDir); err != nil {
-					return "", fmt.Errorf("remove stale clone: %w", err)
+					return "", false, fmt.Errorf("remove stale clone: %w", err)
 				}
 			}
 		}
 	}
 	if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git")); err == nil {
 		// 存量浅克隆（v1 用 --depth=1 建立）→ 补全历史：贡献者统计依赖完整 git log。
+		// 升级后必须重建全部页面的贡献者缓存（P1：幂等同步不会触碰未变化页面）。
 		if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git", "shallow")); err == nil {
 			if out, err := runGit(cfg.CloneDir, "fetch", "--unshallow", "origin", cfg.Branch); err != nil {
-				return "", fmt.Errorf("git fetch --unshallow: %w: %s", err, out)
+				return "", false, fmt.Errorf("git fetch --unshallow: %w: %s", err, out)
 			}
+			unshallowed = true
 		}
 		if out, err := runGit(cfg.CloneDir, "fetch", "origin", cfg.Branch); err != nil {
-			return "", fmt.Errorf("git fetch: %v: %s", err, out)
+			return "", unshallowed, fmt.Errorf("git fetch: %v: %s", err, out)
 		}
 		if out, err := runGit(cfg.CloneDir, "reset", "--hard", "origin/"+cfg.Branch); err != nil {
-			return "", fmt.Errorf("git reset: %v: %s", err, out)
+			return "", unshallowed, fmt.Errorf("git reset: %v: %s", err, out)
 		}
 	} else {
 		if err := os.MkdirAll(cfg.CloneDir, 0o755); err != nil {
-			return "", fmt.Errorf("mkdir clone dir: %w", err)
+			return "", false, fmt.Errorf("mkdir clone dir: %w", err)
 		}
-		// 全量 clone（不用 --depth=1）：贡献者统计依赖完整 git log 历史。
-		if out, err := runGit("", "clone", "--branch", cfg.Branch, cfg.Repo, cfg.CloneDir); err != nil {
-			return "", fmt.Errorf("git clone: %v: %s", err, out)
+		// 全量 clone（不用 --depth=1，贡献者统计依赖完整 git log 历史）+
+		// --single-branch（只取配置分支，避免拉取无关长驻分支的冗余对象）。
+		if out, err := runGit("", "clone", "--single-branch", "--branch", cfg.Branch, cfg.Repo, cfg.CloneDir); err != nil {
+			return "", false, fmt.Errorf("git clone: %v: %s", err, out)
 		}
 	}
 	out, err := runGit(cfg.CloneDir, "rev-parse", "HEAD")
 	if err != nil {
-		return "", fmt.Errorf("git rev-parse: %v: %s", err, out)
+		return "", unshallowed, fmt.Errorf("git rev-parse: %v: %s", err, out)
 	}
-	return strings.TrimSpace(out), nil
+	return strings.TrimSpace(out), unshallowed, nil
 }
 
 // sameRemote 归一化比较仓库地址（忽略尾部 / 与 .git）。
@@ -450,19 +455,20 @@ func scanRepoFiles(cloneDir string) ([]repoFile, error) {
 }
 
 // gitContributor 仓库 git log 贡献者快照条目（BuildContributors 数据源）。
-// Email 用于聚合（同人改名不裂）；Username 由 GitHub noreply 邮箱解析，
-// 供前端拼头像与主页外链；自定义邮箱贡献者 username 为空（无链接降级）。
+// 注意：email 仅作内存聚合键，不持久化（P2：原始邮箱属个人数据，contributors_json
+// 会进入 DB/备份；BuildContributors 也不需要 email）。Username 由 GitHub noreply
+// 邮箱解析，供前端拼头像与主页外链；自定义邮箱贡献者 username 为空（无链接降级）。
 type gitContributor struct {
 	Name     string `json:"name"`
-	Email    string `json:"email,omitempty"`
 	Username string `json:"username,omitempty"`
 	Count    int    `json:"count"`
 }
 
 // buildContributorsSnapshot 从 git log 统计某文件贡献者（同步时写入页面缓存）。
 // 公开仓库无鉴权；失败返回空快照（不阻断同步）。
-// 聚合键 = email（GitHub 隐私邮箱可解析 username；自定义邮箱按 email 聚合，
-// 仅当 email 也缺失时才退回按 name 聚合）；展示名取该邮箱最近一次提交的 name。
+// 聚合键优先级：username（GitHub noreply 可解析，合并新旧邮箱格式同人）→
+// email（自定义邮箱）→ name（匿名提交兜底）。email 仅内存聚合键，不序列化。
+// 展示名取该聚合键最近一次提交的 name。
 func buildContributorsSnapshot(cloneDir, relPath string) string {
 	out, err := runGit(cloneDir, "log", "--pretty=format:%an%x1f%ae", "--", relPath)
 	if err != nil || strings.TrimSpace(out) == "" {
@@ -485,8 +491,9 @@ func buildContributorsSnapshot(cloneDir, relPath string) string {
 		if len(parts) > 1 {
 			email = strings.TrimSpace(parts[1])
 		}
-		// 聚合键优先级：username（GitHub noreply 可解析——合并新旧邮箱格式、
-		// 以及「noreply + 自定义邮箱」双邮箱同人）→ email → name（匿名提交兜底）。
+		// 聚合键优先级：username（GitHub noreply 可解析——合并新旧邮箱格式同人）→
+		// email（自定义邮箱）→ name（匿名提交兜底）。注意：同人混用 noreply 与
+		// 自定义邮箱时无可靠身份源（无 mailmap）可合并，会按不同键拆分为两人。
 		key := githubUsernameFromEmail(email)
 		if key == "" {
 			key = email
@@ -507,7 +514,6 @@ func buildContributorsSnapshot(cloneDir, relPath string) string {
 	for _, item := range byKey {
 		items = append(items, gitContributor{
 			Name:     item.name,
-			Email:    item.email,
 			Username: item.username,
 			Count:    item.count,
 		})
@@ -718,7 +724,7 @@ func syncOnce(cfg GitConfig, trigger string) (*SyncResult, error) {
 		return nil, fmt.Errorf("create sync run: %w", err)
 	}
 
-	head, err := ensureClone(cfg)
+	head, unshallowed, err := ensureClone(cfg)
 	if err != nil {
 		if merr := wikiSyncRuns.MarkFinished(run.Id, wikiSyncRuns.StatusFailed, "", 0, 0, 0, err.Error()); merr != nil {
 			slog.Error("wiki sync: mark run failed (clone) failed", "runId", run.Id, "error", merr)
@@ -732,6 +738,11 @@ func syncOnce(cfg GitConfig, trigger string) (*SyncResult, error) {
 			slog.Error("wiki sync: mark run failed (projection) failed", "runId", run.Id, "error", merr)
 		}
 		return result, err
+	}
+	// 浅克隆→全量升级（review P1）：幂等同步跳过未变化页面，此处全量重建
+	// 贡献者缓存，否则存量 depth-1 页面的 contributors_json 永远停留最后一位作者。
+	if unshallowed {
+		rebuildGitTraces(cfg)
 	}
 	if merr := wikiSyncRuns.MarkFinished(run.Id, wikiSyncRuns.StatusSuccess, head, result.PagesAdded, result.PagesUpdated, result.PagesDeleted, ""); merr != nil {
 		slog.Error("wiki sync: mark run success failed", "runId", run.Id, "error", merr)
@@ -1572,6 +1583,25 @@ func updateGitTrace(cfg GitConfig, pageID uint64, relPath string) {
 	if err := wikiPages.UpdateGitTrace(pageID, updates); err != nil {
 		slog.Warn("wiki sync: update git trace failed", "pageId", pageID, "error", err)
 	}
+}
+
+// rebuildGitTraces 浅克隆→全量升级后重建全部页面的 git 溯源缓存
+// （review P1）：applyRepoToDB 幂等跳过未变化页面，若不在此全量重建，
+// 存量 depth-1 页面的 contributors_json 永远停留在最后一位作者。
+// 单页失败仅记日志，不阻断整体重建。
+func rebuildGitTraces(cfg GitConfig) {
+	pages, err := wikiPages.ListAll()
+	if err != nil {
+		slog.Warn("wiki sync: rebuild git traces failed to list pages", "error", err)
+		return
+	}
+	for _, p := range pages {
+		if p.SourcePath == "" {
+			continue
+		}
+		updateGitTrace(cfg, p.Id, p.SourcePath)
+	}
+	slog.Info("wiki sync: rebuilt git traces after unshallow upgrade", "pages", len(pages))
 }
 
 // encodeTOCOrEmpty 编码 TOC，失败返回空串（不阻断同步）。

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -330,6 +330,12 @@ func ensureClone(cfg GitConfig) (string, error) {
 		}
 	}
 	if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git")); err == nil {
+		// 存量浅克隆（v1 用 --depth=1 建立）→ 补全历史：贡献者统计依赖完整 git log。
+		if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git", "shallow")); err == nil {
+			if out, err := runGit(cfg.CloneDir, "fetch", "--unshallow", "origin", cfg.Branch); err != nil {
+				return "", fmt.Errorf("git fetch --unshallow: %v: %s", err, out)
+			}
+		}
 		if out, err := runGit(cfg.CloneDir, "fetch", "origin", cfg.Branch); err != nil {
 			return "", fmt.Errorf("git fetch: %v: %s", err, out)
 		}
@@ -340,8 +346,8 @@ func ensureClone(cfg GitConfig) (string, error) {
 		if err := os.MkdirAll(cfg.CloneDir, 0o755); err != nil {
 			return "", fmt.Errorf("mkdir clone dir: %w", err)
 		}
-		// 新 clone：--depth=1 只拉默认分支最新（同步只关心 head）。
-		if out, err := runGit("", "clone", "--depth=1", "--branch", cfg.Branch, cfg.Repo, cfg.CloneDir); err != nil {
+		// 全量 clone（不用 --depth=1）：贡献者统计依赖完整 git log 历史。
+		if out, err := runGit("", "clone", "--branch", cfg.Branch, cfg.Repo, cfg.CloneDir); err != nil {
 			return "", fmt.Errorf("git clone: %v: %s", err, out)
 		}
 	}
@@ -444,32 +450,67 @@ func scanRepoFiles(cloneDir string) ([]repoFile, error) {
 }
 
 // gitContributor 仓库 git log 贡献者快照条目（BuildContributors 数据源）。
+// Email 用于聚合（同人改名不裂）；Username 由 GitHub noreply 邮箱解析，
+// 供前端拼头像与主页外链；自定义邮箱贡献者 username 为空（无链接降级）。
 type gitContributor struct {
-	Name  string `json:"name"`
-	Count int    `json:"count"`
+	Name     string `json:"name"`
+	Email    string `json:"email,omitempty"`
+	Username string `json:"username,omitempty"`
+	Count    int    `json:"count"`
 }
 
 // buildContributorsSnapshot 从 git log 统计某文件贡献者（同步时写入页面缓存）。
 // 公开仓库无鉴权；失败返回空快照（不阻断同步）。
+// 聚合键 = email（GitHub 隐私邮箱可解析 username；自定义邮箱按 email 聚合，
+// 仅当 email 也缺失时才退回按 name 聚合）；展示名取该邮箱最近一次提交的 name。
 func buildContributorsSnapshot(cloneDir, relPath string) string {
-	out, err := runGit(cloneDir, "log", "--pretty=format:%an", "--", relPath)
+	out, err := runGit(cloneDir, "log", "--pretty=format:%an%x1f%ae", "--", relPath)
 	if err != nil || strings.TrimSpace(out) == "" {
 		return ""
 	}
-	counts := make(map[string]int)
+	type agg struct {
+		name     string
+		email    string
+		username string
+		count    int
+	}
+	byKey := make(map[string]*agg)
 	for _, line := range strings.Split(out, "\n") {
-		name := strings.TrimSpace(line)
-		if name != "" {
-			counts[name]++
+		parts := strings.SplitN(line, "\x1f", 2)
+		name := strings.TrimSpace(parts[0])
+		if name == "" {
+			continue
 		}
+		email := ""
+		if len(parts) > 1 {
+			email = strings.TrimSpace(parts[1])
+		}
+		// 聚合键优先级：username（GitHub noreply 可解析——合并新旧邮箱格式、
+		// 以及「noreply + 自定义邮箱」双邮箱同人）→ email → name（匿名提交兜底）。
+		key := githubUsernameFromEmail(email)
+		if key == "" {
+			key = email
+		}
+		if key == "" {
+			key = name
+		}
+		item := byKey[key]
+		if item == nil {
+			// git log 新→旧：首个出现的提交即该贡献者最近一次提交，
+			// name 取首次（最新）值，后续旧提交不覆盖显示名。
+			item = &agg{name: name, email: email, username: githubUsernameFromEmail(email)}
+			byKey[key] = item
+		}
+		item.count++
 	}
-	type item struct {
-		Name  string `json:"name"`
-		Count int    `json:"count"`
-	}
-	items := make([]item, 0, len(counts))
-	for name, c := range counts {
-		items = append(items, item{Name: name, Count: c})
+	items := make([]gitContributor, 0, len(byKey))
+	for _, item := range byKey {
+		items = append(items, gitContributor{
+			Name:     item.name,
+			Email:    item.email,
+			Username: item.username,
+			Count:    item.count,
+		})
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Count > items[j].Count })
 	data, err := json.Marshal(items)
@@ -477,6 +518,54 @@ func buildContributorsSnapshot(cloneDir, relPath string) string {
 		return ""
 	}
 	return string(data)
+}
+
+// githubNoReplySuffix GitHub 隐私邮箱后缀（公开仓库贡献者默认开启邮箱隐私）。
+const githubNoReplySuffix = "@users.noreply.github.com"
+
+// githubUsernameFromEmail 从 GitHub noreply 隐私邮箱解析用户名：
+//   - 新版格式 {id}+{username}@users.noreply.github.com（2021+）
+//   - 旧版格式 {username}@users.noreply.github.com（2017-2021）
+//   - 自定义邮箱 / 无法解析 → 返回空（前端降级为首字母占位、无外链）。
+func githubUsernameFromEmail(email string) string {
+	email = strings.TrimSpace(email)
+	local, ok := strings.CutSuffix(email, githubNoReplySuffix)
+	if !ok || local == "" {
+		return ""
+	}
+	// 新版 {id}+{username}：取最后一个 + 之后的部分（id 全数字）。
+	if i := strings.LastIndex(local, "+"); i >= 0 {
+		local = local[i+1:]
+	}
+	if !validGithubUsername(local) {
+		return ""
+	}
+	return local
+}
+
+// validGithubUsername GitHub 用户名宽松校验：字母数字连字符，不以连字符开头/结尾。
+func validGithubUsername(name string) bool {
+	if name == "" || len(name) > 39 || name[0] == '-' || name[len(name)-1] == '-' {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// githubAvatarURL GitHub 官方动态头像直链（无需 API/token；size 控制分辨率）。
+func githubAvatarURL(username string) string {
+	return "https://github.com/" + username + ".png?size=56"
+}
+
+// githubProfileURL GitHub 用户主页外链。
+func githubProfileURL(username string) string {
+	return "https://github.com/" + username
 }
 
 // ---------- frontmatter 解析 ----------

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -308,9 +308,17 @@ func ReconcileStaleRuns() {
 
 // ---------- git 操作 ----------
 
+// unshallowMarkerFile 浅克隆→全量升级的「待重建 git trace」持久化标记
+// （review P1）：unshallow 成功后写入 .git/ 内（fetch/reset/扫描均不触碰），
+// rebuildGitTraces 完成后删除。投影失败/进程崩溃后标记保留，下次同步的
+// ensureClone 仍会检测到并重建存量页面贡献者缓存——否则 .git/shallow 已被
+// git 删除，仅靠局部变量会永久丢失升级机会，depth-1 快照残留。
+const unshallowMarkerFile = "wiki-trace-rebuild"
+
 // ensureClone 确保本地 clone 存在且 remote 与配置一致（无则 clone，有则 fetch + reset --hard）。
-// 返回当前 head SHA，以及本次是否发生了浅克隆→全量升级（unshallowed：调用方需要
-// 据此重建全部页面的 git 溯源缓存——存量 depth-1 缓存只有最后一位作者）。
+// 返回当前 head SHA，以及本次是否需要重建全部页面的 git 溯源缓存（unshallowed）：
+// 触发条件 = 本次发生浅克隆→全量升级，或存在未消费的升级标记（上次升级后投影
+// 失败/崩溃，重建未完成）。存量 depth-1 缓存只有最后一位作者，必须全量重建。
 // 本地工作区永不手动修改，reset --hard 比 pull 更确定。
 // 配置变更（repo 换源）时丢弃缓存 clone 重建，避免投影到错误仓库。
 func ensureClone(cfg GitConfig) (head string, unshallowed bool, err error) {
@@ -332,6 +340,12 @@ func ensureClone(cfg GitConfig) (head string, unshallowed bool, err error) {
 		}
 	}
 	if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git")); err == nil {
+		markerPath := filepath.Join(cfg.CloneDir, ".git", unshallowMarkerFile)
+		// 未消费的升级标记：上次 unshallow 后投影失败/崩溃，全量重建未完成
+		// → 本次仍须重建（review P1：.git/shallow 已删除，无法再靠它检测）。
+		if _, err := os.Stat(markerPath); err == nil {
+			unshallowed = true
+		}
 		// 存量浅克隆（v1 用 --depth=1 建立）→ 补全历史：贡献者统计依赖完整 git log。
 		// 升级后必须重建全部页面的贡献者缓存（P1：幂等同步不会触碰未变化页面）。
 		if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git", "shallow")); err == nil {
@@ -339,6 +353,11 @@ func ensureClone(cfg GitConfig) (head string, unshallowed bool, err error) {
 				return "", false, fmt.Errorf("git fetch --unshallow: %w: %s", err, out)
 			}
 			unshallowed = true
+			// 持久化待重建标记：本次投影失败时，下次同步仍会重建
+			// （review P1：unshallow 后 shallow 文件已删除，状态必须落盘）。
+			if err := os.WriteFile(markerPath, []byte("1"), 0o644); err != nil {
+				return "", false, fmt.Errorf("write git trace rebuild marker: %w", err)
+			}
 		}
 		if out, err := runGit(cfg.CloneDir, "fetch", "origin", cfg.Branch); err != nil {
 			return "", unshallowed, fmt.Errorf("git fetch: %w: %s", err, out)
@@ -1600,7 +1619,10 @@ func updateGitTrace(cfg GitConfig, pageID uint64, relPath string) {
 // rebuildGitTraces 浅克隆→全量升级后重建全部页面的 git 溯源缓存
 // （review P1）：applyRepoToDB 幂等跳过未变化页面，若不在此全量重建，
 // 存量 depth-1 页面的 contributors_json 永远停留在最后一位作者。
-// 单页失败仅记日志，不阻断整体重建。
+// 重建完成后删除持久化升级标记（unshallowMarkerFile）——标记由 ensureClone
+// 在 unshallow 成功时写入，投影失败/崩溃时保留，本次成功消费后才清除：
+// 保证「unshallow 后首次投影失败、修复后重试」仍会刷新未变化页面（review P1）。
+// 单页失败仅记日志，不阻断整体重建；标记清除失败仅告警（下次同步仍会重建）。
 func rebuildGitTraces(cfg GitConfig) {
 	pages, err := wikiPages.ListAll()
 	if err != nil {
@@ -1612,6 +1634,10 @@ func rebuildGitTraces(cfg GitConfig) {
 			continue
 		}
 		updateGitTrace(cfg, p.Id, p.SourcePath)
+	}
+	markerPath := filepath.Join(cfg.CloneDir, ".git", unshallowMarkerFile)
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		slog.Warn("wiki sync: remove git trace rebuild marker failed", "error", err)
 	}
 	slog.Info("wiki sync: rebuilt git traces after unshallow upgrade", "pages", len(pages))
 }

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -464,13 +464,25 @@ type gitContributor struct {
 	Count    int    `json:"count"`
 }
 
+// gitLogPath 把页面 source_path（仓库相对路径，去 .md 后缀）规范化为 git pathspec
+// 可精确匹配的仓库文件路径（补 .md）：git log pathspec 是精确匹配，
+// `git log -- guide/start` 匹配不到仓库中的 guide/start.md。
+func gitLogPath(sourcePath string) string {
+	if strings.HasSuffix(sourcePath, ".md") {
+		return sourcePath
+	}
+	return sourcePath + ".md"
+}
+
 // buildContributorsSnapshot 从 git log 统计某文件贡献者（同步时写入页面缓存）。
 // 公开仓库无鉴权；失败返回空快照（不阻断同步）。
 // 聚合键优先级：username（GitHub noreply 可解析，合并新旧邮箱格式同人）→
 // email（自定义邮箱）→ name（匿名提交兜底）。email 仅内存聚合键，不序列化。
 // 展示名取该聚合键最近一次提交的 name。
 func buildContributorsSnapshot(cloneDir, relPath string) string {
-	out, err := runGit(cloneDir, "log", "--pretty=format:%an%x1f%ae", "--", relPath)
+	// --follow：贡献者统计跨 Git 重命名历史（issue #288 收养的页面在新路径下
+	// 仍能归因旧路径提交；无 --follow 时 git log -- new.md 只返回重命名后的提交）。
+	out, err := runGit(cloneDir, "log", "--follow", "--pretty=format:%an%x1f%ae", "--", gitLogPath(relPath))
 	if err != nil || strings.TrimSpace(out) == "" {
 		return ""
 	}
@@ -1562,7 +1574,7 @@ func updateGitTrace(cfg GitConfig, pageID uint64, relPath string) {
 	contributors := buildContributorsSnapshot(cfg.CloneDir, relPath)
 	commitSha := ""
 	var commitAt time.Time
-	if out, err := runGit(cfg.CloneDir, "log", "-1", "--format=%H%n%cI", "--", relPath); err == nil {
+	if out, err := runGit(cfg.CloneDir, "log", "--follow", "-1", "--format=%H%n%cI", "--", gitLogPath(relPath)); err == nil {
 		lines := strings.SplitN(strings.TrimSpace(out), "\n", 2)
 		if len(lines) > 0 {
 			commitSha = strings.TrimSpace(lines[0])

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -333,7 +333,7 @@ func ensureClone(cfg GitConfig) (string, error) {
 		// 存量浅克隆（v1 用 --depth=1 建立）→ 补全历史：贡献者统计依赖完整 git log。
 		if _, err := os.Stat(filepath.Join(cfg.CloneDir, ".git", "shallow")); err == nil {
 			if out, err := runGit(cfg.CloneDir, "fetch", "--unshallow", "origin", cfg.Branch); err != nil {
-				return "", fmt.Errorf("git fetch --unshallow: %v: %s", err, out)
+				return "", fmt.Errorf("git fetch --unshallow: %w: %s", err, out)
 			}
 		}
 		if out, err := runGit(cfg.CloneDir, "fetch", "origin", cfg.Branch); err != nil {

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -1,6 +1,7 @@
 package wikiservice
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -267,6 +268,100 @@ func TestSyncOnceReconcilesStaleRunningRuns(t *testing.T) {
 	}
 	if latest.Id == stale.Id || latest.Status != wikiSyncRuns.StatusSuccess {
 		t.Fatalf("latest run = id %d status %d, want new success run", latest.Id, latest.Status)
+	}
+}
+
+// TestUnshallowMarkerSurvivesProjectionFailure 评论 P1 回归：unshallow 后
+// 首次投影失败、修复后重试仍刷新未变化页面的贡献者缓存。
+// 机制：ensureClone 在 unshallow 成功后写持久化标记（.git/wiki-trace-rebuild），
+// rebuildGitTraces 完成后删除；投影失败/崩溃后标记保留，下次同步的 ensureClone
+// 仍返回 unshallowed=true——.git/shallow 已被 git 删除，仅靠局部变量会永久
+// 丢失升级机会，depth-1 快照残留。
+func TestUnshallowMarkerSurvivesProjectionFailure(t *testing.T) {
+	setupWikiTestDB(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	// 源仓库：两位作者两次提交（贡献者统计依赖完整历史）。
+	src := t.TempDir()
+	git := func(dir string, args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git(src, "init", "-q", "-b", "main")
+	git(src, "config", "user.email", "alice@users.noreply.github.com")
+	git(src, "config", "user.name", "Alice")
+	writeRepoFile(t, src, "docs/page.md", "---\ntitle: 页面\n---\n\n# 一")
+	git(src, "add", "-A")
+	git(src, "commit", "-q", "-m", "c1")
+	git(src, "config", "user.email", "12345+bob@users.noreply.github.com")
+	git(src, "config", "user.name", "Bob")
+	writeRepoFile(t, src, "docs/page.md", "---\ntitle: 页面\n---\n\n# 二")
+	git(src, "add", "-A")
+	git(src, "commit", "-q", "-m", "c2")
+
+	// 存量浅克隆（模拟 v1 --depth=1 部署）。
+	cloneDir := filepath.Join(t.TempDir(), "clone")
+	if out, err := exec.Command("git", "clone", "-q", "--depth=1", "file://"+src, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("shallow clone: %v: %s", err, out)
+	}
+	if _, err := os.Stat(filepath.Join(cloneDir, ".git", "shallow")); err != nil {
+		t.Fatal("test setup: expected shallow marker file")
+	}
+
+	cfg := GitConfig{Repo: "file://" + src, Branch: "main", CloneDir: cloneDir}
+	// 预置页面 + depth-1 时代缓存（只有 1 位作者）。
+	page := seedProjectedWikiPage(t, "docs", "docs/page", "页面", time.Now())
+	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", page.Id).
+		Update("source_path", "docs/page").Error; err != nil {
+		t.Fatalf("set source_path: %v", err)
+	}
+	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", page.Id).
+		Update("contributors_json", `[{"name":"test","count":1}]`).Error; err != nil {
+		t.Fatalf("set old contributors: %v", err)
+	}
+
+	// 第一次同步：unshallow 成功 + 写标记；随后模拟投影失败（不消费标记）。
+	head, unshallowed, err := ensureClone(cfg)
+	if err != nil {
+		t.Fatalf("ensureClone: %v", err)
+	}
+	if head == "" || !unshallowed {
+		t.Fatalf("ensureClone after unshallow = (%q, %v), want unshallowed=true", head, unshallowed)
+	}
+	markerPath := filepath.Join(cloneDir, ".git", unshallowMarkerFile)
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatal("unshallow marker not written after unshallow")
+	}
+
+	// 第二次同步（修复后重试）：.git/shallow 已删除，但标记保留 → 仍须重建。
+	if _, unshallowed, err = ensureClone(cfg); err != nil {
+		t.Fatalf("ensureClone retry: %v", err)
+	}
+	if !unshallowed {
+		t.Fatal("unshallowed lost after projection failure: marker present but ensureClone returned false")
+	}
+
+	// 重建完成：贡献者缓存刷新为 2 位作者，标记删除，后续同步不再重建。
+	rebuildGitTraces(cfg)
+	page = wikiPages.Get(page.Id)
+	var got []gitContributor
+	if err := json.Unmarshal([]byte(page.ContributorsJSON), &got); err != nil {
+		t.Fatalf("unmarshal refreshed contributors %q: %v", page.ContributorsJSON, err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("contributors=%d, want 2 (both authors after rebuild): %+v", len(got), got)
+	}
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatal("unshallow marker not removed after rebuildGitTraces")
+	}
+	if _, unshallowed, err = ensureClone(cfg); err != nil {
+		t.Fatalf("ensureClone after rebuild: %v", err)
+	}
+	if unshallowed {
+		t.Fatal("unshallowed should be false after marker consumed")
 	}
 }
 

--- a/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
+++ b/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
@@ -541,6 +541,120 @@ func TestBuildContributorsSnapshotAggregatesByUsername(t *testing.T) {
 	}
 }
 
+// TestRebuildGitTracesRefreshesUnchangedPages 浅克隆→全量升级后全量重建贡献者
+// 缓存（review P1 回归）：applyRepoToDB 幂等跳过内容未变的页面，rebuildGitTraces
+// 必须仍然刷新存量页面的 contributors_json——旧 depth-1 缓存只有一位作者，
+// 且生产 source_path 不带 .md 后缀（gitLogPath 补全后 git pathspec 才能匹配）。
+func TestRebuildGitTracesRefreshesUnchangedPages(t *testing.T) {
+	setupWikiTestDB(t)
+	repo := t.TempDir()
+	writeRepoFile(t, repo, "guide/start.md", "# 一")
+	initGitRepo(t, repo)
+	// 第二个 noreply 作者提交 → git log 有两位作者。
+	git := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git("config", "user.email", "12345+alice@users.noreply.github.com")
+	git("config", "user.name", "Alice")
+	writeRepoFile(t, repo, "guide/start.md", "# 二")
+	git("add", "-A")
+	git("commit", "-q", "-m", "c2")
+
+	page := seedProjectedWikiPage(t, "guide", "guide/start", "Start", time.Now())
+	// 生产数据：source_path 不带 .md（gitLogPath 必须补全才能匹配 pathspec）。
+	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", page.Id).
+		Update("source_path", "guide/start").Error; err != nil {
+		t.Fatalf("set source_path: %v", err)
+	}
+	// 旧缓存：只有 1 位作者（模拟 depth-1 时代的缓存）。
+	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", page.Id).
+		Update("contributors_json", `[{"name":"test","count":1}]`).Error; err != nil {
+		t.Fatalf("set old contributors: %v", err)
+	}
+
+	rebuildGitTraces(GitConfig{CloneDir: repo})
+
+	page = wikiPages.Get(page.Id)
+	if page.ContributorsJSON == `[{"name":"test","count":1}]` {
+		t.Fatal("contributors_json not refreshed after rebuildGitTraces")
+	}
+	var got []gitContributor
+	if err := json.Unmarshal([]byte(page.ContributorsJSON), &got); err != nil {
+		t.Fatalf("unmarshal refreshed contributors %q: %v", page.ContributorsJSON, err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("contributors=%d, want 2 (both git authors): %+v", len(got), got)
+	}
+	foundAlice := false
+	for _, c := range got {
+		if c.Username == "alice" {
+			foundAlice = true
+		}
+	}
+	if !foundAlice {
+		t.Fatalf("alice missing after rebuild: %+v", got)
+	}
+	if page.LastCommitSha == "" {
+		t.Fatal("last_commit_sha not set after rebuild")
+	}
+}
+
+// TestBuildContributorsSnapshotFollowsRename 贡献者统计跨 Git 重命名历史
+// （review P2 回归）：git mv 后在新路径 git log --follow 必须归因重命名前的
+// 旧作者；source_path 不带 .md 的形式同样工作（gitLogPath 补全）。
+func TestBuildContributorsSnapshotFollowsRename(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	repo := t.TempDir()
+	git := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git("init", "-q", "-b", "main")
+	git("config", "user.email", "alice@users.noreply.github.com")
+	git("config", "user.name", "Alice")
+	writeRepoFile(t, repo, "guide/old.md", "# 一")
+	git("add", "-A")
+	git("commit", "-q", "-m", "c1")
+	git("config", "user.email", "bob@users.noreply.github.com")
+	git("config", "user.name", "Bob")
+	git("mv", "guide/old.md", "guide/new.md")
+	git("commit", "-q", "-m", "c2 rename")
+
+	// 新路径：--follow 必须归因重命名前的 Alice。
+	raw := buildContributorsSnapshot(repo, "guide/new.md")
+	var got []gitContributor
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal snapshot %q: %v", raw, err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("contributors=%d, want 2 (alice+bob via --follow): %+v", len(got), got)
+	}
+	byName := map[string]int{}
+	for _, c := range got {
+		byName[c.Name] = c.Count
+	}
+	if byName["Alice"] != 1 || byName["Bob"] != 1 {
+		t.Fatalf("rename attribution wrong: %+v", got)
+	}
+
+	// source_path 形式（不带 .md）也必须工作：gitLogPath 补 .md。
+	raw2 := buildContributorsSnapshot(repo, "guide/new")
+	var got2 []gitContributor
+	if err := json.Unmarshal([]byte(raw2), &got2); err != nil {
+		t.Fatalf("unmarshal snapshot (no .md) %q: %v", raw2, err)
+	}
+	if len(got2) != 2 {
+		t.Fatalf("contributors (no .md path)=%d, want 2: %+v", len(got2), got2)
+	}
+}
+
 // TestHasPageManagerPermission PageManager（含 Admin）权限判定。
 func TestHasPageManagerPermission(t *testing.T) {
 	setupWikiTestDB(t)

--- a/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
+++ b/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
@@ -1,7 +1,9 @@
 package wikiservice
 
 import (
+	"encoding/json"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -423,12 +425,16 @@ func TestLoadPageDetailFromProjection(t *testing.T) {
 }
 
 // TestBuildContributorsFromProjection 贡献者读 wiki_pages.contributors_json 缓存；
-// GitHub 贡献者无论坛账号，userId/avatarUrl 恒为空，仅 username/count。
+// GitHub 贡献者无论坛账号，userId 恒 0；noreply 邮箱解析出 username 时
+// avatarUrl/githubUrl 可用，否则三者皆空（前端降级首字母占位）。
 func TestBuildContributorsFromProjection(t *testing.T) {
 	setupWikiTestDB(t)
 	page := seedProjectedWikiPage(t, "docs", "docs/contrib", "Contrib", time.Now())
 	if err := dbconnect.Connect().Table("wiki_pages").Where("id = ?", page.Id).
-		Update("contributors_json", `[{"name":"Alice","count":5},{"name":"Bob","count":2}]`).Error; err != nil {
+		Update("contributors_json", `[
+			{"name":"Alice","email":"12345+alice@users.noreply.github.com","username":"alice","count":5},
+			{"name":"Bob","email":"bob@example.com","count":2}
+		]`).Error; err != nil {
 		t.Fatalf("set contributors: %v", err)
 	}
 	contribs := BuildContributors(page.Id)
@@ -438,14 +444,100 @@ func TestBuildContributorsFromProjection(t *testing.T) {
 	if contribs[0].Username != "Alice" || contribs[0].Count != 5 {
 		t.Fatalf("contributors[0]=%+v, want Alice/5", contribs[0])
 	}
+	if contribs[0].UserId != 0 {
+		t.Fatalf("contributor userId should be 0: %+v", contribs[0])
+	}
+	if contribs[0].AvatarUrl != "https://github.com/alice.png?size=56" {
+		t.Fatalf("contributor avatarUrl = %q, want github avatar URL", contribs[0].AvatarUrl)
+	}
+	if contribs[0].GithubUrl != "https://github.com/alice" {
+		t.Fatalf("contributor githubUrl = %q, want github profile URL", contribs[0].GithubUrl)
+	}
+	// 自定义邮箱：无头像/链接（降级）。
 	if contribs[1].Username != "Bob" || contribs[1].Count != 2 {
 		t.Fatalf("contributors[1]=%+v, want Bob/2", contribs[1])
 	}
-	if contribs[0].UserId != 0 || contribs[0].AvatarUrl != "" {
-		t.Fatalf("contributor user linkage should be empty: %+v", contribs[0])
+	if contribs[1].AvatarUrl != "" || contribs[1].GithubUrl != "" {
+		t.Fatalf("custom-email contributor should have no avatar/link: %+v", contribs[1])
 	}
 	if got := BuildContributors(0); len(got) != 0 {
 		t.Fatalf("unknown page contributors=%d, want 0", len(got))
+	}
+}
+
+// TestGithubUsernameFromEmail 从 GitHub noreply 隐私邮箱解析用户名：
+// 新版 {id}+{username}、旧版 {username}、自定义邮箱/非法用户名返回空。
+func TestGithubUsernameFromEmail(t *testing.T) {
+	cases := []struct {
+		email string
+		want  string
+	}{
+		{"12345+alice@users.noreply.github.com", "alice"},
+		{"bob@users.noreply.github.com", "bob"},
+		{"c-harlie@users.noreply.github.com", "c-harlie"},
+		{"bob@example.com", ""},                    // 自定义邮箱
+		{"", ""},                                   // 空
+		{"-bad@users.noreply.github.com", ""},      // 连字符开头非法
+		{"bad-@users.noreply.github.com", ""},      // 连字符结尾非法
+		{"has space@users.noreply.github.com", ""}, // 空格非法
+		{"12345+@users.noreply.github.com", ""},    // + 后为空
+		{"@users.noreply.github.com", ""},          // local 为空
+	}
+	for _, tc := range cases {
+		if got := githubUsernameFromEmail(tc.email); got != tc.want {
+			t.Errorf("githubUsernameFromEmail(%q) = %q, want %q", tc.email, got, tc.want)
+		}
+	}
+}
+
+// TestBuildContributorsSnapshotAggregatesByUsername 贡献者快照按可解析 username
+// 聚合（合并 GitHub 新旧 noreply 格式——username 相同；自定义邮箱降级按 email），
+// 展示名取最近提交的 name，count 排序。
+func TestBuildContributorsSnapshotAggregatesByUsername(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	repo := t.TempDir()
+	git := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	git("init", "-q", "-b", "main")
+	// 旧版 noreply 格式：{username}@users.noreply.github.com。
+	git("config", "user.email", "old@users.noreply.github.com")
+	git("config", "user.name", "Old Name")
+	writeRepoFile(t, repo, "guide/start.md", "# 一")
+	git("add", "-A")
+	git("commit", "-q", "-m", "c1")
+	// 同一人换新版 noreply 格式（{id}+{username}）+ 改显示名 → 按 username 合并为 1 人。
+	git("config", "user.email", "12345+old@users.noreply.github.com")
+	git("config", "user.name", "New Name")
+	writeRepoFile(t, repo, "guide/start.md", "# 二")
+	git("add", "-A")
+	git("commit", "-q", "-m", "c2")
+	// 自定义邮箱另一人（无法解析 username，按 email 聚合）。
+	git("config", "user.email", "bob@example.com")
+	git("config", "user.name", "Bob")
+	writeRepoFile(t, repo, "guide/start.md", "# 三")
+	git("add", "-A")
+	git("commit", "-q", "-m", "c3")
+
+	raw := buildContributorsSnapshot(repo, "guide/start.md")
+	var got []gitContributor
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unmarshal snapshot %q: %v", raw, err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("contributors=%d, want 2 (same user merged): %+v", len(got), got)
+	}
+	// 同人合并后 count=2，展示名 = 最近提交的 New Name。
+	if got[0].Name != "New Name" || got[0].Count != 2 || got[0].Username != "old" {
+		t.Fatalf("merged contributor = %+v, want New Name/2/old", got[0])
+	}
+	if got[1].Name != "Bob" || got[1].Count != 1 || got[1].Username != "" {
+		t.Fatalf("custom email contributor = %+v, want Bob/1/no username", got[1])
 	}
 }
 

--- a/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
+++ b/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
@@ -1062,7 +1062,10 @@ export interface WikiTocItem {
 export interface WikiContributorPayload {
   userId: number
   username: string
+  /** GitHub noreply 邮箱可解析时的动态头像直链；自定义邮箱贡献者为空。 */
   avatarUrl: string
+  /** GitHub 主页外链（{username}）；自定义邮箱贡献者为空。 */
+  githubUrl?: string
   count: number
   lastEditedAt: string
 }

--- a/apps/gooseforum/resource/src/site/pages/WikiPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/WikiPage.vue
@@ -181,6 +181,30 @@ function sameUrl(left: string, right: string) {
                       <span class="min-w-0 flex-1 truncate text-[13px] font-medium text-base-content/80">{{ contributor.username }}</span>
                       <span class="shrink-0 text-xs tabular-nums text-base-content/45">{{ contributor.count }}</span>
                     </a>
+                    <a
+                      v-else-if="contributor.githubUrl"
+                      :href="contributor.githubUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="flex min-w-0 items-center gap-2.5 rounded-md p-1 transition-colors hover:bg-base-200"
+                      :title="contributor.githubUrl"
+                    >
+                      <img
+                        v-if="contributor.avatarUrl"
+                        :src="contributor.avatarUrl"
+                        :alt="contributor.username"
+                        loading="lazy"
+                        class="h-7 w-7 shrink-0 rounded-full object-cover ring-1 ring-line"
+                      />
+                      <span
+                        v-else
+                        class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-base-200 text-[11px] font-bold text-base-content/55"
+                      >
+                        {{ contributor.username.slice(0, 1).toUpperCase() }}
+                      </span>
+                      <span class="min-w-0 flex-1 truncate text-[13px] font-medium text-base-content/80">{{ contributor.username }}</span>
+                      <span class="shrink-0 text-xs tabular-nums text-base-content/45">{{ contributor.count }}</span>
+                    </a>
                     <div
                       v-else
                       class="flex min-w-0 items-center gap-2.5 rounded-md p-1"

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -57,8 +57,11 @@ The contract capability is **Partial**. The controlled OpenAPI 3.1 entry point i
 - Wiki 首页/详情兼容性（issue #291）：GitHub SSOT 下站内无「编辑者」概念，
   `GET /api/wiki/home` 的 `recent[]` 与 wiki 详情负载的 `editorId`/`editorName`
   字段已**移除**（此前恒为零值且违反 OpenAPI `editorId minimum: 1`）。消费方需删除
-  对这两个字段的依赖；Git 作者信息改由详情页 `contributors[]`（用户名/头像可为空，
-  无论坛数字用户 ID）提供。OpenAPI `WikiRecentPage`/`WikiTreePage`/`WikiNamespaceSummary`
+  对这两个字段的依赖；Git 作者信息由详情页 `contributors[]` 提供（无论坛数字
+  用户 ID）：同步器从仓库 `git log` 按 email 聚合贡献者与提交数，GitHub
+  noreply 隐私邮箱可解析出 `username` → 前端拼 `avatarUrl`（`github.com/{user}.png`）
+  与 `githubUrl` 外链；自定义邮箱贡献者两者为空（前端降级首字母占位）。
+  OpenAPI `WikiRecentPage`/`WikiTreePage`/`WikiNamespaceSummary`
   的旧「approved revision」措辞已同步改为 GitHub SSOT 投影语义。
 
 Paths are split per domain under `packages/api-contract/paths/` (for example `auth.yaml`,

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -103,7 +103,9 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
   大小写仓库，首次同步会软删旧的小写路径页面并以仓库实际大小写重建（新 topic，
   原评论/互动不迁移）；当前 `YourTJ-Wiki` 仓库全小写目录，零影响。中文目录在
   `index.md` 声明 `slug` 后，页面 URL 首段迁移为 slug，旧链接仍可经显示名回退解析）。
-  （同步用 `clone --depth=1` + `fetch` + `reset --hard`，**不使用 pull**）。
+  （同步用全量 `clone --single-branch` + `fetch` + `reset --hard`，**不使用 pull**；
+  全量历史用于页面贡献者统计。存量浅克隆（旧版 `--depth=1`）在下次同步自动
+  `fetch --unshallow` 补全历史并重建全部页面贡献者缓存，升级首轮耗时取决于仓库大小）。
 - **本地 clone**：默认 `./storage/wiki-repo`（`main`/`dev` 实例各自独立），可被 `[wiki.git].clone_dir` 覆盖。
 - **同步记录**：每次同步写入 `wiki_sync_runs`（trigger/status/变更计数/错误），管理端可查最近 20 条；
   同步幂等（正文 sha256 比对），重复同步零变更；软删页面在仓库重新出现时自动恢复（含 topic 生命周期）；

--- a/docs/product/wiki-authoring.md
+++ b/docs/product/wiki-authoring.md
@@ -78,3 +78,12 @@ Repository hygiene requirements:
   syntax cannot represent them reliably.
 
 The top-level namespace `_assets` is reserved for the controlled asset route.
+
+## Contributors (Current)
+
+Wiki 详情页右侧「贡献者」区块显示页面的 Git 作者（`Current` 行为）：每次同步
+（webhook/手动/定时）从仓库 `git log` 重新聚合**每个页面**的编辑者与提交数，
+并缓存于 `wiki_pages.contributors_json`。展示按 GitHub noreply 隐私邮箱解析出的
+username 聚合（合并新旧邮箱格式同人），同时提供 GitHub 头像直链与主页外链；
+自定义邮箱贡献者无头像/外链，降级为首字母占位。贡献者无需论坛账号（无数字
+用户 ID）。GitHub 作者（非 PR 审核者）即该页面的贡献者名单。


### PR DESCRIPTION
## Summary
- Wiki 详情页右侧「贡献者」区块升级：新增 GitHub 头像直链（`github.com/{username}.png`）与主页外链，自定义邮箱贡献者降级为首字母占位
- 贡献者快照改为 `git log` name+email 双字段，按 **username（GitHub noreply 隐私邮箱解析）→ email → name** 聚合，合并新旧 noreply 格式同人；展示名取最近一次提交
- **修复生产数据缺陷**：`ensureClone` 原用 `--depth=1` 浅克隆，`git log` 只有 1 条提交 → 贡献者统计永远只有最后一位作者。改为全量 clone，存量浅克隆检测 `.git/shallow` 后 `fetch --unshallow` 补全历史
- 前端 `WikiContributorPayload` 加 `githubUrl?` 字段

## Verification
- `go test ./app/service/wikiservice/ ./app/http/controllers/forum/` 全绿
- 新增 3 个测试：投影→payload 映射、noreply 邮箱解析表驱动、真实 git 仓库同人合并场景
- `pnpm typecheck` 通过
- pre-push 三件套（`go vet` / `golangci-lint` / frontend typecheck）通过

## Notes
- 每次同步（webhook/手动/定时）自动刷新每页贡献者与 commits 数，无需额外 job
- 首轮部署时存量浅克隆会一次性补拉全量历史（耗时取决于仓库大小）
- 数据结构 `contributors_json` 升级为 `[{name,email,username,count}]`，兼容旧缓存格式