### PR TITLE
[Fix] 修复认证、删除积分与异步投影一致性缺陷

### DIFF
--- a/apps/gooseforum/app/http/routes/routes_dump_test.go
+++ b/apps/gooseforum/app/http/routes/routes_dump_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
 	"github.com/gin-gonic/gin"
 )
 
@@ -43,6 +44,13 @@ func routesSnapshotPath(t *testing.T) string {
 func collectRouteSnapshot(t *testing.T) []routeSnapshotEntry {
 	t.Helper()
 	setupMcpRouteTestDB(t) // mcpRoute needs the page_config table migrated
+	// The committed snapshot describes the production single-binary route
+	// surface. Isolate this assembly from tests that temporarily switch the
+	// process-wide environment to local development (which enables Vite proxy
+	// routes under /assets/*path).
+	previousEnv := preferences.Get("app.env", "production")
+	preferences.Set("app.env", "production")
+	t.Cleanup(func() { preferences.Set("app.env", previousEnv) })
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	RegisterByGin(router)

--- a/apps/gooseforum/app/migration/migration.go
+++ b/apps/gooseforum/app/migration/migration.go
@@ -76,6 +76,10 @@ func migrateSchema() {
 	var err error
 
 	db := dbconnect.Connect()
+	if err = validateUniqueUserEmails(db); err != nil {
+		slog.Error("dbconnect migration email uniqueness preflight failed", "err", err)
+		os.Exit(1)
+	}
 	if err = validateUniqueUsernames(db); err != nil {
 		slog.Error("dbconnect migration preflight failed", "err", err)
 		os.Exit(1)
@@ -118,6 +122,41 @@ func migrateSchema() {
 type duplicateUsername struct {
 	Username string
 	Count    int64
+}
+
+type duplicateUserEmail struct {
+	Email string
+	Count int64
+}
+
+// validateUniqueUserEmails fails before AutoMigrate attempts to add the
+// partial unique index for non-empty user emails. Empty emails are valid for
+// bot/OAuth accounts and are intentionally excluded from the index. Identity
+// rows are never rewritten automatically: legacy duplicate non-empty emails
+// require an operator to resolve the conflicting accounts before startup.
+func validateUniqueUserEmails(db *gorm.DB) error {
+	if !db.Migrator().HasTable("users") {
+		return nil
+	}
+
+	var duplicates []duplicateUserEmail
+	if err := db.Table("users").
+		Select("email, COUNT(*) AS count").
+		Where("email IS NOT NULL AND email <> ?", "").
+		Group("email").
+		Having("COUNT(*) > 1").
+		Order("email ASC").
+		Limit(10).
+		Scan(&duplicates).Error; err != nil {
+		return fmt.Errorf("inspect duplicate user emails: %w", err)
+	}
+	if len(duplicates) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"cannot create uniq_users_email_nonempty: found duplicate non-empty user emails %v; resolve each conflicting account before restarting",
+		duplicates,
+	)
 }
 
 // validateUniqueUsernames fails before AutoMigrate attempts to add the global

--- a/apps/gooseforum/app/migration/migration_pg_test.go
+++ b/apps/gooseforum/app/migration/migration_pg_test.go
@@ -83,6 +83,7 @@ func TestSchemaMigratesOnPostgreSQL(t *testing.T) {
 	if !db.Migrator().HasColumn(&users.EntityComplete{}, "actor_type") {
 		t.Error("users.actor_type column missing after postgres migration")
 	}
+	assertUniqueUserEmailSchema(t, db)
 	assertPkFetchLogLeaseSchema(t, db)
 	assertPointsSourceKeySchema(t, db)
 	assertCourseTeacherIdentitySchema(t, db)
@@ -123,6 +124,9 @@ func TestSchemaUpgradeCreatesNewTablesOnPostgreSQL(t *testing.T) {
 	if err := db.Migrator().DropIndex(&users.EntityComplete{}, "uniq_users_username"); err != nil {
 		t.Fatalf("drop legacy-missing username index: %v", err)
 	}
+	if err := db.Migrator().DropIndex(&users.EntityComplete{}, "uniq_users_email_nonempty"); err != nil {
+		t.Fatalf("drop legacy-missing email index: %v", err)
+	}
 	if err := db.Migrator().DropColumn(&pointsRecord.Entity{}, "source_key"); err != nil {
 		t.Fatalf("drop legacy-missing points_record.source_key: %v", err)
 	}
@@ -138,6 +142,9 @@ func TestSchemaUpgradeCreatesNewTablesOnPostgreSQL(t *testing.T) {
 	if db.Migrator().HasIndex(&users.EntityComplete{}, "uniq_users_username") {
 		t.Fatal("precondition failed: legacy users table should not have username unique index")
 	}
+	if db.Migrator().HasIndex(&users.EntityComplete{}, "uniq_users_email_nonempty") {
+		t.Fatal("precondition failed: legacy users table should not have email unique index")
+	}
 	if db.Migrator().HasColumn(&pointsRecord.Entity{}, "source_key") {
 		t.Fatal("precondition failed: legacy points_record table should not have source_key")
 	}
@@ -148,6 +155,9 @@ func TestSchemaUpgradeCreatesNewTablesOnPostgreSQL(t *testing.T) {
 	// 部署新二进制：全量 AutoMigrate 应补齐新表且不破坏旧表
 	if err := validateUniqueUsernames(db); err != nil {
 		t.Fatalf("username preflight on postgres upgrade failed: %v", err)
+	}
+	if err := validateUniqueUserEmails(db); err != nil {
+		t.Fatalf("email preflight on postgres upgrade failed: %v", err)
 	}
 	if err := db.AutoMigrate(SchemaModels()...); err != nil {
 		t.Fatalf("upgrade AutoMigrate on postgres failed: %v", err)
@@ -183,6 +193,7 @@ func TestSchemaUpgradeCreatesNewTablesOnPostgreSQL(t *testing.T) {
 	if !db.Migrator().HasIndex(&users.EntityComplete{}, "uniq_users_username") {
 		t.Error("users username unique index missing after upgrade migration")
 	}
+	assertUniqueUserEmailSchema(t, db)
 	assertPkFetchLogLeaseSchema(t, db)
 	assertPointsSourceKeySchema(t, db)
 	assertCourseTeacherIdentitySchema(t, db)

--- a/apps/gooseforum/app/migration/migration_schema_test.go
+++ b/apps/gooseforum/app/migration/migration_schema_test.go
@@ -1,15 +1,101 @@
 package migration
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestUsersEmailSchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:migration-email-schema?mode=memory&cache=shared"), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&users.EntityComplete{}); err != nil {
+		t.Fatalf("migrate users schema: %v", err)
+	}
+	assertUniqueUserEmailSchema(t, db)
+}
+
+func TestValidateUniqueUserEmails(t *testing.T) {
+	tests := []struct {
+		name   string
+		emails []string
+		want   string
+	}{
+		{name: "missing table"},
+		{name: "unique non-empty and multiple empty", emails: []string{"alice@example.com", "", ""}},
+		{name: "duplicate non-empty", emails: []string{"alice@example.com", "alice@example.com"}, want: "alice@example.com"},
+	}
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:migration-email-%d?mode=memory&cache=shared", index)), &gorm.Config{})
+			if err != nil {
+				t.Fatalf("open sqlite: %v", err)
+			}
+			if tt.emails != nil {
+				if err := db.Exec(`CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL DEFAULT '')`).Error; err != nil {
+					t.Fatalf("create legacy users table: %v", err)
+				}
+				for _, email := range tt.emails {
+					if err := db.Exec("INSERT INTO users (email) VALUES (?)", email).Error; err != nil {
+						t.Fatalf("insert email %q: %v", email, err)
+					}
+				}
+			}
+
+			err = validateUniqueUserEmails(db)
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("validateUniqueUserEmails() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("validateUniqueUserEmails() error = %v, want containing %q", err, tt.want)
+			}
+			var count int64
+			if err := db.Table("users").Where("email = ?", tt.want).Count(&count).Error; err != nil {
+				t.Fatalf("count duplicate email rows: %v", err)
+			}
+			if count != 2 {
+				t.Fatalf("duplicate email row count = %d, want 2; validator must not rewrite data", count)
+			}
+		})
+	}
+}
+
+// assertUniqueUserEmailSchema verifies the cross-dialect contract: blank
+// emails remain compatible with bot/OAuth accounts, while non-empty emails
+// are rejected by the database even if application-level checks race.
+func assertUniqueUserEmailSchema(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if !db.Migrator().HasIndex(&users.EntityComplete{}, "uniq_users_email_nonempty") {
+		t.Fatal("users.uniq_users_email_nonempty partial unique index missing after migration")
+	}
+
+	for _, user := range []*users.EntityComplete{
+		{Username: "email-schema-empty-a"},
+		{Username: "email-schema-empty-b"},
+	} {
+		if err := db.Create(user).Error; err != nil {
+			t.Fatalf("insert empty-email user %q: %v", user.Username, err)
+		}
+	}
+	if err := db.Create(&users.EntityComplete{Username: "email-schema-nonempty", Email: "email-schema@example.com"}).Error; err != nil {
+		t.Fatalf("insert non-empty-email user: %v", err)
+	}
+	if err := db.Create(&users.EntityComplete{Username: "email-schema-duplicate", Email: "email-schema@example.com"}).Error; !errors.Is(err, gorm.ErrDuplicatedKey) {
+		t.Fatalf("duplicate non-empty email error = %v, want gorm.ErrDuplicatedKey", err)
+	}
+}
 
 func TestValidateUniqueUsernames(t *testing.T) {
 	tests := []struct {

--- a/apps/gooseforum/app/models/forum/posts/posts_rep.go
+++ b/apps/gooseforum/app/models/forum/posts/posts_rep.go
@@ -9,6 +9,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/postRevisions"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 func SaveOrCreateById(entity *Entity) int64 {
@@ -99,6 +100,12 @@ func ResetPendingReview(id uint64) error {
 	return builder().Unscoped().Where(queryopt.Eq("id", id)).Update("process_status", ProcessStatusNormal).Error
 }
 
+// ResetPendingReviewTx resets moderation state as part of the delete transaction.
+func ResetPendingReviewTx(tx *gorm.DB, id uint64) error {
+	return tx.Table(tableName).Unscoped().Where(queryopt.Eq("id", id)).
+		Update("process_status", ProcessStatusNormal).Error
+}
+
 // UpdateWikiSyncedContentTx 事务内只更新由 wiki 修订派生的首楼字段
 // （正文/渲染/版本/待审状态/水印/更新时间）。不得整行保存事务外读取的
 // 帖子——整行 Save 会把并发回复写入的统计字段回写成旧值（review High）。
@@ -120,6 +127,16 @@ func UnscopedGet(id uint64) (entity Entity) {
 	return
 }
 
+// GetUnscopedTx returns a post with a row lock held by the caller's transaction.
+// Delete and reward transitions must inspect the same post state before either
+// side of the transition is committed.
+func GetUnscopedTx(tx *gorm.DB, id uint64) (entity Entity, err error) {
+	err = tx.Table(tableName).Unscoped().
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where(queryopt.Eq("id", id)).Take(&entity).Error
+	return
+}
+
 // HasChildren 判断回复是否存在未被删除的子回复（reply_to_post_id 指向它）。
 func HasChildren(postId uint64) bool {
 	var count int64
@@ -128,6 +145,17 @@ func HasChildren(postId uint64) bool {
 		Where("deleted_at IS NULL").
 		Count(&count)
 	return count > 0
+}
+
+// HasChildrenTx checks for active children inside the caller's transaction.
+func HasChildrenTx(tx *gorm.DB, postID uint64) (bool, error) {
+	var count int64
+	if err := tx.Table(tableName).
+		Where(queryopt.Eq("reply_to_post_id", postID)).
+		Where("deleted_at IS NULL").Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 // GetUserDeletedPage 分页返回用户已删除的回复（含软删行与墓碑态行）。
@@ -171,6 +199,11 @@ func MarkUserDeleted(id uint64, deletedBy uint64, reason string) error {
 	}).Error
 }
 
+// MarkUserDeletedTx marks a post as user-deleted in the caller's transaction.
+func MarkUserDeletedTx(tx *gorm.DB, id uint64, deletedBy uint64, reason string) error {
+	return markDeletedTx(tx, id, VisibilityUserDeleted, deletedBy, reason, true)
+}
+
 // MarkUserDeletedKeepVisible 标记回复为用户删除但保留行可见（墓碑态）：
 // 用于"存在子回复"的场景，讨论树需要保留该行以维持结构，正文由前端渲染为占位。
 // 墓碑态行不置 deleted_at（保持讨论树可见），以 updated_at 作为删除时刻的近似：
@@ -184,6 +217,12 @@ func MarkUserDeletedKeepVisible(id uint64, deletedBy uint64, reason string) erro
 		"deleted_by":        deletedBy,
 		"delete_reason":     reason,
 	}).Error
+}
+
+// MarkUserDeletedKeepVisibleTx marks a post as a user-deleted tombstone in the
+// caller's transaction.
+func MarkUserDeletedKeepVisibleTx(tx *gorm.DB, id uint64, deletedBy uint64, reason string) error {
+	return markDeletedTx(tx, id, VisibilityUserDeleted, deletedBy, reason, false)
 }
 
 // MarkDeletedKeepVisible 标记回复为删除但保留行可见（墓碑态），visibility 区分用户/管理员来源。
@@ -209,6 +248,34 @@ func MarkModeratorRemoved(id uint64, deletedBy uint64, reason string) error {
 		"deleted_by":        deletedBy,
 		"delete_reason":     reason,
 	}).Error
+}
+
+// MarkModeratorRemovedTx marks a post as moderator-deleted in the caller's
+// transaction.
+func MarkModeratorRemovedTx(tx *gorm.DB, id uint64, deletedBy uint64, reason string) error {
+	return markDeletedTx(tx, id, VisibilityModeratorRemoved, deletedBy, reason, true)
+}
+
+func markDeletedTx(tx *gorm.DB, id uint64, visibility string, deletedBy uint64, reason string, setDeletedAt bool) error {
+	values := map[string]any{
+		"visibility_status": visibility,
+		"retention_status":  RetentionRecoverable,
+		"deleted_by":        deletedBy,
+		"delete_reason":     reason,
+	}
+	if setDeletedAt {
+		values["deleted_at"] = time.Now()
+	} else {
+		values["updated_at"] = time.Now()
+	}
+	result := tx.Table(tableName).Unscoped().Where(queryopt.Eq("id", id)).Updates(values)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 // SoftDeleteByIDs 按回复 ID 列表软删（级联删除），返回受影响行数。

--- a/apps/gooseforum/app/models/forum/users/users.go
+++ b/apps/gooseforum/app/models/forum/users/users.go
@@ -85,17 +85,17 @@ type ExternalInformation struct {
 
 type EntityComplete struct {
 	// base
-	Id             uint64     `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                                                //
-	Username       string     `gorm:"column:username;uniqueIndex:uniq_users_username;type:varchar(64);not null;default:'';" json:"username"` //
-	Email          string     `gorm:"column:email;index;type:varchar(128);not null;default:'';" json:"email"`                                //
-	Password       string     `gorm:"column:password;type:varchar(128);not null;default:'';" json:"-"`                                       //
-	TokenVersion   uint64     `gorm:"column:token_version;not null;default:0;" json:"-"`                                                     // 登录令牌版本，改密后自增
-	Locale         string     `gorm:"column:locale;type:varchar(16);not null;default:'';" json:"locale"`                                     // 用户语言偏好
-	IsFrozen       int8       `gorm:"column:is_frozen;not null;default:0;" json:"isFrozen"`                                                  // 状态：0正常 1冻结
-	IsActivated    int8       `gorm:"column:is_activated;not null;default:0;" json:"isActivated"`                                            // 是否验证通过: 0未激活 1 已激活
-	ActivatedAt    *time.Time `gorm:"column:activated_at;" json:"activatedAt"`                                                               // 激活时间
-	EmailChangedAt *time.Time `gorm:"column:email_changed_at;" json:"emailChangedAt"`                                                        // 邮箱变更时间（24 小时冷静期起点）
-	ActorType      int8       `gorm:"column:actor_type;not null;default:0;" json:"actorType"`                                                // 账号主体类型：0 人类 1 机器人（Agent）
+	Id             uint64     `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`                                                                         //
+	Username       string     `gorm:"column:username;uniqueIndex:uniq_users_username;type:varchar(64);not null;default:'';" json:"username"`                          //
+	Email          string     `gorm:"column:email;index;uniqueIndex:uniq_users_email_nonempty,where:email <> '';type:varchar(128);not null;default:'';" json:"email"` // 非空邮箱全局唯一；空邮箱允许多个机器人/OAuth账号共存
+	Password       string     `gorm:"column:password;type:varchar(128);not null;default:'';" json:"-"`                                                                //
+	TokenVersion   uint64     `gorm:"column:token_version;not null;default:0;" json:"-"`                                                                              // 登录令牌版本，改密后自增
+	Locale         string     `gorm:"column:locale;type:varchar(16);not null;default:'';" json:"locale"`                                                              // 用户语言偏好
+	IsFrozen       int8       `gorm:"column:is_frozen;not null;default:0;" json:"isFrozen"`                                                                           // 状态：0正常 1冻结
+	IsActivated    int8       `gorm:"column:is_activated;not null;default:0;" json:"isActivated"`                                                                     // 是否验证通过: 0未激活 1 已激活
+	ActivatedAt    *time.Time `gorm:"column:activated_at;" json:"activatedAt"`                                                                                        // 激活时间
+	EmailChangedAt *time.Time `gorm:"column:email_changed_at;" json:"emailChangedAt"`                                                                                 // 邮箱变更时间（24 小时冷静期起点）
+	ActorType      int8       `gorm:"column:actor_type;not null;default:0;" json:"actorType"`                                                                         // 账号主体类型：0 人类 1 机器人（Agent）
 
 	// info
 	Nickname            string              `gorm:"column:nickname;type:varchar(64);not null;default:'';" json:"nickname"`                                  //

--- a/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
@@ -219,40 +219,58 @@ func clearTopicCaches(topicID uint64) {
 //   - 无子回复：软删，直接消失。
 //   - 有子回复：墓碑态（保留行可见，正文由前端渲染为占位），讨论树完整。
 func DeletePostByUser(userID uint64, postID uint64) (DeletePostResult, error) {
-	post := posts.Get(postID)
-	if post.Id == 0 || post.PostNo <= 1 {
-		return DeletePostResult{}, component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
-	}
-	if post.UserId != userID {
-		return DeletePostResult{}, component.NewMessageError(component.MessageTopicOperationDenied, "不能删除他人的回复", nil)
-	}
+	var post posts.Entity
+	var result DeletePostResult
+	err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
+		loaded, err := posts.GetUnscopedTx(tx, postID)
+		if errors.Is(err, gorm.ErrRecordNotFound) || loaded.Id == 0 {
+			return component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
+		}
+		if err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
+		if loaded.PostNo <= 1 {
+			return component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
+		}
+		post = loaded
+		if post.UserId != userID {
+			return component.NewMessageError(component.MessageTopicOperationDenied, "不能删除他人的回复", nil)
+		}
 
-	hasChildren := posts.HasChildren(postID)
-	if post.VisibilityStatus != posts.VisibilityActive || post.RetentionStatus != posts.RetentionNormal {
-		if post.VisibilityStatus == posts.VisibilityUserDeleted && post.DeletedBy == userID {
-			return DeletePostResult{HasChildren: hasChildren}, nil
+		hasChildren, err := posts.HasChildrenTx(tx, postID)
+		if err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
 		}
-		return DeletePostResult{}, component.NewMessageError(component.MessageTopicOperationDenied, "该回复已被处理", nil)
-	}
-	// 撤销发帖积分（dev 合并语义：删除回复即撤销 PostCreated 奖励，防刷分）。
-	// 幂等：重复撤销由 points_record.source_key 唯一索引 + 既有 tombstone 保证；
-	// 失败则中止删除（帖子保持 ACTIVE，用户可重试）。
-	if err := pointservice.ReversePostReward(post.UserId, postID); err != nil {
-		return DeletePostResult{}, component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
-	}
-	if hasChildren {
-		if err := posts.MarkUserDeletedKeepVisible(postID, userID, ""); err != nil {
-			return DeletePostResult{}, component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		result.HasChildren = hasChildren
+		if post.VisibilityStatus != posts.VisibilityActive || post.RetentionStatus != posts.RetentionNormal {
+			if post.VisibilityStatus == posts.VisibilityUserDeleted && post.DeletedBy == userID {
+				return nil
+			}
+			return component.NewMessageError(component.MessageTopicOperationDenied, "该回复已被处理", nil)
 		}
-	} else {
-		if err := posts.MarkUserDeleted(postID, userID, ""); err != nil {
-			return DeletePostResult{}, component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+
+		// Reward reversal and content deletion must commit or roll back together.
+		// ReversePostRewardTx is idempotent through the deletion tombstone key.
+		if err := pointservice.ReversePostRewardTx(tx, post.UserId, postID); err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
 		}
+		if hasChildren {
+			err = posts.MarkUserDeletedKeepVisibleTx(tx, postID, userID, "")
+		} else {
+			err = posts.MarkUserDeletedTx(tx, postID, userID, "")
+		}
+		if err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
+		// 作废待审状态：被删回复不应继续停留在管理审核队列（PRD R1）。
+		if err := posts.ResetPendingReviewTx(tx, postID); err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
+		return nil
+	})
+	if err != nil {
+		return DeletePostResult{}, err
 	}
-	// 作废待审状态：被删回复不应继续停留在管理审核队列（PRD R1）。
-	_ = posts.ResetPendingReview(postID)
-	// 回滚创建奖励（对齐 dev 删除路径的积分语义）。
-	reversePostReward(post.UserId, postID)
 
 	topicEntity := topics.GetSimple(post.TopicId)
 	if topicEntity.Id > 0 {
@@ -270,7 +288,7 @@ func DeletePostByUser(userID uint64, postID uint64) (DeletePostResult, error) {
 	})
 	moderationservice.PostDeleted(userID, postDeletionSnapshot(post), "", userID)
 	recordEvent(contentDeleteEvent.EventDeleted, ContentTypePost, postID, post.TopicId, userID)
-	return DeletePostResult{HasChildren: hasChildren}, nil
+	return result, nil
 }
 
 // DeletePostAsModerator 管理员删除回复（治理删除），作者不可自行恢复。
@@ -278,32 +296,45 @@ func DeletePostAsModerator(moderatorID uint64, postID uint64, reason string) err
 	if strings.TrimSpace(reason) == "" {
 		return component.NewMessageError(component.MessageRequestInvalidParams, "管理员删除回复必须填写原因", nil)
 	}
-	// 用 UnscopedGet 读取含已软删行：作者自删（USER_DELETED）的回复也必须能
-	// 升级为治理删除，否则"自删+恢复"可绕过版主删除（review H1 逃罚）。
-	post := posts.UnscopedGet(postID)
-	if post.Id == 0 {
-		return component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
-	}
-	// 首楼守卫：治理删除话题应走 admin/topics/delete，不允许通过回复删除端点
-	// 删除话题首楼（否则话题渲染/搜索索引/统计错乱，review H3）。
-	if post.PostNo <= 1 {
-		return component.NewMessageError(component.MessageRequestInvalidParams, "不能删除话题首楼，请使用话题删除", nil)
-	}
-	// 幂等：已 PURGED 或隐私擦除（ACCOUNT_ANONYMIZED）的内容不再处理。
-	if post.RetentionStatus == posts.RetentionPurged {
+	var post posts.Entity
+	if err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
+		loaded, err := posts.GetUnscopedTx(tx, postID)
+		if errors.Is(err, gorm.ErrRecordNotFound) || loaded.Id == 0 {
+			return component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
+		}
+		if err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
+		post = loaded
+		// 首楼守卫：治理删除话题应走 admin/topics/delete，不允许通过回复删除端点
+		// 删除话题首楼（否则话题渲染/搜索索引/统计错乱，review H3）。
+		if post.PostNo <= 1 {
+			return component.NewMessageError(component.MessageRequestInvalidParams, "不能删除话题首楼，请使用话题删除", nil)
+		}
+		// 幂等：已 PURGED 或隐私擦除（ACCOUNT_ANONYMIZED）的内容不再处理。
+		if post.RetentionStatus == posts.RetentionPurged {
+			return nil
+		}
+		// 幂等：已是治理删除态，直接成功（不覆盖原删除原因）。
+		if post.VisibilityStatus == posts.VisibilityModeratorRemoved {
+			return nil
+		}
+
+		// Reward reversal and moderator deletion must commit or roll back together.
+		if err := pointservice.ReversePostRewardTx(tx, post.UserId, postID); err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
+		if err := posts.MarkModeratorRemovedTx(tx, postID, moderatorID, reason); err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
+		// 作废待审状态：被删回复不应继续停留在管理审核队列（PRD R1）。
+		if err := posts.ResetPendingReviewTx(tx, postID); err != nil {
+			return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
+		}
 		return nil
+	}); err != nil {
+		return err
 	}
-	// 幂等：已是治理删除态，直接成功（不覆盖原删除原因）。
-	if post.VisibilityStatus == posts.VisibilityModeratorRemoved {
-		return nil
-	}
-	if err := posts.MarkModeratorRemoved(postID, moderatorID, reason); err != nil {
-		return component.NewMessageError(component.MessageContentDeleteFailed, "删除回复失败", component.MessageParams{"error": err.Error()})
-	}
-	// 作废待审状态：被删回复不应继续停留在管理审核队列（PRD R1）。
-	_ = posts.ResetPendingReview(postID)
-	// 回滚创建奖励（治理删除同样撤销积分）。
-	reversePostReward(post.UserId, postID)
 	fileusageservice.HardenTargetFiles(postsTarget(postID), time.Now().Add(RecoveryWindow))
 	topicEntity := topics.GetSimple(post.TopicId)
 	if topicEntity.Id > 0 {
@@ -813,19 +844,6 @@ func topicsTarget(topicID uint64) fileusageservice.TargetRef {
 
 func postsTarget(postID uint64) fileusageservice.TargetRef {
 	return fileusageservice.TargetRef{TargetType: "post", TargetID: postID}
-}
-
-// reversePostReward 删除回复时回滚其创建奖励（与 dev 物理删除路径一致）。
-// ReversePostRewardTx 幂等：无对应奖励记录时只写回滚墓碑、不动余额。
-func reversePostReward(userId, postID uint64) {
-	if userId == 0 || postID == 0 {
-		return
-	}
-	if err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
-		return pointservice.ReversePostRewardTx(tx, userId, postID)
-	}); err != nil {
-		slog.Error("reverse post reward on delete failed", "userId", userId, "postId", postID, "err", err)
-	}
 }
 
 // reapplyPostReward 恢复回复时回补创建奖励。先清除删除回滚墓碑（post-deleted:ID），

--- a/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
@@ -223,7 +223,7 @@ func DeletePostByUser(userID uint64, postID uint64) (DeletePostResult, error) {
 	var result DeletePostResult
 	err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
 		loaded, err := posts.GetUnscopedTx(tx, postID)
-		if errors.Is(err, gorm.ErrRecordNotFound) || loaded.Id == 0 {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
 		}
 		if err != nil {
@@ -299,7 +299,7 @@ func DeletePostAsModerator(moderatorID uint64, postID uint64, reason string) err
 	var post posts.Entity
 	if err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
 		loaded, err := posts.GetUnscopedTx(tx, postID)
-		if errors.Is(err, gorm.ErrRecordNotFound) || loaded.Id == 0 {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return component.NewMessageError(component.MessagePostNotFound, "回复不存在", nil)
 		}
 		if err != nil {

--- a/apps/gooseforum/app/service/contentdeleteservice/reward_consistency_test.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/reward_consistency_test.go
@@ -1,0 +1,126 @@
+package contentdeleteservice
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pointsRecord"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userPoints"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/pointservice"
+	"gorm.io/gorm"
+)
+
+func TestDeletePostByUserRollsBackRewardWhenContentDeleteFails(t *testing.T) {
+	conn := setupContentDeleteTestDB(t)
+	const topicID uint64 = 950100
+	_, replyAuthorID := seedTopicWithOptionalReply(t, conn, topicID, true)
+	const postID = topicID + 200
+	seedReplyReward(t, conn, replyAuthorID, postID)
+
+	installSQLiteTrigger(t, conn, "fail_user_post_delete", fmt.Sprintf(
+		"CREATE TRIGGER fail_user_post_delete BEFORE UPDATE OF visibility_status ON posts "+
+			"WHEN OLD.id = %d AND NEW.visibility_status = '%s' BEGIN "+
+			"SELECT RAISE(ABORT, 'forced user content delete failure'); END",
+		postID, posts.VisibilityUserDeleted,
+	))
+
+	if _, err := DeletePostByUser(replyAuthorID, postID); err == nil {
+		t.Fatal("DeletePostByUser succeeded despite forced content update failure")
+	}
+	assertPostRemainsActive(t, conn, postID)
+	assertReplyRewardUnchanged(t, conn, replyAuthorID, postID)
+}
+
+func TestDeletePostAsModeratorRollsBackContentWhenRewardReversalFails(t *testing.T) {
+	conn := setupContentDeleteTestDB(t)
+	const topicID uint64 = 950500
+	_, replyAuthorID := seedTopicWithOptionalReply(t, conn, topicID, true)
+	const postID = topicID + 200
+	seedReplyReward(t, conn, replyAuthorID, postID)
+
+	installSQLiteTrigger(t, conn, "fail_moderator_reward_reversal", fmt.Sprintf(
+		"CREATE TRIGGER fail_moderator_reward_reversal BEFORE INSERT ON points_record "+
+			"WHEN NEW.source_key = 'post-deleted:%d' BEGIN "+
+			"SELECT RAISE(ABORT, 'forced reward reversal failure'); END",
+		postID,
+	))
+
+	if err := DeletePostAsModerator(topicID+99, postID, "forced failure test"); err == nil {
+		t.Fatal("DeletePostAsModerator succeeded despite forced reward reversal failure")
+	}
+	assertPostRemainsActive(t, conn, postID)
+	assertReplyRewardUnchanged(t, conn, replyAuthorID, postID)
+}
+
+func installSQLiteTrigger(t *testing.T, conn *gorm.DB, name, statement string) {
+	t.Helper()
+	if err := conn.Exec(statement).Error; err != nil {
+		t.Fatalf("install forced-failure trigger: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Exec("DROP TRIGGER IF EXISTS " + name).Error; err != nil {
+			t.Errorf("drop forced-failure trigger %s: %v", name, err)
+		}
+	})
+}
+
+func seedReplyReward(t *testing.T, conn *gorm.DB, userID, postID uint64) {
+	t.Helper()
+	if err := conn.Model(&users.EntityComplete{}).Where("id = ?", userID).Update("prestige", pointservice.PostCreatedReward).Error; err != nil {
+		t.Fatalf("seed user prestige: %v", err)
+	}
+	if err := conn.Create(&userPoints.Entity{UserId: userID, CurrentPoints: 100 + pointservice.PostCreatedReward}).Error; err != nil {
+		t.Fatalf("seed user points: %v", err)
+	}
+	sourceKey := fmt.Sprintf("post:%d", postID)
+	if err := conn.Create(&pointsRecord.Entity{
+		UserId:       userID,
+		Action:       pointservice.PointsActionPostCreated.Code(),
+		PointsChange: pointservice.PostCreatedReward,
+		SourceKey:    &sourceKey,
+	}).Error; err != nil {
+		t.Fatalf("seed post reward: %v", err)
+	}
+}
+
+func assertPostRemainsActive(t *testing.T, conn *gorm.DB, postID uint64) {
+	t.Helper()
+	var post posts.Entity
+	if err := conn.Unscoped().Where("id = ?", postID).Take(&post).Error; err != nil {
+		t.Fatalf("load post after forced failure: %v", err)
+	}
+	if post.VisibilityStatus != posts.VisibilityActive || post.RetentionStatus != posts.RetentionNormal || post.DeletedAt.Valid {
+		t.Fatalf("post state after forced failure = %s/%s deleted=%t, want ACTIVE/NORMAL/not deleted", post.VisibilityStatus, post.RetentionStatus, post.DeletedAt.Valid)
+	}
+}
+
+func assertReplyRewardUnchanged(t *testing.T, conn *gorm.DB, userID, postID uint64) {
+	t.Helper()
+	var balance userPoints.Entity
+	if err := conn.Where("user_id = ?", userID).Take(&balance).Error; err != nil {
+		t.Fatalf("load user points after forced failure: %v", err)
+	}
+	if balance.CurrentPoints != 100+pointservice.PostCreatedReward {
+		t.Errorf("current points after forced failure = %d, want %d", balance.CurrentPoints, 100+pointservice.PostCreatedReward)
+	}
+	var user users.EntityComplete
+	if err := conn.Where("id = ?", userID).Take(&user).Error; err != nil {
+		t.Fatalf("load user after forced failure: %v", err)
+	}
+	if user.Prestige != pointservice.PostCreatedReward {
+		t.Errorf("prestige after forced failure = %d, want %d", user.Prestige, pointservice.PostCreatedReward)
+	}
+	var original pointsRecord.Entity
+	if err := conn.Where("source_key = ?", fmt.Sprintf("post:%d", postID)).Take(&original).Error; err != nil {
+		t.Fatalf("load original reward after forced failure: %v", err)
+	}
+	var reversalCount int64
+	if err := conn.Model(&pointsRecord.Entity{}).Where("source_key = ?", fmt.Sprintf("post-deleted:%d", postID)).Count(&reversalCount).Error; err != nil {
+		t.Fatalf("count reversal after forced failure: %v", err)
+	}
+	if reversalCount != 0 {
+		t.Errorf("reversal records after forced failure = %d, want 0", reversalCount)
+	}
+}

--- a/apps/gooseforum/app/service/courseservice/importer.go
+++ b/apps/gooseforum/app/service/courseservice/importer.go
@@ -34,11 +34,12 @@ type ImportManifest struct {
 	Counts            map[string]int    `yaml:"counts" json:"counts"`
 }
 
-// ImportError 单行导入错误。
+// ImportError 单行导入错误。ExternalID 为外部实体 ID；catalog 导入的业务隔离错误必须设置。
 type ImportError struct {
-	Line   int    `json:"line"`
-	Entity string `json:"entity"`
-	Reason string `json:"reason"`
+	Line       int    `json:"line"`
+	Entity     string `json:"entity"`
+	ExternalID string `json:"externalId,omitempty"`
+	Reason     string `json:"reason"`
 }
 
 // CatalogImportReport 目录导入结果报告。
@@ -312,14 +313,20 @@ func parseJSONL[T any](data []byte, out *[]T) (int, error) {
 
 // validateRows 校验行间约束与依赖；dry-run 与真实导入共用，保证语义一致。
 // 返回被隔离的行集合（entityType|externalID -> true），applyRows 会跳过这些行。
+func quarantineCatalogRow(report *CatalogImportReport, entity, externalID, reason string) {
+	report.Quarantined++
+	report.Errors = append(report.Errors, ImportError{
+		Entity:     entity,
+		ExternalID: externalID,
+		Reason:     reason,
+	})
+}
+
 func validateRows(rows importRows, report *CatalogImportReport) map[string]bool {
 	quarantined := make(map[string]bool)
-	quarantine := func(entity, key, reason string) {
-		report.Quarantined++
-		report.Errors = append(report.Errors, ImportError{Entity: entity, Reason: reason})
-		if key != "" {
-			quarantined[key] = true
-		}
+	quarantine := func(entity, externalID, reason string) {
+		quarantineCatalogRow(report, entity, externalID, reason)
+		quarantined[entity+"|"+externalID] = true
 	}
 
 	// (primary_code, teacher_code) 复合去重（issue #326）：同一 code 不同教师
@@ -328,23 +335,22 @@ func validateRows(rows importRows, report *CatalogImportReport) map[string]bool 
 	externalIDs := make(map[string]string) // external id -> primary_code
 	for _, row := range rows.courses {
 		code := strings.TrimSpace(row.Code)
-		key := course.EntityTypeCourse + "|" + row.ID
 		if strings.TrimSpace(row.ID) == "" {
-			quarantine("course", key, "missing external id")
+			quarantine("course", row.ID, "missing external id")
 			continue
 		}
 		if prev, ok := externalIDs[row.ID]; ok && prev != code {
-			quarantine("course", key, fmt.Sprintf("duplicate external id %s (codes %s vs %s)", row.ID, prev, code))
+			quarantine("course", row.ID, fmt.Sprintf("duplicate external id %s (codes %s vs %s)", row.ID, prev, code))
 			continue
 		}
 		externalIDs[row.ID] = code
 		if code == "" || strings.TrimSpace(row.Name) == "" {
-			quarantine("course", key, "missing code or name")
+			quarantine("course", row.ID, "missing code or name")
 			continue
 		}
 		dupKey := code + "|" + strings.TrimSpace(row.TeacherCode)
 		if prev, ok := courseByKey[dupKey]; ok && prev != row.ID {
-			quarantine("course", key, fmt.Sprintf("duplicate (code, teacher) %s (external %s vs %s)", dupKey, prev, row.ID))
+			quarantine("course", row.ID, fmt.Sprintf("duplicate (code, teacher) %s (external %s vs %s)", dupKey, prev, row.ID))
 			continue
 		}
 		courseByKey[dupKey] = row.ID
@@ -352,14 +358,13 @@ func validateRows(rows importRows, report *CatalogImportReport) map[string]bool 
 	// alias 冲突检查：manifest 内 + 已入库
 	batchAliases := make(map[string]string) // normalized -> course external id
 	for _, row := range rows.courses {
-		key := course.EntityTypeCourse + "|" + row.ID
 		for _, alias := range row.Aliases {
 			norm := Normalize(alias)
 			if norm == "" {
 				continue
 			}
 			if prev, ok := batchAliases[norm]; ok && prev != row.ID {
-				quarantine("course", key, fmt.Sprintf("alias %q conflicts within manifest (course %s)", alias, prev))
+				quarantine("course", row.ID, fmt.Sprintf("alias %q conflicts within manifest (course %s)", alias, prev))
 				continue
 			}
 			batchAliases[norm] = row.ID
@@ -367,7 +372,7 @@ func validateRows(rows importRows, report *CatalogImportReport) map[string]bool 
 			if err == nil {
 				existingCourse := course.GetCourse(existing.CourseId)
 				if existingCourse.PrimaryCode != row.Code {
-					quarantine("course", key, fmt.Sprintf("alias %q conflicts with course %s", alias, existingCourse.PrimaryCode))
+					quarantine("course", row.ID, fmt.Sprintf("alias %q conflicts with course %s", alias, existingCourse.PrimaryCode))
 				}
 			}
 		}
@@ -375,15 +380,14 @@ func validateRows(rows importRows, report *CatalogImportReport) map[string]bool 
 	instructorKeys := make(map[string]string) // name|dept -> external id
 	instructorIDs := make(map[string]struct{})
 	for _, row := range rows.instructors {
-		key := course.EntityTypeInstructor + "|" + row.ID
 		if strings.TrimSpace(row.ID) == "" {
-			quarantine("instructor", key, "missing external id")
+			quarantine("instructor", row.ID, "missing external id")
 			continue
 		}
 		instructorIDs[row.ID] = struct{}{}
 		naturalKey := Normalize(row.Name) + "|" + Normalize(row.Department)
 		if prev, ok := instructorKeys[naturalKey]; ok && prev != row.ID {
-			quarantine("instructor", key, fmt.Sprintf("ambiguous natural key %q (external %s vs %s)", naturalKey, prev, row.ID))
+			quarantine("instructor", row.ID, fmt.Sprintf("ambiguous natural key %q (external %s vs %s)", naturalKey, prev, row.ID))
 			delete(instructorIDs, row.ID)
 			continue
 		}
@@ -401,7 +405,7 @@ func validateRows(rows importRows, report *CatalogImportReport) map[string]bool 
 		tc := strings.TrimSpace(row.TeacherCode)
 		if tc != "" {
 			if _, ok := instructorIDs[tc]; !ok {
-				quarantine("course", key, fmt.Sprintf("unresolvable teacher_code %s", tc))
+				quarantine("course", row.ID, fmt.Sprintf("unresolvable teacher_code %s", tc))
 			}
 		}
 	}
@@ -411,26 +415,25 @@ func validateRows(rows importRows, report *CatalogImportReport) map[string]bool 
 		courseIDs[row.ID] = struct{}{}
 	}
 	for _, row := range rows.offerings {
-		key := course.EntityTypeOffering + "|" + row.ID
 		if strings.TrimSpace(row.ID) == "" {
-			quarantine("offering", key, "missing external id")
+			quarantine("offering", row.ID, "missing external id")
 			continue
 		}
 		if _, ok := courseIDs[row.CourseID]; !ok {
-			quarantine("offering", key, fmt.Sprintf("unknown course_id %s", row.CourseID))
+			quarantine("offering", row.ID, fmt.Sprintf("unknown course_id %s", row.CourseID))
 			continue
 		}
 		if quarantined[course.EntityTypeCourse+"|"+row.CourseID] {
-			quarantine("offering", key, fmt.Sprintf("course %s quarantined", row.CourseID))
+			quarantine("offering", row.ID, fmt.Sprintf("course %s quarantined", row.CourseID))
 			continue
 		}
 		if strings.TrimSpace(row.Term) == "" {
-			quarantine("offering", key, "missing term")
+			quarantine("offering", row.ID, "missing term")
 			continue
 		}
 		for _, insID := range row.InstructorIDs {
 			if _, ok := instructorIDs[insID]; !ok {
-				quarantine("offering", key, fmt.Sprintf("unresolvable instructor_id %s", insID))
+				quarantine("offering", row.ID, fmt.Sprintf("unresolvable instructor_id %s", insID))
 				break
 			}
 		}
@@ -520,7 +523,7 @@ func applyCourseRow(tx *gorm.DB, runID uint64, source string, row importCourseRo
 	code := strings.TrimSpace(row.Code)
 	name := strings.TrimSpace(row.Name)
 	if code == "" || name == "" {
-		report.Quarantined++
+		quarantineCatalogRow(report, "course", row.ID, "missing code or name")
 		return nil
 	}
 	checksum := rowChecksum(row)
@@ -548,8 +551,11 @@ func applyCourseRow(tx *gorm.DB, runID uint64, source string, row importCourseRo
 	if tc := strings.TrimSpace(row.TeacherCode); tc != "" {
 		insID, err := sourceRefLocalID(tx, source, tc, course.EntityTypeInstructor)
 		if err != nil {
-			report.Quarantined++
-			return nil //nolint:nilerr // 教师引用不可解析 → 隔离该行（与 offering 引用不可解析同语义），不中断整批导入
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				quarantineCatalogRow(report, "course", row.ID, fmt.Sprintf("unresolvable teacher_code %s", tc))
+				return nil
+			}
+			return fmt.Errorf("lookup instructor source ref %s: %w", tc, err)
 		}
 		teacherId = insID
 	}
@@ -607,7 +613,7 @@ func applyCourseRow(tx *gorm.DB, runID uint64, source string, row importCourseRo
 		existingAlias, err := course.GetAliasByNormalizedValueTx(tx, course.AliasKindName, norm)
 		if err == nil {
 			if existingAlias.CourseId != entity.Id {
-				report.Quarantined++
+				quarantineCatalogRow(report, "course", row.ID, fmt.Sprintf("alias %q conflicts with course %d", alias, existingAlias.CourseId))
 				continue
 			}
 			// 同课程已存在：若此前被软删（唯一索引仍占位），恢复该行
@@ -660,7 +666,7 @@ func applyCourseRow(tx *gorm.DB, runID uint64, source string, row importCourseRo
 func applyInstructorRow(tx *gorm.DB, runID uint64, source string, row importInstructorRow, report *CatalogImportReport) error {
 	name := strings.TrimSpace(row.Name)
 	if name == "" {
-		report.Quarantined++
+		quarantineCatalogRow(report, "instructor", row.ID, "missing name")
 		return nil
 	}
 	checksum := rowChecksum(row)
@@ -738,8 +744,11 @@ func applyInstructorRow(tx *gorm.DB, runID uint64, source string, row importInst
 func applyOfferingRow(tx *gorm.DB, runID uint64, source string, row importOfferingRow, report *CatalogImportReport) error {
 	courseLocalID, err := sourceRefLocalID(tx, source, row.CourseID, course.EntityTypeCourse)
 	if err != nil {
-		report.Quarantined++
-		return nil
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			quarantineCatalogRow(report, "offering", row.ID, fmt.Sprintf("unresolvable course_id %s", row.CourseID))
+			return nil
+		}
+		return fmt.Errorf("lookup course source ref %s: %w", row.CourseID, err)
 	}
 	checksum := rowChecksum(row)
 	termEntity, err := getOrCreateTermTx(tx, strings.TrimSpace(row.Term))
@@ -751,8 +760,11 @@ func applyOfferingRow(tx *gorm.DB, runID uint64, source string, row importOfferi
 	for _, insID := range row.InstructorIDs {
 		ins, err := sourceRefLocalID(tx, source, insID, course.EntityTypeInstructor)
 		if err != nil {
-			report.Quarantined++
-			return nil
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				quarantineCatalogRow(report, "offering", row.ID, fmt.Sprintf("unresolvable instructor_id %s", insID))
+				return nil
+			}
+			return fmt.Errorf("lookup instructor source ref %s: %w", insID, err)
 		}
 		instructorLocalIDs = append(instructorLocalIDs, ins)
 	}

--- a/apps/gooseforum/app/service/courseservice/importer_test.go
+++ b/apps/gooseforum/app/service/courseservice/importer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
 )
 
 // writeManifestFixture 在临时目录写入 JSONL 数据文件并生成带 sha256 的 manifest（source 固定 test-fixture）。
@@ -341,4 +344,155 @@ func TestImportCatalogIsolatesSources(t *testing.T) {
 	if refA.LocalId == refB.LocalId {
 		t.Fatalf("two sources must map to distinct courses, both local_id=%d", refA.LocalId)
 	}
+}
+
+func TestValidateRowsOfferingQuarantineIncludesExternalID(t *testing.T) {
+	rows := importRows{
+		courses: []importCourseRow{{ID: "c1", Code: "100001", Name: "高等数学"}},
+		offerings: []importOfferingRow{
+			{ID: "o-missing-course", CourseID: "missing-course", Term: "2025-2026-1"},
+			{ID: "o-missing-instructor", CourseID: "c1", Term: "2025-2026-1", InstructorIDs: []string{"missing-instructor"}},
+		},
+	}
+	report := &CatalogImportReport{Errors: []ImportError{}}
+
+	quarantined := validateRows(rows, report)
+
+	if !quarantined[course.EntityTypeOffering+"|o-missing-course"] || !quarantined[course.EntityTypeOffering+"|o-missing-instructor"] {
+		t.Fatalf("expected both offering rows to be quarantined, got %v", quarantined)
+	}
+	if report.Quarantined != 2 || len(report.Errors) != 2 {
+		t.Fatalf("expected two offering quarantine errors, got quarantined=%d errors=%v", report.Quarantined, report.Errors)
+	}
+	for _, err := range report.Errors {
+		if err.Entity != "offering" || err.ExternalID == "" || err.Reason == "" {
+			t.Fatalf("offering quarantine error must include entity, external ID, and reason: %+v", err)
+		}
+	}
+}
+
+func TestImportCatalogOfferingQuarantineDryRunParity(t *testing.T) {
+	migrateCourseImportTables(t)
+	manifestPath := writeManifestFixture(t, map[string]string{
+		"courses.jsonl":     `{"id":"c1","code":"100001","name":"高等数学"}` + "\n",
+		"instructors.jsonl": `{"id":"i1","name":"张三","department":"数学科学学院"}` + "\n",
+		"offerings.jsonl":   `{"id":"o1","course_id":"c1","term":"2025-2026-1","instructor_ids":["missing-instructor"]}` + "\n",
+	})
+
+	dryReport, err := ImportCatalog(context.Background(), manifestPath, true)
+	if err != nil {
+		t.Fatalf("dry-run import: %v", err)
+	}
+	realReport, err := ImportCatalog(context.Background(), manifestPath, false)
+	if err != nil {
+		t.Fatalf("real import: %v", err)
+	}
+
+	if dryReport.Quarantined != 1 || realReport.Quarantined != 1 {
+		t.Fatalf("dry-run and real import must quarantine one offering: dry=%+v real=%+v", dryReport, realReport)
+	}
+	if len(dryReport.Errors) != 1 || len(realReport.Errors) != 1 {
+		t.Fatalf("dry-run and real import must report one offering error: dry=%+v real=%+v", dryReport, realReport)
+	}
+	if dryReport.Errors[0] != realReport.Errors[0] {
+		t.Fatalf("dry-run and real import quarantine errors differ: dry=%+v real=%+v", dryReport.Errors[0], realReport.Errors[0])
+	}
+	if got := realReport.Errors[0]; got.Entity != "offering" || got.ExternalID != "o1" || got.Reason != "unresolvable instructor_id missing-instructor" {
+		t.Fatalf("unexpected offering quarantine error: %+v", got)
+	}
+}
+
+func TestApplyOfferingRowQuarantinesMissingSourceRefWithReport(t *testing.T) {
+	db := newOfferingImportTestDB(t)
+	report := &CatalogImportReport{Errors: []ImportError{}}
+
+	err := applyOfferingRow(db, 1, "test-source", importOfferingRow{
+		ID:       "o-missing-course",
+		CourseID: "missing-course",
+		Term:     "2025-2026-1",
+	}, report)
+
+	if err != nil {
+		t.Fatalf("missing course source ref should quarantine, got error: %v", err)
+	}
+	if report.Quarantined != 1 || len(report.Errors) != 1 {
+		t.Fatalf("expected one quarantine error, got quarantined=%d errors=%v", report.Quarantined, report.Errors)
+	}
+	got := report.Errors[0]
+	if got.Entity != "offering" || got.ExternalID != "o-missing-course" || got.Reason != "unresolvable course_id missing-course" {
+		t.Fatalf("unexpected quarantine error: %+v", got)
+	}
+}
+
+func TestApplyOfferingRowQuarantinesMissingInstructorSourceRefWithReport(t *testing.T) {
+	db := newOfferingImportTestDB(t)
+	if err := db.Create(&course.SourceRefEntity{
+		ImportRunId: 1,
+		Source:      "test-source",
+		EntityType:  course.EntityTypeCourse,
+		ExternalId:  "course-1",
+		LocalId:     1,
+		Checksum:    "course-checksum",
+	}).Error; err != nil {
+		t.Fatalf("create course source ref: %v", err)
+	}
+	report := &CatalogImportReport{Errors: []ImportError{}}
+
+	err := applyOfferingRow(db, 1, "test-source", importOfferingRow{
+		ID:            "o-missing-instructor",
+		CourseID:      "course-1",
+		Term:          "2025-2026-1",
+		InstructorIDs: []string{"missing-instructor"},
+	}, report)
+
+	if err != nil {
+		t.Fatalf("missing instructor source ref should quarantine, got error: %v", err)
+	}
+	if report.Quarantined != 1 || len(report.Errors) != 1 {
+		t.Fatalf("expected one quarantine error, got quarantined=%d errors=%v", report.Quarantined, report.Errors)
+	}
+	got := report.Errors[0]
+	if got.Entity != "offering" || got.ExternalID != "o-missing-instructor" || got.Reason != "unresolvable instructor_id missing-instructor" {
+		t.Fatalf("unexpected quarantine error: %+v", got)
+	}
+}
+
+func TestApplyOfferingRowAbortsOnSourceRefDatabaseError(t *testing.T) {
+	db := newOfferingImportTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql db: %v", err)
+	}
+	if err := sqlDB.Close(); err != nil {
+		t.Fatalf("close sql db: %v", err)
+	}
+	report := &CatalogImportReport{Errors: []ImportError{}}
+
+	err = applyOfferingRow(db, 1, "test-source", importOfferingRow{
+		ID:       "o-database-error",
+		CourseID: "course-1",
+		Term:     "2025-2026-1",
+	}, report)
+
+	if err == nil {
+		t.Fatal("expected database error to abort offering batch")
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("database error must not be classified as business quarantine: %v", err)
+	}
+	if report.Quarantined != 0 || len(report.Errors) != 0 {
+		t.Fatalf("database error must not increment quarantine report: %+v", report)
+	}
+}
+
+func newOfferingImportTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "course-import.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&course.TermEntity{}, &course.SourceRefEntity{}); err != nil {
+		t.Fatalf("migrate test db: %v", err)
+	}
+	return db
 }

--- a/apps/gooseforum/app/service/courseservice/importer_test.go
+++ b/apps/gooseforum/app/service/courseservice/importer_test.go
@@ -491,6 +491,16 @@ func newOfferingImportTestDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
+	// Windows 下不关闭连接会锁住文件，导致 t.TempDir() 清理失败。
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sql db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close test db: %v", err)
+		}
+	})
 	if err := db.AutoMigrate(&course.TermEntity{}, &course.SourceRefEntity{}); err != nil {
 		t.Fatalf("migrate test db: %v", err)
 	}

--- a/apps/gooseforum/app/service/eventhandlers/search_handler.go
+++ b/apps/gooseforum/app/service/eventhandlers/search_handler.go
@@ -121,7 +121,10 @@ func handleUserSignUpSearchIndex(ctx context.Context, event *UserSignUpEvent) er
 	}
 	user, err := users.Get(event.UserId)
 	if err != nil {
-		return nil
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil
+		}
+		return err
 	}
 	_, err = searchservice.BuildSingleUserSearchDocument(&user)
 	return err

--- a/apps/gooseforum/app/service/eventhandlers/search_handler_test.go
+++ b/apps/gooseforum/app/service/eventhandlers/search_handler_test.go
@@ -90,8 +90,32 @@ func TestHandleUserSignUpSearchIndex(t *testing.T) {
 	if err := handleUserSignUpSearchIndex(ctx, nil); err != nil {
 		t.Fatalf("handleUserSignUpSearchIndex(nil) error = %v, want nil", err)
 	}
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
+		t.Fatalf("migrate users table: %v", err)
+	}
 	if err := handleUserSignUpSearchIndex(ctx, &UserSignUpEvent{UserId: 999999}); err != nil {
 		t.Fatalf("handleUserSignUpSearchIndex(event) error = %v, want nil", err)
+	}
+}
+
+func TestHandleUserSignUpSearchIndexReturnsDatabaseError(t *testing.T) {
+	ctx := context.Background()
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
+		t.Fatalf("migrate users table: %v", err)
+	}
+	if err := conn.Migrator().DropTable(&users.EntityComplete{}); err != nil {
+		t.Fatalf("drop users table: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
+			t.Errorf("restore users table: %v", err)
+		}
+	})
+
+	if err := handleUserSignUpSearchIndex(ctx, &UserSignUpEvent{UserId: 999999}); err == nil {
+		t.Fatal("handleUserSignUpSearchIndex(event) error = nil, want database error")
 	}
 }
 

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -29,6 +29,7 @@ import (
 	"github.com/markbates/goth/providers/github"
 	"github.com/markbates/goth/providers/google"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 )
 
 const (
@@ -169,8 +170,11 @@ func bindOAuthByTrustedEmail(userInfo OAuthUserInfo) (*users.EntityComplete, err
 	}
 
 	user, err := users.GetByEmail(userInfo.VerifiedEmail)
-	if err != nil || user.Id == 0 {
+	if errors.Is(err, gorm.ErrRecordNotFound) || (err == nil && user.Id == 0) {
 		return nil, nil // 无同邮箱账号，走注册
+	}
+	if err != nil {
+		return nil, fmt.Errorf("查询可信邮箱账号失败: %w", err)
 	}
 
 	// 与既有 OAuth 绑定路径一致的账号状态检查（issue #130 冻结语义保留）。

--- a/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
@@ -153,7 +153,7 @@ func TestCreateUserFromOAuthUnmatchedDomainFollowsSwitch(t *testing.T) {
 	})
 	user2, err := createUserFromOAuth(OAuthUserInfo{
 		ID: "2", Login: "outside-user2", Provider: ProviderGitHub,
-		VerifiedEmail: "bob@gmail.com", EmailVerified: true,
+		VerifiedEmail: "bob2@gmail.com", EmailVerified: true,
 	})
 	if err != nil {
 		t.Fatalf("createUserFromOAuth() error = %v", err)

--- a/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
@@ -248,6 +248,38 @@ func TestBindOAuthByTrustedEmailBindsExisting(t *testing.T) {
 	}
 }
 
+// TestBindOAuthByTrustedEmailPropagatesDatabaseError 数据库查询失败时不得降级为注册。
+func TestBindOAuthByTrustedEmailPropagatesDatabaseError(t *testing.T) {
+	conn := setupOAuthTestDB(t)
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		AllowedDomains: []string{"tongji.edu.cn"},
+	})
+
+	if bound, err := bindOAuthByTrustedEmail(OAuthUserInfo{
+		VerifiedEmail: "missing@tongji.edu.cn",
+		EmailVerified: true,
+	}); bound != nil || err != nil {
+		t.Fatalf("bindOAuthByTrustedEmail() for missing account = (%v, %v), want (nil, nil)", bound, err)
+	}
+
+	if err := conn.Exec(`ALTER TABLE users RENAME TO users_lookup_error`).Error; err != nil {
+		t.Fatalf("rename users table: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Exec(`ALTER TABLE users_lookup_error RENAME TO users`).Error; err != nil {
+			t.Errorf("restore users table: %v", err)
+		}
+	})
+
+	_, err := bindOAuthByTrustedEmail(OAuthUserInfo{
+		VerifiedEmail: "broken@tongji.edu.cn",
+		EmailVerified: true,
+	})
+	if err == nil {
+		t.Fatal("bindOAuthByTrustedEmail() error = nil, want database error")
+	}
+}
+
 // TestBindOAuthByTrustedEmailSkipsUnmatchedDomain 信任域名外 verified 邮箱 → 不绑定，走注册。
 func TestBindOAuthByTrustedEmailSkipsUnmatchedDomain(t *testing.T) {
 	setupOAuthTestDB(t)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-28
 
 This is the single entry point for yourtj-hub product, architecture, development, and operations specs.
 Docs describe only the currently supported model; stale phase plans, PR delivery checklists, and

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-14
+> Last verified: 2026-08-28
 
 ## Contract status
 
@@ -228,5 +228,6 @@ and per-topic documents preserve the stored Markdown source.
   generated-artifact placeholder until the OpenAPI pipeline lands). Backend/TS contract changes that
   affect the mobile surface must update the Dart mirrors in the same PR; fixture contract tests
   (`core/test/fixtures`) back runtime deserialization.
-- Dart generation and full-route coverage are Planned; do not claim they are current contract gates.
+- Automated Dart generation remains Planned; route coverage is a current contract gate as described
+  above and is not a Planned capability.
 - Docs status words updated in step (docs/README.md).

--- a/docs/product/current-state.md
+++ b/docs/product/current-state.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-17
+> Last verified: 2026-08-28
 
 ## What works
 

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers, Security reviewer
 >
-> Last verified: 2026-08-11
+> Last verified: 2026-08-28
 
 ## Identity model
 
@@ -97,8 +97,11 @@
   implemented; administrators retain the console command for recovery.
 - Ban/freeze: the forum `users.is_frozen` flag is authoritative; the OIDC userinfo endpoint and
   exchange path reject frozen accounts.
-- Deletion/export: `Planned` (per product principle 12: answer purpose, visibility, retention, export,
-  deletion before persisting).
+- Content deletion/export: `Current` for the implemented forum and admin flows. Users can list,
+  restore, batch-delete, purge, and privacy-erase their own content; account closure applies the
+  content lifecycle rules, and administrators can export/import supported forum data. Retention,
+  recovery-window, audit, and evidence-hold behavior remain governed by the corresponding domain
+  services and operations documentation.
 
 ## Bot personas (Agents)
 


### PR DESCRIPTION
## Summary / 摘要

Fixes #332. 修复认证、删除积分与异步搜索投影中的一致性缺陷，并补齐迁移与导入错误的可观测性。

## Behavior change / 行为变更

- OAuth trusted-email lookup 只有在明确 `record not found` 时才降级注册；其他数据库错误会向上返回，避免认证失败被误判为新账号。
- `users.email` 增加非空邮箱数据库唯一约束；空邮箱仍允许多个 bot/OAuth 账号共存。启动迁移前会发现并拒绝遗留重复非空邮箱，不自动改写身份数据。
- 用户/管理员删除回复与发帖积分撤销合并为同一数据库事务，并对目标帖子加行锁；任一侧失败都会回滚另一侧。
- 用户注册搜索索引处理器会区分“用户已不存在”和可重试数据库错误。
- 课程目录导入的业务隔离错误记录 entity、external ID 和 reason；来源映射数据库错误会中止批次，不再静默吞掉。
- 修正 OAuth 测试夹具与路由快照测试的全局配置隔离，避免新唯一约束和测试顺序造成误报。

## Verification / 验证

- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go test -race ./app/service/contentdeleteservice ./app/service/eventhandlers ./app/service/courseservice`
- [x] PostgreSQL schema gate: `go test ./app/migration/ -run 'TestSchema' -v`（通过）
- [x] `golangci-lint run --new-from-rev=origin/dev`
- [x] `pnpm typecheck`
- [x] `NODE_OPTIONS='--localstorage-file=/tmp/yourtj-issue332-vitest-localstorage' pnpm test`（38 个文件、261 个测试通过）
- [x] `pnpm check:i18n`
- [x] `pnpm run check`（832 fixtures、route coverage 通过）
- [x] `pnpm build`
- [x] `make build`
- [x] 推送前 lefthook：go vet、增量 golangci-lint、frontend typecheck 全部通过

## Docs & contract impact / 文档与契约影响

- 同步 `docs/README.md`、`docs/product/current-state.md`、`docs/product/identity-and-access.md`、`docs/architecture/contracts-and-data.md` 的验证日期、内容生命周期和契约状态描述。
- 未新增或修改 HTTP 路由、OpenAPI operation、生成 TypeScript、Dart mirror 或 fixture 契约；因此没有生成契约产物 diff。
- 数据模型/迁移测试已覆盖 SQLite 与 PostgreSQL；启动预检对遗留重复邮箱 fail closed。

## Known gaps / 已知缺口

- 本次事务覆盖帖子状态与积分账本的数据库原子性；缓存、搜索投影、通知、文件使用量、统计和审计等提交后副作用仍按现有架构 best-effort 处理。
- eventbus 在耗尽重试后仍会丢弃事件；本 PR 只修复数据库错误被 handler 错误吞掉的问题，不把内存 eventbus 改造成持久队列。
- 本机未安装 Flutter/melos，因此未运行 mobile 工具链；本次没有 mobile 文件变更，CI 仍需执行其固定版本门禁。
- 本机 Node 26 的 Vitest 需要显式 localStorage 文件参数；CI 使用仓库固定的 Node 24。
- GitHub 当前报告默认分支存在一个独立的 high Dependabot alert（js-yaml / GHSA-5p4m-2wfm-xmqj，位于 `packages/api-contract/pnpm-lock.yaml`），未纳入本 PR 范围。