### PR TITLE
fix(ci): normalize main's CRLF blobs before merging dev on release

### DIFF
--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -79,6 +79,12 @@ jobs:
           git config user.name "${GH_USER}"
           git config user.email "${GH_EMAIL}"
           git checkout -b main origin/main
+          # main 上残留的 CRLF blob 在 .gitattributes(text eol=lf) 下会被识别成本地修改,
+          # 直接 merge 会被 "local changes would be overwritten" 中止; 合并前先就地归一化
+          git add --renormalize .
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: normalize line endings on main"
+          fi
           git merge origin/dev --no-ff -m "chore: release $NEW_VERSION from dev"
           git tag "$NEW_VERSION"
           REMOTE="https://x-access-token:${RELEASE_TOKEN}@github.com/YourTongji/YourTJ-Hub.git"


### PR DESCRIPTION
## Problem

`release-to-main` fails at the `合并 dev → main 并打 tag` step for every run since
`83230dd6`:

```
warning: in the working copy of '.../Badge.vue', CRLF will be replaced by LF the next time Git touches it
error: Your local changes to the following files would be overwritten by merge:
	apps/gooseforum/resource/src/admin/components/ui/badge/Badge.vue
	apps/gooseforum/resource/src/admin/components/ui/button/Button.vue
Aborting
```

## Cause

`main` still stores those two files with CRLF (25 and 29 CR lines), while
`.gitattributes` declares `text eol=lf`. As soon as the workflow checks out
`origin/main`, git writes LF into the working tree and both files count as
locally modified, so `git merge origin/dev` refuses to overwrite them.

`83230dd6` (#338) rewrote both files as LF on `dev` (0 CR lines), which is what
turned main's legacy CRLF blobs into a release blocker — before that, both sides
were CRLF and the merge was a no-op for these paths.

| file | `origin/main` CR lines | `origin/dev` CR lines |
| --- | --- | --- |
| `Badge.vue` | 25 | 0 |
| `Button.vue` | 29 | 0 |

## Fix

Normalize main's tracked files (`git add --renormalize .`) and commit the result
**before** the merge, so the merge runs against a clean tree. The commit only
happens when there is something to normalize, so this step becomes a no-op once
main carries LF blobs after this release.

## Scope

- `.github/workflows/release-to-main.yml` only — no product code touched.
- Line-ending normalization is semantically a no-op (verified with
  `git diff --cached --ignore-cr-at-eol`, which is empty).

## Verification

- `yaml.safe_load` parses the updated workflow.
- To be confirmed by re-running `release-to-main` after this PR merges.
