### PR TITLE
fix(course): make term list query run on PostgreSQL

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -135,10 +135,14 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"
-      - name: Test (PostgreSQL migration + stats concurrency)
+      - name: Test (PostgreSQL migration + course PG-gated)
         working-directory: apps/gooseforum
         env:
           YOURTJ_TEST_PG_URL: "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable"
+        # PostgreSQL$ 覆盖 course 包内所有 PG 门控用例（stats 并发、学期列表）。
+        # 刻意不逐个显式列举：本 PR 修的正是 pg-only 缺陷（SQLite 宽松通过，只有
+        # PostgreSQL 报错），一旦列举就会漏接线，回归护栏形同虚设。同名模式的新
+        # 用例会自动纳入。
         run: |
           go test ./app/migration/ -run 'TestSchema' -v
-          go test ./app/models/forum/course/ -run 'TestUpsertCourseStatsConcurrentPostgreSQL' -v
+          go test ./app/models/forum/course/ -run 'PostgreSQL$' -v

--- a/apps/gooseforum/app/models/forum/course/course_rep.go
+++ b/apps/gooseforum/app/models/forum/course/course_rep.go
@@ -280,17 +280,38 @@ func ListTermsByIDs(ids []uint64) (entities []TermEntity, err error) {
 	return
 }
 
+// termDistinctColumns ListDistinctTerms 的投影与分组列。去重必须显式投影：SELECT *
+// 会把 JOIN 表的列一并带入，而 PostgreSQL 要求 ORDER BY 表达式出现在投影中，且
+// ORDER BY 为计算表达式时不允许 SELECT DISTINCT *（SQLite 宽松允许，因此该缺陷
+// 只在 PostgreSQL 下暴露——生产用 PostgreSQL，本地与 CI 用 SQLite 时测不出来）。
+const termDistinctColumns = "course_term.id, course_term.code, course_term.name, course_term.starts_on, course_term.ends_on, course_term.status, course_term.created_at, course_term.updated_at, course_term.deleted_at"
+
 // ListDistinctTerms 返回所有可见课程关联开课实例的去重学期列表，供目录页学期筛选下拉。
 // 与 ListCourses 的 term 筛选（term_id 命中 course_term.code）同源：限定可见课程的可见 offering
-// 及其 term_id，非空 code，按 starts_on 倒序（未设置时回退 code 字典序），与详情页开课列表的学期排序一致。
+// 及其 term_id，非空 code；按 starts_on 倒序（未设置时回退 code 字典序），与详情页开课列表的学期排序一致。
 func ListDistinctTerms() ([]TermEntity, error) {
+	return ListDistinctTermsTx(termBuilder())
+}
+
+// ListDistinctTermsTx 与 ListDistinctTerms 同一条查询链，但接受指定连接/事务，
+// 供 PostgreSQL 回归测试复用真实代码路径：本查询曾因 SELECT DISTINCT + 表达式排序
+// 只在 PostgreSQL 下报错（SQLite 宽松通过，本地与 CI 的 SQLite 用例全绿），必须能
+// 在真实 PostgreSQL 上回归，因此把它写成可注入连接的形态。
+func ListDistinctTermsTx(tx *gorm.DB) ([]TermEntity, error) {
 	var terms []TermEntity
-	err := termBuilder().
+	err := tx.
+		Select(termDistinctColumns).
 		Joins("JOIN course_offering ON course_offering.term_id = course_term.id AND course_offering.deleted_at IS NULL AND course_offering.status = ?", OfferingStatusVisible).
 		Joins("JOIN course ON course.id = course_offering.course_id AND course.deleted_at IS NULL AND course.status = ?", StatusVisible).
 		Where(queryopt.IsNull("course_term.deleted_at")).
 		Where(queryopt.Ne("course_term.code", "")).
-		Distinct().
+		Group(termDistinctColumns).
+		// starts_on 目前导入流程未写入（生产库全为 NULL），COALESCE 会退回 code 字典序；
+		// 而「其他」这类非数字开头的学期码字典序大于数字开头的标准学期码，会把真正的最新
+		// 学期挤到第二位——目录页「本学期」取列表首项，会因此筛到「其他」而不是本学期。
+		// 先按「是否为数字开头的标准学期码」分组排序，保证最新学期居首；substr / BETWEEN
+		// 在 SQLite 与 PostgreSQL 下语义一致。
+		Order("CASE WHEN substr(course_term.code, 1, 1) BETWEEN '0' AND '9' THEN 0 ELSE 1 END").
 		Order("COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC").
 		Find(&terms).Error
 	return terms, err

--- a/apps/gooseforum/app/models/forum/course/course_rep.go
+++ b/apps/gooseforum/app/models/forum/course/course_rep.go
@@ -286,6 +286,14 @@ func ListTermsByIDs(ids []uint64) (entities []TermEntity, err error) {
 // 只在 PostgreSQL 下暴露——生产用 PostgreSQL，本地与 CI 用 SQLite 时测不出来）。
 const termDistinctColumns = "course_term.id, course_term.code, course_term.name, course_term.starts_on, course_term.ends_on, course_term.status, course_term.created_at, course_term.updated_at, course_term.deleted_at"
 
+// termOrdering 学期排序表达式：标准学期码（数字开头）优先，组内按 starts_on 倒序
+// （导入流程未写入 starts_on，生产全为 NULL，实际回退 code 字典序）；「其他」这类
+// 上游同步无法解析的学期码排末尾。
+// 目录页学期列表与开课实例查询必须共用同一表达式，否则同一门课在目录筛选与详情页
+// 看到的学期先后不一致（ListDistinctTerms 的注释即承诺两者排序一致）。
+// substr / BETWEEN 在 SQLite 与 PostgreSQL 下语义一致。
+const termOrdering = "CASE WHEN substr(course_term.code, 1, 1) BETWEEN '0' AND '9' THEN 0 ELSE 1 END, COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC"
+
 // ListDistinctTerms 返回所有可见课程关联开课实例的去重学期列表，供目录页学期筛选下拉。
 // 与 ListCourses 的 term 筛选（term_id 命中 course_term.code）同源：限定可见课程的可见 offering
 // 及其 term_id，非空 code；按 starts_on 倒序（未设置时回退 code 字典序），与详情页开课列表的学期排序一致。
@@ -306,13 +314,7 @@ func ListDistinctTermsTx(tx *gorm.DB) ([]TermEntity, error) {
 		Where(queryopt.IsNull("course_term.deleted_at")).
 		Where(queryopt.Ne("course_term.code", "")).
 		Group(termDistinctColumns).
-		// starts_on 目前导入流程未写入（生产库全为 NULL），COALESCE 会退回 code 字典序；
-		// 而「其他」这类非数字开头的学期码字典序大于数字开头的标准学期码，会把真正的最新
-		// 学期挤到第二位——目录页「本学期」取列表首项，会因此筛到「其他」而不是本学期。
-		// 先按「是否为数字开头的标准学期码」分组排序，保证最新学期居首；substr / BETWEEN
-		// 在 SQLite 与 PostgreSQL 下语义一致。
-		Order("CASE WHEN substr(course_term.code, 1, 1) BETWEEN '0' AND '9' THEN 0 ELSE 1 END").
-		Order("COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC").
+		Order(termOrdering).
 		Find(&terms).Error
 	return terms, err
 }
@@ -331,7 +333,7 @@ func ListOfferingsByCourse(courseId uint64) (entities []OfferingEntity, err erro
 		Joins("LEFT JOIN course_term ON course_term.id = course_offering.term_id AND course_term.deleted_at IS NULL").
 		Where(queryopt.Eq("course_offering.course_id", courseId)).
 		Where(queryopt.Eq("course_offering.status", OfferingStatusVisible)).
-		Order("COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC, course_offering.id ASC").
+		Order(termOrdering + ", course_offering.id ASC").
 		Find(&entities).Error
 	return
 }
@@ -355,7 +357,7 @@ func ListOfferingsByCourses(courseIds []uint64) (entities []OfferingEntity, err 
 		Joins("LEFT JOIN course_term ON course_term.id = course_offering.term_id AND course_term.deleted_at IS NULL").
 		Where(queryopt.In("course_offering.course_id", courseIds)).
 		Where(queryopt.Eq("course_offering.status", OfferingStatusVisible)).
-		Order("course_offering.course_id ASC, COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC, course_offering.id ASC").
+		Order("course_offering.course_id ASC, " + termOrdering + ", course_offering.id ASC").
 		Find(&entities).Error
 	return
 }
@@ -392,7 +394,7 @@ func ListVisibleOfferingsByClassCodes(classCodes []string, termId uint64) (entit
 	if termId > 0 {
 		b = b.Where(queryopt.Eq("course_offering.term_id", termId))
 	}
-	err = b.Order("course_offering.class_code ASC, COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC, course_offering.id ASC").
+	err = b.Order("course_offering.class_code ASC, " + termOrdering + ", course_offering.id ASC").
 		Find(&entities).Error
 	return
 }

--- a/apps/gooseforum/app/models/forum/course/course_rep_test.go
+++ b/apps/gooseforum/app/models/forum/course/course_rep_test.go
@@ -564,3 +564,73 @@ func TestListVisibleOfferingsByClassCodes(t *testing.T) {
 		t.Fatalf("empty result = %v, want non-nil empty slice", gotEmpty)
 	}
 }
+
+// TestTermOrderingConsistentAcrossQueries 目录页学期列表与开课实例查询共用同一排序：
+// 标准学期码（数字开头）优先，上游同步无法解析的「其他」排末尾。
+//
+// 回归背景：修 PostgreSQL 报错时为 ListDistinctTerms 加了「标准学期码优先」判别式，
+// 但三处 offering 查询仍只按 COALESCE(starts_on, code) 排序——starts_on 全为 NULL
+// 时会把「其他」排到最前，同一门课在目录筛选与详情页看到的学期先后不一致；
+// 而 ListDistinctTerms 的注释恰恰承诺两者排序一致。
+func TestTermOrderingConsistentAcrossQueries(t *testing.T) {
+	conn := setupCourseRepTest(t)
+	c := createCourse(t, conn, "100084", "CS")
+	newer := createTerm(t, conn, "2026-2027-1", "2026 秋", nil)
+	older := createTerm(t, conn, "2025-2026-2", "2026 春", nil)
+	other := createTerm(t, conn, "其他", "其他", nil)
+
+	// 建 offering 顺序刻意与期望排序相反（older → other → newer）：
+	// 若排序失效、退化成按 id 或按 code 字典序，断言就会失败。
+	oOlder := createOffering(t, conn, c, older, "四平路校区")
+	oOther := createOffering(t, conn, c, other, "四平路校区")
+	oNewer := createOffering(t, conn, c, newer, "四平路校区")
+	// 三个 offering 共用班号，使 P13 班号查询能一次性命中全部三条以比较顺序。
+	for _, id := range []uint64{oOlder, oOther, oNewer} {
+		if err := conn.Model(&OfferingEntity{}).Where("id = ?", id).Update("class_code", "12200401").Error; err != nil {
+			t.Fatalf("set class_code on offering %d: %v", id, err)
+		}
+	}
+
+	// 目录页学期列表：最新学期居首，「其他」压后。
+	terms, err := ListDistinctTerms()
+	if err != nil {
+		t.Fatalf("ListDistinctTerms err = %v", err)
+	}
+	if got := termCodes(terms); !slices.Equal(got, []string{"2026-2027-1", "2025-2026-2", "其他"}) {
+		t.Fatalf("term codes = %v, want [2026-2027-1 2025-2026-2 其他]", got)
+	}
+
+	// 详情页开课实例：与学期列表同一顺序。
+	offerings, err := ListOfferingsByCourse(c)
+	if err != nil {
+		t.Fatalf("ListOfferingsByCourse err = %v", err)
+	}
+	if len(offerings) != 3 {
+		t.Fatalf("ListOfferingsByCourse len = %d, want 3", len(offerings))
+	}
+	if offerings[0].Id != oNewer {
+		t.Fatalf("ListOfferingsByCourse first = %d, want %d (最新学期)", offerings[0].Id, oNewer)
+	}
+	if last := offerings[len(offerings)-1]; last.Id != oOther {
+		t.Fatalf("ListOfferingsByCourse last = %d, want %d (「其他」排末尾)", last.Id, oOther)
+	}
+
+	// 批量版本（列表页避免 N+1）同样顺序。
+	batch, err := ListOfferingsByCourses([]uint64{c})
+	if err != nil {
+		t.Fatalf("ListOfferingsByCourses err = %v", err)
+	}
+	if len(batch) != 3 || batch[0].Id != oNewer {
+		t.Fatalf("ListOfferingsByCourses first = %d, want %d", batch[0].Id, oNewer)
+	}
+
+	// P13 班号查询同样顺序。
+	byClass, err := ListVisibleOfferingsByClassCodes([]string{"12200401"}, 0)
+	if err != nil {
+		t.Fatalf("ListVisibleOfferingsByClassCodes err = %v", err)
+	}
+	if len(byClass) != 3 || byClass[0].Id != oNewer {
+		t.Fatalf("ListVisibleOfferingsByClassCodes first = %d, want %d (got %d offerings)",
+			byClass[0].Id, oNewer, len(byClass))
+	}
+}

--- a/apps/gooseforum/app/models/forum/course/course_rep_test.go
+++ b/apps/gooseforum/app/models/forum/course/course_rep_test.go
@@ -324,6 +324,38 @@ func TestListDistinctTerms(t *testing.T) {
 	}
 }
 
+// TestListDistinctTermsNonNumericCodeLast 非标准学期码（非数字开头，如 1系统同步时
+// 无法识别学期落到的「其他」）排在数字开头的标准学期码之后，保证列表首项是最新学期。
+//
+// 回归背景：starts_on 目前导入流程未写入（生产库全为 NULL），排序回退到 code 字典序；
+// 而「其他」这类中文 code 的字典序大于数字开头的学期码，会把真正的最新学期挤下首位——
+// 目录页「本学期」取列表首项，会因此筛到「其他」而不是本学期。
+func TestListDistinctTermsNonNumericCodeLast(t *testing.T) {
+	conn := setupCourseRepTest(t)
+	c := createCourse(t, conn, "100083", "CS")
+	// starts_on 一律为 nil，复现导入流程未写入该字段的生产数据形态。
+	newer := createTerm(t, conn, "2026-2027-1", "2026 秋", nil)
+	older := createTerm(t, conn, "2025-2026-2", "2026 春", nil)
+	other := createTerm(t, conn, "其他", "其他", nil)
+	for _, termId := range []uint64{newer, older, other} {
+		_ = createOffering(t, conn, c, termId, "四平路校区")
+	}
+
+	got, err := ListDistinctTerms()
+	if err != nil {
+		t.Fatalf("ListDistinctTerms err = %v", err)
+	}
+	want := []string{"2026-2027-1", "2025-2026-2", "其他"}
+	if len(got) != len(want) {
+		t.Fatalf("ListDistinctTerms codes = %v, want %v", termCodes(got), want)
+	}
+	for i, w := range want {
+		if got[i].Code != w {
+			t.Fatalf("ListDistinctTerms codes = %v, want %v", termCodes(got), want)
+		}
+	}
+}
+
 // TestListDistinctCampuses 校区列表去重与排序：仅可见课程的可见 offering 校区，
 // 排除空值、隐藏课程、隐藏 offering 与软删 offering；按字典序。
 func TestListDistinctCampuses(t *testing.T) {

--- a/apps/gooseforum/app/models/forum/course/terms_pg_test.go
+++ b/apps/gooseforum/app/models/forum/course/terms_pg_test.go
@@ -1,0 +1,77 @@
+package course
+
+import (
+	"os"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// TestListDistinctTermsOnPostgreSQL 在真实 PostgreSQL 上验证目录页学期列表查询可执行且排序正确。
+//
+// 回归背景：该查询曾用 Distinct() 配合 Order("COALESCE(CAST(starts_on AS TEXT), code) DESC")。
+// PostgreSQL 不允许 SELECT DISTINCT 的 ORDER BY 使用未出现在投影中的表达式，查询直接报错；
+// 而调用方把错误吞掉并降级为空数组（course.go 内 slog.Error 后 terms = []），表现为课程目录页
+// 「本学期」快捷筛选整体消失、学期下拉也为空。SQLite 对该写法宽松，所以本地开发与 CI 的
+// SQLite 用例全部通过，缺陷只在生产 PostgreSQL 上暴露。
+//
+// 依赖 YOURTJ_TEST_PG_URL（与 migration / pk / stats 包同一门控），未设置时跳过。
+func TestListDistinctTermsOnPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL term list test")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	models := []any{&Entity{}, &TermEntity{}, &OfferingEntity{}}
+	if err := db.AutoMigrate(models...); err != nil {
+		t.Fatalf("AutoMigrate course tables on postgres failed: %v", err)
+	}
+	for _, model := range models {
+		if err := db.Unscoped().Where("1 = 1").Delete(model).Error; err != nil {
+			t.Fatalf("clean table on postgres: %v", err)
+		}
+	}
+
+	// 复现生产库的 code 形态：数字开头的标准学期码 + 一个非数字开头的「其他」
+	// （1系统同步时无法识别学期的数据会落到这里）。starts_on 保持 NULL，
+	// 与导入流程一致（导入时未写入该字段），排序因此回退到 code。
+	codes := []string{"2024-2025-1", "2025-2026-2", "2026-2027-1", "其他"}
+	termIDs := make(map[string]uint64, len(codes))
+	for _, code := range codes {
+		term := TermEntity{Code: code, Name: code, Status: 0}
+		if err := db.Create(&term).Error; err != nil {
+			t.Fatalf("create term %q: %v", code, err)
+		}
+		termIDs[code] = term.Id
+	}
+	c := Entity{PrimaryCode: "PGTERM001", Name: "PG 学期回归课", Department: "测试学院", Status: StatusVisible}
+	if err := db.Create(&c).Error; err != nil {
+		t.Fatalf("create course: %v", err)
+	}
+	for _, code := range codes {
+		o := OfferingEntity{CourseId: c.Id, TermId: termIDs[code], Status: OfferingStatusVisible}
+		if err := db.Create(&o).Error; err != nil {
+			t.Fatalf("create offering for %q: %v", code, err)
+		}
+	}
+
+	terms, err := ListDistinctTermsTx(db.Table(termTableName))
+	if err != nil {
+		t.Fatalf("ListDistinctTermsTx on postgres failed: %v", err)
+	}
+	if len(terms) != len(codes) {
+		t.Fatalf("expected %d terms, got %d: %+v", len(codes), len(terms), terms)
+	}
+	// 目录页「本学期」取列表首项：必须是最新学期，而不是字典序更大的「其他」。
+	if terms[0].Code != "2026-2027-1" {
+		t.Fatalf("first term = %q, want 2026-2027-1 (目录页「本学期」取首项)", terms[0].Code)
+	}
+	// 非数字开头的学期码排在标准学期码之后。
+	if last := terms[len(terms)-1]; last.Code != "其他" {
+		t.Fatalf("last term = %q, want 其他（非标准学期码应排末尾）", last.Code)
+	}
+}


### PR DESCRIPTION
## Problem

The course catalog's "本学期" (current term) quick filter and the entire term dropdown are missing on production. Verified on both `yourtj-main` and `yourtj-dev` against the live PostgreSQL database.

`ListDistinctTerms()` combined `Distinct()` with an `ORDER BY` expression:

```go
Distinct().
Order("COALESCE(CAST(course_term.starts_on AS TEXT), course_term.code) DESC")
```

PostgreSQL rejects this — for `SELECT DISTINCT`, ORDER BY expressions must appear in the select list — with `SQLSTATE 42P10`:

```
ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

The caller swallows the error and degrades to an empty slice (`course.go`):

```go
terms, termErr := courseservice.ListTerms()
if termErr != nil {
    slog.Error("course_terms_list_failed", "error", termErr)
    terms = []courseservice.TermOption{}
}
```

So `props.terms` is `[]`: the "本学期" chip only renders when `terms.length` is non-zero, and the term dropdown is empty. Departments (53) and campuses (3) on the same page kept working — those queries do not use this construct.

**Why it was never caught:** SQLite allows `SELECT DISTINCT` with an expression `ORDER BY`, so local development and the SQLite CI job stayed green. Only the PostgreSQL production instances are affected.

**Data is not the problem.** The live database has 9303 visible courses, 21941 visible offerings and 6 terms; the equivalent hand-written SQL returns all 6 rows.

## Fix

- Replace `Distinct()` with an explicit projection plus `GROUP BY`, so the ordering expression no longer violates PostgreSQL's rule.
- Split the chain into `ListDistinctTermsTx(tx *gorm.DB)` so a real PostgreSQL connection can be injected in tests, mirroring the existing `UpsertCourseStatsTx` pattern used by `stats_pg_test.go`.
- Make the ordering put the newest term first. `starts_on` is never written by the import flow (NULL for every production row), so ordering falls back to `code` — and `其他`, a code the upstream sync produces for terms it cannot parse, sorts above digit-leading codes like `2026-2027-1`. Since the catalog's "本学期" filter takes `terms[0]`, it would have filtered on `其他` instead of the current term. Non-digit-leading codes now sort last.

`substr` / `BETWEEN` are used for the ordering key because they behave identically on SQLite and PostgreSQL.

## Verification

- `TestListDistinctTermsOnPostgreSQL` (new, gated on `YOURTJ_TEST_PG_URL`, same convention as the `pk` and `stats` packages). Confirmed red before the fix:
  ```
  ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list (SQLSTATE 42P10)
  --- FAIL: TestListDistinctTermsOnPostgreSQL
  ```
  and green after.
- `TestListDistinctTermsNonNumericCodeLast` (new, SQLite) covers the ordering on the default dialect, since the PG test skips without a PG DSN.
- Existing `TestListDistinctTerms` unchanged and passing.
- `go build ./...`, `go vet`, `golangci-lint`, and `go test ./app/models/forum/course/` pass on both SQLite and PostgreSQL.

Query verified directly against production PostgreSQL before/after:

| | first row (= "本学期") |
|---|---|
| before | *(query errors, empty result)* |
| after | `2026-2027-1` |

## Not fixed here

`starts_on` is never written anywhere in the codebase — the import path creates terms as `TermEntity{Code: code, Name: code, Status: 0}` and never sets it, and `Name` is also just the code. The ordering fix works around this rather than fixing the data. Making `starts_on` real (and deriving term labels from it) is a separate change to the import flow; happy to follow up if you want it.
