### PR TITLE
fix(pk): treat onesystem code=200 as success in course-pk-sync

### DIFF
--- a/apps/gooseforum/app/service/pkservice/client.go
+++ b/apps/gooseforum/app/service/pkservice/client.go
@@ -65,7 +65,7 @@ type TeacherRaw struct {
 }
 
 type manualArrangePage struct {
-	Code onesystemCode `json:"code"` // 0=成功；非 0=业务/鉴权失败（一系统 HTTP 200 信封）
+	Code onesystemCode `json:"code"` // 0 或 200=成功；其他=业务/鉴权失败（一系统 HTTP 200 信封，真实成功码为 200）
 	Msg  string        `json:"msg"`
 	Data struct {
 		Total_ int         `json:"total_"`
@@ -73,8 +73,9 @@ type manualArrangePage struct {
 	} `json:"data"`
 }
 
-// onesystemCode 解析一系统响应信封的 code 字段：0 表示成功，非 0 表示业务/鉴权失败。
-// 上游 code 通常为整数，但为稳健兼容整数、数字字符串与缺失（缺失/空/null 一律视为成功 0）。
+// onesystemCode 解析一系统响应信封的 code 字段：0 或 200 表示成功，其他表示业务/鉴权失败。
+// 对照 serverless 上游（courseSync.ts code===200、sync.ts 仅检查 HTTP res.ok），
+// 一系统 manualArrange 的成功码是 200；兼容历史假设的 0 一并视为成功。
 type onesystemCode int64
 
 // UnmarshalJSON 兼容数字（1）、数字字符串（"1"）、null 与缺失。
@@ -156,7 +157,9 @@ func (c *onesystemClient) fetchPage(ctx context.Context, cookie string, calendar
 	}
 
 	var lastErr error
+	attempts := 0
 	for attempt := 1; attempt <= c.maxAttempts; attempt++ {
+		attempts = attempt
 		page, retryable, err := c.tryFetch(ctx, cookie, body)
 		if err == nil {
 			return page, nil
@@ -167,7 +170,7 @@ func (c *onesystemClient) fetchPage(ctx context.Context, cookie string, calendar
 		}
 		c.sleep(c.backoff(attempt))
 	}
-	return nil, fmt.Errorf("一系统请求失败（已重试 %d 次）: %w", c.maxAttempts, lastErr)
+	return nil, fmt.Errorf("一系统请求失败（尝试 %d 次后失败）: %w", attempts, lastErr)
 }
 
 // tryFetch 执行单次 POST；返回 (page, 是否可重试, 错误)。
@@ -195,8 +198,8 @@ func (c *onesystemClient) tryFetch(ctx context.Context, cookie string, body []by
 		if err := json.Unmarshal(respBody, &page); err != nil {
 			return nil, false, fmt.Errorf("一系统返回无法解析: %w", err)
 		}
-		if code := int64(page.Code); code != 0 {
-			// HTTP 200 但业务/鉴权失败（code!=0）：勿当成功页，否则会误删存量数据（review HIGH）。
+		if code := int64(page.Code); code != 0 && code != 200 {
+			// HTTP 200 但业务/鉴权失败（code 非 0/200）：勿当成功页，否则会误删存量数据（review HIGH）。
 			// 鉴权失败不可重试，直接以明确错误中止；错误体需脱敏。
 			hint := redactCredentials(strings.TrimSpace(page.Msg))
 			if hint == "" {

--- a/apps/gooseforum/app/service/pkservice/client_test.go
+++ b/apps/gooseforum/app/service/pkservice/client_test.go
@@ -189,6 +189,49 @@ func TestFetchPageCodeZeroIsSuccess(t *testing.T) {
 	}
 }
 
+func TestFetchPageCode200IsSuccess(t *testing.T) {
+	// 一系统 manualArrange 实际成功码是 200（对照 serverless 上游 courseSync.ts code===200），
+	// 而非 0。带完整数据的 code=200 响应必须按成功页处理，否则同步永久失败。
+	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"code":200,"msg":"","data":{"total_":4155,"list":[` +
+			`{"id":1111111124948791,"code":"5000033001001","name":"01班"}]}}`))
+	}))
+	page, err := c.fetchPage(context.Background(), "cookie", 121, 1, 200)
+	if err != nil {
+		t.Fatalf("code=200 应视为成功页: %v", err)
+	}
+	if page.Data.Total_ != 4155 || len(page.Data.List) != 1 {
+		t.Errorf("code=200 数据未透传: total=%d list=%d", page.Data.Total_, len(page.Data.List))
+	}
+}
+
+func TestFetchPageCode200WithDataAndOtherCodeFails(t *testing.T) {
+	// 字符串形式 code="200" 同样按成功处理；其余非 0/200 code 仍按业务失败拦截。
+	str200 := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"code":"200","msg":"","data":{"total_":1,"list":[]}}`))
+	}))
+	if _, err := str200.fetchPage(context.Background(), "cookie", 121, 1, 200); err != nil {
+		t.Fatalf("字符串 code=\"200\" 应视为成功页: %v", err)
+	}
+
+	other := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"code":500,"msg":"服务端异常","data":null}`))
+	}))
+	_, err := other.fetchPage(context.Background(), "cookie", 121, 1, 200)
+	if err == nil {
+		t.Fatal("code=500 应视为业务失败")
+	}
+	if !strings.Contains(err.Error(), "code=500") {
+		t.Errorf("error should mention code=500, got: %v", err)
+	}
+}
+
 func TestFetchPageRejectsStringBusinessCode(t *testing.T) {
 	// 字符串形式的 code="1" 同样应拦截（勿因 JSON 字符串引号误判为成功）。
 	c := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

修复 `course-pk-sync`（一系统课程同步）永远失败的问题：一系统 `manualArrange/page` 的真实业务成功码是 **200**，但客户端把 `code != 0` 一律判为业务失败，导致每次同步都在首页被拒并报"一系统请求失败（已重试 5 次）: 一系统返回业务失败: code=200"。

- 成功码放宽为 `0` 或 `200`，其余 code 仍按业务失败拦截（保留 review HIGH 语义：不会把失败页当成功空页误删存量数据）
- 错误文案如实报告实际尝试次数，不再恒为 `maxAttempts`（业务失败第 1 次即退出，原日志"已重试 5 次"有误导）
- 新增回归测试：`code=200`（数字/字符串）按成功透传数据、`code=500` 仍拦截

## 对照上游（YourTJCourse-Serverless）

- `scheduler/src/utils/courseSync.ts:223` — `if (response.data.code === 200)`，确认一系统信封成功码为 200
- `backend/src/pk/sync.ts:361-382` — 抓取 `manualArrange/page` 仅检查 HTTP `res.ok`，从不检查 body code

## Verification

- 先写红测试确认复现（`code=200 应视为成功页` 失败），再修复转绿
- `go test ./app/service/pkservice/` ✅（含全部 sync AC 测试）
- `go vet ./app/service/pkservice/` ✅
- `go build ./...` ✅