### PR TITLE
fix(schedule): load grades on first visit and stale-term fallback

### DIFF
--- a/apps/gooseforum/resource/src/site/components/schedule/ScheduleMajorSelector.vue
+++ b/apps/gooseforum/resource/src/site/components/schedule/ScheduleMajorSelector.vue
@@ -88,10 +88,16 @@ function resetSelection() {
 async function restoreSelection() {
   isRestoring = true
   await loadCalendars()
-  const selection = store.state.majorSelected
-  if (selection.calendarId !== undefined && selection.grade !== undefined) {
-    await loadGrades(selection.calendarId)
-    if (selection.major) await loadMajors(selection.grade, selection.calendarId)
+  // 首次访问（无已存选择）或已存学期失效回退时，Term 已按默认学期选中：
+  // 必须按最终选中的学期加载年级，否则年级/专业下拉永远为空。
+  const calendarId = calendarValue.value ? Number(calendarValue.value) : undefined
+  if (calendarId !== undefined) {
+    await loadGrades(calendarId)
+    const selection = store.state.majorSelected
+    // loadGrades 已恢复匹配的年级；仅当年级恢复成功且有已存专业时再加载专业。
+    if (gradeValue.value && selection.major) {
+      await loadMajors(Number(gradeValue.value), calendarId)
+    }
   }
   isRestoring = false
 }

--- a/apps/gooseforum/resource/src/site/components/schedule/ScheduleMajorSelector.vue
+++ b/apps/gooseforum/resource/src/site/components/schedule/ScheduleMajorSelector.vue
@@ -88,14 +88,22 @@ function resetSelection() {
 async function restoreSelection() {
   isRestoring = true
   await loadCalendars()
-  // 首次访问（无已存选择）或已存学期失效回退时，Term 已按默认学期选中：
-  // 必须按最终选中的学期加载年级，否则年级/专业下拉永远为空。
+  const restored = store.state.majorSelected
   const calendarId = calendarValue.value ? Number(calendarValue.value) : undefined
+  // 首次访问（无已存选择）或已存学期失效回退时，isRestoring 抑制 watch，
+  // 必须把最终选中的学期写回 store；否则后续选年级时 calendarId 为
+  // undefined（首次）或旧学期（回退），专业与课程将按错误学期加载。
+  const calendarChanged = calendarId !== undefined && calendarId !== restored.calendarId
+  if (calendarChanged) {
+    store.setMajorInfo({ calendarId, grade: undefined, major: undefined })
+    // 旧学期已失效：清掉其课程缓存，防跨学期污染（对齐学期变更 watch 语义）。
+    resetSelection()
+  }
   if (calendarId !== undefined) {
     await loadGrades(calendarId)
-    const selection = store.state.majorSelected
-    // loadGrades 已恢复匹配的年级；仅当年级恢复成功且有已存专业时再加载专业。
-    if (gradeValue.value && selection.major) {
+    // 仅当学期未变（有效恢复）且年级/专业均恢复成功时加载专业；
+    // 回退场景专业已清空，等用户重新选择（watch 使用已写回的 calendarId）。
+    if (gradeValue.value && restored.major && !calendarChanged) {
       await loadMajors(Number(gradeValue.value), calendarId)
     }
   }

--- a/apps/gooseforum/resource/test/schedule-major-selector.test.ts
+++ b/apps/gooseforum/resource/test/schedule-major-selector.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+
+import { i18n } from '../src/runtime/i18n'
+
+const getPkCalendars = vi.fn()
+const getPkGrades = vi.fn()
+const getPkMajors = vi.fn()
+vi.mock('../src/runtime/pk-api', () => ({
+  getPkCalendars: () => getPkCalendars(),
+  getPkGrades: (calendarId: number) => getPkGrades(calendarId),
+  getPkMajors: (grade: number, calendarId: number) => getPkMajors(grade, calendarId),
+}))
+
+import ScheduleMajorSelector from '../src/site/components/schedule/ScheduleMajorSelector.vue'
+import { useScheduleStore } from '../src/site/composables/useScheduleStore'
+
+/** 三个 SiteSelect：学期=0、年级=1、专业=2（顺序稳定，不依赖 locale 文案）。 */
+function comboboxes(wrapper: VueWrapper) {
+  return wrapper.findAll('[role="combobox"]')
+}
+
+/** 预置 store 中的已存选择（SchedulePage 挂载时 loadSolidify 的职责，测试直接设置）。 */
+function setStoredSelection(selection: { calendarId?: number; grade?: number; major?: string }) {
+  const store = useScheduleStore()
+  store.state.majorSelected = {
+    calendarId: selection.calendarId,
+    grade: selection.grade,
+    major: selection.major,
+  }
+}
+
+describe('ScheduleMajorSelector 初始化加载', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    localStorage.clear()
+    setStoredSelection({})
+    getPkCalendars.mockResolvedValue([{ calendarId: 121, calendarName: '2025-2026学年第2学期' }])
+  })
+
+  test('无已存选择时，默认第一个学期也应加载年级', async () => {
+    // 回归：restoreSelection 只在 localStorage 有完整选择时加载年级，
+    // 首次访问（无选择）Term 默认选中但 Grade 永远为空。
+    getPkGrades.mockResolvedValue([2025, 2024])
+    getPkMajors.mockResolvedValue([])
+
+    const wrapper = mount(ScheduleMajorSelector, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(getPkGrades).toHaveBeenCalledWith(121)
+
+    // Grade 下拉应包含年级选项（打开后可见 2025/2024）。
+    await comboboxes(wrapper)[1].trigger('click')
+    await flushPromises()
+    const options = wrapper.findAll('[role="option"]').map((o) => o.text())
+    expect(options).toContain('2025')
+    expect(options).toContain('2024')
+  })
+
+  test('localStorage 有完整选择时恢复年级+专业', async () => {
+    setStoredSelection({ calendarId: 121, grade: 2025, major: '00301' })
+    getPkGrades.mockResolvedValue([2025, 2024])
+    getPkMajors.mockResolvedValue([{ code: '00301', name: '2025(00301 数学类)' }])
+
+    const wrapper = mount(ScheduleMajorSelector, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(getPkGrades).toHaveBeenCalledWith(121)
+    expect(getPkMajors).toHaveBeenCalledWith(2025, 121)
+    // 已选年级与专业应显示在触发按钮上。
+    expect(comboboxes(wrapper)[1].text()).toContain('2025')
+    expect(comboboxes(wrapper)[2].text()).toContain('00301')
+  })
+
+  test('localStorage 学期已不存在时回退第一个学期并加载年级', async () => {
+    // 旧学期（如 122）被同步清空后，恢复逻辑应回退到当前学期并加载年级，
+    // 而不是按失效的 calendarId 请求空数据。
+    setStoredSelection({ calendarId: 122, grade: 2025, major: '00301' })
+    getPkGrades.mockResolvedValue([2025, 2024])
+    getPkMajors.mockResolvedValue([])
+
+    const wrapper = mount(ScheduleMajorSelector, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(getPkGrades).toHaveBeenCalledWith(121)
+    await comboboxes(wrapper)[1].trigger('click')
+    await flushPromises()
+    expect(wrapper.findAll('[role="option"]').map((o) => o.text())).toContain('2025')
+  })
+})

--- a/apps/gooseforum/resource/test/schedule-major-selector.test.ts
+++ b/apps/gooseforum/resource/test/schedule-major-selector.test.ts
@@ -39,16 +39,19 @@ describe('ScheduleMajorSelector 初始化加载', () => {
     getPkCalendars.mockResolvedValue([{ calendarId: 121, calendarName: '2025-2026学年第2学期' }])
   })
 
-  test('无已存选择时，默认第一个学期也应加载年级', async () => {
-    // 回归：restoreSelection 只在 localStorage 有完整选择时加载年级，
-    // 首次访问（无选择）Term 默认选中但 Grade 永远为空。
+  test('无已存选择时：默认学期加载年级并写回 store，选年级可加载专业', async () => {
+    // 回归（PR #323 review P1）：restoreSelection 期间 isRestoring 抑制 watch，
+    // 必须把最终学期写回 store；否则选年级时 calendarId 为 undefined，专业永远加载不出。
     getPkGrades.mockResolvedValue([2025, 2024])
-    getPkMajors.mockResolvedValue([])
+    getPkMajors.mockResolvedValue([{ code: '00301', name: '2025(00301 数学类)' }])
 
     const wrapper = mount(ScheduleMajorSelector, { global: { plugins: [i18n] } })
     await flushPromises()
 
+    // 默认第一个学期（121）已加载年级，且 store 中的学期已写回。
     expect(getPkGrades).toHaveBeenCalledWith(121)
+    const store = useScheduleStore()
+    expect(store.state.majorSelected.calendarId).toBe(121)
 
     // Grade 下拉应包含年级选项（打开后可见 2025/2024）。
     await comboboxes(wrapper)[1].trigger('click')
@@ -56,6 +59,12 @@ describe('ScheduleMajorSelector 初始化加载', () => {
     const options = wrapper.findAll('[role="option"]').map((o) => o.text())
     expect(options).toContain('2025')
     expect(options).toContain('2024')
+
+    // 用户选择年级 2025 → watch 触发 → 用已写回的 calendarId 加载专业。
+    const option = wrapper.findAll('[role="option"]').find((o) => o.text() === '2025')
+    await option!.trigger('click')
+    await flushPromises()
+    expect(getPkMajors).toHaveBeenCalledWith(2025, 121)
   })
 
   test('localStorage 有完整选择时恢复年级+专业', async () => {
@@ -84,8 +93,41 @@ describe('ScheduleMajorSelector 初始化加载', () => {
     await flushPromises()
 
     expect(getPkGrades).toHaveBeenCalledWith(121)
+
+    // P1：回退后 store 必须使用有效学期，旧学期/年级/专业清空（防跨学期污染）。
+    const store = useScheduleStore()
+    expect(store.state.majorSelected.calendarId).toBe(121)
+    expect(store.state.majorSelected.grade).toBeUndefined()
+    expect(store.state.majorSelected.major).toBeUndefined()
+
+    // 回退后年级下拉有数据，且用户重新选年级可用新学期加载专业。
     await comboboxes(wrapper)[1].trigger('click')
     await flushPromises()
     expect(wrapper.findAll('[role="option"]').map((o) => o.text())).toContain('2025')
+  })
+
+  test('localStorage 学期已不存在时清空旧学期已选课程', async () => {
+    // P1：替换失效学期时清掉旧学期课程缓存（对齐学期变更 watch 语义）。
+    const store = useScheduleStore()
+    store.state.commonLists.stagedCourses = [
+      {
+        courseCode: '122004',
+        courseName: '高等数学(122004)',
+        courseNameReserved: '高等数学',
+        credit: 4,
+        courseType: '必',
+        teacher: [],
+        status: 1,
+        courseDetail: [],
+      },
+    ]
+    setStoredSelection({ calendarId: 122, grade: 2025, major: '00301' })
+    getPkGrades.mockResolvedValue([2025, 2024])
+    getPkMajors.mockResolvedValue([])
+
+    mount(ScheduleMajorSelector, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(store.state.commonLists.stagedCourses).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

修复排课器 `/schedule` 年级/专业下拉为空（PR #322 合入后仍复现的场景）：**首次访问（无已存选择）或 localStorage 学期失效回退时**，Term 默认选中第一个学期但年级/专业永远为空。

## 根因（浏览器实测 dev.yourtj.de/schedule）

- 数据侧正常（121 学期 `gradeList:[2025..2020]`）、无 console 错误、无 grades 请求
- `ScheduleMajorSelector.restoreSelection()` 只在 localStorage 有完整 `calendarId+grade` 选择时才调用 `loadGrades`；首次访问或已存学期（如旧的 122）被同步清空回退时，Term 已默认选中但年级从不加载
- `isRestoring` 标志在初始化期间抑制 watch，所以也不会触发补加载

## 改动

- `resource/src/site/components/schedule/ScheduleMajorSelector.vue`：`restoreSelection()` 改为按最终选中的学期（恢复成功或默认第一个）无条件加载年级；年级恢复成功且有已存专业时再加载专业
- `resource/test/schedule-major-selector.test.ts`（新增）：3 个用例覆盖首次访问、完整恢复、失效学期回退（先红后绿）

## Verification

- 新测试先红（`getPkGrades` 0 次调用）→ 修复后 **3/3 通过**
- 全量前端测试 **231/231 通过**
- `pnpm typecheck` ✅、`pnpm build` ✅

只动前端选择器初始化逻辑，后端与契约未改。