### PR TITLE
refactor(go): prune legacy helpers

### DIFF
--- a/apps/gooseforum/app/datastruct/common/name.go
+++ b/apps/gooseforum/app/datastruct/common/name.go
@@ -1,3 +1,0 @@
-package common
-
-const DefaultUserName = "陶渊明"

--- a/apps/gooseforum/app/datastruct/enum.go
+++ b/apps/gooseforum/app/datastruct/enum.go
@@ -1,5 +1,0 @@
-package datastruct
-
-type Enum interface {
-	Name() string
-}

--- a/apps/gooseforum/app/service/chatservice/chatservice.go
+++ b/apps/gooseforum/app/service/chatservice/chatservice.go
@@ -2,6 +2,7 @@ package chatservice
 
 import (
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/vo"
@@ -172,7 +173,7 @@ func GetMessages(userId, convId uint64, beforeId, afterId uint64, limit int) (*M
 		msgs = msgs[:limit]
 	}
 	if afterId == 0 {
-		reverseMessages(msgs)
+		slices.Reverse(msgs)
 	}
 
 	list := lo.Map(msgs, func(m messages.Entity, _ int) *vo.MessageVo {
@@ -200,12 +201,6 @@ func GetMessages(userId, convId uint64, beforeId, afterId uint64, limit int) (*M
 		result.HasMoreBefore = hasMore
 	}
 	return result, nil
-}
-
-func reverseMessages(msgs []messages.Entity) {
-	for left, right := 0, len(msgs)-1; left < right; left, right = left+1, right-1 {
-		msgs[left], msgs[right] = msgs[right], msgs[left]
-	}
 }
 
 // MarkRead 清除指定会话的未读状态。

--- a/apps/gooseforum/app/service/moderationservice/access.go
+++ b/apps/gooseforum/app/service/moderationservice/access.go
@@ -138,11 +138,13 @@ func loadSnapshot() Snapshot {
 
 func uniqueUint64(values []uint64) []uint64 {
 	res := make([]uint64, 0, len(values))
+	seen := make(map[uint64]struct{}, len(values))
 	for _, value := range values {
-		seen := slices.Contains(res, value)
-		if !seen {
-			res = append(res, value)
+		if _, ok := seen[value]; ok {
+			continue
 		}
+		seen[value] = struct{}{}
+		res = append(res, value)
 	}
 	return res
 }

--- a/apps/gooseforum/app/service/moderationservice/status_test.go
+++ b/apps/gooseforum/app/service/moderationservice/status_test.go
@@ -1,6 +1,7 @@
 package moderationservice
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -38,5 +39,14 @@ func TestInvalidateTopicClearsCategoryStatusCache(t *testing.T) {
 	InvalidateTopic(970010)
 	if got := hasOpenReport(key, []uint64{970003}); !got {
 		t.Fatal("open report cache after invalidation = false, want true")
+	}
+}
+
+func TestUniqueUint64PreservesFirstOccurrenceOrder(t *testing.T) {
+	values := []uint64{17, 3, 17, 9, 3, 1, 9, 5}
+	want := []uint64{17, 3, 9, 1, 5}
+
+	if got := uniqueUint64(values); !slices.Equal(got, want) {
+		t.Fatalf("uniqueUint64(%v) = %v, want %v", values, got, want)
 	}
 }


### PR DESCRIPTION
关联 #345。

- 用 Go 1.26 slices.Reverse 删除私有反转 helper。
- moderation scope 去重改为保留首个出现顺序的 O(n) map 去重。
- 删除已验证零引用的 datastruct Enum 与 DefaultUserName。

验证：Go 1.26 全量测试、go vet、增量 golangci-lint（0 issues）和 diff check 均通过。