### PR TITLE
docs: align development branch base

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-08-31
 
 Any code, contract, migration, CI, or documentation change starts here. `AGENTS.md` holds repository hard
 constraints; this directory holds the executable process. Do not copy development steps from historical
@@ -19,7 +19,7 @@ PRs or chat messages.
 2. Determine whether the request is read-only analysis, a change, or explicitly authorizes
    commit/push/open PR.
 3. Check branch, worktree, and uncommitted content; never overwrite or commit others' changes.
-4. Create a feature/fix/docs branch from `origin/main`.
+4. Create a feature/fix/docs branch from `origin/dev`.
 5. Write the change impact: backend, web, contract, migration, auth/PII, search, deploy, docs.
 
 The repository-level `$yourtj-development` skill lives in `.agents/skills/yourtj-development` and unifies


### PR DESCRIPTION
## Motivation

The development entry instructed contributors to branch from origin/main, conflicting with AGENTS.md and the pull-request guide, which define dev as the main development line.

## Changes

- change the development entry branch base from origin/main to origin/dev
- update the document verification date

## Verification

- git diff --check
- repository-wide search confirms no remaining instruction to create feature/fix/docs branches from origin/main
- pre-push hook passed go vet, incremental golangci-lint, and frontend typecheck

## Documentation and contract impact

Documentation-only process correction. No product behavior, API contract, schema, or generated artifact changes.

## Known gaps

None.