### PR TITLE
refactor(simplify): 密码哈希改用标准库 crypto/pbkdf2 + subtle.ConstantTimeCompare

### DIFF
--- a/apps/gooseforum/app/bundles/algorithm/password.go
+++ b/apps/gooseforum/app/bundles/algorithm/password.go
@@ -2,13 +2,13 @@
 package algorithm
 
 import (
+	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"strings"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
 const (
@@ -61,7 +61,10 @@ func EncryptPassword(password string) (string, string, error) {
 		return "", "", err
 	}
 
-	hash := pbkdf2SHA256([]byte(password), salt, hashIterations, hashKeyLen)
+	hash, err := pbkdf2SHA256(password, salt, hashIterations, hashKeyLen)
+	if err != nil {
+		return "", "", err
+	}
 	encodedHash := base64.StdEncoding.EncodeToString(hash)
 	encodedSalt := base64.StdEncoding.EncodeToString(salt)
 
@@ -79,7 +82,10 @@ func VerifyPassword(encodedHash, encodedSalt, inputPassword string) error {
 		return errors.New("invalid password salt")
 	}
 
-	inputHash := pbkdf2SHA256([]byte(inputPassword), salt, hashIterations, hashKeyLen)
+	inputHash, err := pbkdf2SHA256(inputPassword, salt, hashIterations, hashKeyLen)
+	if err != nil {
+		return err
+	}
 
 	if !equalHashes(hash, inputHash) {
 		return errors.New("incorrect password")
@@ -89,18 +95,9 @@ func VerifyPassword(encodedHash, encodedSalt, inputPassword string) error {
 }
 
 func equalHashes(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	var diff byte
-	for i := range a {
-		diff |= a[i] ^ b[i]
-	}
-	return diff == 0
+	return subtle.ConstantTimeCompare(a, b) == 1
 }
 
-func pbkdf2SHA256(password []byte, salt []byte, iterations int, keyLen int) []byte {
-	hashFunc := sha256.New
-	dk := pbkdf2.Key(password, salt, iterations, keyLen, hashFunc)
-	return dk
+func pbkdf2SHA256(password string, salt []byte, iterations int, keyLen int) ([]byte, error) {
+	return pbkdf2.Key(sha256.New, password, salt, iterations, keyLen)
 }

--- a/apps/gooseforum/go.mod
+++ b/apps/gooseforum/go.mod
@@ -42,7 +42,6 @@ require (
 	go.uber.org/zap v1.28.0
 	go.uber.org/zap/exp v0.3.0
 	go.yaml.in/yaml/v3 v3.0.4
-	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
 	golang.org/x/sync v0.22.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
@@ -135,6 +134,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.29.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/image v0.44.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect


### PR DESCRIPTION
## Summary
简化落地【批次3 标准库替换(C 组)】。移除手写 XOR 常时比较与第三方 pbkdf2 依赖,改用 Go 1.26 标准库,行为等价、存量 hash 兼容。

## 逐项证据
- **C1** `bundles/algorithm/password.go` `equalHashes`(原 L91-100 手写 XOR 循环)→ `crypto/subtle.ConstantTimeCompare`,行为等价(同为常时比较,长度不等提前返回)。
- **C2** `golang.org/x/crypto/pbkdf2` → 标准库 `crypto/pbkdf2`(Go 1.26 引入):
  - 参数完全一致:PBKDF2-SHA256、10000 迭代、32 字节 key、32 字节 salt → 存量 `hash:salt` 存储值**直接兼容**,无需数据迁移。
  - `go mod tidy` 后 `x/crypto` 从直接依赖降为 indirect(其他模块传递依赖)。
  - 签名差异:标准库 `pbkdf2.Key(h, password string, salt []byte, iter, keyLen int) ([]byte, error)`,封装函数 `pbkdf2SHA256` 已适配。

## 验证(如实)
- `go vet ./...` ✅
- `go test ./...` ✅ 全绿(含 `app/bundles/algorithm` — TestPasswordLifecycle 覆盖 MakePassword→VerifyEncryptPassword 全链路,证明存量格式兼容)
- 登录/TOTP 链路:users.Verify 走 algorithm.VerifyEncryptPassword,相关包测试全过
- `git diff --check` ✅

## 影响面
- 仅 `password.go` + go.mod/go.sum;无契约/迁移/前端影响
- 存量密码无需重哈希