### PR TITLE
feat(course): 教学班班号导入与展示，消除主码课双写

### DIFF
--- a/apps/gooseforum/app/http/routes/contract_course_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_test.go
@@ -106,12 +106,14 @@ func seedCourseContractData(t *testing.T, conn *gorm.DB) {
 		t.Fatalf("create instructor 李四: %v", err)
 	}
 	offering := &course.OfferingEntity{
-		Id:       901,
-		CourseId: entity.Id,
-		TermId:   term.Id,
-		Campus:   "四平路校区",
-		Faculty:  "数学科学学院",
-		Status:   course.OfferingStatusVisible,
+		Id:        901,
+		CourseId:  entity.Id,
+		TermId:    term.Id,
+		Campus:    "四平路校区",
+		Faculty:   "数学科学学院",
+		ClassCode: "10000101",
+		ClassName: "01班",
+		Status:    course.OfferingStatusVisible,
 	}
 	if err := conn.Create(offering).Error; err != nil {
 		t.Fatalf("create offering: %v", err)

--- a/apps/gooseforum/app/models/forum/course/offering.go
+++ b/apps/gooseforum/app/models/forum/course/offering.go
@@ -15,6 +15,8 @@ type OfferingEntity struct {
 	TermId    uint64         `gorm:"column:term_id;not null;default:0;index:idx_course_offering_term;" json:"termId"`
 	Campus    string         `gorm:"column:campus;type:varchar(64);not null;default:'';" json:"campus"`
 	Faculty   string         `gorm:"column:faculty;type:varchar(255);not null;default:'';" json:"faculty"`
+	ClassCode string         `gorm:"column:class_code;type:varchar(64);not null;default:'';" json:"classCode"`
+	ClassName string         `gorm:"column:class_name;type:varchar(255);not null;default:'';" json:"className"`
 	Status    int8           `gorm:"column:status;not null;default:0;" json:"status"`
 	CreatedAt time.Time      `gorm:"column:created_at;autoCreateTime;<-:create;" json:"createdAt"`
 	UpdatedAt time.Time      `gorm:"column:updated_at;autoUpdateTime;" json:"updatedAt"`

--- a/apps/gooseforum/app/service/courseservice/catalog.go
+++ b/apps/gooseforum/app/service/courseservice/catalog.go
@@ -25,12 +25,15 @@ type CourseSummary struct {
 }
 
 // OfferingSummary 开课实例摘要（详情页；B1 携带 offering 级评分聚合）。
+// ClassCode/ClassName 为班号信息（如 32000101 / 01班），旧数据包导入时为空。
 type OfferingSummary struct {
 	Id          uint64   `json:"id"`
 	TermCode    string   `json:"termCode"`
 	TermName    string   `json:"termName,omitempty"`
 	Campus      string   `json:"campus,omitempty"`
 	Faculty     string   `json:"faculty,omitempty"`
+	ClassCode   string   `json:"classCode,omitempty"`
+	ClassName   string   `json:"className,omitempty"`
 	Instructors []string `json:"instructors,omitempty"`
 	RatingAvg   *float64 `json:"ratingAvg,omitempty"`
 	ReviewCount int      `json:"reviewCount,omitempty"`
@@ -239,6 +242,8 @@ func GetCourseDetail(id uint64) (CourseDetail, error) {
 			Id:          o.Id,
 			Campus:      o.Campus,
 			Faculty:     o.Faculty,
+			ClassCode:   o.ClassCode,
+			ClassName:   o.ClassName,
 			Instructors: instructorsByOffering[o.Id],
 		}
 		if s, ok := offeringStats[o.Id]; ok {

--- a/apps/gooseforum/app/service/courseservice/import_e2e_test.go
+++ b/apps/gooseforum/app/service/courseservice/import_e2e_test.go
@@ -85,7 +85,7 @@ func TestE2ELegacyImportFullChain(t *testing.T) {
 		"courses.jsonl": `{"id":"c1","code":"100001","name":"高等数学(A)上","department":"数学科学学院","credit":5,"aliases":["高数"]}` + "\n" +
 			`{"id":"c2","code":"100002","name":"线性代数","department":"数学科学学院","credit":3}` + "\n",
 		"instructors.jsonl": `{"id":"i1","name":"张三","department":"数学科学学院","title":"教授"}` + "\n",
-		"offerings.jsonl": `{"id":"o1","course_id":"c1","term":"2025-2026-1","campus":"四平路校区","faculty":"数学科学学院","instructor_ids":["i1"]}` + "\n" +
+		"offerings.jsonl": `{"id":"o1","course_id":"c1","term":"2025-2026-1","campus":"四平路校区","faculty":"数学科学学院","class_code":"10000101","class_name":"01班","instructor_ids":["i1"]}` + "\n" +
 			`{"id":"o2","course_id":"c2","term":"2025-2026-1","campus":"嘉定校区","instructor_ids":["i1"]}` + "\n",
 		"reviews.jsonl": `{"offering_external_id":"o1","rating":4,"content":"老师讲得很清楚","created_at":"2023-06-01T08:00:00+08:00","legacy_helpful_count":3}` + "\n" +
 			`{"offering_external_id":"o2","rating":0,"content":"无评分历史评价","created_at":"2023-06-02T08:00:00+08:00","legacy_helpful_count":1}` + "\n",
@@ -185,6 +185,9 @@ func TestE2ELegacyImportFullChain(t *testing.T) {
 	}
 	if len(detail.Offerings) != 1 || detail.Offerings[0].TermCode != "2025-2026-1" {
 		t.Fatalf("course detail offerings unexpected: %+v", detail.Offerings)
+	}
+	if detail.Offerings[0].ClassCode != "10000101" || detail.Offerings[0].ClassName != "01班" {
+		t.Fatalf("course detail offering class info unexpected: %+v", detail.Offerings[0])
 	}
 	if detail.RatingAvg == nil || *detail.RatingAvg != 4.0 {
 		t.Fatalf("detail rating avg = %v, want 4.0", detail.RatingAvg)

--- a/apps/gooseforum/app/service/courseservice/importer.go
+++ b/apps/gooseforum/app/service/courseservice/importer.go
@@ -79,6 +79,10 @@ type importOfferingRow struct {
 	Campus        string   `json:"campus"`
 	Faculty       string   `json:"faculty"`
 	InstructorIDs []string `json:"instructor_ids,omitempty"`
+	// 班号信息（上游导出器提供）：教学班 code（如 32000101）与班名（如 01班）。
+	// 用于详情页按班展示；旧数据包无此字段时为空。
+	ClassCode string `json:"class_code,omitempty"`
+	ClassName string `json:"class_name,omitempty"`
 }
 
 // --- 导入实现 ---
@@ -734,10 +738,12 @@ func applyOfferingRow(tx *gorm.DB, runID uint64, source string, row importOfferi
 		// 课程修正也一并更新，防止 offering 挂在旧课程上。
 		// 注意：更新路径不写 status——管理员隐藏的 offering 不能被重导静默复活。
 		updates := map[string]any{
-			"course_id": courseLocalID,
-			"term_id":   termEntity.Id,
-			"campus":    row.Campus,
-			"faculty":   row.Faculty,
+			"course_id":  courseLocalID,
+			"term_id":    termEntity.Id,
+			"campus":     row.Campus,
+			"faculty":    row.Faculty,
+			"class_code": row.ClassCode,
+			"class_name": row.ClassName,
 		}
 		if err := tx.Model(&course.OfferingEntity{}).Where("id = ?", offering.Id).Updates(updates).Error; err != nil {
 			return fmt.Errorf("update offering %d: %w", offering.Id, err)
@@ -763,11 +769,13 @@ func applyOfferingRow(tx *gorm.DB, runID uint64, source string, row importOfferi
 	}
 
 	offeringEntity := course.OfferingEntity{
-		CourseId: courseLocalID,
-		TermId:   termEntity.Id,
-		Campus:   row.Campus,
-		Faculty:  row.Faculty,
-		Status:   course.OfferingStatusVisible,
+		CourseId:  courseLocalID,
+		TermId:    termEntity.Id,
+		Campus:    row.Campus,
+		Faculty:   row.Faculty,
+		ClassCode: row.ClassCode,
+		ClassName: row.ClassName,
+		Status:    course.OfferingStatusVisible,
 	}
 	if err := tx.Model(&course.OfferingEntity{}).Create(&offeringEntity).Error; err != nil {
 		return fmt.Errorf("create offering: %w", err)

--- a/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
+++ b/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
@@ -1007,6 +1007,9 @@ export interface CourseDetailPageProps {
       termName?: string
       campus?: string
       faculty?: string
+      // 班号信息（如 32000101 / 01班）；旧数据包导入的 offering 无此字段。
+      classCode?: string
+      className?: string
       instructors?: string[]
       ratingAvg?: number
       reviewCount?: number

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -1793,6 +1793,10 @@ export interface components {
             termName?: string;
             campus?: string;
             faculty?: string;
+            /** @description Class code for this offering (e.g. 32000101); empty for legacy packages without class info. */
+            classCode?: string;
+            /** @description Class name for this offering (e.g. 01班); empty for legacy packages without class info. */
+            className?: string;
             instructors?: string[];
             /**
              * Format: double

--- a/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
@@ -49,7 +49,8 @@ function formatCredit(creditX10: number) {
 function offeringLabel(id: number) {
   const offering = page.props.course.offerings?.find((item) => item.id === id)
   if (!offering) return `#${id}`
-  return [offering.termCode, offering.campus, offering.instructors?.join('、')].filter(Boolean).join(' · ')
+  const classLabel = offering.className || offering.classCode || ''
+  return [offering.termCode, classLabel, offering.campus, offering.instructors?.join('、')].filter(Boolean).join(' · ')
 }
 
 function formatRating(avg: number) {
@@ -470,6 +471,12 @@ onMounted(() => {
         >
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
             <span class="gf-badge gf-badge-muted">{{ offering.termCode }}</span>
+            <span v-if="offering.className" class="gf-badge gf-badge-primary/10 text-[11px]">
+              {{ offering.className }}
+            </span>
+            <span v-else-if="offering.classCode" class="gf-badge gf-badge-primary/10 text-[11px]">
+              {{ offering.classCode }}
+            </span>
             <span v-if="offering.campus" class="text-[12px] text-base-content/55">{{ offering.campus }}</span>
             <span v-if="offering.faculty" class="text-[12px] text-base-content/55">{{ offering.faculty }}</span>
           </div>

--- a/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/CourseDetailPage.vue
@@ -471,10 +471,10 @@ onMounted(() => {
         >
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
             <span class="gf-badge gf-badge-muted">{{ offering.termCode }}</span>
-            <span v-if="offering.className" class="gf-badge gf-badge-primary/10 text-[11px]">
+            <span v-if="offering.className" class="gf-badge gf-badge-info text-[11px]">
               {{ offering.className }}
             </span>
-            <span v-else-if="offering.classCode" class="gf-badge gf-badge-primary/10 text-[11px]">
+            <span v-else-if="offering.classCode" class="gf-badge gf-badge-info text-[11px]">
               {{ offering.classCode }}
             </span>
             <span v-if="offering.campus" class="text-[12px] text-base-content/55">{{ offering.campus }}</span>

--- a/apps/mobile/packages/core/lib/src/gen/content_pages.dart
+++ b/apps/mobile/packages/core/lib/src/gen/content_pages.dart
@@ -184,6 +184,8 @@ abstract class CourseOfferingPayload with _$CourseOfferingPayload {
     String? termName,
     String? campus,
     String? faculty,
+    String? classCode,
+    String? className,
     List<String>? instructors,
     double? ratingAvg,
     int? reviewCount,

--- a/apps/mobile/packages/core/lib/src/gen/content_pages.freezed.dart
+++ b/apps/mobile/packages/core/lib/src/gen/content_pages.freezed.dart
@@ -3207,6 +3207,8 @@ mixin _$CourseOfferingPayload {
   String? get termName => throw _privateConstructorUsedError;
   String? get campus => throw _privateConstructorUsedError;
   String? get faculty => throw _privateConstructorUsedError;
+  String? get classCode => throw _privateConstructorUsedError;
+  String? get className => throw _privateConstructorUsedError;
   List<String>? get instructors => throw _privateConstructorUsedError;
   double? get ratingAvg => throw _privateConstructorUsedError;
   int? get reviewCount => throw _privateConstructorUsedError;
@@ -3234,6 +3236,8 @@ abstract class $CourseOfferingPayloadCopyWith<$Res> {
     String? termName,
     String? campus,
     String? faculty,
+    String? classCode,
+    String? className,
     List<String>? instructors,
     double? ratingAvg,
     int? reviewCount,
@@ -3263,6 +3267,8 @@ class _$CourseOfferingPayloadCopyWithImpl<
     Object? termName = freezed,
     Object? campus = freezed,
     Object? faculty = freezed,
+    Object? classCode = freezed,
+    Object? className = freezed,
     Object? instructors = freezed,
     Object? ratingAvg = freezed,
     Object? reviewCount = freezed,
@@ -3289,7 +3295,14 @@ class _$CourseOfferingPayloadCopyWithImpl<
                 ? _value.faculty
                 : faculty // ignore: cast_nullable_to_non_nullable
                       as String?,
-            instructors: freezed == instructors
+            classCode: freezed == classCode
+                ? _value.classCode
+                : classCode // ignore: cast_nullable_to_non_nullable
+                      as String?,
+            className: freezed == className
+                ? _value.className
+                : className // ignore: cast_nullable_to_non_nullable
+                      as String?,
                 ? _value.instructors
                 : instructors // ignore: cast_nullable_to_non_nullable
                       as List<String>?,
@@ -3322,6 +3335,8 @@ abstract class _$$CourseOfferingPayloadImplCopyWith<$Res>
     String? termName,
     String? campus,
     String? faculty,
+    String? classCode,
+    String? className,
     List<String>? instructors,
     double? ratingAvg,
     int? reviewCount,
@@ -3348,6 +3363,8 @@ class __$$CourseOfferingPayloadImplCopyWithImpl<$Res>
     Object? termName = freezed,
     Object? campus = freezed,
     Object? faculty = freezed,
+    Object? classCode = freezed,
+    Object? className = freezed,
     Object? instructors = freezed,
     Object? ratingAvg = freezed,
     Object? reviewCount = freezed,
@@ -3373,6 +3390,14 @@ class __$$CourseOfferingPayloadImplCopyWithImpl<$Res>
         faculty: freezed == faculty
             ? _value.faculty
             : faculty // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        classCode: freezed == classCode
+            ? _value.classCode
+            : classCode // ignore: cast_nullable_to_non_nullable
+                  as String?,
+        className: freezed == className
+            ? _value.className
+            : className // ignore: cast_nullable_to_non_nullable
                   as String?,
         instructors: freezed == instructors
             ? _value._instructors
@@ -3400,6 +3425,8 @@ class _$CourseOfferingPayloadImpl implements _CourseOfferingPayload {
     this.termName,
     this.campus,
     this.faculty,
+    this.classCode,
+    this.className,
     final List<String>? instructors,
     this.ratingAvg,
     this.reviewCount,
@@ -3418,6 +3445,10 @@ class _$CourseOfferingPayloadImpl implements _CourseOfferingPayload {
   final String? campus;
   @override
   final String? faculty;
+  @override
+  final String? classCode;
+  @override
+  final String? className;
   final List<String>? _instructors;
   @override
   List<String>? get instructors {
@@ -3435,7 +3466,7 @@ class _$CourseOfferingPayloadImpl implements _CourseOfferingPayload {
 
   @override
   String toString() {
-    return 'CourseOfferingPayload(id: $id, termCode: $termCode, termName: $termName, campus: $campus, faculty: $faculty, instructors: $instructors, ratingAvg: $ratingAvg, reviewCount: $reviewCount)';
+    return 'CourseOfferingPayload(id: $id, termCode: $termCode, termName: $termName, campus: $campus, faculty: $faculty, classCode: $classCode, className: $className, instructors: $instructors, ratingAvg: $ratingAvg, reviewCount: $reviewCount)';
   }
 
   @override
@@ -3448,8 +3479,11 @@ class _$CourseOfferingPayloadImpl implements _CourseOfferingPayload {
                 other.termCode == termCode) &&
             (identical(other.termName, termName) ||
                 other.termName == termName) &&
-            (identical(other.campus, campus) || other.campus == campus) &&
             (identical(other.faculty, faculty) || other.faculty == faculty) &&
+            (identical(other.classCode, classCode) ||
+                other.classCode == classCode) &&
+            (identical(other.className, className) ||
+                other.className == className) &&
             const DeepCollectionEquality().equals(
               other._instructors,
               _instructors,
@@ -3469,6 +3503,8 @@ class _$CourseOfferingPayloadImpl implements _CourseOfferingPayload {
     termName,
     campus,
     faculty,
+    classCode,
+    className,
     const DeepCollectionEquality().hash(_instructors),
     ratingAvg,
     reviewCount,
@@ -3499,6 +3535,8 @@ abstract class _CourseOfferingPayload implements CourseOfferingPayload {
     final String? termName,
     final String? campus,
     final String? faculty,
+    final String? classCode,
+    final String? className,
     final List<String>? instructors,
     final double? ratingAvg,
     final int? reviewCount,
@@ -3517,6 +3555,10 @@ abstract class _CourseOfferingPayload implements CourseOfferingPayload {
   String? get campus;
   @override
   String? get faculty;
+  @override
+  String? get classCode;
+  @override
+  String? get className;
   @override
   List<String>? get instructors;
   @override

--- a/apps/mobile/packages/core/lib/src/gen/content_pages.freezed.dart
+++ b/apps/mobile/packages/core/lib/src/gen/content_pages.freezed.dart
@@ -3120,19 +3120,18 @@ class _$CourseCatalogQueryPayloadImpl implements _CourseCatalogQueryPayload {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode =>
-      Object.hash(
-        runtimeType,
-        keyword,
-        department,
-        term,
-        campus,
-        instructor,
-        onlyWithReviews,
-        sortBy,
-        page,
-        size,
-      );
+  int get hashCode => Object.hash(
+    runtimeType,
+    keyword,
+    department,
+    term,
+    campus,
+    instructor,
+    onlyWithReviews,
+    sortBy,
+    page,
+    size,
+  );
 
   /// Create a copy of CourseCatalogQueryPayload
   /// with the given fields replaced by the non-null parameter values.
@@ -3303,6 +3302,7 @@ class _$CourseOfferingPayloadCopyWithImpl<
                 ? _value.className
                 : className // ignore: cast_nullable_to_non_nullable
                       as String?,
+            instructors: freezed == instructors
                 ? _value.instructors
                 : instructors // ignore: cast_nullable_to_non_nullable
                       as List<String>?,
@@ -3479,6 +3479,7 @@ class _$CourseOfferingPayloadImpl implements _CourseOfferingPayload {
                 other.termCode == termCode) &&
             (identical(other.termName, termName) ||
                 other.termName == termName) &&
+            (identical(other.campus, campus) || other.campus == campus) &&
             (identical(other.faculty, faculty) || other.faculty == faculty) &&
             (identical(other.classCode, classCode) ||
                 other.classCode == classCode) &&

--- a/apps/mobile/packages/core/lib/src/gen/content_pages.g.dart
+++ b/apps/mobile/packages/core/lib/src/gen/content_pages.g.dart
@@ -275,6 +275,8 @@ _$CourseOfferingPayloadImpl _$$CourseOfferingPayloadImplFromJson(
   termName: json['termName'] as String?,
   campus: json['campus'] as String?,
   faculty: json['faculty'] as String?,
+  classCode: json['classCode'] as String?,
+  className: json['className'] as String?,
   instructors: (json['instructors'] as List<dynamic>?)
       ?.map((e) => e as String)
       .toList(),
@@ -290,6 +292,8 @@ Map<String, dynamic> _$$CourseOfferingPayloadImplToJson(
   'termName': instance.termName,
   'campus': instance.campus,
   'faculty': instance.faculty,
+  'classCode': instance.classCode,
+  'className': instance.className,
   'instructors': instance.instructors,
   'ratingAvg': instance.ratingAvg,
   'reviewCount': instance.reviewCount,

--- a/docs/operations/course-import-e2e.md
+++ b/docs/operations/course-import-e2e.md
@@ -4,10 +4,14 @@
 
 ## 数据包格式（上游导出器输出）
 
-`export_legacy_course_package.py` 输出**单包 4 文件 + 1 manifest**（同一目录）：
+`jcourse_to_manifest.py`（`import-data/`，上游 jcourse SQLite 快照 → manifest 包）输出**单包 4 文件 + 1 manifest**（同一目录）：
 
 - `courses.jsonl` / `instructors.jsonl` / `offerings.jsonl` / `reviews.jsonl`
 - `manifest.yaml`：`schema_version: 1` + `source` + `source_commit` + `exported_at` + `rights_approval_ref` + `files{sha256}` + `counts`
+
+`offerings.jsonl` 每行含 `class_code` / `class_name` 班号信息（如 `32000101` / `01班`），
+供 Hub 课程详情页按班展示；每个教学班只挂载一门课（班号课优先，其次主码课），
+避免同一教学班同时挂主码课与班号课造成目录双写（旧版多挂载行为已废弃）。
 
 Hub 导入器按命令消费同一包：`course-import`（catalog）只处理前三个 JSONL，`course-import reviews` 只处理 reviews.jsonl；manifest 中属于其他命令的文件与计数被跳过，由对应命令校验。
 

--- a/docs/operations/course-import-e2e.md
+++ b/docs/operations/course-import-e2e.md
@@ -4,10 +4,11 @@
 
 ## 数据包格式（上游导出器输出）
 
-`jcourse_to_manifest.py`（`import-data/`，上游 jcourse SQLite 快照 → manifest 包）输出**单包 4 文件 + 1 manifest**（同一目录）：
+`jcourse_to_manifest.py`（`import-data/`，上游 jcourse SQLite 快照 → manifest 包）输出**单包 4 文件 + 2 manifest**（同一目录）：
 
 - `courses.jsonl` / `instructors.jsonl` / `offerings.jsonl` / `reviews.jsonl`
-- `manifest.yaml`：`schema_version: 1` + `source` + `source_commit` + `exported_at` + `rights_approval_ref` + `files{sha256}` + `counts`
+- `manifest-catalog.yaml`：`schema_version: 1` + `source` + `files{sha256}` + `counts`
+- `manifest-reviews.yaml`：同 catalog，另含 `rights_approval_ref`（评价导入必填）
 
 `offerings.jsonl` 每行含 `class_code` / `class_name` 班号信息（如 `32000101` / `01班`），
 供 Hub 课程详情页按班展示；每个教学班只挂载一门课（班号课优先，其次主码课），
@@ -19,16 +20,16 @@ Hub 导入器按命令消费同一包：`course-import`（catalog）只处理前
 
 ```bash
 # 1) catalog dry-run：0 冲突、计数与 manifest 一致
-go run ./cmd/gooseforum course-import /path/to/package/manifest.yaml --dry-run
+go run ./cmd/gooseforum course-import /path/to/package/manifest-catalog.yaml --dry-run
 
 # 2) catalog 正式导入：import_run completed（重复执行 manifest 级幂等跳过）
-go run ./cmd/gooseforum course-import /path/to/package/manifest.yaml
+go run ./cmd/gooseforum course-import /path/to/package/manifest-catalog.yaml
 
 # 3) reviews dry-run：0 冲突、rights_approval_ref 必填
-go run ./cmd/gooseforum course-import reviews --manifest /path/to/package/manifest.yaml --dry-run
+go run ./cmd/gooseforum course-import reviews --manifest /path/to/package/manifest-reviews.yaml --dry-run
 
 # 4) reviews 正式导入（重复执行幂等）
-go run ./cmd/gooseforum course-import reviews --manifest /path/to/package/manifest.yaml
+go run ./cmd/gooseforum course-import reviews --manifest /path/to/package/manifest-reviews.yaml
 
 # 5) 统计投影重建（rebuild-course-stats 等价命令，成功即一致性）
 go run ./cmd/gooseforum rebuild-course-stats

--- a/import-data/jcourse_to_manifest.py
+++ b/import-data/jcourse_to_manifest.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""jcourse SQLite snapshot -> yourtj-hub course-import manifest 包。
+
+用法:
+    python3 jcourse_to_manifest.py <snapshot.db> <outdir>
+
+输出 (outdir/):
+    manifest-catalog.yaml   目录导入 manifest（courses/instructors/offerings）
+    manifest-reviews.yaml   评价导入 manifest（reviews.jsonl，含 rights_approval_ref）
+    courses.jsonl           course 目录（按 code 去重）
+    instructors.jsonl       教师（teacher.teacherCode 去重）
+    offerings.jsonl         开课（coursedetail 每行一个，按 calendarId 映射学期）
+    reviews.jsonl           历史评价（全量导出；学期精确匹配挂真实 offering，
+                            匹配不上挂该课程 "其他" 学期 offering，一条不丢）
+    mapping_report.json     转换统计与无法映射明细计数
+
+已知取舍（详见 mapping_report）:
+    - course_aliases (onesystem 课号变体) 不导入：hub importer 仅支持 name 别名，
+      课号别名会与 primary_code 语义冲突且大量撞 normalized 唯一键。
+    - reviews.semester 为自由文本；能规范化到 calendar 学期且该课程该学期有
+      开课记录的评论挂真实 offering；其余（老学期/其他/空文本/学期不匹配/
+      无开课记录）统一挂该课程 "其他（历史导入）" 学期 offering，一条不丢。
+    - courses 与 coursedetail 按四字段关联（courseCode/newCourseCode/code/newCode）；
+      每个教学班只挂一门课：优先班号课（code 精确匹配，如 32000101），无班号课
+      则挂主码课（courseCode/newCourseCode/newCode，如 320001）。offering 行携带
+      class_code/class_name 班号信息供 hub 侧按班展示。旧版"每匹配课程生成一个
+      offering"会把同一教学班同时挂到主码课与班号课（双写，如体育 295 班 ->
+      295 条主码 offering + 102 条班号 offering），已废弃。
+    - courses 重复 code（同课不同教师行）合并为单条 course，教师信息由 offering 承载。
+    - catalog（courses/instructors/offerings）与 reviews 拆分为两个 manifest：
+      hub 的 catalog importer 遇到 reviews 文件会拒绝，二者必须分开导入
+      （先 catalog 后 reviews，source 一致保证 offering 映射可解析）。
+"""
+
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# calendarId -> term code "YYYY-YYYY-N"，与 hub course_term.code 对应
+CALENDAR_TERM = {
+    118: "2024-2025-1",
+    119: "2024-2025-2",
+    120: "2025-2026-1",
+    121: "2025-2026-2",
+    122: "2026-2027-1",
+}
+_CN_NUM = {
+    "一": "1",
+    "二": "2",
+    "三": "3",
+    "四": "4",
+    "五": "5",
+    "六": "6",
+    "七": "7",
+    "八": "8",
+    "九": "9",
+}
+
+_SEM_PATTERNS = [
+    (re.compile(r"^(\d{4})-(\d{4})学年第(\d)学期$"), None),
+    (re.compile(r"^(\d{4})-(\d{4})第(\d)学期$"), None),
+    (re.compile(r"^(\d{4})-(\d{4})学年第([一二三四])学期$"), None),
+    (re.compile(r"^(\d{4})-(\d{4})第([一二三四])学期$"), None),
+    (re.compile(r"^(\d{4})-(\d{4})-(\d)$"), None),
+    (re.compile(r"^(\d{4})-(\d{4}) (\d)$"), None),
+    (re.compile(r"^(\d{4})-(\d{4})(学年第)?第二学期$"), 2),
+    (re.compile(r"^(\d{4})-(\d{4}) w$"), 2),
+    (re.compile(r"^(\d{2})-(\d{2})-(\d)$"), None),
+    (re.compile(r"^（(\d{4})-(\d{4})-(\d)）$"), None),
+    (re.compile(r"^(\d{2})(\d{2})(\d)$"), None),  # 25262 -> 25-26-2
+]
+
+
+def norm_semester(raw: str):
+    """自由文本学期 -> "YYYY-YYYY-N"，识别不了返回 None。"""
+    s = (raw or "").strip().replace(" ", "")
+    if not s:
+        return None
+    for pat, fixed_n in _SEM_PATTERNS:
+        m = pat.match(s)
+        if not m:
+            continue
+        g = m.groups()
+        if fixed_n is not None:  # 学年 + 固定学期（无捕获组或固定为 2）
+            nums = [x for x in g if x]
+            if len(nums) == 2:
+                return f"{nums[0]}-{nums[1]}-{fixed_n}"
+            return None
+        if len(g) == 2:  # 学年 + 中文数字学期
+            return f"{g[0]}-{g[1]}-{_CN_NUM[g[1]]}"
+        if len(g) == 3:
+            a, b, n = g
+            if len(a) == 2:
+                a, b = "20" + a, "20" + b
+            if n in _CN_NUM:
+                n = _CN_NUM[n]
+            return f"{a}-{b}-{n}"
+    return None
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__)
+        return 2
+    src, outdir = Path(sys.argv[1]), Path(sys.argv[2])
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    db = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+    db.execute("PRAGMA busy_timeout=5000")
+    db.row_factory = sqlite3.Row
+    cur = db.cursor()
+
+    report = {
+        "courses_raw": 0,
+        "courses_merged": 0,
+        "courses_dup_code_merged": 0,
+        "instructors": 0,
+        "offerings_real": 0,
+        "offerings_class_attached": 0,
+        "offerings_course_attached": 0,
+        "offerings_other": 0,
+        "courses_with_other_only": 0,
+        "reviews_raw": 0,
+        "reviews_exact": 0,
+        "reviews_other": 0,
+        "reviews_unmapped": 0,
+        "unmapped_semesters": {},  # 原始 semester 文本 -> 条数
+    }
+
+    # ---- courses：按 code 去重（重复行合并，取第一条有意义的） ----
+    code_to_ext = {}
+    courses_out = []
+    for r in cur.execute(
+        "SELECT id, code, name, credit, department FROM courses ORDER BY id"
+    ):
+        report["courses_raw"] += 1
+        code = (r["code"] or "").strip()
+        if not code or not (r["name"] or "").strip():
+            continue
+        if code in code_to_ext:
+            report["courses_dup_code_merged"] += 1
+            continue  # 同课不同教师行：教师信息由 offering 承载
+        ext = str(r["id"])
+        code_to_ext[code] = ext
+        courses_out.append(
+            {
+                "id": ext,
+                "code": code,
+                "name": r["name"].strip(),
+                "department": (r["department"] or "").strip(),
+                "credit": float(r["credit"] or 0),
+            }
+        )
+    report["courses_merged"] = len(courses_out)
+
+    # ---- instructors：teacher 表按 teacherCode 去重，department/title 从 teachers 补 ----
+    # hub importer 按 (name, dept) 自然键去重；jcourse 存在同名同院系多工号
+    # （130 组、164 行），必须用工号消歧：冲突组的教师名加 " (工号)" 后缀，
+    # 保证自然键唯一，offering 引用工号不变。
+    teacher_meta = {}
+    for r in cur.execute(
+        "SELECT tid, name, title, department FROM teachers WHERE tid IS NOT NULL AND trim(tid) != ''"
+    ):
+        tid = r["tid"].strip()
+        if tid not in teacher_meta:
+            teacher_meta[tid] = {
+                "title": r["title"] or "",
+                "department": r["department"] or "",
+            }
+    # 预扫描自然键冲突：name+dept -> [codes]
+    natural_key_groups = {}
+    for r in cur.execute(
+        "SELECT DISTINCT teacherCode, teacherName FROM teacher WHERE teacherCode IS NOT NULL AND trim(teacherCode) != '' AND teacherName IS NOT NULL AND trim(teacherName) != ''"
+    ):
+        code = r["teacherCode"].strip()
+        name = (r["teacherName"] or "").strip()
+        meta = teacher_meta.get(code, {})
+        dept = meta.get("department", "")
+        natural_key_groups.setdefault((name, dept), set()).add(code)
+    conflicted = {
+        code
+        for codes in natural_key_groups.values()
+        if len(codes) > 1
+        for code in codes
+    }
+
+    instructors_out = []
+    seen_codes = set()
+    for r in cur.execute(
+        "SELECT DISTINCT teacherCode, teacherName FROM teacher WHERE teacherCode IS NOT NULL AND trim(teacherCode) != '' AND teacherName IS NOT NULL AND trim(teacherName) != ''"
+    ):
+        code = r["teacherCode"].strip()
+        name = (r["teacherName"] or "").strip()
+        if not name or code in seen_codes:
+            continue
+        seen_codes.add(code)
+        meta = teacher_meta.get(code, {})
+        dept = meta.get("department", "")
+        display_name = f"{name} ({code})" if code in conflicted else name
+        instructors_out.append(
+            {
+                "id": code,
+                "name": display_name,
+                "department": dept,
+                "title": meta.get("title", ""),
+            }
+        )
+    report["instructors"] = len(instructors_out)
+    report["instructor_natural_key_conflicts"] = len(conflicted)
+
+    # ---- offerings：coursedetail 每行一个，term 由 calendarId 映射 ----
+    # 四字段关联（与上游 010_materialize_courses_from_pk.sql 一致）：courseCode /
+    # newCourseCode / code / newCode 任一等于 courses.code 即可挂载，但每个教学班
+    # 只挂一门课（班号课优先，其次主码课），避免同一班在 Hub 目录双写。
+    # offering 行附带 class_code/class_name 班号信息，供 hub 侧按班展示。
+    instructor_of_class = {}
+    for r in cur.execute(
+        "SELECT teachingClassId, teacherCode FROM teacher WHERE teachingClassId IS NOT NULL AND teacherCode IS NOT NULL AND trim(teacherCode) != ''"
+    ):
+        instructor_of_class.setdefault(r["teachingClassId"], []).append(
+            r["teacherCode"].strip()
+        )
+
+    campus_names = {
+        r["campus"]: r["campusI18n"]
+        for r in cur.execute("SELECT campus, campusI18n FROM campus")
+    }
+    faculty_names = {
+        r["faculty"]: r["facultyI18n"]
+        for r in cur.execute("SELECT faculty, facultyI18n FROM faculty")
+    }
+
+    # course_id -> course external id（供 reviews 预扫与导出）
+    course_id_to_ext = {
+        r["id"]: code_to_ext[(r["code"] or "").strip()]
+        for r in cur.execute("SELECT id, code FROM courses")
+        if (r["code"] or "").strip() in code_to_ext
+    }
+
+    # reviews 预扫：每门课需要哪些学期（可规范化的）+ 是否有无法规范化的评价
+    course_norm_terms = {}
+    course_has_unmapped_sem = {}
+    for r in cur.execute("SELECT course_id, semester FROM reviews"):
+        course_ext = course_id_to_ext.get(r["course_id"])
+        if course_ext is None:
+            continue
+        sem = norm_semester(r["semester"])
+        if sem is not None:
+            course_norm_terms.setdefault(course_ext, set()).add(sem)
+        else:
+            course_has_unmapped_sem[course_ext] = True
+
+    offerings_out = []
+    offering_by_course_term = {}  # course_ext -> {term: [offering ids]}
+    seen_offering = set()
+    for r in cur.execute(
+        "SELECT id, courseCode, newCourseCode, code, newCode, name, calendarId, campus, faculty FROM coursedetail ORDER BY id"
+    ):
+        term = CALENDAR_TERM.get(r["calendarId"])
+        if term is None:
+            continue
+        class_id = r["id"]
+        instructor_ids = list(dict.fromkeys(instructor_of_class.get(class_id, [])))
+        # 单挂载优先链：班号课（code）> 主码课（courseCode）> newCourseCode > newCode。
+        # 每个教学班只挂一门课，消除"同一班同时挂主码课与班号课"的双写。
+        attached_course = None
+        for code_field in (
+            r["code"],
+            r["courseCode"],
+            r["newCourseCode"],
+            r["newCode"],
+        ):
+            code = (code_field or "").strip()
+            if not code:
+                continue
+            course_ext = code_to_ext.get(code)
+            if course_ext is not None:
+                attached_course = course_ext
+                break
+        course_exts = [attached_course] if attached_course is not None else []
+        for course_ext in course_exts:
+            if course_ext == code_to_ext.get((r["code"] or "").strip()):
+                report["offerings_class_attached"] += 1
+            else:
+                report["offerings_course_attached"] += 1
+            offering_id = f"{class_id}-{course_ext}"
+            if offering_id in seen_offering:
+                continue
+            seen_offering.add(offering_id)
+            offerings_out.append(
+                {
+                    "id": offering_id,
+                    "course_id": course_ext,
+                    "term": term,
+                    "campus": campus_names.get(r["campus"], "") or "",
+                    "faculty": faculty_names.get(r["faculty"], "") or "",
+                    "instructor_ids": instructor_ids,
+                    # 班号信息：教学班 code（如 32000101）与班名（如 01班）。
+                    # hub importer 当前忽略未知字段，模型支持后可按班展示/分组。
+                    "class_code": (r["code"] or "").strip(),
+                    "class_name": (r["name"] or "").strip(),
+                }
+            )
+            offering_by_course_term.setdefault(course_ext, {}).setdefault(
+                term, []
+            ).append(offering_id)
+    # 每 (course, term) 保留教学班 id 最小的 offering（评价只挂一个，聚合不分散）
+    offering_min_by_course_term = {
+        course_ext: {
+            term: min(ids, key=lambda x: int(x.split("-")[0]))
+            for term, ids in terms.items()
+        }
+        for course_ext, terms in offering_by_course_term.items()
+    }
+    report["offerings_raw"] = cur.execute(
+        "SELECT COUNT(*) FROM coursedetail"
+    ).fetchone()[0]
+    report["offerings_real"] = len(offerings_out)
+
+    # ---- "其他（历史导入）"学期 offering：有评价但学期匹配不上的课程 ----
+    # 生成条件：课程有评价，且存在 (a) 无法规范化的学期文本，或 (b) 规范化后
+    # 不在该课程真实 offering 学期集合里，或 (c) 该课程没有任何真实 offering。
+    real_terms_by_course = {
+        course_ext: set(terms.keys())
+        for course_ext, terms in offering_by_course_term.items()
+    }
+    other_offering_ids = {}
+    other_needed_courses = set(course_norm_terms.keys()) | set(
+        course_has_unmapped_sem.keys()
+    )
+    for course_ext in sorted(other_needed_courses):
+        needed = course_norm_terms.get(course_ext, set())
+        real = real_terms_by_course.get(course_ext, set())
+        if course_has_unmapped_sem.get(course_ext) or not needed.issubset(real):
+            offering_id = f"other-{course_ext}"
+            other_offering_ids[course_ext] = offering_id
+            offerings_out.append(
+                {
+                    "id": offering_id,
+                    "course_id": course_ext,
+                    "term": "其他",
+                    "campus": "",
+                    "faculty": "",
+                    "instructor_ids": [],
+                }
+            )
+    report["offerings_other"] = len(other_offering_ids)
+    report["courses_with_other_only"] = sum(
+        1 for c in other_offering_ids if c not in offering_by_course_term
+    )
+
+    # ---- reviews：全量导出；精确学期匹配挂真实 offering，其余挂该课程 other ----
+    reviews_out = []
+    unmapped_by_sem = {}
+    for r in cur.execute(
+        "SELECT id, course_id, semester, rating, comment, created_at, approve_count FROM reviews ORDER BY id"
+    ):
+        report["reviews_raw"] += 1
+        course_ext = course_id_to_ext.get(r["course_id"])
+        offering_ext = None
+        if course_ext is not None:
+            sem = norm_semester(r["semester"])
+            if sem is not None:
+                offering_ext = offering_min_by_course_term.get(course_ext, {}).get(sem)
+        if offering_ext is None and course_ext is not None:
+            offering_ext = other_offering_ids.get(course_ext)
+        if offering_ext is None:
+            report["reviews_unmapped"] += 1
+            raw = (r["semester"] or "").strip() or "(empty)"
+            unmapped_by_sem[raw] = unmapped_by_sem.get(raw, 0) + 1
+            continue
+        if offering_ext == other_offering_ids.get(course_ext):
+            report["reviews_other"] += 1
+        else:
+            report["reviews_exact"] += 1
+        created = datetime.fromtimestamp(r["created_at"], tz=timezone.utc).isoformat()
+        reviews_out.append(
+            {
+                "id": str(r["id"]),
+                "offering_external_id": offering_ext,
+                "rating": int(r["rating"] or 0),
+                "content": r["comment"] or "",
+                "created_at": created,
+                "legacy_helpful_count": int(r["approve_count"] or 0),
+            }
+        )
+    report["reviews_written"] = len(reviews_out)
+    report["unmapped_semesters"] = dict(
+        sorted(unmapped_by_sem.items(), key=lambda kv: -kv[1])
+    )
+
+    db.close()
+
+    # ---- 写 JSONL ----
+    def write_jsonl(name, rows):
+        p = outdir / name
+        with p.open("w", encoding="utf-8") as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        return p
+
+    p_courses = write_jsonl("courses.jsonl", courses_out)
+    p_instructors = write_jsonl("instructors.jsonl", instructors_out)
+    p_offerings = write_jsonl("offerings.jsonl", offerings_out)
+    p_reviews = write_jsonl("reviews.jsonl", reviews_out)
+
+    def manifest_text(files, counts, rights_approval_ref=""):
+        m = "schema_version: 1\nsource: jcourse-snapshot-20260814\n"
+        if rights_approval_ref:
+            m += f'rights_approval_ref: "{rights_approval_ref}"\n'
+        m += "counts:\n"
+        for name, n in counts.items():
+            m += f"  {name}: {n}\n"
+        m += "files:\n"
+        for name, digest in files.items():
+            m += f"  {name}: {digest}\n"
+        return m
+
+    catalog_files = {}
+    catalog_counts = {}
+    for p in (p_courses, p_instructors, p_offerings):
+        catalog_files[p.name] = sha256_file(p)
+        catalog_counts[p.name] = sum(1 for _ in p.open(encoding="utf-8"))
+    (outdir / "manifest-catalog.yaml").write_text(
+        manifest_text(catalog_files, catalog_counts), encoding="utf-8"
+    )
+
+    reviews_files = {p_reviews.name: sha256_file(p_reviews)}
+    reviews_counts = {p_reviews.name: sum(1 for _ in p_reviews.open(encoding="utf-8"))}
+    (outdir / "manifest-reviews.yaml").write_text(
+        manifest_text(
+            reviews_files,
+            reviews_counts,
+            rights_approval_ref="本地导入验证 2026-08-14（数据源: /opt/yourtjcourse/data/jcourse.db 一致性快照）",
+        ),
+        encoding="utf-8",
+    )
+
+    (outdir / "mapping_report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    print(f"\ncatalog manifest:  {outdir / 'manifest-catalog.yaml'}")
+    print(f"reviews manifest:  {outdir / 'manifest-reviews.yaml'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/import-data/jcourse_to_manifest.py
+++ b/import-data/jcourse_to_manifest.py
@@ -76,29 +76,34 @@ _SEM_PATTERNS = [
 
 
 def norm_semester(raw: str):
-    """自由文本学期 -> "YYYY-YYYY-N"，识别不了返回 None。"""
-    s = (raw or "").strip().replace(" ", "")
-    if not s:
+    """自由文本学期 -> "YYYY-YYYY-N"，识别不了返回 None。
+
+    先按原样匹配（覆盖 "2025-2026 1" / "2025-2026 w" 这类带空格形式），
+    匹配不上再去掉所有空格重试（覆盖 "2025-2026第二学期" 等紧凑形式）。
+    """
+    s0 = (raw or "").strip()
+    if not s0:
         return None
-    for pat, fixed_n in _SEM_PATTERNS:
-        m = pat.match(s)
-        if not m:
-            continue
-        g = m.groups()
-        if fixed_n is not None:  # 学年 + 固定学期（无捕获组或固定为 2）
-            nums = [x for x in g if x]
-            if len(nums) == 2:
-                return f"{nums[0]}-{nums[1]}-{fixed_n}"
-            return None
-        if len(g) == 2:  # 学年 + 中文数字学期
-            return f"{g[0]}-{g[1]}-{_CN_NUM[g[1]]}"
-        if len(g) == 3:
-            a, b, n = g
-            if len(a) == 2:
-                a, b = "20" + a, "20" + b
-            if n in _CN_NUM:
-                n = _CN_NUM[n]
-            return f"{a}-{b}-{n}"
+    for s in dict.fromkeys((s0, s0.replace(" ", ""))):
+        for pat, fixed_n in _SEM_PATTERNS:
+            m = pat.match(s)
+            if not m:
+                continue
+            g = m.groups()
+            if fixed_n is not None:  # 学年 + 固定学期（无捕获组或固定为 2）
+                nums = [x for x in g if x]
+                if len(nums) == 2:
+                    return f"{nums[0]}-{nums[1]}-{fixed_n}"
+                return None
+            if len(g) == 2:  # 学年 + 中文数字学期
+                return f"{g[0]}-{g[1]}-{_CN_NUM[g[1]]}"
+            if len(g) == 3:
+                a, b, n = g
+                if len(a) == 2:
+                    a, b = "20" + a, "20" + b
+                if n in _CN_NUM:
+                    n = _CN_NUM[n]
+                return f"{a}-{b}-{n}"
     return None
 
 
@@ -308,7 +313,7 @@ def main() -> int:
                     "faculty": faculty_names.get(r["faculty"], "") or "",
                     "instructor_ids": instructor_ids,
                     # 班号信息：教学班 code（如 32000101）与班名（如 01班）。
-                    # hub importer 当前忽略未知字段，模型支持后可按班展示/分组。
+                    # hub importer 落库 class_code/class_name，详情页按班展示。
                     "class_code": (r["code"] or "").strip(),
                     "class_name": (r["name"] or "").strip(),
                 }

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -1089,6 +1089,12 @@ OfferingSummary:
       type: string
     faculty:
       type: string
+    classCode:
+      type: string
+      description: Class code for this offering (e.g. 32000101); empty for legacy packages without class info.
+    className:
+      type: string
+      description: Class name for this offering (e.g. 01班); empty for legacy packages without class info.
     instructors:
       type: array
       items:

--- a/packages/api-contract/fixtures/course-detail-success.json
+++ b/packages/api-contract/fixtures/course-detail-success.json
@@ -15,6 +15,8 @@
         "termName": "2025-2026 第一学期",
         "campus": "四平路校区",
         "faculty": "数学科学学院",
+        "classCode": "10000101",
+        "className": "01班",
         "instructors": [
           "张三",
           "李四"


### PR DESCRIPTION
## Summary
- **导出器修复**（`import-data/jcourse_to_manifest.py`）：每个教学班**单挂载**（班号课 `code` 优先，其次主码课 `courseCode`），消除"同一教学班同时挂主码课与班号课"的双写；offering 行新增 `class_code`/`class_name`（如 `32000101` / `01班`）
- **Hub 导入器**：`importOfferingRow` + `OfferingEntity` 落库班号字段（`course_offering.class_code`/`class_name`）
- **展示**：课程详情页开课记录展示班号（className 优先，回退 classCode），写评选择器/评价标签同样带班号
- **契约**：`OfferingSummary` 新增 `classCode`/`className`，fixture、生成的 TS、Dart 镜像同步更新
- **测试**：e2e 全链路 + 契约测试覆盖班号字段落库与输出

## 背景
线上体育课被"聚合"到主码课 `320001`（295 个 offering）的根因：旧导出器对每个教学班按四字段（courseCode/newCourseCode/code/newCode）**全部匹配**生成 offering，体育班 `code=32000101` + `courseCode=320001` 同时命中 → 双写；193 个无班号课程行的班只能挂主码课。修复后体育课正确分布到班号课（每班唯一挂载）。

## 验证
- `go test ./app/service/courseservice/ ./app/http/routes/` 全绿
- PG 迁移测试 `TestSchema*` 通过（`course_offering` 新列）
- `pnpm typecheck` / `pnpm build` 通过
- 契约 `pnpm run check` 通过（lint + bundle + generate + check-ts-gen）
- 新导出器实跑快照：offerings 29189 → 20834（= 教学班行数），真实教学班重复数 16710 → 0