### PR TITLE
chore: 规范体系二期 — PR 模板、测试布局文档与三个仓库 skill

### DIFF
--- a/.agents/skills/yourtj-code-review/SKILL.md
+++ b/.agents/skills/yourtj-code-review/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: yourtj-code-review
+description: Use when reviewing a yourtj-hub code change (own or others') before merge — checking contract impact, database migration safety, security boundaries, performance, and maintainability against the repository's hard constraints. Not for running toolchain checks (use $yourtj-pre-push-checks) or implementing changes (use $yourtj-development).
+---
+
+# Reviewing YourTJ Hub Changes
+
+按风险面分层评审；每层给出阻塞项（blocker，必须修）与建议项（should/nit，可以修）。证据优先：
+读代码与测试，不凭记忆。
+
+## Contract impact
+
+- 改动是否触及 OpenAPI 覆盖的操作？是 → 检查 `packages/api-contract/openapi.yaml`、生成 TypeScript 输出
+  （`apps/gooseforum/resource/packages/client/src/gen`）、fixture 契约测试是否同 PR 同步；未完全覆盖的操作
+  还需同步 mobile Dart 镜像（`apps/mobile/packages/core/lib/src/gen/`）。
+- 路由/请求/响应结构是否改变？与 `packages/api-contract/openapi.yaml` 或 `app/http/controllers` 实际行为核对。
+
+## Database & migration safety
+
+- 模型/迁移改动必须过 PG 门禁：`YOURTJ_TEST_PG_URL` 下跑 `TestSchema*`（`app/migration/migration_pg_test.go`）。
+- 模型禁止 MySQL-only 类型标签（`bigint unsigned` / `datetime` / `tinyint`）。
+- 迁移是否 append-only？backfill/数据迁移是否可重入、有游标/幂等？删除生命周期（`contentdeleteservice`）
+  是否覆盖关联数据（附件、搜索索引、通知、审计）？
+
+## Security boundaries
+
+- auth/PII/隐私/保留/审计：会话（`jti` + `user_sessions`）、TOTP、OIDC Provider、GitHub OAuth 路径。
+- 用户 ID 必须 numeric（uint64）；forum JWT 是会话凭证不是身份真相，不发给外部 OIDC 客户端。
+- `config.toml` 含 signingKey —— 永不提交。权限白名单、越权（水平/垂直）、限流、文件上传类型与路径、
+  搜索注入、外部动作（通知/webhook/CDN/Meilisearch 写入）的来源验证与幂等。
+
+## Performance & resource risk
+
+- 热路径（topic/post 列表、搜索、通知、事件处理）是否有 N+1、全表扫描、无界内存、锁竞争？
+- 事件驱动搜索同步：幂等、重试、死信？后台 worker 并发与 backoff？
+
+## Maintainability
+
+- 分层边界：bundles → models → service → http/controllers；跨域访问走 owner 公共 API，无外域 SQL。
+- 命名/重复/死代码/投机抽象；TODO 三档（`FIXME` 阻塞发布 / `TODO` 近期 / `XXX` 远期）。
+- 与周围模式一致；新抽象是否降低净复杂度。
+
+## Output
+
+- 每个发现：文件+行、严重级（blocker / should / nit）、理由、建议修法。
+- blocker 必须修才能合；should 尽量修或明确记录；nit 可留。
+- 汇总：整体就绪度（approve / needs changes）、剩余风险、需 reviewer 关注点。

--- a/.agents/skills/yourtj-doc-standards/SKILL.md
+++ b/.agents/skills/yourtj-doc-standards/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: yourtj-doc-standards
+description: Use when writing, moving, reviewing, or auditing documentation in the yourtj-hub repository — choosing which docs tier a fact belongs in, applying the four status words, checking fact sources and links, or keeping docs in sync with a code change. Not for implementing code changes (route those to $yourtj-development).
+---
+
+# Applying the YourTJ Hub Documentation Standard
+
+文档标准的事实源是 `docs/development/documentation.md` 与 `docs/README.md`；本 skill 提供执行工作流。
+指导而非脚本。
+
+## Sources of truth (read, don't re-summarize)
+
+- `docs/README.md` — 事实源表、四状态词、文档生命周期（Active/Draft/Deprecated）
+- `docs/development/documentation.md` — 文档治理：同 PR 更新、只描述当前模型、状态词、变更流程
+- 根 `AGENTS.md` §3 — 「新功能必建文档」硬约束
+
+不建 `docs/AGENTS.md` 或子目录 AGENTS.md：文档标准已由 documentation.md 承担，再建即双源。
+
+## Before writing: choose the home
+
+1. 用 docs/README.md 事实源表定位归属：产品行为 → `docs/product/`；安全/隐私 → AGENTS.md（直到
+   `docs/security/` 存在）；HTTP 结构 → `apps/gooseforum/app/http/controllers` + `packages/api-contract/openapi.yaml`；
+   DB 结构 → `apps/gooseforum/app/migration/`；开发/测试/PR 流程 → `docs/development/`；部署与运维 → `docs/operations/`。
+2. 文档只描述当前支持模型：无时间线、里程碑、PR 交付清单、历史叙事（git history 拥有归档）。
+3. 状态词只用于可验证的具体行为，不用于整个领域：`Current` / `Partial` / `Planned` / `Decision needed`。
+   文档自身生命周期用 `Active` / `Draft` / `Deprecated`，与实现状态分离。
+4. 移动/重命名文档前 grep 入站引用（Markdown 链接与 #fragment、代码注释中的 `docs/*.md` 引用）；
+   移动是原子的：旧家删除、新家添加、所有入站链接同一次改动修复。
+
+## Keeping docs in sync with code
+
+- 任何改变产品行为、契约、schema、安全边界或部署的 PR 必须同 PR 更新受影响的文档；不同步即缺陷。
+- 用户可见功能：更新 docs 中心 + 状态词。纯内部功能：至少更新相关 README 或代码注释（最小集）。
+- 代码是权威：契约变化时更新所属文档，不保留历史版本的平行叙事。
+- 事实源冲突时按缺陷处理：同 PR 修复契约、实现、测试与相关文档，或显式记录为 `Partial`。
+
+## Auditing docs
+
+- 用最便宜的探针开始：grep 独特短语找重复（保留一处，其余改链接）；检查状态词是否被误用于整个领域；
+  检查是否出现 PR-relative 标签（"shipped this" / "later"）。
+- 找 reasoning-transcript 泄漏：叙述历史、死亡设计会话引用、评审编排、控制流叙述、测试 walkthrough——
+  只保留非显然的契约或持久理由；同一理由重复出现时保留一个家。
+- 手写目录/测试状态清单/API 复述 → 替换为权威树、脚本或生成引用。
+- 删陈旧内容而不是保留 "deprecated but useful" 副本；git history 拥有归档。
+
+## Validation
+
+- `git diff --check`；grep 确认所有新增/移动文档的入站链接指向存在文件（仓库暂无 verify-md-links 门禁时手动核对）。
+- 确认状态词拼写与四词一致；确认 docs 索引（`docs/README.md`、`docs/development/README.md`）覆盖新增文档。
+- 报告：文档变更清单、链接核对结果、状态词更新点。

--- a/.agents/skills/yourtj-simplifications/SKILL.md
+++ b/.agents/skills/yourtj-simplifications/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: yourtj-simplifications
+description: Use when asked to find non-obvious simplification candidates in the yourtj-hub repository — auditing dead, duplicated, speculative, over-built, or hand-rolled-where-a-dependency-exists code — or to fold worthwhile simplification ideas into Agent Notes or TODO/FIXME/XXX markers. Not for implementing changes (route those to $yourtj-development).
+---
+
+# Finding YourTJ Hub Simplifications
+
+把「找点能简化的东西」变成有证据支撑的清理候选。这是指导，不是检查表：跟随代码、保持判断力，
+宁要几个经过验证的强候选，不要一堆薄猜测。
+
+## Start with repo context
+
+- 读根 `AGENTS.md`（尤其 §3 硬约束与 §4 验证哲学）、`docs/development/testing.md`、
+  `docs/development/coding-conventions.md`（TODO 三档语义）。
+- 用 `docs/README.md` 事实源表判断领域归属；简化候选若与架构边界（bundles → models → service → http）冲突，需额外证据。
+- 本仓库的 Agent Note 记录在 Synergy 原生 note（yourtj-hub ADR note），不在仓库内——简化候选的输出落点是
+  note 或代码内 TODO/XXX 标记，不在仓库建 `.agents/notes` 目录。
+
+## What counts as a strong candidate
+
+强候选 = 移除/折叠/降级某样真实存在的东西，且有明确证据表明当前设计成本大于收益：
+
+- 公开方法、事件、配置开关、helper、包、测试产物没有生产消费者。
+- 测试或文档是唯一消费者，且其钉住的行为不承重。
+- 两份表示镜像同一事实（尤其是持久化与瞬态事件各存一份）。
+- 某个 seam 的方法所有实现都必须支持，但没有消费者使用。
+- 独立包仅为测试/演示/支持代码存在，增加发布或依赖开销。
+- 投机性产品泛化：多会话/会话加载、后台任务名册、实时注册表失效、mid-turn 控制等无产品所有者的设计。
+- 手写代码重新实现了维护良好的外部包或语言内置能力，且替换能删掉实现加其专属测试。
+- 简化后行为可能略有不同，但新行为依然合理且更容易解释。
+
+薄候选通常不够格：删一个 typo、跑一次静态检查、删一个有意文档化的后端、「这看起来很复杂」而无调用点证据。
+
+## Survey broadly
+
+用户要广度时用并行 subagent 分域调查，要求证据而非猜测。可用分域：
+
+- backend service（`app/service/**`）：重复生命周期/防御机制、双表示、死分支
+- models / migration（`app/models`、`app/migration`）：冗余列/索引、无消费者的模型方法
+- bundles（`app/bundles/**`）：手写 vs 依赖、无消费者工具
+- frontend（`resource/src/**`、`resource/test/**`）：死组件、重复状态、投机抽象
+- contract / scripts / tests：包拆分、静态清单、冗余 fixture
+
+不要被第一个好候选挡住；从最大的生产代码 delta 开始。
+
+## Audit trust and lifecycle boundaries
+
+对每个防御性拷贝、freeze、validator、回调捕获，说明值从哪里来、下一手归谁。同进程的类型化调用通常借用
+只读值；解析器、配置加载、队列、模型/工具 JSON、持久化文件、worker、进程、wire 解码器拥有或校验自己的
+数据。围绕 hostile getter、伪造类型对象、回调替换或同进程交接后变更的测试，是投机契约的证据，不是保留理由。
+
+复杂异步代码画所有权图：每个 sentinel、readiness promise、取消路径、disposer、状态旗标映射到唯一所有者或
+转移。多个机制镜像同一 liveness/settlement 事实时，提议一个事务或生命周期控制器；保留保护同步发布与回滚、
+回调包含、first-terminal-outcome 仲裁、worker/进程所有权、dispose-to-quiescence 的独立机制。
+
+## Hand-rolled code vs a dependency
+
+引入依赖是合法的简化动作：问协议解析器、framing、重试/退避循环、glob 匹配、diff 引擎等，维护良好的
+外部包或语言内置是否已提供。证明依赖交换候选时：
+
+- 读手写实现，说出包覆盖的确切面；包不覆盖的残余语义计入反对并保留在候选里。
+- 诚实检查包健康度（维护、采用、传递依赖体积）；Go 标准库与 Flutter 生态有大量内置，先查内置再引依赖。
+
+## Output
+
+- 每个候选给出：位置、证据（调用点/消费者 grep）、建议动作（删/折叠/降级/换依赖）、影响面（契约/迁移/文档）。
+- 按强弱排序；强候选写 Agent Note（Synergy 原生 note）或代码内 TODO/XXX 标记，弱候选列表给用户。
+- 不实现：发现与建议到此为止，实施交给 `$yourtj-development`。

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary / 摘要
+
+<!-- 一句话说明这个 PR 做什么、为什么。 -->
+
+## Behavior change / 行为变更
+
+<!-- 列出用户可见行为、接口、数据或部署行为的变化；无则写「无」。 -->
+
+## Verification / 验证
+
+<!-- 列出实际运行的命令与结果；本地子集不是 CI 通过。 -->
+
+- [ ] `git diff --check`
+
+## Docs & contract impact / 文档与契约影响
+
+<!-- 是否更新 docs 中心与状态词、OpenAPI 契约与生成产物；纯内部改动说明 README/注释最小集。 -->
+
+## Known gaps / 已知缺口
+
+<!-- 未覆盖的测试、遗留问题（FIXME/TODO/XXX）、需要 reviewer 特别关注的点。 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,9 @@ docs/        Docs center (product/architecture/development/operations)
   are exempt; the regression test stays.
 - TODO markers use three tiers (`FIXME` / `TODO` / `XXX`), see
   docs/development/coding-conventions.md.
+- Test layout follows the per-language convention (Go `*_test.go` co-located, frontend `resource/test/`,
+  Flutter `test/`, contract fixtures under `packages/api-contract/fixtures/`), see
+  docs/development/testing.md#test-layout.
 
 - Backend: `cd apps/gooseforum && go vet ./... && go test ./...` (use `GOPROXY=https://goproxy.cn,direct`
   if module fetch times out). **Any model/migration change must also pass the PostgreSQL migration
@@ -144,5 +147,7 @@ docs/        Docs center (product/architecture/development/operations)
 
 - [Docs center](docs/README.md) (fact-source table + status words)
 - [Development entry](docs/development/README.md)
+- Repository skills: `$yourtj-development`, `$yourtj-pre-push-checks`, `$yourtj-simplifications`,
+  `$yourtj-doc-standards`, `$yourtj-code-review` (see `.agents/skills/`)
 - Architecture decision records live in the project note (yourtj-hub ADR note), not in git
 - Upstream: GooseForum (apps/gooseforum, the fork itself); YourTJ-Platform (local, same-brand archived repo)

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -52,6 +52,20 @@ make build && ./bin/yourtj-hub serve   # then curl http://localhost:5234
 | mobile | widget/unit | flutter test (melos analyze + test; see local-development.md) |
 | mobile OIDC | controller chain unit + E2E script | `auth/test/oidc_controller_test.dart` (authorize→exchange 调用链) + `scripts/oidc_e2e.sh` (本地内建 Provider → AppAuth 模拟器回跳 → exchange 验证) |
 
+## Test layout
+
+测试与被测代码放在一起，按语言惯例分层；**不要为迁移而迁移**，新测试遵守以下归属：
+
+| 层 | 位置 | 约定 |
+|---|---|---|
+| Go 单元测试（bundles/models/service 内部逻辑） | 与被测文件同包同目录的 `*_test.go` | Go 工具链/覆盖率/重构联动依赖同包布局；白盒测试访问包内未导出符号 |
+| Go 黑盒测试（外部契约/集成行为） | 同目录 `*_test.go`，`package xxx_test` | 只通过导出 API 验证行为；需要外部文件（样例输入、golden 输出）时放同包 `testdata/` |
+| 前端组件/单元测试 | `apps/gooseforum/resource/test/*.test.ts` | Vitest 独立目录，避免混入 `src/`；fixtures 就近放 `test/fixtures/` |
+| Flutter 测试 | 各包 `apps/mobile/packages/<pkg>/test/` | `widget_test.dart` / `*_test.dart`，fixtures 放同目录 |
+| 契约测试与 fixtures | `packages/api-contract/fixtures/` | OpenAPI 生成的 TS 类型 + 路由级 HTTP fixture 断言；测试本身在 `go test ./...` 门禁内 |
+
+模型/迁移测试必须同时满足 PG 门禁（见下方 CI mapping 的 `ci-backend-pg`）。
+
 ## CI mapping
 
 All CI `push` triggers are limited to `dev` and `main`, so a push to an in-repository


### PR DESCRIPTION
## Summary / 摘要

规范体系二期（延续 8 月 15 日 `chore/dev-standards` 一期：lefthook 门禁 / CONTRIBUTING / TODO 三档 / skill 对齐），参考 deepseek-harness 的 `.agents/skills` 窄 skill 模式，补齐仓库级工程规范：PR 模板、测试布局规则、以及 simplification / doc-standards / code-review 三个 skill。

## Behavior change / 行为变更

无业务行为变更。纯配置/文档/skill 变更：

- **PR 模板**（`.github/pull_request_template.md`，此前不存在）：提交 PR 时强制填写摘要、行为变更、验证命令与结果、文档与契约影响、已知缺口
- **测试布局文档**（`docs/development/testing.md` 新增 Test layout 节）：按语言惯例明确测试归属——Go 同包白盒 `*_test.go` + 黑盒 `package xxx_test` + `testdata/`；前端 `resource/test/`；Flutter `test/`；契约 fixtures `packages/api-contract/fixtures/`。明确"不为迁移而迁移"，现有 115+ Go 测试保持同包布局
- **三个新 skill**（`.agents/skills/`）：
  - `yourtj-simplifications`：证据驱动的简化审计（死代码/重复/投机/手写 vs 依赖），输出 Agent Note 或 TODO 三档
  - `yourtj-doc-standards`：文档分级、四状态词、事实源核对、doc-sync 纪律
  - `yourtj-code-review`：分层评审（契约/迁移/安全/性能/维护性），blocker/should/nit 分级
- **AGENTS.md**：§4 加测试布局指针，§6 补仓库 skill 索引

## Verification / 验证

- pre-commit（whitespace + gofmt）✅ 通过
- pre-push（`go vet` 5.2s + `golangci-lint` 增量 6.0s + `pnpm typecheck` 11.3s）✅ 全部通过
- `git diff --check` ✅ 无空白错误
- 新 skill frontmatter（name/description）与现有 SKILL.md 格式一致

## Docs & contract impact / 文档与契约影响

- `docs/development/testing.md` 新增 Test layout 节（文档治理同步）
- `AGENTS.md` §4/§6 指针更新
- OpenAPI 契约、生成产物、数据库：零改动

## Known gaps / 已知缺口

- 未做：issue 模板扩展（bug/feature 已够用）、CI 文件名规范门禁（均属后续可选增强）
- 未迁移现有 Go 测试文件（Go 生态惯例为同包布局，迁移纯 churn）
- 未引入 i18n 双语与 `.agents/notes` 仓库目录（沿用既有决策：Agent Note 用 Synergy 原生 note）
