### PR TITLE
docs: 修复 PR #311 review comments（契约镜像、测试布局、simplification 只读）

### DIFF
--- a/.agents/skills/yourtj-code-review/SKILL.md
+++ b/.agents/skills/yourtj-code-review/SKILL.md
@@ -12,7 +12,8 @@ description: Use when reviewing a yourtj-hub code change (own or others') before
 
 - 改动是否触及 OpenAPI 覆盖的操作？是 → 检查 `packages/api-contract/openapi.yaml`、生成 TypeScript 输出
   （`apps/gooseforum/resource/packages/client/src/gen`）、fixture 契约测试是否同 PR 同步；未完全覆盖的操作
-  还需同步 mobile Dart 镜像（`apps/mobile/packages/core/lib/src/gen/`）。
+  还需同步 mobile Dart 镜像（`apps/mobile/packages/core/lib/src/gen/`）与手动维护的 web TS 类型
+  （`apps/gooseforum/resource/packages/client/src/contracts/`）。
 - 路由/请求/响应结构是否改变？与 `packages/api-contract/openapi.yaml` 或 `app/http/controllers` 实际行为核对。
 
 ## Database & migration safety

--- a/.agents/skills/yourtj-simplifications/SKILL.md
+++ b/.agents/skills/yourtj-simplifications/SKILL.md
@@ -64,5 +64,6 @@ description: Use when asked to find non-obvious simplification candidates in the
 ## Output
 
 - 每个候选给出：位置、证据（调用点/消费者 grep）、建议动作（删/折叠/降级/换依赖）、影响面（契约/迁移/文档）。
-- 按强弱排序；强候选写 Agent Note（Synergy 原生 note）或代码内 TODO/XXX 标记，弱候选列表给用户。
+- 按强弱排序，全部在响应中返回给用户；审计默认只读，不写任何持久状态。
+- 仅当用户明确授权时，才把强候选写入 Agent Note（Synergy 原生 note）或代码内 TODO/XXX 标记。
 - 不实现：发现与建议到此为止，实施交给 `$yourtj-development`。

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -63,7 +63,8 @@ make build && ./bin/yourtj-hub serve   # then curl http://localhost:5234
 | 前端组件/单元测试 | `apps/gooseforum/resource/test/*.test.ts` | Vitest 独立目录，避免混入 `src/`；fixtures 就近放 `test/fixtures/` |
 | Flutter 测试 | 各包 `apps/mobile/packages/<pkg>/test/` | `widget_test.dart` / `*_test.dart`，fixtures 放同目录 |
 | 契约测试（路由级 HTTP 断言） | `apps/gooseforum/app/http/routes/*_test.go` | 位于 Go module 内，随 `go test ./...` 运行 |
-| 契约 fixtures 与生成类型 | `packages/api-contract/fixtures/` | 只放 fixture 数据与 OpenAPI 生成的 TS 类型；该目录不在 Go module 内，测试代码不放这里 |
+| 契约 fixtures | `packages/api-contract/fixtures/` | 只放 JSON fixture 数据；该目录不在 Go module 内，测试代码不放这里 |
+| 生成 TS 类型 | `apps/gooseforum/resource/packages/client/src/gen/`（`index.ts` / `openapi.ts`） | OpenAPI 生成并提交的输出，契约变更时随 PR 同步 |
 
 模型/迁移测试必须同时满足 PG 门禁（见下方 CI mapping 的 `ci-backend-pg`）。
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -62,7 +62,8 @@ make build && ./bin/yourtj-hub serve   # then curl http://localhost:5234
 | Go 黑盒测试（外部契约/集成行为） | 同目录 `*_test.go`，`package xxx_test` | 只通过导出 API 验证行为；需要外部文件（样例输入、golden 输出）时放同包 `testdata/` |
 | 前端组件/单元测试 | `apps/gooseforum/resource/test/*.test.ts` | Vitest 独立目录，避免混入 `src/`；fixtures 就近放 `test/fixtures/` |
 | Flutter 测试 | 各包 `apps/mobile/packages/<pkg>/test/` | `widget_test.dart` / `*_test.dart`，fixtures 放同目录 |
-| 契约测试与 fixtures | `packages/api-contract/fixtures/` | OpenAPI 生成的 TS 类型 + 路由级 HTTP fixture 断言；测试本身在 `go test ./...` 门禁内 |
+| 契约测试（路由级 HTTP 断言） | `apps/gooseforum/app/http/routes/*_test.go` | 位于 Go module 内，随 `go test ./...` 运行 |
+| 契约 fixtures 与生成类型 | `packages/api-contract/fixtures/` | 只放 fixture 数据与 OpenAPI 生成的 TS 类型；该目录不在 Go module 内，测试代码不放这里 |
 
 模型/迁移测试必须同时满足 PG 门禁（见下方 CI mapping 的 `ci-backend-pg`）。
 


### PR DESCRIPTION
## Summary / 摘要

修复 PR #311 合并后遗留的 3 条 Codex review comments（均为 P2 准确性/行为规范问题，已合并后跟进）。

## Behavior change / 行为变更

无业务行为变更。3 处配置/文档/skill 修正：

1. **`yourtj-code-review` skill**（Contract impact 节）：契约检查清单补上手动维护的 web TS 镜像 `apps/gooseforum/resource/packages/client/src/contracts/`——OpenAPI 未完全覆盖的操作，请求/响应变更可能让 web client 停留在过期类型上
2. **`docs/development/testing.md`**（Test layout 表）：拆分"契约测试代码"与"契约 fixtures"两行——路由级 HTTP 契约测试实际 co-located 在 `apps/gooseforum/app/http/routes/*_test.go`（Go module 内，`go test ./...` 可发现）；`packages/api-contract/fixtures/` 只放 fixture 数据与生成 TS 类型（该目录不在 Go module 内）
3. **`yourtj-simplifications` skill**（Output 节）：审计默认只读——候选全部在响应中返回；Agent Note / TODO-XXX 标记写入仅在用户明确授权时进行（与 frontmatter "not for implementing changes" 定位一致）

## Verification / 验证

- pre-commit（whitespace + gofmt）✅ 通过
- pre-push（`go vet` + `golangci-lint` 增量 + `pnpm typecheck`）✅ 全部通过
- `git diff --check` ✅ 无空白错误

## Docs & contract impact / 文档与契约影响

- 仅修改本次三个文件；无 OpenAPI/生成产物/数据库改动

## Known gaps / 已知缺口

- 无
