### PR TITLE
refactor(go): modernize typed sorting

### DIFF
--- a/apps/gooseforum/app/bundles/closer/closer.go
+++ b/apps/gooseforum/app/bundles/closer/closer.go
@@ -2,10 +2,11 @@
 package closer
 
 import (
+	"cmp"
 	"fmt"
 	"log/slog"
 	"runtime"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 )
@@ -86,11 +87,8 @@ func CloseAll() {
 	entries = nil
 	mu.Unlock()
 
-	sort.SliceStable(items, func(i, j int) bool {
-		if items[i].priority != items[j].priority {
-			return items[i].priority < items[j].priority
-		}
-		return items[i].seq > items[j].seq
+	slices.SortStableFunc(items, func(a, b closerEntry) int {
+		return cmp.Or(cmp.Compare(a.priority, b.priority), cmp.Compare(b.seq, a.seq))
 	})
 
 	slog.Info("closer: starting to close all registered resources", "count", len(items))

--- a/apps/gooseforum/app/bundles/connect/sqlconnect/sqlitehandle.go
+++ b/apps/gooseforum/app/bundles/connect/sqlconnect/sqlitehandle.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -83,10 +83,16 @@ func cleanOldBackups(sourcePath string, keep int) {
 	}
 
 	// 按修改时间排序（旧文件在前）
-	sort.Slice(files, func(i, j int) bool {
-		infoI, _ := os.Stat(files[i])
-		infoJ, _ := os.Stat(files[j])
-		return infoI.ModTime().Before(infoJ.ModTime())
+	slices.SortFunc(files, func(a, b string) int {
+		infoA, _ := os.Stat(a)
+		infoB, _ := os.Stat(b)
+		if infoA.ModTime().Before(infoB.ModTime()) {
+			return -1
+		}
+		if infoA.ModTime().After(infoB.ModTime()) {
+			return 1
+		}
+		return 0
 	})
 
 	// 删除超量旧备份

--- a/apps/gooseforum/app/http/controllers/api/adminController.go
+++ b/apps/gooseforum/app/http/controllers/api/adminController.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -1541,7 +1542,9 @@ func sanitizeScheduleSectionTimes(input []pageConfig.ScheduleSectionTime) ([]pag
 		seen[item.Section] = true
 		times = append(times, item)
 	}
-	sort.Slice(times, func(i, j int) bool { return times[i].Section < times[j].Section })
+	slices.SortFunc(times, func(a, b pageConfig.ScheduleSectionTime) int {
+		return cmp.Compare(a.Section, b.Section)
+	})
 	return times, true
 }
 

--- a/apps/gooseforum/app/http/controllers/markdown2html/markdown2html_test.go
+++ b/apps/gooseforum/app/http/controllers/markdown2html/markdown2html_test.go
@@ -1,11 +1,12 @@
 package markdown2html
 
 import (
+	"cmp"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"testing"
 
@@ -271,6 +272,8 @@ func loadMarkdownCompatFixtures(t *testing.T) []markdownCompatCase {
 		}
 		fixtures = append(fixtures, fixture)
 	}
-	sort.Slice(fixtures, func(i, j int) bool { return fixtures[i].Name < fixtures[j].Name })
+	slices.SortFunc(fixtures, func(a, b markdownCompatCase) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
 	return fixtures
 }

--- a/apps/gooseforum/app/http/routes/routes_dump_test.go
+++ b/apps/gooseforum/app/http/routes/routes_dump_test.go
@@ -1,11 +1,13 @@
 package routes
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -65,11 +67,8 @@ func collectRouteSnapshot(t *testing.T) []routeSnapshotEntry {
 		seen[entry] = true
 		entries = append(entries, entry)
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].Method != entries[j].Method {
-			return entries[i].Method < entries[j].Method
-		}
-		return entries[i].Path < entries[j].Path
+	slices.SortFunc(entries, func(a, b routeSnapshotEntry) int {
+		return cmp.Or(cmp.Compare(a.Method, b.Method), cmp.Compare(a.Path, b.Path))
 	})
 	return entries
 }

--- a/apps/gooseforum/app/service/badgeservice/badgeservice.go
+++ b/apps/gooseforum/app/service/badgeservice/badgeservice.go
@@ -1,7 +1,8 @@
 package badgeservice
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/localcache"
@@ -75,11 +76,8 @@ func buildAllForAdmin() []AdminBadge {
 		result = append(result, AdminBadge{Badge: fromEntity(entity), IsSystem: false, CanDelete: true})
 	}
 
-	sort.SliceStable(result, func(i, j int) bool {
-		if result[i].SortOrder == result[j].SortOrder {
-			return result[i].Code < result[j].Code
-		}
-		return result[i].SortOrder < result[j].SortOrder
+	slices.SortStableFunc(result, func(a, b AdminBadge) int {
+		return cmp.Or(cmp.Compare(a.SortOrder, b.SortOrder), cmp.Compare(a.Code, b.Code))
 	})
 	return result
 }
@@ -132,11 +130,8 @@ func GetUserBadges(userID uint64) []UserBadge {
 			GrantedAt: record.GrantedAt.Format(time.RFC3339),
 		})
 	}
-	sort.SliceStable(result, func(i, j int) bool {
-		if result[i].SortOrder == result[j].SortOrder {
-			return result[i].GrantedAt > result[j].GrantedAt
-		}
-		return result[i].SortOrder < result[j].SortOrder
+	slices.SortStableFunc(result, func(a, b UserBadge) int {
+		return cmp.Or(cmp.Compare(a.SortOrder, b.SortOrder), cmp.Compare(b.GrantedAt, a.GrantedAt))
 	})
 	return result
 }

--- a/apps/gooseforum/app/service/courseservice/related.go
+++ b/apps/gooseforum/app/service/courseservice/related.go
@@ -142,7 +142,7 @@ func buildRelatedTeacherCourses(courseIds []uint64) ([]RelatedCourseItem, error)
 	return items, nil
 }
 
-// sortRelatedItems 稳定排序：review_count 降序 → 平均分降序 → id 降序。
+// sortRelatedItems 排序：review_count 降序 → 平均分降序 → id 降序（末级 id 唯一，结果确定）。
 func sortRelatedItems(items []RelatedCourseItem) {
 	slices.SortFunc(items, func(a, b RelatedCourseItem) int {
 		if a.ReviewCount != b.ReviewCount {

--- a/apps/gooseforum/app/service/courseservice/related.go
+++ b/apps/gooseforum/app/service/courseservice/related.go
@@ -1,7 +1,8 @@
 package courseservice
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
 )
@@ -143,14 +144,20 @@ func buildRelatedTeacherCourses(courseIds []uint64) ([]RelatedCourseItem, error)
 
 // sortRelatedItems 稳定排序：review_count 降序 → 平均分降序 → id 降序。
 func sortRelatedItems(items []RelatedCourseItem) {
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].ReviewCount != items[j].ReviewCount {
-			return items[i].ReviewCount > items[j].ReviewCount
+	slices.SortFunc(items, func(a, b RelatedCourseItem) int {
+		if a.ReviewCount != b.ReviewCount {
+			return cmp.Compare(b.ReviewCount, a.ReviewCount)
 		}
-		if items[i].RatingAvg != items[j].RatingAvg {
-			return items[i].RatingAvg > items[j].RatingAvg
+		if a.RatingAvg != b.RatingAvg {
+			if a.RatingAvg > b.RatingAvg {
+				return -1
+			}
+			if a.RatingAvg < b.RatingAvg {
+				return 1
+			}
+			return 0
 		}
-		return items[i].Id > items[j].Id
+		return cmp.Compare(b.Id, a.Id)
 	})
 }
 

--- a/apps/gooseforum/app/service/courseservice/stats_read.go
+++ b/apps/gooseforum/app/service/courseservice/stats_read.go
@@ -1,7 +1,8 @@
 package courseservice
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strings"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
@@ -109,6 +110,8 @@ func attachCourseStats(entities []course.Entity) []CourseStatsBrief {
 		}
 		out = append(out, brief)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].CourseId < out[j].CourseId })
+	slices.SortFunc(out, func(a, b CourseStatsBrief) int {
+		return cmp.Compare(a.CourseId, b.CourseId)
+	})
 	return out
 }

--- a/apps/gooseforum/app/service/pkservice/arrange.go
+++ b/apps/gooseforum/app/service/pkservice/arrange.go
@@ -1,7 +1,9 @@
 package pkservice
 
 import (
+	"cmp"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -179,25 +181,25 @@ func mergeArrangementInfo(teachers []teacherRow) []ArrangementInfo {
 	for _, line := range uniq {
 		objs = append(objs, arrangementTextToObj(line))
 	}
-	sort.SliceStable(objs, func(i, j int) bool {
+	slices.SortStableFunc(objs, func(a, b ArrangementInfo) int {
 		ad, bd := 99, 99
-		if objs[i].OccupyDay != nil {
-			ad = *objs[i].OccupyDay
+		if a.OccupyDay != nil {
+			ad = *a.OccupyDay
 		}
-		if objs[j].OccupyDay != nil {
-			bd = *objs[j].OccupyDay
+		if b.OccupyDay != nil {
+			bd = *b.OccupyDay
 		}
 		if ad != bd {
-			return ad < bd
+			return cmp.Compare(ad, bd)
 		}
 		at, bt := 99, 99
-		if len(objs[i].OccupyTime) > 0 {
-			at = objs[i].OccupyTime[0]
+		if len(a.OccupyTime) > 0 {
+			at = a.OccupyTime[0]
 		}
-		if len(objs[j].OccupyTime) > 0 {
-			bt = objs[j].OccupyTime[0]
+		if len(b.OccupyTime) > 0 {
+			bt = b.OccupyTime[0]
 		}
-		return at < bt
+		return cmp.Compare(at, bt)
 	})
 	return objs
 }

--- a/apps/gooseforum/app/service/pkservice/courses.go
+++ b/apps/gooseforum/app/service/pkservice/courses.go
@@ -1,9 +1,9 @@
 package pkservice
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 	"strconv"
-	"strings"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
 )
@@ -149,8 +149,8 @@ func FindCoursesByMajor(grade int, code string, calendarId int) ([]CourseByMajor
 			CourseNature: uniqueText(groupToNature[groupKey]),
 			Courses:      buildClassItems(courseRows, teachersByClass, groupExclusive[groupKey]),
 		}
-		sort.SliceStable(item.Courses, func(i, j int) bool {
-			return strings.Compare(item.Courses[i].Code, item.Courses[j].Code) < 0
+		slices.SortStableFunc(item.Courses, func(a, b CourseClassItem) int {
+			return cmp.Compare(a.Code, b.Code)
 		})
 		output = append(output, item)
 	}

--- a/apps/gooseforum/app/service/pkservice/nature.go
+++ b/apps/gooseforum/app/service/pkservice/nature.go
@@ -1,9 +1,10 @@
 package pkservice
 
 import (
+	"cmp"
+	"slices"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
 )
@@ -112,13 +113,13 @@ func FindCoursesByNature(calendarId int, ids []int) ([]CourseByNatureItem, error
 		item := byLabel[labelName]
 		item.CourseLabelIds = uniqueIntsDesc(item.CourseLabelIds)
 		item.CourseLabelId = maxInt(item.CourseLabelIds)
-		sort.SliceStable(item.Courses, func(i, j int) bool {
-			return strings.Compare(item.Courses[i].CourseCode, item.Courses[j].CourseCode) < 0
+		slices.SortStableFunc(item.Courses, func(a, b NatureCourseItem) int {
+			return cmp.Compare(a.CourseCode, b.CourseCode)
 		})
 		output = append(output, *item)
 	}
-	sort.SliceStable(output, func(i, j int) bool {
-		return output[i].CourseLabelId > output[j].CourseLabelId
+	slices.SortStableFunc(output, func(a, b CourseByNatureItem) int {
+		return cmp.Compare(b.CourseLabelId, a.CourseLabelId)
 	})
 	return output, nil
 }

--- a/apps/gooseforum/app/service/pkservice/sync_status.go
+++ b/apps/gooseforum/app/service/pkservice/sync_status.go
@@ -1,9 +1,10 @@
 package pkservice
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -87,7 +88,9 @@ func SyncStatusOverview() ([]SyncStatusItem, error) {
 		attachFetchLog(&item, log)
 		items = append(items, item)
 	}
-	sort.Slice(items, func(i, j int) bool { return items[i].CalendarId > items[j].CalendarId })
+	slices.SortFunc(items, func(a, b SyncStatusItem) int {
+		return cmp.Compare(b.CalendarId, a.CalendarId)
+	})
 	return items, nil
 }
 

--- a/apps/gooseforum/app/service/wikiservice/search.go
+++ b/apps/gooseforum/app/service/wikiservice/search.go
@@ -1,7 +1,7 @@
 package wikiservice
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/wikiPages"
@@ -107,8 +107,14 @@ func SearchPages(query string, limit int) (*PageSearchResponse, error) {
 	for _, pageID := range order {
 		result.Items = append(result.Items, *byPage[pageID])
 	}
-	sort.SliceStable(result.Items, func(i, j int) bool {
-		return result.Items[i].Score > result.Items[j].Score
+	slices.SortStableFunc(result.Items, func(a, b PageSearchResult) int {
+		if a.Score > b.Score {
+			return -1
+		}
+		if a.Score < b.Score {
+			return 1
+		}
+		return 0
 	})
 	if len(result.Items) > limit {
 		result.Items = result.Items[:limit]

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -2,6 +2,7 @@ package wikiservice
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -13,7 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -469,7 +470,9 @@ func scanRepoFiles(cloneDir string) ([]repoFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	slices.SortFunc(files, func(a, b repoFile) int {
+		return cmp.Compare(a.Path, b.Path)
+	})
 	return files, nil
 }
 
@@ -549,7 +552,9 @@ func buildContributorsSnapshot(cloneDir, relPath string) string {
 			Count:    item.count,
 		})
 	}
-	sort.Slice(items, func(i, j int) bool { return items[i].Count > items[j].Count })
+	slices.SortFunc(items, func(a, b gitContributor) int {
+		return cmp.Compare(b.Count, a.Count)
+	})
 	data, err := json.Marshal(items)
 	if err != nil {
 		return ""


### PR DESCRIPTION
## Motivation

The Go 1.26 backend still used legacy index-based sort helpers at 17 verified call sites. This focused refactor adopts the typed `slices` sorting APIs without changing ordering semantics.

## Changes

- replace 8 `sort.Slice` calls with `slices.SortFunc`;
- replace 9 `sort.SliceStable` calls with `slices.SortStableFunc`;
- preserve each existing sort key, direction, tie-break and stable-order guarantee;
- use explicit comparisons for floating-point search/rating scores so `NaN` retains the prior comparison behavior.

## Verification

- `gofmt` on all 14 changed Go files
- `git diff --check origin/dev...HEAD`
- `GOTOOLCHAIN=go1.26.0 go test ./app/bundles/closer ./app/bundles/connect/sqlconnect ./app/http/controllers/api ./app/http/controllers/markdown2html ./app/http/routes ./app/service/badgeservice ./app/service/courseservice ./app/service/pkservice ./app/service/wikiservice`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 /tmp/yourtj-lint-go126/golangci-lint run --new-from-rev=origin/dev` (0 issues)

## Contract and documentation impact

No API, OpenAPI, migration, configuration, dependency, or behavior change. No `go.mod`/`go.sum` changes.

Part of #345.