### PR TITLE
chore: complete issue 351 modernization

### DIFF
--- a/apps/gooseforum/app/bundles/captchaOpt/captcha.go
+++ b/apps/gooseforum/app/bundles/captchaOpt/captcha.go
@@ -1,6 +1,7 @@
 package captchaOpt
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 	"sync"
@@ -86,7 +87,9 @@ var (
 // StartCleanup starts the expired captcha cleanup worker.
 func StartCleanup() {
 	cleanupOnce.Do(func() {
-		closer.RegisterPriority(closer.PriorityCache, StopCleanup)
+		closer.RegisterPriorityContext(closer.PriorityCache, func(context.Context) error {
+			return StopCleanup()
+		})
 		cleanupWg.Go(func() {
 			defer paniclog.Recover("captcha_cleanup")
 			ticker := time.NewTicker(time.Minute) // 每分钟清理一次

--- a/apps/gooseforum/app/bundles/closer/closer.go
+++ b/apps/gooseforum/app/bundles/closer/closer.go
@@ -3,6 +3,8 @@ package closer
 
 import (
 	"cmp"
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime"
@@ -10,6 +12,11 @@ import (
 	"sync"
 	"time"
 )
+
+// CloseFunc is a cooperative shutdown callback. Implementations must stop
+// work and return when ctx is canceled; Go cannot interrupt a callback that
+// ignores its context.
+type CloseFunc func(context.Context) error
 
 type Priority int
 
@@ -30,33 +37,54 @@ var (
 )
 
 type closerEntry struct {
-	f        func() error
+	f        CloseFunc
 	caller   string
 	priority Priority
 	seq      uint64
 }
 
-// Register adds f to the process shutdown callback list.
+// Register adds a legacy non-context callback to the process shutdown list.
+// New code should use RegisterContext so shutdown can cancel owned work.
 func Register(f func() error) {
+	RegisterContext(func(context.Context) error { return f() })
+}
+
+// RegisterContext adds a cooperative shutdown callback to the process list.
+func RegisterContext(f CloseFunc) {
 	register(1, PriorityDefault, f)
 }
 
-// RegisterPriority adds f to the shutdown callback list with an explicit close phase.
+// RegisterPriority adds a legacy non-context callback with an explicit close phase.
 func RegisterPriority(priority Priority, f func() error) {
+	RegisterPriorityContext(priority, func(context.Context) error { return f() })
+}
+
+// RegisterPriorityContext adds a cooperative callback with an explicit close phase.
+func RegisterPriorityContext(priority Priority, f CloseFunc) {
 	register(1, priority, f)
 }
 
 // Bind registers the Close method of c as a shutdown callback.
 func Bind(c interface{ Close() error }) {
-	register(1, PriorityDefault, c.Close)
+	Register(c.Close)
+}
+
+// BindContext registers a context-aware Close method as a shutdown callback.
+func BindContext(c interface{ Close(context.Context) error }) {
+	RegisterContext(c.Close)
 }
 
 // BindPriority registers the Close method of c with an explicit close phase.
 func BindPriority(priority Priority, c interface{ Close() error }) {
-	register(1, priority, c.Close)
+	RegisterPriority(priority, c.Close)
 }
 
-func register(skip int, priority Priority, f func() error) {
+// BindPriorityContext registers a context-aware Close method with a phase.
+func BindPriorityContext(priority Priority, c interface{ Close(context.Context) error }) {
+	RegisterPriorityContext(priority, c.Close)
+}
+
+func register(skip int, priority Priority, f CloseFunc) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -80,8 +108,17 @@ func register(skip int, priority Priority, f func() error) {
 	)
 }
 
-// CloseAll runs all registered shutdown callbacks in reverse registration order.
-func CloseAll() {
+// CloseAll runs all registered shutdown callbacks in deterministic priority
+// order. It invokes callbacks synchronously so a non-cooperative legacy
+// callback remains visible instead of leaking an untracked goroutine after a
+// timeout. The variadic form preserves callers that do not yet have a root
+// context while allowing the server to provide one.
+func CloseAll(parentContexts ...context.Context) error {
+	parent := context.Background()
+	if len(parentContexts) > 0 && parentContexts[0] != nil {
+		parent = parentContexts[0]
+	}
+
 	mu.Lock()
 	items := append([]closerEntry(nil), entries...)
 	entries = nil
@@ -92,6 +129,7 @@ func CloseAll() {
 	})
 
 	slog.Info("closer: starting to close all registered resources", "count", len(items))
+	var closeErrors []error
 
 	for i := range items {
 		entry := items[i]
@@ -100,7 +138,8 @@ func CloseAll() {
 			"priority", entry.priority,
 			"registered_at", entry.caller,
 		)
-		if err := closeWithTimeout(entry); err != nil {
+		if err := closeWithTimeout(parent, entry); err != nil {
+			closeErrors = append(closeErrors, err)
 			slog.Error("closer: failed to close resource",
 				"index", i,
 				"priority", entry.priority,
@@ -111,18 +150,28 @@ func CloseAll() {
 	}
 
 	slog.Info("closer: all resources closed")
+	return errors.Join(closeErrors...)
 }
 
-func closeWithTimeout(entry closerEntry) error {
-	done := make(chan error, 1)
-	go func() {
-		done <- entry.f()
-	}()
+func closeWithTimeout(parent context.Context, entry closerEntry) error {
+	ctx, cancel := context.WithTimeoutCause(parent, closeTimeout, errCloseTimeout)
+	defer cancel()
 
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(closeTimeout):
-		return fmt.Errorf("close timed out after %s: priority=%d registered_at=%s", closeTimeout, entry.priority, entry.caller)
+	err := entry.f(ctx)
+	if err != nil {
+		if errors.Is(context.Cause(ctx), errCloseTimeout) {
+			return timeoutError(entry)
+		}
+		return fmt.Errorf("close failed: priority=%d registered_at=%s: %w", entry.priority, entry.caller, err)
 	}
+	if errors.Is(context.Cause(ctx), errCloseTimeout) {
+		return timeoutError(entry)
+	}
+	return nil
+}
+
+var errCloseTimeout = errors.New("closer: callback deadline exceeded")
+
+func timeoutError(entry closerEntry) error {
+	return fmt.Errorf("close timed out after %s: priority=%d registered_at=%s: %w", closeTimeout, entry.priority, entry.caller, errCloseTimeout)
 }

--- a/apps/gooseforum/app/bundles/closer/closer.go
+++ b/apps/gooseforum/app/bundles/closer/closer.go
@@ -109,10 +109,9 @@ func register(skip int, priority Priority, f CloseFunc) {
 }
 
 // CloseAll runs all registered shutdown callbacks in deterministic priority
-// order. It invokes callbacks synchronously so a non-cooperative legacy
-// callback remains visible instead of leaking an untracked goroutine after a
-// timeout. The variadic form preserves callers that do not yet have a root
-// context while allowing the server to provide one.
+// order and waits synchronously for each callback up to the hard timeout. The
+// variadic form preserves callers that do not yet have a root context while
+// allowing the server to provide one.
 func CloseAll(parentContexts ...context.Context) error {
 	parent := context.Background()
 	if len(parentContexts) > 0 && parentContexts[0] != nil {
@@ -157,17 +156,20 @@ func closeWithTimeout(parent context.Context, entry closerEntry) error {
 	ctx, cancel := context.WithTimeoutCause(parent, closeTimeout, errCloseTimeout)
 	defer cancel()
 
-	err := entry.f(ctx)
-	if err != nil {
+	result := make(chan error, 1)
+	go func() { result <- entry.f(ctx) }()
+	select {
+	case err := <-result:
 		if errors.Is(context.Cause(ctx), errCloseTimeout) {
 			return timeoutError(entry)
 		}
-		return fmt.Errorf("close failed: priority=%d registered_at=%s: %w", entry.priority, entry.caller, err)
-	}
-	if errors.Is(context.Cause(ctx), errCloseTimeout) {
+		if err != nil {
+			return fmt.Errorf("close failed: priority=%d registered_at=%s: %w", entry.priority, entry.caller, err)
+		}
+		return nil
+	case <-ctx.Done():
 		return timeoutError(entry)
 	}
-	return nil
 }
 
 var errCloseTimeout = errors.New("closer: callback deadline exceeded")

--- a/apps/gooseforum/app/bundles/closer/closer_test.go
+++ b/apps/gooseforum/app/bundles/closer/closer_test.go
@@ -132,6 +132,39 @@ func TestCloseAllTimesOutBlockedCallback(t *testing.T) {
 	}
 }
 
+func TestCloseAllHardTimeoutReturnsFromUncooperativeCallback(t *testing.T) {
+	resetCloserForTest(t)
+	t.Cleanup(func() {
+		resetCloserForTest(t)
+	})
+
+	closeTimeout = 20 * time.Millisecond
+	started := make(chan struct{})
+	release := make(chan struct{})
+	RegisterContext(func(context.Context) error {
+		close(started)
+		<-release
+		return nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		CloseAll()
+		close(done)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("uncooperative callback did not start")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("CloseAll did not enforce its hard timeout")
+	}
+	close(release)
+}
+
 func TestCloseWithTimeoutIncludesEntryDetails(t *testing.T) {
 	resetCloserForTest(t)
 	t.Cleanup(func() {

--- a/apps/gooseforum/app/bundles/closer/closer_test.go
+++ b/apps/gooseforum/app/bundles/closer/closer_test.go
@@ -1,6 +1,7 @@
 package closer
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -108,8 +109,9 @@ func TestCloseAllTimesOutBlockedCallback(t *testing.T) {
 	})
 
 	closeTimeout = 20 * time.Millisecond
-	Register(func() error {
-		select {}
+	RegisterContext(func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
 	})
 
 	start := time.Now()
@@ -137,9 +139,10 @@ func TestCloseWithTimeoutIncludesEntryDetails(t *testing.T) {
 	})
 
 	closeTimeout = time.Millisecond
-	err := closeWithTimeout(closerEntry{
-		f: func() error {
-			select {}
+	err := closeWithTimeout(context.Background(), closerEntry{
+		f: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
 		},
 		caller:   "test.go:42",
 		priority: PriorityFlush,
@@ -153,5 +156,32 @@ func TestCloseWithTimeoutIncludesEntryDetails(t *testing.T) {
 		if !strings.Contains(message, want) {
 			t.Fatalf("timeout error %q does not contain %q", message, want)
 		}
+	}
+}
+
+func TestCloseAllJoinsErrorsAndPassesCancellationContext(t *testing.T) {
+	resetCloserForTest(t)
+	t.Cleanup(func() {
+		resetCloserForTest(t)
+	})
+
+	first := errors.New("first close error")
+	second := errors.New("second close error")
+	RegisterContext(func(ctx context.Context) error {
+		if ctx == nil {
+			t.Fatal("close callback received nil context")
+		}
+		return first
+	})
+	RegisterContext(func(ctx context.Context) error {
+		if ctx == nil {
+			t.Fatal("close callback received nil context")
+		}
+		return second
+	})
+
+	err := CloseAll()
+	if !errors.Is(err, first) || !errors.Is(err, second) {
+		t.Fatalf("CloseAll() error = %v, want both callback errors", err)
 	}
 }

--- a/apps/gooseforum/app/bundles/connect/db4fileconnect/dbconnect.go
+++ b/apps/gooseforum/app/bundles/connect/db4fileconnect/dbconnect.go
@@ -1,6 +1,7 @@
 package db4fileconnect
 
 import (
+	"context"
 	"sync"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
@@ -23,12 +24,20 @@ func Connect() *gorm.DB {
 	once.Do(func() {
 		dbConnect = sqlconnect.ConnectByPrefix("db.file")
 		// 注册到全局关闭管理器
-		closer.RegisterPriority(closer.PriorityDatabase, func() error {
+		closer.RegisterPriorityContext(closer.PriorityDatabase, func(context.Context) error {
 			dbConnect.Close()
 			return nil
 		})
 	})
 	return dbConnect.Connect
+}
+
+// ConnectContext returns the file database handle bound to ctx.
+func ConnectContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return Connect().WithContext(ctx)
 }
 
 func IsSqlite() bool {

--- a/apps/gooseforum/app/bundles/connect/dbconnect/dbconnect.go
+++ b/apps/gooseforum/app/bundles/connect/dbconnect/dbconnect.go
@@ -1,6 +1,7 @@
 package dbconnect
 
 import (
+	"context"
 	"sync"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
@@ -23,12 +24,22 @@ func Connect() *gorm.DB {
 	once.Do(func() {
 		dbConnect = sqlconnect.ConnectByPrefix("db.default")
 		// 注册到全局关闭管理器
-		closer.RegisterPriority(closer.PriorityDatabase, func() error {
+		closer.RegisterPriorityContext(closer.PriorityDatabase, func(context.Context) error {
 			dbConnect.Close()
 			return nil
 		})
 	})
 	return dbConnect.Connect
+}
+
+// ConnectContext returns the default database handle bound to ctx. Queries
+// started from request or worker code should use this entry point so driver
+// cancellation reaches the database instead of continuing in the background.
+func ConnectContext(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return Connect().WithContext(ctx)
 }
 
 func IsSqlite() bool {

--- a/apps/gooseforum/app/bundles/eventbus/eventbus.go
+++ b/apps/gooseforum/app/bundles/eventbus/eventbus.go
@@ -126,9 +126,10 @@ func Publish(ctx context.Context, event any) {
 	}
 }
 
-// DetachedContext marks an event/outbox consumer as intentionally independent
-// from the request that triggered it. It preserves values for logging while
-// removing request cancellation and deadlines from post-commit work.
+// DetachedContext marks post-commit work as intentionally independent from
+// the request that triggered it. It removes request cancellation and
+// deadlines; values are preserved by context.WithoutCancel, but the current
+// event bus may replace the context at the consumer boundary.
 func DetachedContext(ctx context.Context) context.Context {
 	if ctx == nil {
 		return context.Background()

--- a/apps/gooseforum/app/bundles/eventbus/eventbus.go
+++ b/apps/gooseforum/app/bundles/eventbus/eventbus.go
@@ -23,7 +23,7 @@ var (
 	eventProcessor *cqrs.EventProcessor
 	once           sync.Once
 	logger         = &dynamicSlogLogger{}
-	cancelFunc     context.CancelFunc
+	cancelFunc     context.CancelCauseFunc
 	stopWg         sync.WaitGroup
 )
 
@@ -55,7 +55,9 @@ func InitEventBus() {
 		}
 
 		// 注册到全局关闭管理器
-		closer.RegisterPriority(closer.PriorityProducer, Close)
+		closer.RegisterPriorityContext(closer.PriorityProducer, func(ctx context.Context) error {
+			return Close(ctx)
+		})
 
 		// 添加中间件
 		router.AddMiddleware(
@@ -124,6 +126,16 @@ func Publish(ctx context.Context, event any) {
 	}
 }
 
+// DetachedContext marks an event/outbox consumer as intentionally independent
+// from the request that triggered it. It preserves values for logging while
+// removing request cancellation and deadlines from post-commit work.
+func DetachedContext(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return context.WithoutCancel(ctx)
+}
+
 // PublishE 发布事件，并把发布错误返回给调用方。
 func PublishE(ctx context.Context, event any) error {
 	if eventBus == nil {
@@ -152,7 +164,7 @@ func Start(handlers ...cqrs.EventHandler) {
 	}
 
 	var ctx context.Context
-	ctx, cancelFunc = context.WithCancel(context.Background())
+	ctx, cancelFunc = context.WithCancelCause(context.Background())
 
 	stopWg.Go(func() {
 		defer paniclog.Recover("eventbus_router")
@@ -165,10 +177,22 @@ func Start(handlers ...cqrs.EventHandler) {
 
 }
 
-// Close 关闭事件总线
-func Close() error {
+// Close 关闭事件总线。事件处理器必须响应 ctx 取消；等待超时由上层
+// closer 的 context deadline 统一决定，不再在这里隐藏固定等待时间。
+func Close(parentContexts ...context.Context) error {
+	shutdownCtx := context.Background()
+	if len(parentContexts) > 0 && parentContexts[0] != nil {
+		shutdownCtx = parentContexts[0]
+	}
+
+	var cancelCause error
+	if cause := context.Cause(shutdownCtx); cause != nil {
+		cancelCause = cause
+	} else {
+		cancelCause = context.Canceled
+	}
 	if cancelFunc != nil {
-		cancelFunc()
+		cancelFunc(cancelCause)
 	}
 
 	// 等待 router 停止
@@ -178,15 +202,19 @@ func Close() error {
 		close(done)
 	}()
 
+	var closeErrors []error
 	select {
 	case <-done:
 		slog.Info("event bus stopped")
-	case <-time.After(3 * time.Second):
-		slog.Warn("event bus shutdown timed out")
+	case <-shutdownCtx.Done():
+		closeErrors = append(closeErrors, fmt.Errorf("eventbus: router shutdown: %w", shutdownCtx.Err()))
+		slog.Warn("event bus shutdown timed out", "err", shutdownCtx.Err())
 	}
 
 	if pubSub != nil {
-		return pubSub.Close()
+		if err := pubSub.Close(); err != nil {
+			closeErrors = append(closeErrors, fmt.Errorf("eventbus: close pubsub: %w", err))
+		}
 	}
-	return nil
+	return errors.Join(closeErrors...)
 }

--- a/apps/gooseforum/app/bundles/localcache/cache.go
+++ b/apps/gooseforum/app/bundles/localcache/cache.go
@@ -32,7 +32,7 @@ type Cache[V any] struct {
 	cache       *ttlcache.Cache[string, cachedEntry[V]]
 	group       singleflight.Group
 	epoch       atomic.Uint64
-	versionMu   sync.Mutex
+	versionMu   sync.RWMutex
 	keyVersions map[string]uint64
 }
 
@@ -174,8 +174,8 @@ func (c *Cache[V]) Delete(key string) {
 }
 
 func (c *Cache[V]) currentKeyVersion(key string) uint64 {
-	c.versionMu.Lock()
-	defer c.versionMu.Unlock()
+	c.versionMu.RLock()
+	defer c.versionMu.RUnlock()
 	return c.keyVersions[key]
 }
 

--- a/apps/gooseforum/app/bundles/localcache/cache.go
+++ b/apps/gooseforum/app/bundles/localcache/cache.go
@@ -1,15 +1,16 @@
 package localcache
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/cacheconfig"
+	"github.com/jellydator/ttlcache/v3"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -19,30 +20,29 @@ var errCacheInvalidated = errors.New("localcache: value invalidated during load"
 
 // Cache is a small in-process cache facade backed by ttlcache.
 //
-// Invalidation is epoch-based so that a value loaded concurrently with an
-// invalidation is never served afterwards: every mutation that can make
-// in-flight loads stale (Set, Delete, Clear, UpdateIfPresent) bumps the cache
-// epoch, and every entry records the epoch it was produced under. A read
-// accepts an entry only when its epoch matches the current one, so a stale
-// write that lands after a Delete is treated as a miss and reloaded instead
-// of being served. Security-relevant caches (e.g. the user-info snapshot used
-// for TokenVersion checks) rely on this under concurrent "revoke all
-// sessions" style invalidations.
+// Invalidation is version-based so that a value loaded concurrently with an
+// invalidation is never served afterwards. Clear advances the whole-cache
+// epoch; key mutations advance only that key's version. A read accepts an
+// entry only when both versions match, so a stale write that lands after a
+// Delete is treated as a miss and reloaded instead of being served.
 type Cache[V any] struct {
 	MaxEntries uint64
 
-	once  sync.Once
-	cache *ttlcache.Cache[string, cachedEntry[V]]
-	group singleflight.Group
-	epoch atomic.Uint64
+	once        sync.Once
+	cache       *ttlcache.Cache[string, cachedEntry[V]]
+	group       singleflight.Group
+	epoch       atomic.Uint64
+	versionMu   sync.Mutex
+	keyVersions map[string]uint64
 }
 
 // cachedEntry couples a value with the cache epoch it was produced under.
 // Entries whose epoch no longer matches the current one are stale and must
 // not be served.
 type cachedEntry[V any] struct {
-	value V
-	epoch uint64
+	value      V
+	epoch      uint64
+	keyVersion uint64
 }
 
 func (c *Cache[V]) init() {
@@ -52,7 +52,7 @@ func (c *Cache[V]) init() {
 			ttlcache.WithDisableTouchOnHit[string, cachedEntry[V]](),
 		)
 		go c.cache.Start()
-		closer.RegisterPriority(closer.PriorityCache, func() error {
+		closer.RegisterPriorityContext(closer.PriorityCache, func(context.Context) error {
 			c.cache.Stop()
 			return nil
 		})
@@ -97,12 +97,13 @@ func (c *Cache[V]) GetOrLoadE(
 				return value, nil
 			}
 			epoch := c.epoch.Load()
+			keyVersion := c.currentKeyVersion(key)
 			newVal, err := getData()
 			if err != nil {
 				slog.Debug("localcache: loader error", "key", key, "err", err)
 				return *new(V), err
 			}
-			c.cache.Set(key, cachedEntry[V]{value: newVal, epoch: epoch}, timeout)
+			c.cache.Set(key, cachedEntry[V]{value: newVal, epoch: epoch, keyVersion: keyVersion}, timeout)
 			slog.Debug("localcache: stored", "key", key, "ttl", timeout)
 			return newVal, nil
 		})
@@ -129,7 +130,7 @@ func (c *Cache[V]) getValid(key string) (V, bool) {
 		return *new(V), false
 	}
 	entry := item.Value()
-	if entry.epoch != c.epoch.Load() {
+	if entry.epoch != c.epoch.Load() || entry.keyVersion != c.currentKeyVersion(key) {
 		slog.Debug("localcache: dropping stale entry", "key", key)
 		c.cache.Delete(key)
 		return *new(V), false
@@ -141,12 +142,15 @@ func (c *Cache[V]) Clear() {
 	c.init()
 	c.cache.DeleteAll()
 	c.epoch.Add(1)
+	c.versionMu.Lock()
+	clear(c.keyVersions)
+	c.versionMu.Unlock()
 }
 
 func (c *Cache[V]) Set(key string, value V, timeout time.Duration) {
 	c.init()
-	c.epoch.Add(1)
-	c.cache.Set(key, cachedEntry[V]{value: value, epoch: c.epoch.Load()}, timeout)
+	keyVersion := c.bumpKeyVersion(key)
+	c.cache.Set(key, cachedEntry[V]{value: value, epoch: c.epoch.Load(), keyVersion: keyVersion}, timeout)
 	slog.Debug("localcache: set", "key", key, "ttl", timeout)
 }
 
@@ -156,8 +160,8 @@ func (c *Cache[V]) UpdateIfPresent(key string, update func(V) V, timeout time.Du
 	if item == nil {
 		return false
 	}
-	c.epoch.Add(1)
-	c.cache.Set(key, cachedEntry[V]{value: update(item.Value().value), epoch: c.epoch.Load()}, timeout)
+	keyVersion := c.bumpKeyVersion(key)
+	c.cache.Set(key, cachedEntry[V]{value: update(item.Value().value), epoch: c.epoch.Load(), keyVersion: keyVersion}, timeout)
 	slog.Debug("localcache: updated", "key", key, "ttl", timeout)
 	return true
 }
@@ -165,6 +169,22 @@ func (c *Cache[V]) UpdateIfPresent(key string, update func(V) V, timeout time.Du
 func (c *Cache[V]) Delete(key string) {
 	c.init()
 	c.cache.Delete(key)
-	c.epoch.Add(1)
+	c.bumpKeyVersion(key)
 	slog.Debug("localcache: deleted", "key", key)
+}
+
+func (c *Cache[V]) currentKeyVersion(key string) uint64 {
+	c.versionMu.Lock()
+	defer c.versionMu.Unlock()
+	return c.keyVersions[key]
+}
+
+func (c *Cache[V]) bumpKeyVersion(key string) uint64 {
+	c.versionMu.Lock()
+	defer c.versionMu.Unlock()
+	if c.keyVersions == nil {
+		c.keyVersions = make(map[string]uint64)
+	}
+	c.keyVersions[key]++
+	return c.keyVersions[key]
 }

--- a/apps/gooseforum/app/bundles/localcache/cache_test.go
+++ b/apps/gooseforum/app/bundles/localcache/cache_test.go
@@ -158,6 +158,27 @@ func TestCache_DeleteAndClear(t *testing.T) {
 	}
 }
 
+func TestCache_DeleteKeepsOtherKeys(t *testing.T) {
+	c := Cache[string]{}
+	defer stopTestCache(&c)
+
+	c.Set("first", "a", time.Minute)
+	c.Set("second", "b", time.Minute)
+	c.Delete("first")
+
+	loads := 0
+	got, err := c.GetOrLoadE("second", func() (string, error) {
+		loads++
+		return "reloaded", nil
+	}, time.Minute)
+	if err != nil {
+		t.Fatalf("GetOrLoadE() error = %v", err)
+	}
+	if got != "b" || loads != 0 {
+		t.Fatalf("unrelated key = %q with %d loads, want cached b with no reload", got, loads)
+	}
+}
+
 func stopTestCache[V any](c *Cache[V]) {
 	if c.cache != nil {
 		c.cache.Stop()

--- a/apps/gooseforum/app/bundles/logging/logger.go
+++ b/apps/gooseforum/app/bundles/logging/logger.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -166,7 +167,7 @@ func Init() {
 	slog.SetDefault(logger)
 
 	// 注册到全局关闭管理器
-	closer.RegisterPriority(closer.PriorityLogger, func() error {
+	closer.RegisterPriorityContext(closer.PriorityLogger, func(context.Context) error {
 		Shutdown()
 		return nil
 	})

--- a/apps/gooseforum/app/bundles/ratelimit/ratelimit.go
+++ b/apps/gooseforum/app/bundles/ratelimit/ratelimit.go
@@ -9,6 +9,7 @@
 package ratelimit
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -142,7 +143,9 @@ func Default() Store {
 // StartCleanup starts the periodic expired-window cleanup worker.
 func StartCleanup() {
 	cleanupOnce.Do(func() {
-		closer.RegisterPriority(closer.PriorityCache, StopCleanup)
+		closer.RegisterPriorityContext(closer.PriorityCache, func(context.Context) error {
+			return StopCleanup()
+		})
 		cleanupWg.Go(func() {
 			defer paniclog.Recover("ratelimit_cleanup")
 			ticker := time.NewTicker(time.Minute)

--- a/apps/gooseforum/app/console/job/cron.go
+++ b/apps/gooseforum/app/console/job/cron.go
@@ -1,8 +1,9 @@
 package job
 
 import (
-	"errors"
+	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
@@ -25,10 +26,36 @@ import (
 var scheduler = cron.New(
 	cron.WithLogger(cron.VerbosePrintfLogger(logging.CronLogging{})),
 )
-var running = false
+var (
+	runMu      sync.Mutex
+	running    bool
+	registered bool
+)
 
 func Run() {
-	closer.RegisterPriority(closer.PriorityProducer, Stop)
+	if !preferences.GetBool("cron.enabled", true) {
+		slog.Info("cron disabled", "compensation", "durable workers and explicit operator jobs remain available")
+		return
+	}
+
+	runMu.Lock()
+	defer runMu.Unlock()
+	if running {
+		slog.Debug("cron already running")
+		return
+	}
+	if !registered {
+		closer.RegisterPriorityContext(closer.PriorityProducer, func(ctx context.Context) error {
+			return Stop(ctx)
+		})
+		registerJobs()
+		registered = true
+	}
+	running = true
+	scheduler.Start()
+}
+
+func registerJobs() {
 	slog.Info("start cron")
 	backupSpec := preferences.Get("db.spec", "0 3 * * *")
 	entryID, err := scheduler.AddFunc(backupSpec, upCmd(func() {
@@ -107,22 +134,29 @@ func Run() {
 		}
 	}))
 	slog.Info("reg cron", "entryID", entryID, "spec", wikiSpec, "err", err)
-	running = true
-	scheduler.Start()
 }
 
-func Stop() error {
+func Stop(parentContexts ...context.Context) error {
+	shutdownCtx := context.Background()
+	if len(parentContexts) > 0 && parentContexts[0] != nil {
+		shutdownCtx = parentContexts[0]
+	}
+
+	runMu.Lock()
 	if !running {
+		runMu.Unlock()
 		return nil
 	}
-	ctx := scheduler.Stop()
+	running = false
+	stopCtx := scheduler.Stop()
+	runMu.Unlock()
+
 	select {
-	case <-ctx.Done():
-		running = false
+	case <-stopCtx.Done():
 		return nil
-	case <-time.After(10 * time.Second):
-		slog.Error("timed out waiting for job to stop")
-		return errors.New("timed out waiting for job to stop")
+	case <-shutdownCtx.Done():
+		slog.Error("timed out waiting for job to stop", "err", shutdownCtx.Err())
+		return shutdownCtx.Err()
 	}
 }
 

--- a/apps/gooseforum/app/console/serve.go
+++ b/apps/gooseforum/app/console/serve.go
@@ -158,7 +158,11 @@ func ginServe() {
 	mailservice.RecoverStaleTasks()
 	filemigrateservice.RecoverStaleTasks()
 	dataservice.RecoverStaleTasks()
+	dataservice.RecoverImportTasks()
 	searchservice.RecoverStaleTasks()
+	searchservice.RecoverTopicSearchTasks()
+	searchservice.RecoverUserSearchTasks()
+	searchservice.RecoverCategorySearchTasks()
 	// 启动时确保话题索引的 filterable 属性配置（topicType 过滤依赖；见
 	// EnsureTopicIndexConfigured 注释，review N2：仅手动 rebuild 不覆盖存量部署）。
 	searchservice.EnsureTopicIndexConfigured()
@@ -168,8 +172,15 @@ func ginServe() {
 	backgroundservice.RunWorker("file_migrate_worker", filemigrateservice.TaskTypeFileMigrate, filemigrateservice.RunMigrateTask)
 	// 数据导出 worker：处理管理面板创建的 export 任务
 	backgroundservice.RunWorker("data_export_worker", dataservice.TaskTypeExport, dataservice.RunExportTask)
+	// 数据导入 worker：消费 import 任务，事务化导入暂存文件中的数据。
+	backgroundservice.RunWorker("data_import_worker", dataservice.TaskTypeImport, dataservice.RunImportTask)
 	// 课程搜索同步 worker：消费 course-search. 前缀 outbox 任务，投影到 Meili
 	backgroundservice.RunWorker("course_search_worker", searchservice.TaskTypeCourseSearch, searchservice.RunCourseSearchTask)
+	// 主题、用户、分类搜索 worker：消费 transaction-bound outbox，避免业务
+	// 请求/事件 consumer 同步等待 Meilisearch。
+	backgroundservice.RunWorker("topic_search_worker", searchservice.TaskTypeTopicSearch, searchservice.RunTopicSearchTask)
+	backgroundservice.RunWorker("user_search_worker", searchservice.TaskTypeUserSearch, searchservice.RunUserSearchTask)
+	backgroundservice.RunWorker("category_search_worker", searchservice.TaskTypeCategorySearch, searchservice.RunCategorySearchTask)
 	// 课程统计重建 worker：消费 course-stats. 前缀任务（管理页“重建课程统计”触发）
 	backgroundservice.RunWorker("course_stats_worker", courseservice.TaskTypeCourseStatsRebuild, courseservice.RunCourseStatsRebuildTask)
 	// 课评删除隔离窗口清理 worker（issue #175 B3 隐私合规）：消费

--- a/apps/gooseforum/app/http/controllers/api/adminController.go
+++ b/apps/gooseforum/app/http/controllers/api/adminController.go
@@ -1944,10 +1944,10 @@ type ImportTaskReq struct {
 
 // ReplayImportTask requeues a failed import while preserving its staged body.
 func ReplayImportTask(req component.BetterRequest[ImportTaskReq]) component.Response {
-	task, err := dataservice.ReplayImportTask(req.Params.TaskId)
+	task, err := dataservice.ReplayImportTaskContext(requestContext(req.GinContext), req.Params.TaskId)
 	if err != nil {
 		return component.FailResponseCode(component.MessageOperationFailed,
-			component.MessageParams{"error": err.Error()})
+			component.MessageParams{"error": "导入任务当前不可重放"})
 	}
 	return component.SuccessResponse(task)
 }
@@ -1964,14 +1964,14 @@ func ImportData(c *gin.Context) {
 	src, err := file.Open()
 	if err != nil {
 		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportFailed,
-			component.MessageParams{"error": err.Error()}))
+			component.MessageParams{"error": "读取上传文件失败，请稍后重试"}))
 		return
 	}
 	defer func() { _ = src.Close() }()
 	data, err := io.ReadAll(io.LimitReader(src, dataservice.MaxImportSize+1))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportFailed,
-			component.MessageParams{"error": err.Error()}))
+			component.MessageParams{"error": "读取上传文件失败，请稍后重试"}))
 		return
 	}
 	if len(data) > dataservice.MaxImportSize {
@@ -1981,8 +1981,14 @@ func ImportData(c *gin.Context) {
 	}
 	report, err := dataservice.EnqueueImport(c.Request.Context(), data, "json")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportInvalidFormat,
-			component.MessageParams{"error": err.Error()}))
+		if errors.Is(err, dataservice.ErrImportInvalidFormat) {
+			c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportInvalidFormat,
+				component.MessageParams{"error": "导入文件格式无效"}))
+			return
+		}
+		slog.Error("admin import enqueue failed", "error", err)
+		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportFailed,
+			component.MessageParams{"error": "导入任务暂存失败，请稍后重试"}))
 		return
 	}
 	c.JSON(http.StatusOK, component.SuccessData(report))

--- a/apps/gooseforum/app/http/controllers/api/adminController.go
+++ b/apps/gooseforum/app/http/controllers/api/adminController.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/buildinfo"
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/eventbus"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/jsonopt"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/llmprovider"
@@ -58,6 +59,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
+	"gorm.io/gorm"
 )
 
 type TrafficOverviewReq struct {
@@ -564,7 +566,12 @@ func EditTopic(req component.BetterRequest[EditTopicReq]) component.Response {
 		return component.SuccessResponseCode("操作成功", component.MessageOperationSuccess, nil)
 	}
 
-	if err := topics.UpdateProcessStatus(topic.Id, req.Params.ProcessStatus); err != nil {
+	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := topics.UpdateProcessStatusTx(tx, topic.Id, req.Params.ProcessStatus); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
+	}); err != nil {
 		return component.FailResponseCode(component.MessageOperationFailed, nil)
 	}
 	topic.ProcessStatus = req.Params.ProcessStatus
@@ -579,11 +586,7 @@ func EditTopic(req component.BetterRequest[EditTopicReq]) component.Response {
 		"status": statusCode,
 	})
 	moderationservice.TopicStatusChanged(req.UserId, topic.Id, topic.Title, req.Params.ProcessStatus == 1)
-	firstPost := posts.Get(topic.FirstPostId)
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
-	}
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 	// 封禁/解封不发布 Topic*Event，需同步清理 LLMS 公开投影缓存，避免封禁内容在 10s 窗口内继续导出。
 	llmsservice.ClearCache()
 	return component.SuccessResponseCode("操作成功", component.MessageOperationSuccess, nil)
@@ -647,7 +650,7 @@ func EditTopicPin(req component.BetterRequest[EditTopicPinReq]) component.Respon
 	if err := topics.UpdatePinWeight(topic.Id, req.Params.PinWeight); err != nil {
 		return component.FailResponseCode(component.MessageOperationFailed, nil)
 	}
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 	optlogger.UserOptCode(req.UserId, optlogger.EditTopic, topic.Id, "admin.opt.topic.pinWeightChanged", optlogger.MessageParams{
 		"title":        topic.Title,
 		"oldPinWeight": oldPinWeight,
@@ -678,11 +681,15 @@ func EditTopicCategories(req component.BetterRequest[EditTopicCategoriesReq]) co
 
 	oldCategoryIds := append([]uint64(nil), topic.CategoryIds...)
 	topic.CategoryIds = categoryIds
-	if err := topics.SaveNoUpdate(&topic); err != nil {
-		return component.FailResponseCode(component.MessageOperationFailed, nil)
-	}
-
-	if err := topicCategoryIndex.ReplaceTopicCategories(topic.Id, categoryIds); err != nil {
+	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := topics.UpdateCategoryIDsTx(tx, topic.Id, categoryIds); err != nil {
+			return err
+		}
+		if err := topicCategoryIndex.ReplaceTopicCategoriesTx(tx, topic.Id, categoryIds); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
+	}); err != nil {
 		return component.FailResponseCode(component.MessageOperationFailed, nil)
 	}
 	optlogger.UserOptCode(req.UserId, optlogger.EditTopic, topic.Id, "admin.opt.topic.categoriesChanged", optlogger.MessageParams{
@@ -690,11 +697,7 @@ func EditTopicCategories(req component.BetterRequest[EditTopicCategoriesReq]) co
 		"oldCategoryIds": oldCategoryIds,
 		"categoryIds":    categoryIds,
 	})
-	firstPost := posts.Get(topic.FirstPostId)
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
-	}
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(append(oldCategoryIds, categoryIds...)...)
 	// 分类变更不发布事件，同步清理 LLMS 投影缓存（投影内嵌 Categories 列表）。
 	llmsservice.ClearCache()
 	return component.SuccessResponseCode("操作成功", component.MessageOperationSuccess, nil)
@@ -1131,9 +1134,15 @@ func SaveCategory(req component.BetterRequest[CategorySaveReq]) component.Respon
 	entity.Slug = req.Params.Slug
 	entity.Sort = req.Params.Sort
 
-	category.SaveOrCreateById(&entity)
+	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := category.SaveTx(tx, &entity); err != nil {
+			return err
+		}
+		return searchservice.EnqueueCategorySearchTask(tx, entity.Id)
+	}); err != nil {
+		return component.FailResponseCode(component.MessageOperationFailed, nil)
+	}
 	hotdataserve.ClearCategoryCache()
-	eventbus.Publish(context.Background(), &eventhandlers.CategorySearchIndexUpdatedEvent{CategoryId: entity.Id})
 	return component.SuccessResponse(true)
 }
 
@@ -1151,9 +1160,15 @@ func DeleteCategory(req component.BetterRequest[struct {
 	if topicCategoryIndex.GetOneByCategoryId(entity.Id).Id > 0 {
 		return component.FailResponseCode(component.MessageAdminCategoryHasTopics, nil)
 	}
-	category.DeleteEntity(&entity)
+	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := category.DeleteTx(tx, &entity); err != nil {
+			return err
+		}
+		return searchservice.EnqueueCategorySearchTask(tx, entity.Id)
+	}); err != nil {
+		return component.FailResponseCode(component.MessageOperationFailed, nil)
+	}
 	hotdataserve.ClearCategoryCache()
-	eventbus.Publish(context.Background(), &eventhandlers.CategorySearchIndexDeletedEvent{CategoryId: entity.Id})
 	return component.SuccessResponse(true)
 }
 
@@ -1814,7 +1829,7 @@ func TestStorageConnection(req component.BetterRequest[TestStorageConnectionReq]
 			MessageCode: component.MessageAdminStorageTestSuccess,
 		})
 	}
-	if err := storageservice.TestConnection(context.Background(), cfg); err != nil {
+	if err := storageservice.TestConnection(requestContext(req.GinContext), cfg); err != nil {
 		return component.SuccessResponse(TestStorageConnectionResp{
 			Success:     false,
 			MessageCode: component.MessageAdminStorageTestFailed,
@@ -1886,8 +1901,6 @@ func ListExportTasks(req component.BetterRequest[component.Null]) component.Resp
 }
 
 // DownloadExportTask 下载导出文件（issue #324 S4：下载操作审计）。
-// maxDataImportSize 限制导入请求体大小。
-const maxDataImportSize = 50 << 20 // 50MB
 func DownloadExportTask(c *gin.Context) {
 	taskID := c.Param("taskId")
 	task, err := taskQueue.GetByID(taskID)
@@ -1916,9 +1929,32 @@ func DownloadExportTask(c *gin.Context) {
 	c.File(path)
 }
 
+// ListImportTasks 获取导入任务状态列表。
+func ListImportTasks(req component.BetterRequest[component.Null]) component.Response {
+	tasks, err := dataservice.ListImportTasks(20)
+	if err != nil {
+		return component.FailResponseCode(component.MessageOperationFailed, nil)
+	}
+	return component.SuccessResponse(tasks)
+}
+
+type ImportTaskReq struct {
+	TaskId uint64 `uri:"taskId" validate:"required"`
+}
+
+// ReplayImportTask requeues a failed import while preserving its staged body.
+func ReplayImportTask(req component.BetterRequest[ImportTaskReq]) component.Response {
+	task, err := dataservice.ReplayImportTask(req.Params.TaskId)
+	if err != nil {
+		return component.FailResponseCode(component.MessageOperationFailed,
+			component.MessageParams{"error": err.Error()})
+	}
+	return component.SuccessResponse(task)
+}
+
 // ImportData 导入 JSON 数据（multipart file 字段）
 func ImportData(c *gin.Context) {
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxDataImportSize)
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, dataservice.MaxImportSize)
 	file, err := c.FormFile("file")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportFailed,
@@ -1932,13 +1968,18 @@ func ImportData(c *gin.Context) {
 		return
 	}
 	defer func() { _ = src.Close() }()
-	data, err := io.ReadAll(src)
+	data, err := io.ReadAll(io.LimitReader(src, dataservice.MaxImportSize+1))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportFailed,
 			component.MessageParams{"error": err.Error()}))
 		return
 	}
-	report, err := dataservice.ImportData(context.Background(), data, "json")
+	if len(data) > dataservice.MaxImportSize {
+		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportFailed,
+			component.MessageParams{"error": "导入文件超过 50MB 限制"}))
+		return
+	}
+	report, err := dataservice.EnqueueImport(c.Request.Context(), data, "json")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, component.FailDataCode(component.MessageAdminDataImportInvalidFormat,
 			component.MessageParams{"error": err.Error()}))
@@ -2072,30 +2113,35 @@ func ReviewAction(req component.BetterRequest[ReviewActionReq]) component.Respon
 		if topic.ProcessStatus != topics.ProcessStatusPending {
 			return component.FailResponseCode(component.MessageAdminReviewProcessed, nil)
 		}
-		if err := topics.UpdateProcessStatus(topic.Id, targetStatus); err != nil {
+		if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+			if err := topics.UpdateProcessStatusTx(tx, topic.Id, targetStatus); err != nil {
+				return err
+			}
+			// 首楼同步状态
+			if topic.FirstPostId > 0 {
+				if err := posts.UpdateProcessStatusTx(tx, topic.FirstPostId, targetStatus); err != nil {
+					return err
+				}
+			}
+			return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
+		}); err != nil {
 			return component.FailResponseCode(component.MessageAdminReviewFailed,
 				component.MessageParams{"error": err.Error()})
 		}
-		// 首楼同步状态
-		if topic.FirstPostId > 0 {
-			_ = posts.UpdateProcessStatus(topic.FirstPostId, targetStatus)
-		}
-		hotdataserve.ClearTopicListCache()
+		topic.ProcessStatus = targetStatus
+		hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 		// 审核后无条件重建搜索索引（issue #132）：拒绝（ProcessStatus→blocked）
 		// 时 BuildSingleTopicSearchDocument 会把文档从索引删除，避免被拒话题
 		// 残留在公共搜索；批准时 upsert 恢复（下方事件也会重建，幂等）。
 		firstPost := posts.Get(topic.FirstPostId)
-		if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-			slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
-		}
 		// 批准后补发事件：新建主题发完整发布事件（搜索索引/统计/积分/活动/通知），
 		// 编辑主题仅重建索引与通知，避免重复积分。
 		if req.Params.Approve && topic.Status == 1 {
 			if userActivities.HasRecord(userActivities.ActionPost, userActivities.SubjectTopic, topic.Id) {
-				eventbus.Publish(context.Background(), &eventhandlers.TopicUpdatedEvent{Topic: &topic, FirstPost: &firstPost})
+				eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicUpdatedEvent{Topic: &topic, FirstPost: &firstPost})
 			} else {
 				userStatistics.WriteTopic(topic.UserId)
-				eventbus.Publish(context.Background(), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
+				eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
 			}
 		}
 		optlogger.UserOptCode(req.UserId, optlogger.EditTopic, topic.Id, "admin.opt.review.topic",
@@ -2113,11 +2159,17 @@ func ReviewAction(req component.BetterRequest[ReviewActionReq]) component.Respon
 		if post.ProcessStatus != posts.ProcessStatusPending {
 			return component.FailResponseCode(component.MessageAdminReviewProcessed, nil)
 		}
-		if err := posts.UpdateProcessStatus(post.Id, targetStatus); err != nil {
+		topicEntity := topics.GetSimple(post.TopicId)
+		if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+			if err := posts.UpdateProcessStatusTx(tx, post.Id, targetStatus); err != nil {
+				return err
+			}
+			return searchservice.EnqueueTopicSearchTask(tx, topicEntity.Id)
+		}); err != nil {
 			return component.FailResponseCode(component.MessageAdminReviewFailed,
 				component.MessageParams{"error": err.Error()})
 		}
-		hotdataserve.ClearTopicListCache()
+		hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		// 批准后补发事件：仅对新建待审回复补发（编辑场景创建时已发布过事件）。
 		if req.Params.Approve && !userActivities.HasRecord(userActivities.ActionComment, userActivities.SubjectPost, post.Id) {
 			userStatistics.WriteComment(post.UserId)
@@ -2128,7 +2180,7 @@ func ReviewAction(req component.BetterRequest[ReviewActionReq]) component.Respon
 					replyToAuthorID = parent.UserId
 				}
 			}
-			eventbus.Publish(context.Background(), &eventhandlers.CommentCreatedEvent{
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.CommentCreatedEvent{
 				TopicId:             post.TopicId,
 				PostId:              post.Id,
 				UserId:              post.UserId,

--- a/apps/gooseforum/app/http/controllers/api/admin_topic_management_test.go
+++ b/apps/gooseforum/app/http/controllers/api/admin_topic_management_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/moderationLog"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/optRecord"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicCategoryIndex"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
@@ -28,6 +29,7 @@ func setupAdminTopicTestDB(t *testing.T) *gorm.DB {
 		&topicCategoryIndex.Entity{},
 		&optRecord.Entity{},
 		&moderationLog.Entity{},
+		&taskQueue.Entity{},
 	); err != nil {
 		t.Fatalf("migrate admin topic tables: %v", err)
 	}

--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"strings"
 	"time"
 
@@ -19,11 +18,11 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/validate"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
+	"github.com/gin-gonic/gin"
 )
 
 func Logout(c *gin.Context) {
@@ -126,7 +125,7 @@ func Register(c *gin.Context) {
 		slog.Debug("注册激活邮件任务已提交", "userId", userEntity.Id, "email", userEntity.Email, "enableEmailVerification", securityConfig.EnableEmailVerification)
 	}
 
-	eventbus.Publish(context.Background(), &eventhandlers.UserSignUpEvent{
+	eventbus.Publish(detachedRequestContext(c), &eventhandlers.UserSignUpEvent{
 		UserId:   userEntity.Id,
 		Username: userEntity.Username,
 	})

--- a/apps/gooseforum/app/http/controllers/api/llms_cache_test.go
+++ b/apps/gooseforum/app/http/controllers/api/llms_cache_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pointsRecord"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/postRevisions"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicCategoryIndex"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userPoints"
@@ -272,6 +273,7 @@ func setupLLMSCacheTestDB(t *testing.T) *gorm.DB {
 		&category.Entity{},
 		&topicCategoryIndex.Entity{},
 		&users.EntityComplete{},
+		&taskQueue.Entity{},
 		&fileUsage.Entity{},
 		&contentDeleteEvent.Entity{},
 	)

--- a/apps/gooseforum/app/http/controllers/api/pk_admin.go
+++ b/apps/gooseforum/app/http/controllers/api/pk_admin.go
@@ -57,7 +57,9 @@ func SyncPkCalendar(req component.BetterRequest[SyncPkCalendarReq]) component.Re
 		"depth": depth,
 	})
 
+	jobCtx, cancel := detachedJobContext(req.GinContext)
 	go func() {
+		defer cancel()
 		defer func() {
 			if p := recover(); p != nil {
 				slog.Error("pk sync panic", "err", p)
@@ -66,7 +68,7 @@ func SyncPkCalendar(req component.BetterRequest[SyncPkCalendarReq]) component.Re
 				}
 			}
 		}()
-		report, syncErr := runPkSync(context.Background(), cookie, calendarId, depth, false, claim, resume)
+		report, syncErr := runPkSync(jobCtx, cookie, calendarId, depth, false, claim, resume)
 		if syncErr != nil {
 			slog.Error("pk sync failed", "calendarId", calendarId, "term", term, "err", syncErr)
 			return

--- a/apps/gooseforum/app/http/controllers/api/topicController.go
+++ b/apps/gooseforum/app/http/controllers/api/topicController.go
@@ -41,6 +41,13 @@ func requestContext(c *gin.Context) context.Context {
 	return c.Request.Context()
 }
 
+func betterRequestContext[T any](req component.BetterRequest[T]) context.Context {
+	if req.Context != nil {
+		return req.Context
+	}
+	return requestContext(req.GinContext)
+}
+
 func detachedRequestContext(c *gin.Context) context.Context {
 	return eventbus.DetachedContext(requestContext(c))
 }
@@ -247,7 +254,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 	isEdit := topic.Id > 0
 	// 单事务原子提交：话题 + 首帖 + 指针（首/末帖 ID、最后回复时间）+ 分类索引。
 	// 任一步失败整体回滚，不留孤立话题/缺首帖/缺分类索引；事件与缓存失效仅在提交后执行。
-	err = db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+	err = db.ConnectContext(betterRequestContext(req)).Transaction(func(tx *gorm.DB) error {
 		if isEdit {
 			// 锁序与 UpdatePost 首楼分支保持一致（posts → topics）：先写
 			// firstPost 行、再写 topic 派生字段。若这里先锁 topics 再锁
@@ -369,7 +376,7 @@ func UpdateTopicStatus(req component.BetterRequest[TopicStatusReq]) component.Re
 		return component.SuccessResponse(true)
 	}
 	topic.Status = nextStatus
-	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+	if err := db.ConnectContext(betterRequestContext(req)).Transaction(func(tx *gorm.DB) error {
 		if err := topics.UpdateStatusTx(tx, topic.Id, nextStatus); err != nil {
 			return err
 		}
@@ -637,7 +644,7 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 	}
 
 	now := time.Now()
-	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+	if err := db.ConnectContext(betterRequestContext(req)).Transaction(func(tx *gorm.DB) error {
 		if err := posts.SaveTx(tx, &postEntity); err != nil {
 			return err
 		}

--- a/apps/gooseforum/app/http/controllers/api/topicController.go
+++ b/apps/gooseforum/app/http/controllers/api/topicController.go
@@ -30,8 +30,24 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/searchservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/topicunseenservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
+	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
+
+func requestContext(c *gin.Context) context.Context {
+	if c == nil || c.Request == nil {
+		return context.Background()
+	}
+	return c.Request.Context()
+}
+
+func detachedRequestContext(c *gin.Context) context.Context {
+	return eventbus.DetachedContext(requestContext(c))
+}
+
+func detachedJobContext(c *gin.Context) (context.Context, context.CancelFunc) {
+	return context.WithCancel(detachedRequestContext(c))
+}
 
 // checkContentPolicy 检查内容是否命中敏感词。
 // 返回 (pendingReview, word, err)：
@@ -182,6 +198,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 	}
 	var topic topics.Entity
 	var firstPost posts.Entity
+	var oldCategoryIds []uint64
 	if req.Params.TopicId != 0 {
 		topic = topics.Get(req.Params.TopicId)
 		// wiki 分站页面由 wiki 修订审核流程管理，禁止经论坛编辑端点直接改写
@@ -196,6 +213,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 		if firstPost.Id == 0 {
 			firstPost, _ = posts.GetByTopicPostNoAtOrAfter(topic.Id, 1)
 		}
+		oldCategoryIds = append([]uint64(nil), topic.CategoryIds...)
 	} else {
 		topic.UserId = req.UserId
 	}
@@ -229,7 +247,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 	isEdit := topic.Id > 0
 	// 单事务原子提交：话题 + 首帖 + 指针（首/末帖 ID、最后回复时间）+ 分类索引。
 	// 任一步失败整体回滚，不留孤立话题/缺首帖/缺分类索引；事件与缓存失效仅在提交后执行。
-	err = db.Connect().Transaction(func(tx *gorm.DB) error {
+	err = db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
 		if isEdit {
 			// 锁序与 UpdatePost 首楼分支保持一致（posts → topics）：先写
 			// firstPost 行、再写 topic 派生字段。若这里先锁 topics 再锁
@@ -285,7 +303,10 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 				return err
 			}
 		}
-		return topicCategoryIndex.ReplaceTopicCategoriesTx(tx, topic.Id, req.Params.CategoryId)
+		if err := topicCategoryIndex.ReplaceTopicCategoriesTx(tx, topic.Id, req.Params.CategoryId); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
 	})
 	if err != nil {
 		slog.Error("topic write transaction failed", "topicId", topic.Id, "isEdit", isEdit, "err", err)
@@ -294,20 +315,18 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 
 	// ---- 事务已提交：此后才允许缓存失效、统计与事件发布 ----
 	fileusageservice.ReplaceTopic(topic.Id, req.UserId, firstPost.Content)
-	hotdataserve.ClearTopicListCache()
+	categoryIDs := append(append([]uint64(nil), oldCategoryIds...), topic.CategoryIds...)
+	hotdataserve.InvalidateTopicListCacheForCategories(categoryIDs...)
 	if isEdit {
 		// 编辑分支：无条件重建搜索索引——下架（TopicStatus=0）或转入待审
 		// （ProcessStatus=Pending）时 BuildSingleTopicSearchDocument 会把文档
 		// 从索引删除，避免非公开内容残留在公共搜索（issue #132）。
 		// LLMS 投影缓存同步失效，避免下架内容在 10s 窗口内继续导出。
 		llmsservice.ClearCache()
-		if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-			slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
-		}
 		// 待审（pendingReview）内容未上线，跳过业务事件发布（通知/webhook/统计/积分），
 		// 由审核批准路径补发对应事件，避免敏感内容在审核前外泄。
 		if topic.Status == 1 && !pendingReview {
-			eventbus.Publish(context.Background(), &eventhandlers.TopicUpdatedEvent{Topic: &topic, FirstPost: &firstPost})
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicUpdatedEvent{Topic: &topic, FirstPost: &firstPost})
 		}
 	} else {
 		if topic.Status == 1 && !pendingReview {
@@ -315,7 +334,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 		}
 		userservice.InvalidateUserPublicProfileCache(req.UserId)
 		if topic.Status == 1 && !pendingReview {
-			eventbus.Publish(context.Background(), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
 		}
 		if err := topicunseenservice.MarkVisited(req.UserId, topic.Id, firstPost.Id, time.Now()); err != nil {
 			slog.Warn("mark created topic visited failed", "userId", req.UserId, "topicId", topic.Id, "error", err)
@@ -350,21 +369,23 @@ func UpdateTopicStatus(req component.BetterRequest[TopicStatusReq]) component.Re
 		return component.SuccessResponse(true)
 	}
 	topic.Status = nextStatus
-	if err := topics.Save(&topic); err != nil {
+	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := topics.UpdateStatusTx(tx, topic.Id, nextStatus); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
+	}); err != nil {
 		return component.FailResponseCode(component.MessageTopicSaveFailed, nil)
 	}
 	firstPost := posts.Get(topic.FirstPostId)
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 	// 无条件重建搜索索引（issue #132）：1→0（取消发布）时
 	// BuildSingleTopicSearchDocument 会把文档从索引删除，避免已下架话题
 	// 残留在公共搜索；0→1（重新发布）时 upsert 恢复，幂等无害。
 	// 不发布 TopicUpdatedEvent：下架属用户隐私操作，不触发 webhook 通知。
 	llmsservice.ClearCache()
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
-	}
 	if topic.Status == 1 {
-		eventbus.Publish(context.Background(), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
+		eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicPublishedEvent{Topic: &topic, FirstPost: &firstPost})
 	}
 	return component.SuccessResponse(true)
 }
@@ -496,7 +517,7 @@ func createPost(req component.BetterRequest[CreatePostReq], agent bool) componen
 		userStatistics.WriteComment(req.UserId)
 	}
 	userservice.InvalidateUserPublicProfileCache(req.UserId)
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 
 	// 获取父 post 作者 ID
 	var parentPostAuthorID uint64
@@ -507,7 +528,7 @@ func createPost(req component.BetterRequest[CreatePostReq], agent bool) componen
 	// 待审（pendingReview）内容未上线，跳过事件发布（通知/webhook/统计/积分），
 	// 批准后由 ReviewAction 补发对应事件，避免敏感内容在审核前外泄。
 	if !pendingReview {
-		eventbus.Publish(context.Background(), &eventhandlers.CommentCreatedEvent{
+		eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.CommentCreatedEvent{
 			TopicId:             topicEntity.Id,
 			PostId:              postEntity.Id,
 			UserId:              req.UserId,
@@ -616,7 +637,7 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 	}
 
 	now := time.Now()
-	if err := db.Connect().Transaction(func(tx *gorm.DB) error {
+	if err := db.ConnectContext(requestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
 		if err := posts.SaveTx(tx, &postEntity); err != nil {
 			return err
 		}
@@ -632,6 +653,7 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 			if err := topics.UpdateFirstPostDerivedTx(tx, &topicEntity); err != nil {
 				return err
 			}
+			return searchservice.EnqueueTopicSearchTask(tx, topicEntity.Id)
 		}
 		return nil
 	}); err != nil {
@@ -648,13 +670,10 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 		// 首楼编辑联动：附件重映射、列表缓存、搜索索引与业务事件
 		// （TopicUpdatedEvent 驱动通知/webhook/搜索），与 writeTopic 编辑分支一致。
 		fileusageservice.ReplaceTopic(topicEntity.Id, req.UserId, postEntity.Content)
-		hotdataserve.ClearTopicListCache()
+		hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		llmsservice.ClearCache()
-		if _, err := searchservice.BuildSingleTopicSearchDocument(&topicEntity, &postEntity); err != nil {
-			slog.Error("failed to rebuild topic search document", "topicId", topicEntity.Id, "err", err)
-		}
 		if topicEntity.Status == 1 && !pendingReview {
-			eventbus.Publish(context.Background(), &eventhandlers.TopicUpdatedEvent{Topic: &topicEntity, FirstPost: &postEntity})
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicUpdatedEvent{Topic: &topicEntity, FirstPost: &postEntity})
 		}
 	} else {
 		// 回复编辑不发布事件，同步清理 LLMS 投影缓存。
@@ -729,10 +748,10 @@ func LikeTopic(req component.BetterRequest[LikeTopicReq]) component.Response {
 			userStatistics.GivenLike(req.UserId)
 			userservice.InvalidateUserPublicProfileCache(topicEntity.UserId)
 			userservice.InvalidateUserPublicProfileCache(req.UserId)
-			hotdataserve.ClearTopicListCache()
+			hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 
 			// 发送点赞事件
-			eventbus.Publish(context.Background(), &eventhandlers.TopicLikedEvent{
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.TopicLikedEvent{
 				UserId:  topicEntity.UserId,
 				TopicId: topicEntity.Id,
 				Title:   topicEntity.Title,
@@ -744,7 +763,7 @@ func LikeTopic(req component.BetterRequest[LikeTopicReq]) component.Response {
 			userStatistics.CancelGivenLike(req.UserId)
 			userservice.InvalidateUserPublicProfileCache(topicEntity.UserId)
 			userservice.InvalidateUserPublicProfileCache(req.UserId)
-			hotdataserve.ClearTopicListCache()
+			hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		}
 	}
 	return component.SuccessResponse(true)
@@ -852,7 +871,7 @@ func LikePost(req component.BetterRequest[LikePostReq]) component.Response {
 			userStatistics.GivenLike(req.UserId)
 			// 楼层点赞计入作者"获赞"统计，并发布点赞事件（动态/徽章/通知）
 			userStatistics.LikeTopic(postEntity.UserId)
-			eventbus.Publish(context.Background(), &eventhandlers.PostLikedEvent{
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.PostLikedEvent{
 				UserId:     postEntity.UserId,
 				PostId:     postEntity.Id,
 				TopicId:    postEntity.TopicId,
@@ -940,7 +959,7 @@ func FollowUser(req component.BetterRequest[FollowUserReq]) component.Response {
 
 			// 发送关注通知
 			followerUser, _ := req.GetUser()
-			eventbus.Publish(context.Background(), &eventhandlers.UserFollowedEvent{
+			eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.UserFollowedEvent{
 				UserId:       req.Params.Id,
 				FollowerId:   req.UserId,
 				FollowerName: followerUser.Username,

--- a/apps/gooseforum/app/http/controllers/api/userController.go
+++ b/apps/gooseforum/app/http/controllers/api/userController.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"context"
-
 	"bytes"
 	"errors"
 	"fmt"
@@ -200,7 +198,7 @@ func EditUsername(req component.BetterRequest[EditUsernameReq]) component.Respon
 		return component.FailResponseCode(component.MessageUserUpdateFailed, nil)
 	}
 
-	eventbus.Publish(context.Background(), &eventhandlers.UserSearchIndexUpdatedEvent{UserId: userEntity.Id})
+	eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.UserSearchIndexUpdatedEvent{UserId: userEntity.Id})
 
 	return component.SuccessResponseCode("更新成功", component.MessageUserUpdateSuccess, nil)
 }
@@ -237,7 +235,7 @@ func EditUserInfo(req component.BetterRequest[EditUserInfoReq]) component.Respon
 	if err != nil {
 		return component.FailResponseCode(component.MessageUserUpdateFailed, nil)
 	}
-	eventbus.Publish(context.Background(), &eventhandlers.UserSearchIndexUpdatedEvent{UserId: userEntity.Id})
+	eventbus.Publish(detachedRequestContext(req.GinContext), &eventhandlers.UserSearchIndexUpdatedEvent{UserId: userEntity.Id})
 	return component.SuccessResponseCode("更新成功", component.MessageUserUpdateSuccess, nil)
 }
 

--- a/apps/gooseforum/app/http/controllers/api/wikiSyncController.go
+++ b/apps/gooseforum/app/http/controllers/api/wikiSyncController.go
@@ -43,11 +43,13 @@ func WikiSyncRun(req component.BetterRequest[component.Null]) component.Response
 	if !wikiservice.LoadGitConfig().Enabled() {
 		return component.FailResponseCode(component.MessageWikiSyncFailed, nil)
 	}
+	jobCtx, cancel := detachedJobContext(req.GinContext)
 	go func() {
+		defer cancel()
 		// review MEDIUM：goroutine panic 会终止整个进程（startup/cron 同步
 		// 均有 paniclog.Recover，此处对齐）。
 		defer recovery.Recover("wiki_manual_sync")
-		if _, err := wikiservice.Sync("manual"); err != nil {
+		if _, err := wikiservice.SyncContext(jobCtx, "manual"); err != nil {
 			if errors.Is(err, wikiservice.ErrSyncAlreadyRunning) {
 				return // 已合并：运行中同步完成后会自动补跑（syncPending）
 			}
@@ -216,11 +218,13 @@ func WikiWebhook(c *gin.Context) {
 				}
 			}
 		}
+		jobCtx, cancel := detachedJobContext(c)
 		go func() {
+			defer cancel()
 			// review MEDIUM：goroutine panic 会终止整个进程（startup/cron 同步
 			// 均有 paniclog.Recover，此处对齐）。
 			defer recovery.Recover("wiki_webhook_sync")
-			if _, err := wikiservice.Sync("webhook"); err != nil {
+			if _, err := wikiservice.SyncContext(jobCtx, "webhook"); err != nil {
 				if errors.Is(err, wikiservice.ErrSyncAlreadyRunning) {
 					return // 已合并：运行中同步完成后自动补跑
 				}

--- a/apps/gooseforum/app/http/controllers/component/component.go
+++ b/apps/gooseforum/app/http/controllers/component/component.go
@@ -1,11 +1,12 @@
 package component
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/gin-gonic/gin"
 )
 
 type Status int
@@ -21,6 +22,9 @@ type BetterRequest[T any] struct {
 	userSet    bool
 	userInfo   users.EntityComplete
 	GinContext *gin.Context
+	// Context carries non-HTTP request cancellation for reused controller
+	// paths such as MCP. HTTP adapters may leave it nil and use GinContext.
+	Context context.Context
 }
 type Null struct {
 }

--- a/apps/gooseforum/app/http/controllers/forum/category.go
+++ b/apps/gooseforum/app/http/controllers/forum/category.go
@@ -1,10 +1,9 @@
 package forum
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
-	"github.com/samber/lo"
+	"github.com/gin-gonic/gin"
 	"github.com/spf13/cast"
 )
 
@@ -16,8 +15,14 @@ func Category(c *gin.Context) {
 		return
 	}
 
-	sort, _ := lo.Coalesce(c.Param("sort"), "latest")
-	page := lo.Ternary(cast.ToInt(c.Query("page")) <= 0, 1, cast.ToInt(c.Query("page")))
+	sort := c.Param("sort")
+	if sort == "" {
+		sort = "latest"
+	}
+	page := cast.ToInt(c.Query("page"))
+	if page <= 0 {
+		page = 1
+	}
 	topicPage := hotdataserve.GetTopicsByCategorySimpleVo(id, sort, page)
 
 	payload := PagePayload{

--- a/apps/gooseforum/app/http/controllers/forum/course_ai_summary.go
+++ b/apps/gooseforum/app/http/controllers/forum/course_ai_summary.go
@@ -1,6 +1,7 @@
 package forum
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -40,7 +41,11 @@ func GetCourseSummary(req component.BetterRequest[GetCourseSummaryReq]) componen
 		}
 		return component.SuccessResponse(result)
 	}
-	result, err := courseservice.GetAiSummary(req.Params.CourseId, req.Params.Refresh)
+	ctx := context.Background()
+	if req.GinContext != nil && req.GinContext.Request != nil {
+		ctx = req.GinContext.Request.Context()
+	}
+	result, err := courseservice.GetAiSummaryContext(ctx, req.Params.CourseId, req.Params.Refresh)
 	if err != nil {
 		switch {
 		case errors.Is(err, courseservice.ErrAiSummaryCourseNotFound):

--- a/apps/gooseforum/app/http/controllers/forum/home.go
+++ b/apps/gooseforum/app/http/controllers/forum/home.go
@@ -1,16 +1,21 @@
 package forum
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
-	"github.com/samber/lo"
+	"github.com/gin-gonic/gin"
 	"github.com/spf13/cast"
 )
 
 func Home(c *gin.Context) {
-	sort, _ := lo.Coalesce(c.Query("sort"), "latest")
-	page := lo.Ternary(cast.ToInt(c.Query("page")) <= 0, 1, cast.ToInt(c.Query("page")))
+	sort := c.Query("sort")
+	if sort == "" {
+		sort = "latest"
+	}
+	page := cast.ToInt(c.Query("page"))
+	if page <= 0 {
+		page = 1
+	}
 
 	topicPage := hotdataserve.GetLatestTopicsSimpleVoPaginated(page, sort)
 	payload := PagePayload{

--- a/apps/gooseforum/app/http/controllers/forum/llms_cache_moderation_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/llms_cache_moderation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/moderators"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
@@ -108,6 +109,7 @@ func setupLLMSModerationCacheTestDB(t *testing.T) *gorm.DB {
 		&moderators.Entity{},
 		&moderationLog.Entity{},
 		&users.EntityComplete{},
+		&taskQueue.Entity{},
 	)
 	if err != nil {
 		t.Fatalf("migrate llms moderation cache tables: %v", err)

--- a/apps/gooseforum/app/http/controllers/forum/moderation.go
+++ b/apps/gooseforum/app/http/controllers/forum/moderation.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/eventbus"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/i18n"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
@@ -32,6 +33,17 @@ import (
 )
 
 const moderationPageSize = 20
+
+func moderationRequestContext(c *gin.Context) context.Context {
+	if c == nil || c.Request == nil {
+		return context.Background()
+	}
+	return c.Request.Context()
+}
+
+func detachedModerationRequestContext(c *gin.Context) context.Context {
+	return eventbus.DetachedContext(moderationRequestContext(c))
+}
 
 func Moderation(c *gin.Context) {
 	userID := component.LoginUserId(c)
@@ -195,20 +207,18 @@ func UpdateModerationTopicStatus(req component.BetterRequest[ModerationTopicStat
 	if topic.ProcessStatus == nextStatus {
 		return component.SuccessResponse(true)
 	}
-	if err := topics.UpdateProcessStatus(topic.Id, nextStatus); err != nil {
+	if err := dbconnect.ConnectContext(moderationRequestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := topics.UpdateProcessStatusTx(tx, topic.Id, nextStatus); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
+	}); err != nil {
 		return component.FailResponseCode(component.MessageOperationFailed, nil)
 	}
 	topic.ProcessStatus = nextStatus
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 	// 审核封禁/解封不发布事件，同步清理 LLMS 投影缓存，避免封禁内容在 10s 窗口内继续导出。
 	llmsservice.ClearCache()
-	firstPost := posts.Get(topic.FirstPostId)
-	if firstPost.Id == 0 {
-		firstPost, _ = posts.GetByTopicPostNoAtOrAfter(topic.Id, 1)
-	}
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Error("failed to rebuild topic search document", "topicId", topic.Id, "err", err)
-	}
 	moderationservice.TopicStatusChanged(req.UserId, topic.Id, topic.Title, nextStatus == 1)
 	return component.SuccessResponse(true)
 }
@@ -237,7 +247,7 @@ func CreateReport(req component.BetterRequest[CreateReportReq]) component.Respon
 		return component.FailResponseCode(component.MessageReportDuplicate, nil)
 	}
 	moderationservice.InvalidateTopic(target.TopicID)
-	eventbus.Publish(context.Background(), &eventhandlers.ReportCreatedEvent{
+	eventbus.Publish(detachedModerationRequestContext(req.GinContext), &eventhandlers.ReportCreatedEvent{
 		ReportId:   report.Id,
 		TargetType: report.TargetType,
 		TargetId:   report.TargetId,
@@ -305,7 +315,12 @@ func UpdateModerationPostStatus(req component.BetterRequest[ModerationPostStatus
 	if post.ProcessStatus == nextStatus {
 		return component.SuccessResponse(true)
 	}
-	if err := posts.UpdateProcessStatus(post.Id, nextStatus); err != nil {
+	if err := dbconnect.ConnectContext(moderationRequestContext(req.GinContext)).Transaction(func(tx *gorm.DB) error {
+		if err := posts.UpdateProcessStatusTx(tx, post.Id, nextStatus); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, post.TopicId)
+	}); err != nil {
 		return component.FailResponseCode(component.MessageOperationFailed, nil)
 	}
 	// 审核封禁/解封回复不发布事件，同步清理 LLMS 投影缓存。

--- a/apps/gooseforum/app/http/controllers/forum/payload.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload.go
@@ -2445,13 +2445,17 @@ func buildNotificationsPageProps(c *gin.Context) NotificationsPageProps {
 	notifications, nextCursor, hasNext, _ := notificationservice.GetNotificationCursorList(userID, notificationservice.DefaultNotificationPageSize, 0, false)
 	unreadCount, _ := eventNotification.GetUnreadCount(userID)
 	items := BuildNotificationPayloads(notifications)
+	nextPage := 0
+	if hasNext {
+		nextPage = 2
+	}
 	return NotificationsPageProps{
 		Total:         int64(len(items)),
 		UnreadCount:   unreadCount,
 		Notifications: items,
 		Pagination: PaginationPayload{
 			Page:     1,
-			NextPage: lo.Ternary(hasNext, 2, 0),
+			NextPage: nextPage,
 			HasNext:  hasNext,
 			NextURL:  fmt.Sprintf("/api/forum/notifications?filter=all&cursor=%d&limit=%d", nextCursor, notificationservice.DefaultNotificationPageSize),
 		},

--- a/apps/gooseforum/app/http/controllers/forum/topic_meta_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/topic_meta_test.go
@@ -1,13 +1,14 @@
 package forum
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/vo"
@@ -18,7 +19,21 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/badgeservice"
+	"github.com/gin-gonic/gin"
+	gormLogger "gorm.io/gorm/logger"
 )
+
+type queryCounterLogger struct {
+	count atomic.Int64
+}
+
+func (l *queryCounterLogger) LogMode(gormLogger.LogLevel) gormLogger.Interface { return l }
+func (l *queryCounterLogger) Info(context.Context, string, ...any)             {}
+func (l *queryCounterLogger) Warn(context.Context, string, ...any)             {}
+func (l *queryCounterLogger) Error(context.Context, string, ...any)            {}
+func (l *queryCounterLogger) Trace(context.Context, time.Time, func() (string, int64), error) {
+	l.count.Add(1)
+}
 
 func TestTopicMetaJSONLDIncludesForumRequiredFields(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -235,10 +250,20 @@ func TestBuildTopicDetailPropsReadsTopicPostTables(t *testing.T) {
 	conn.Create(&posts.Entity{Id: secondReplyPostID, TopicId: topicID, PostNo: 3, UserId: replyerID, ReplyToPostId: firstPostID, Content: "second reply", RenderedHTML: "<p>second reply</p>", RenderedVersion: 1, CreatedAt: now.Add(2 * time.Minute), UpdatedAt: now.Add(2 * time.Minute)})
 	conn.Create(&topicUserAction.Entity{UserId: authorID, TopicId: topicID, LikedAt: &now, WatchedAt: &now})
 
+	queryCounter := &queryCounterLogger{}
+	previousLogger := conn.Config.Logger
+	conn.Config.Logger = queryCounter
+	t.Cleanup(func() { conn.Config.Logger = previousLogger })
+	queryStart := queryCounter.count.Load()
 	gin.SetMode(gin.TestMode)
 	c, _ := gin.CreateTestContext(nil)
 	c.Request = httptest.NewRequest(http.MethodGet, "/p/post/990010", nil)
 	props := buildTopicDetailProps(c, &topic, &firstPost, 0)
+	queryCount := queryCounter.count.Load() - queryStart
+	t.Logf("topic detail representative query count=%d; no projection cache added without p95/memory evidence", queryCount)
+	if queryCount == 0 {
+		t.Fatal("topic detail measurement captured no queries")
+	}
 
 	if props.Topic.ID != topicID || props.Topic.MaxPostNo != 3 {
 		t.Fatalf("topic payload mismatch: %#v", props.Topic)

--- a/apps/gooseforum/app/http/middleware/jwtAuth.go
+++ b/apps/gooseforum/app/http/middleware/jwtAuth.go
@@ -1,18 +1,17 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/eventbus"
 	jwt "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/jwtopt"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/authsessionservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/eventhandlers"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/sessionservice"
+	"github.com/gin-gonic/gin"
 )
 
 const SkipUpdateUserActivity = "SkipUpdateUserActivity"
@@ -27,7 +26,7 @@ func JWTAuthCheck(c *gin.Context) {
 	c.Set("userId", userId)
 	c.Next()
 	if !c.GetBool(SkipUpdateUserActivity) {
-		eventbus.Publish(context.Background(), &eventhandlers.UserLastActiveUpdatedEvent{
+		eventbus.Publish(eventbus.DetachedContext(c.Request.Context()), &eventhandlers.UserLastActiveUpdatedEvent{
 			UserId:     userId,
 			ActiveTime: time.Now(),
 		})
@@ -41,7 +40,7 @@ func JWTAuth(c *gin.Context) {
 	}
 	c.Next()
 	if userId != 0 && !c.GetBool(SkipUpdateUserActivity) {
-		eventbus.Publish(context.Background(), &eventhandlers.UserLastActiveUpdatedEvent{
+		eventbus.Publish(eventbus.DetachedContext(c.Request.Context()), &eventhandlers.UserLastActiveUpdatedEvent{
 			UserId:     userId,
 			ActiveTime: time.Now(),
 		})

--- a/apps/gooseforum/app/http/middleware/rateLimit.go
+++ b/apps/gooseforum/app/http/middleware/rateLimit.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/ratelimit"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
@@ -96,8 +95,8 @@ func applyRateLimit(c *gin.Context, action string) {
 		c.Next()
 		return
 	}
-	rule := findRateLimitRule(cfg.Actions, action)
-	if rule == nil || (rule.LimitPerIp <= 0 && rule.LimitPerUser <= 0) {
+	rule, ok := cfg.RuleForAction(action)
+	if !ok || (rule.LimitPerIp <= 0 && rule.LimitPerUser <= 0) {
 		c.Next()
 		return
 	}
@@ -156,13 +155,4 @@ func applyRateLimit(c *gin.Context, action string) {
 		return
 	}
 	c.Next()
-}
-
-func findRateLimitRule(rules []pageConfig.RateLimitRule, action string) *pageConfig.RateLimitRule {
-	for i := range rules {
-		if rules[i].Action == action {
-			return &rules[i]
-		}
-	}
-	return nil
 }

--- a/apps/gooseforum/app/http/middleware/rateLimit_test.go
+++ b/apps/gooseforum/app/http/middleware/rateLimit_test.go
@@ -148,10 +148,8 @@ func TestWriteActionsReturn429(t *testing.T) {
 
 func rateLimitQuotaFor(action string) int {
 	cfg := hotdataserve.GetRateLimitConfigCache()
-	for _, rule := range cfg.Actions {
-		if rule.Action == action {
-			return rule.LimitPerIp
-		}
+	if rule, ok := cfg.RuleForAction(action); ok {
+		return rule.LimitPerIp
 	}
 	return 0
 }
@@ -196,10 +194,8 @@ func TestRateLimitCourseSummaryCheckSeparateQuota(t *testing.T) {
 
 func rateLimitUserQuotaFor(action string) int {
 	cfg := hotdataserve.GetRateLimitConfigCache()
-	for _, rule := range cfg.Actions {
-		if rule.Action == action {
-			return rule.LimitPerUser
-		}
+	if rule, ok := cfg.RuleForAction(action); ok {
+		return rule.LimitPerUser
 	}
 	return 0
 }

--- a/apps/gooseforum/app/http/routes/contract_admin_data_test.go
+++ b/apps/gooseforum/app/http/routes/contract_admin_data_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -56,6 +57,8 @@ func setupAdminDataContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	dataAPI.GET("/data/export/tasks", UpButterReq(api.ListExportTasks))
 	dataAPI.GET("/data/export/download/:taskId", api.DownloadExportTask)
 	dataAPI.POST("/data/import", api.ImportData)
+	dataAPI.GET("/data/import/tasks", UpButterReq(api.ListImportTasks))
+	dataAPI.POST("/data/import/tasks/:taskId/replay", UpUriReq(api.ReplayImportTask))
 	return conn, router
 }
 
@@ -339,11 +342,26 @@ func TestAdminImportDataHTTPContract(t *testing.T) {
 
 	t.Run("success imports an empty users table and reports zero rows", func(t *testing.T) {
 		conn, router := setupAdminDataContractTest(t)
+		restoreImportDir := dataservice.SetImportDirForTest(t.TempDir())
+		defer restoreImportDir()
 		recorder := serveAdminDataMultipart(t, conn, router, path, map[string][]byte{"file": []byte(`{"users":[]}`)})
 		if recorder.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
 		}
-		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "admin-data-import-success.json"))
+		envelope := decodeContractEnvelope(t, recorder)
+		if envelope.Code != 0 {
+			t.Fatalf("code = %d, want 0", envelope.Code)
+		}
+		var result struct {
+			TaskID uint64 `json:"taskId"`
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal(envelope.Result, &result); err != nil {
+			t.Fatalf("decode import task result: %v", err)
+		}
+		if result.TaskID == 0 || result.Status != "pending" {
+			t.Fatalf("import result = %+v, want pending task", result)
+		}
 	})
 
 	t.Run("missing file field fails with 400 importFailed", func(t *testing.T) {

--- a/apps/gooseforum/app/http/routes/contract_admin_data_test.go
+++ b/apps/gooseforum/app/http/routes/contract_admin_data_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -27,14 +28,14 @@ import (
 	"gorm.io/gorm"
 )
 
-// 本文件覆盖 SiteManager 权限组 img-upload + data-portability 5 条路由的契约测试
+// 本文件覆盖 SiteManager 权限组 img-upload + data-portability 7 条路由的契约测试
 // （issue #277 P3 切片六）。img-upload / data/import 为 multipart 裸 gin handler，
 // data/export/download 为文件流裸 handler，均不经 UpButterReq，但守卫中间件链与
 // route4api.go 的生产注册保持一致。任务行用固定字段种子保证 fixture 确定性；
 // 文件内容落独立的 db4fileconnect 连接，单独迁移。
 
 // setupAdminDataContractTest 在共享 harness（setupHTTPContractTest）之上注册
-// img-upload/data 导出导入 5 条路由。
+// img-upload/data 导出导入 7 条路由。
 func setupAdminDataContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	t.Helper()
 	conn, router := setupHTTPContractTest(t)
@@ -62,7 +63,7 @@ func setupAdminDataContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	return conn, router
 }
 
-// adminDataGuardScenarios 跑本文件 5 条路由公共的中间件守卫场景：
+// adminDataGuardScenarios 跑本文件 7 条路由公共的中间件守卫场景：
 // 未登录 401 / 冻结账号 403 / 无 SiteManager 权限 403（params.permission="站点管理"）。
 // 守卫由中间件在绑定前拦截，统一用 JSON 请求即可（含 multipart/文件流路由）。
 func adminDataGuardScenarios(t *testing.T, method, path, fixturePrefix string) {
@@ -122,6 +123,40 @@ func assertAdminDataFixture(t *testing.T, recorder *httptest.ResponseRecorder, w
 		t.Fatalf("status = %d, want %d: %s", recorder.Code, wantStatus, recorder.Body.String())
 	}
 	assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, fixture))
+}
+
+func assertAdminImportAcceptedFixture(t *testing.T, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+	actual := decodeContractEnvelope(t, recorder)
+	fixture := contractFixture(t, "admin-data-import-success.json")
+	if actual.Code != fixture.Code || actual.MessageCode != fixture.MessageCode {
+		t.Fatalf("envelope = %#v, want fixture code/messageCode %d/%q", actual, fixture.Code, fixture.MessageCode)
+	}
+	var actualResult, fixtureResult map[string]any
+	if err := json.Unmarshal(actual.Result, &actualResult); err != nil {
+		t.Fatalf("decode accepted import result: %v", err)
+	}
+	if err := json.Unmarshal(fixture.Result, &fixtureResult); err != nil {
+		t.Fatalf("decode accepted import fixture: %v", err)
+	}
+	if len(actualResult) != len(fixtureResult) {
+		t.Fatalf("accepted import result fields = %#v, want fixture fields %#v", actualResult, fixtureResult)
+	}
+	for name, want := range fixtureResult {
+		got, ok := actualResult[name]
+		if !ok {
+			t.Fatalf("accepted import result missing %q", name)
+		}
+		if name == "taskId" {
+			if id, ok := got.(float64); !ok || id < 1 {
+				t.Fatalf("accepted import taskId = %#v, want a positive number", got)
+			}
+			continue
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("accepted import result.%s = %#v, want fixture value %#v", name, got, want)
+		}
+	}
 }
 
 func TestAdminImgUploadHTTPContract(t *testing.T) {
@@ -342,26 +377,16 @@ func TestAdminImportDataHTTPContract(t *testing.T) {
 
 	t.Run("success imports an empty users table and reports zero rows", func(t *testing.T) {
 		conn, router := setupAdminDataContractTest(t)
+		if err := conn.Where("type = ?", dataservice.TaskTypeImport).Delete(&taskQueue.Entity{}).Error; err != nil {
+			t.Fatalf("clear import tasks: %v", err)
+		}
 		restoreImportDir := dataservice.SetImportDirForTest(t.TempDir())
 		defer restoreImportDir()
 		recorder := serveAdminDataMultipart(t, conn, router, path, map[string][]byte{"file": []byte(`{"users":[]}`)})
 		if recorder.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200: %s", recorder.Code, recorder.Body.String())
 		}
-		envelope := decodeContractEnvelope(t, recorder)
-		if envelope.Code != 0 {
-			t.Fatalf("code = %d, want 0", envelope.Code)
-		}
-		var result struct {
-			TaskID uint64 `json:"taskId"`
-			Status string `json:"status"`
-		}
-		if err := json.Unmarshal(envelope.Result, &result); err != nil {
-			t.Fatalf("decode import task result: %v", err)
-		}
-		if result.TaskID == 0 || result.Status != "pending" {
-			t.Fatalf("import result = %+v, want pending task", result)
-		}
+		assertAdminImportAcceptedFixture(t, recorder)
 	})
 
 	t.Run("missing file field fails with 400 importFailed", func(t *testing.T) {
@@ -377,4 +402,66 @@ func TestAdminImportDataHTTPContract(t *testing.T) {
 	})
 
 	adminDataGuardScenarios(t, http.MethodPost, path, "admin-data-import")
+}
+
+func TestAdminImportTaskHTTPContract(t *testing.T) {
+	t.Run("list returns the seeded import task", func(t *testing.T) {
+		conn, router := setupAdminDataContractTest(t)
+		if err := conn.Where("type = ?", dataservice.TaskTypeImport).Delete(&taskQueue.Entity{}).Error; err != nil {
+			t.Fatalf("clear import tasks: %v", err)
+		}
+		seedContractTask(t, conn, taskQueue.Entity{
+			Id:          990007,
+			Type:        dataservice.TaskTypeImport,
+			Status:      taskQueue.StatusFailed,
+			TaskJson:    `{"fileName":"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f.json","sha256":"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f","format":"json"}`,
+			RetryCount:  2,
+			LastError:   "temporary failure",
+			CreatedAt:   contractTaskCreatedAt,
+			ProcessedAt: contractTaskCreatedAt.Add(time.Minute),
+		})
+		serveAdminSiteOK(t, conn, router, http.MethodGet, "/api/admin/data/import/tasks", "", "admin-data-import-tasks-success.json")
+	})
+
+	t.Run("replay resets a failed task and preserves its staged body", func(t *testing.T) {
+		conn, router := setupAdminDataContractTest(t)
+		if err := conn.Where("type = ?", dataservice.TaskTypeImport).Delete(&taskQueue.Entity{}).Error; err != nil {
+			t.Fatalf("clear import tasks: %v", err)
+		}
+		importDir := t.TempDir()
+		restoreImportDir := dataservice.SetImportDirForTest(importDir)
+		defer restoreImportDir()
+		const fileName = "adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f.json"
+		if err := os.WriteFile(filepath.Join(importDir, fileName), []byte(`{"users":[]}`), 0o600); err != nil {
+			t.Fatalf("stage import body: %v", err)
+		}
+		seedContractTask(t, conn, taskQueue.Entity{
+			Id:          990020,
+			Type:        dataservice.TaskTypeImport,
+			Status:      taskQueue.StatusFailed,
+			TaskJson:    `{"fileName":"` + fileName + `","sha256":"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f","format":"json"}`,
+			RetryCount:  3,
+			LastError:   "temporary failure",
+			CreatedAt:   contractTaskCreatedAt,
+			ProcessedAt: contractTaskCreatedAt.Add(time.Minute),
+		})
+		serveAdminSiteOK(t, conn, router, http.MethodPost, "/api/admin/data/import/tasks/990020/replay", `{}`, "admin-data-import-replay-success.json")
+	})
+
+	t.Run("replay rejects a task that is not failed", func(t *testing.T) {
+		conn, router := setupAdminDataContractTest(t)
+		if err := conn.Where("type = ?", dataservice.TaskTypeImport).Delete(&taskQueue.Entity{}).Error; err != nil {
+			t.Fatalf("clear import tasks: %v", err)
+		}
+		seedContractTask(t, conn, taskQueue.Entity{
+			Id:       990021,
+			Type:     dataservice.TaskTypeImport,
+			Status:   taskQueue.StatusPending,
+			TaskJson: `{"fileName":"missing.json","sha256":"missing","format":"json"}`,
+		})
+		serveAdminSiteOK(t, conn, router, http.MethodPost, "/api/admin/data/import/tasks/990021/replay", `{}`, "admin-data-import-replay-failed.json")
+	})
+
+	adminDataGuardScenarios(t, http.MethodGet, "/api/admin/data/import/tasks", "admin-data-import-tasks")
+	adminDataGuardScenarios(t, http.MethodPost, "/api/admin/data/import/tasks/990020/replay", "admin-data-import-replay")
 }

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -426,6 +426,8 @@ func apiRoute(ginApp *gin.Engine) {
 		GET("data/export/tasks", UpButterReq(api.ListExportTasks)).
 		GET("data/export/download/:taskId", api.DownloadExportTask).
 		POST("data/import", api.ImportData).
+		GET("data/import/tasks", UpButterReq(api.ListImportTasks)).
+		POST("data/import/tasks/:taskId/replay", UpUriReq(api.ReplayImportTask)).
 		POST("review-queue", UpButterReq(api.ReviewQueue)).
 		POST("review-action", UpButterReq(api.ReviewAction))
 

--- a/apps/gooseforum/app/migration/app_migration.go
+++ b/apps/gooseforum/app/migration/app_migration.go
@@ -8,6 +8,13 @@ import (
 )
 
 func runVersionedDataMigrations() {
+	unlock, err := acquireVersionedMigrationLock()
+	if err != nil {
+		slog.Error("app migration lock unavailable", "err", err)
+		return
+	}
+	defer unlock()
+
 	currentVersion := pageConfig.GetMigrationVersion()
 	if currentVersion >= pageConfig.AppMigrationVersion {
 		return

--- a/apps/gooseforum/app/migration/version_lock.go
+++ b/apps/gooseforum/app/migration/version_lock.go
@@ -82,11 +82,15 @@ func acquirePostgresMigrationLock(db *gorm.DB) (func(), error) {
 }
 
 func acquireSQLiteMigrationLock(db *gorm.DB) (func(), error) {
+	return acquireSQLiteMigrationLockWithWait(db, versionedMigrationLockWait)
+}
+
+func acquireSQLiteMigrationLockWithWait(db *gorm.DB, wait time.Duration) (func(), error) {
 	if err := db.Exec(`
 CREATE TABLE IF NOT EXISTS app_migration_lock (
 		id INTEGER PRIMARY KEY,
 		owner TEXT NOT NULL DEFAULT '',
-		expires_at DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00Z'
+		expires_at INTEGER NOT NULL DEFAULT 0
 )`).Error; err != nil {
 		return nil, fmt.Errorf("migration: create sqlite lock table: %w", err)
 	}
@@ -95,7 +99,7 @@ CREATE TABLE IF NOT EXISTS app_migration_lock (
 	}
 
 	owner := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
-	deadline := time.Now().Add(versionedMigrationLockWait)
+	deadline := time.Now().Add(wait)
 	for {
 		now := time.Now().UTC()
 		expiresAt := now.Add(versionedMigrationLockLease)
@@ -104,9 +108,9 @@ UPDATE app_migration_lock
 SET owner = ?, expires_at = ?
 WHERE id = ? AND (owner = '' OR expires_at <= ?)`,
 			owner,
-			expiresAt.Format(time.RFC3339Nano),
+			expiresAt.UnixNano(),
 			versionedMigrationLockID,
-			now.Format(time.RFC3339Nano),
+			now.UnixNano(),
 		)
 		if result.Error != nil {
 			return nil, fmt.Errorf("migration: acquire sqlite lock: %w", result.Error)
@@ -115,7 +119,7 @@ WHERE id = ? AND (owner = '' OR expires_at <= ?)`,
 			return startSQLiteLockLease(db, owner), nil
 		}
 		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("migration: sqlite lock still held after %s", versionedMigrationLockWait)
+			return nil, fmt.Errorf("migration: sqlite lock still held after %s", wait)
 		}
 		time.Sleep(versionedMigrationLockRetry)
 	}
@@ -133,7 +137,7 @@ func startSQLiteLockLease(db *gorm.DB, owner string) func() {
 			case <-ticker.C:
 				now := time.Now().UTC()
 				result := db.Exec(`UPDATE app_migration_lock SET expires_at = ? WHERE id = ? AND owner = ?`,
-					now.Add(versionedMigrationLockLease).Format(time.RFC3339Nano),
+					now.Add(versionedMigrationLockLease).UnixNano(),
 					versionedMigrationLockID,
 					owner,
 				)
@@ -150,7 +154,7 @@ func startSQLiteLockLease(db *gorm.DB, owner string) func() {
 		cancel()
 		<-done
 		if err := db.Exec(`UPDATE app_migration_lock SET owner = '', expires_at = ? WHERE id = ? AND owner = ?`,
-			time.Now().UTC().Format(time.RFC3339Nano), versionedMigrationLockID, owner).Error; err != nil {
+			time.Now().UTC().UnixNano(), versionedMigrationLockID, owner).Error; err != nil {
 			slog.Warn("migration: release sqlite lock failed", "err", err)
 		}
 	})

--- a/apps/gooseforum/app/migration/version_lock.go
+++ b/apps/gooseforum/app/migration/version_lock.go
@@ -1,0 +1,157 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"gorm.io/gorm"
+)
+
+const (
+	versionedMigrationLockID            = 1
+	versionedMigrationLockLease         = 30 * time.Second
+	versionedMigrationLockWait          = 30 * time.Second
+	versionedMigrationLockRetry         = 100 * time.Millisecond
+	versionedMigrationAdvisoryKey int64 = 0x596f7572544a4d
+)
+
+var versionedMigrationProcessMu sync.Mutex
+
+// acquireVersionedMigrationLock serializes the versioned data migration
+// runner across both goroutines in one process and independent app instances.
+// PostgreSQL uses a session-scoped advisory lock; SQLite uses a durable row
+// lease because it has no advisory-lock primitive.
+func acquireVersionedMigrationLock() (func(), error) {
+	versionedMigrationProcessMu.Lock()
+
+	db := dbconnect.Connect()
+	if db == nil {
+		versionedMigrationProcessMu.Unlock()
+		return nil, errors.New("migration: database connection is nil")
+	}
+
+	var unlock func()
+	var err error
+	switch db.Dialector.Name() {
+	case "postgres":
+		unlock, err = acquirePostgresMigrationLock(db)
+	case "sqlite":
+		unlock, err = acquireSQLiteMigrationLock(db)
+	default:
+		err = fmt.Errorf("migration: unsupported database dialect %q", db.Dialector.Name())
+	}
+	if err != nil {
+		versionedMigrationProcessMu.Unlock()
+		return nil, err
+	}
+
+	return sync.OnceFunc(func() {
+		unlock()
+		versionedMigrationProcessMu.Unlock()
+	}), nil
+}
+
+func acquirePostgresMigrationLock(db *gorm.DB) (func(), error) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("migration: get postgres pool: %w", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("migration: pin postgres connection: %w", err)
+	}
+	if _, err := conn.ExecContext(context.Background(), "SELECT pg_advisory_lock($1)", versionedMigrationAdvisoryKey); err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("migration: acquire postgres advisory lock: %w", err)
+	}
+
+	return sync.OnceFunc(func() {
+		if _, err := conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", versionedMigrationAdvisoryKey); err != nil {
+			slog.Warn("migration: release postgres advisory lock failed", "err", err)
+		}
+		if err := conn.Close(); err != nil {
+			slog.Warn("migration: close pinned postgres connection failed", "err", err)
+		}
+	}), nil
+}
+
+func acquireSQLiteMigrationLock(db *gorm.DB) (func(), error) {
+	if err := db.Exec(`
+CREATE TABLE IF NOT EXISTS app_migration_lock (
+		id INTEGER PRIMARY KEY,
+		owner TEXT NOT NULL DEFAULT '',
+		expires_at DATETIME NOT NULL DEFAULT '1970-01-01T00:00:00Z'
+)`).Error; err != nil {
+		return nil, fmt.Errorf("migration: create sqlite lock table: %w", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO app_migration_lock (id) VALUES (?)`, versionedMigrationLockID).Error; err != nil {
+		return nil, fmt.Errorf("migration: seed sqlite lock row: %w", err)
+	}
+
+	owner := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+	deadline := time.Now().Add(versionedMigrationLockWait)
+	for {
+		now := time.Now().UTC()
+		expiresAt := now.Add(versionedMigrationLockLease)
+		result := db.Exec(`
+UPDATE app_migration_lock
+SET owner = ?, expires_at = ?
+WHERE id = ? AND (owner = '' OR expires_at <= ?)`,
+			owner,
+			expiresAt.Format(time.RFC3339Nano),
+			versionedMigrationLockID,
+			now.Format(time.RFC3339Nano),
+		)
+		if result.Error != nil {
+			return nil, fmt.Errorf("migration: acquire sqlite lock: %w", result.Error)
+		}
+		if result.RowsAffected == 1 {
+			return startSQLiteLockLease(db, owner), nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("migration: sqlite lock still held after %s", versionedMigrationLockWait)
+		}
+		time.Sleep(versionedMigrationLockRetry)
+	}
+}
+
+func startSQLiteLockLease(db *gorm.DB, owner string) func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(versionedMigrationLockLease / 3)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				now := time.Now().UTC()
+				result := db.Exec(`UPDATE app_migration_lock SET expires_at = ? WHERE id = ? AND owner = ?`,
+					now.Add(versionedMigrationLockLease).Format(time.RFC3339Nano),
+					versionedMigrationLockID,
+					owner,
+				)
+				if result.Error != nil {
+					slog.Warn("migration: renew sqlite lock failed", "err", result.Error)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return sync.OnceFunc(func() {
+		cancel()
+		<-done
+		if err := db.Exec(`UPDATE app_migration_lock SET owner = '', expires_at = ? WHERE id = ? AND owner = ?`,
+			time.Now().UTC().Format(time.RFC3339Nano), versionedMigrationLockID, owner).Error; err != nil {
+			slog.Warn("migration: release sqlite lock failed", "err", err)
+		}
+	})
+}

--- a/apps/gooseforum/app/migration/version_lock_test.go
+++ b/apps/gooseforum/app/migration/version_lock_test.go
@@ -1,0 +1,29 @@
+package migration
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestSQLiteMigrationLockReleasesLease(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:migration-lock?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+
+	unlock, err := acquireSQLiteMigrationLock(db)
+	if err != nil {
+		t.Fatalf("acquire sqlite lock: %v", err)
+	}
+	unlock()
+
+	var owner string
+	if err := db.Raw("SELECT owner FROM app_migration_lock WHERE id = ?", versionedMigrationLockID).Scan(&owner).Error; err != nil {
+		t.Fatalf("read sqlite lock owner: %v", err)
+	}
+	if owner != "" {
+		t.Fatalf("sqlite migration lock owner = %q after release, want empty", owner)
+	}
+}

--- a/apps/gooseforum/app/migration/version_lock_test.go
+++ b/apps/gooseforum/app/migration/version_lock_test.go
@@ -70,5 +70,14 @@ func openSQLiteMigrationLockDB(t *testing.T) *gorm.DB {
 	if err != nil {
 		t.Fatalf("open sqlite: %v", err)
 	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get sqlite db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sqlDB.Close(); err != nil {
+			t.Errorf("close sqlite db: %v", err)
+		}
+	})
 	return db
 }

--- a/apps/gooseforum/app/migration/version_lock_test.go
+++ b/apps/gooseforum/app/migration/version_lock_test.go
@@ -1,17 +1,16 @@
 package migration
 
 import (
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
 
 func TestSQLiteMigrationLockReleasesLease(t *testing.T) {
-	db, err := gorm.Open(sqlite.Open("file:migration-lock?mode=memory&cache=shared"), &gorm.Config{})
-	if err != nil {
-		t.Fatalf("open sqlite: %v", err)
-	}
+	db := openSQLiteMigrationLockDB(t)
 
 	unlock, err := acquireSQLiteMigrationLock(db)
 	if err != nil {
@@ -26,4 +25,50 @@ func TestSQLiteMigrationLockReleasesLease(t *testing.T) {
 	if owner != "" {
 		t.Fatalf("sqlite migration lock owner = %q after release, want empty", owner)
 	}
+}
+
+func TestSQLiteMigrationLockTakesOverExpiredLease(t *testing.T) {
+	db := openSQLiteMigrationLockDB(t)
+	unlock, err := acquireSQLiteMigrationLock(db)
+	if err != nil {
+		t.Fatalf("acquire sqlite lock: %v", err)
+	}
+	unlock()
+	if err := db.Exec("UPDATE app_migration_lock SET owner = ?, expires_at = ? WHERE id = ?", "expired-owner", time.Now().Add(-time.Second).UnixNano(), versionedMigrationLockID).Error; err != nil {
+		t.Fatalf("seed expired sqlite lock: %v", err)
+	}
+
+	secondUnlock, err := acquireSQLiteMigrationLockWithWait(db, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("acquire expired sqlite lock: %v", err)
+	}
+	secondUnlock()
+}
+
+func TestSQLiteMigrationLockDoesNotTakeLiveFractionalLease(t *testing.T) {
+	db := openSQLiteMigrationLockDB(t)
+	unlock, err := acquireSQLiteMigrationLock(db)
+	if err != nil {
+		t.Fatalf("acquire sqlite lock: %v", err)
+	}
+	unlock()
+	if err := db.Exec("UPDATE app_migration_lock SET owner = ?, expires_at = ? WHERE id = ?", "live-owner", time.Now().Add(500*time.Millisecond).UnixNano(), versionedMigrationLockID).Error; err != nil {
+		t.Fatalf("seed live sqlite lock: %v", err)
+	}
+
+	if _, err := acquireSQLiteMigrationLockWithWait(db, 20*time.Millisecond); err == nil {
+		t.Fatal("acquired a live sqlite lease")
+	}
+	if err := db.Exec("UPDATE app_migration_lock SET owner = '', expires_at = 0 WHERE id = ?", versionedMigrationLockID).Error; err != nil {
+		t.Fatalf("clear live sqlite lock: %v", err)
+	}
+}
+
+func openSQLiteMigrationLockDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "migration-lock.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	return db
 }

--- a/apps/gooseforum/app/models/defaultconfig/defaultconfig.go
+++ b/apps/gooseforum/app/models/defaultconfig/defaultconfig.go
@@ -29,73 +29,52 @@ type pageConfigDefaults struct {
 	AiSummary    pageConfig.AiSummaryConfig
 }
 
-var (
-	loadPageConfigDefaultsOnce sync.Once
-	pageConfigDefaultsValue    pageConfigDefaults
-	errPageConfigDefaults      error
-)
-
-func loadPageConfigDefaults() (pageConfigDefaults, error) {
-	loadPageConfigDefaultsOnce.Do(func() {
-		errPageConfigDefaults = loadJSON("announcement.json", &pageConfigDefaultsValue.Announcement)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("email.json", &pageConfigDefaultsValue.Email)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("friend_links.json", &pageConfigDefaultsValue.FriendLinks)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("posting.json", &pageConfigDefaultsValue.Posting)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("security.json", &pageConfigDefaultsValue.Security)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("site.json", &pageConfigDefaultsValue.Site)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("site_theme.json", &pageConfigDefaultsValue.SiteTheme)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("sponsors.json", &pageConfigDefaultsValue.Sponsors)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("terms.json", &pageConfigDefaultsValue.Terms)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("privacy.json", &pageConfigDefaultsValue.Privacy)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("storage.json", &pageConfigDefaultsValue.Storage)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("ratelimit.json", &pageConfigDefaultsValue.RateLimit)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("mcp.json", &pageConfigDefaultsValue.MCP)
-		if errPageConfigDefaults != nil {
-			return
-		}
-		errPageConfigDefaults = loadJSON("ai_summary.json", &pageConfigDefaultsValue.AiSummary)
-		if errPageConfigDefaults != nil {
-			return
-		}
-	})
-	return pageConfigDefaultsValue, errPageConfigDefaults
-}
+var loadPageConfigDefaults = sync.OnceValues(func() (pageConfigDefaults, error) {
+	var defaults pageConfigDefaults
+	if err := loadJSON("announcement.json", &defaults.Announcement); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("email.json", &defaults.Email); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("friend_links.json", &defaults.FriendLinks); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("posting.json", &defaults.Posting); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("security.json", &defaults.Security); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("site.json", &defaults.Site); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("site_theme.json", &defaults.SiteTheme); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("sponsors.json", &defaults.Sponsors); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("terms.json", &defaults.Terms); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("privacy.json", &defaults.Privacy); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("storage.json", &defaults.Storage); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("ratelimit.json", &defaults.RateLimit); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("mcp.json", &defaults.MCP); err != nil {
+		return defaults, err
+	}
+	if err := loadJSON("ai_summary.json", &defaults.AiSummary); err != nil {
+		return defaults, err
+	}
+	return defaults, nil
+})
 
 func mustPageConfigDefaults() pageConfigDefaults {
 	defaults, err := loadPageConfigDefaults()

--- a/apps/gooseforum/app/models/forum/category/category_rep.go
+++ b/apps/gooseforum/app/models/forum/category/category_rep.go
@@ -1,6 +1,12 @@
 package category
 
-import "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
+import (
+	"context"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
+	"gorm.io/gorm"
+)
 
 func SaveOrCreateById(entity *Entity) int64 {
 	if entity.Id == 0 {
@@ -8,6 +14,11 @@ func SaveOrCreateById(entity *Entity) int64 {
 	}
 
 	return builder().Save(entity).RowsAffected
+}
+
+// SaveTx persists a category inside a caller-owned transaction.
+func SaveTx(tx *gorm.DB, entity *Entity) error {
+	return tx.Table(tableName).Save(entity).Error
 }
 
 func Get(id uint64) (entity Entity) {
@@ -18,6 +29,12 @@ func Get(id uint64) (entity Entity) {
 // GetWithError 返回实体与查询错误，供需要区分“记录不存在”与“查询失败”的调用方使用。
 func GetWithError(id uint64) (entity Entity, err error) {
 	err = builder().First(&entity, id).Error
+	return
+}
+
+// GetWithContext is the cancellable worker/request variant of GetWithError.
+func GetWithContext(ctx context.Context, id uint64) (entity Entity, err error) {
+	err = dbconnect.ConnectContext(ctx).Table(tableName).First(&entity, id).Error
 	return
 }
 
@@ -34,4 +51,9 @@ func All() (entities []*Entity) {
 
 func DeleteEntity(entity *Entity) int64 {
 	return builder().Delete(entity).RowsAffected
+}
+
+// DeleteTx removes a category inside a caller-owned transaction.
+func DeleteTx(tx *gorm.DB, entity *Entity) error {
+	return tx.Table(tableName).Delete(entity).Error
 }

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfig.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfig.go
@@ -514,6 +514,26 @@ type RateLimitConfig struct {
 	NewUserCaptchaAfterPosts int             `json:"newUserCaptchaAfterPosts"` // 新用户窗口内连发 N 帖后要求验证码，0 关闭
 	NewUserCaptchaDays       int             `json:"newUserCaptchaDays"`       // 新用户判定窗口（注册 N 天内），0 表示所有用户
 	MinSubmitSeconds         int             `json:"minSubmitSeconds"`         // 验证码提交耗时下限（秒），低于判定为机器
+	actionIndex              map[string]RateLimitRule
+}
+
+// BuildActionIndex prepares the immutable first-match action lookup used by
+// request paths. Duplicate actions keep the existing first-rule-wins behavior.
+func (c *RateLimitConfig) BuildActionIndex() {
+	index := make(map[string]RateLimitRule, len(c.Actions))
+	for _, rule := range c.Actions {
+		if _, exists := index[rule.Action]; !exists {
+			index[rule.Action] = rule
+		}
+	}
+	c.actionIndex = index
+}
+
+// RuleForAction returns a configured action without scanning the rule slice.
+// The index is built at the hot-reload boundary before the config is published.
+func (c RateLimitConfig) RuleForAction(action string) (RateLimitRule, bool) {
+	rule, ok := c.actionIndex[action]
+	return rule, ok
 }
 
 type HttpNotifyConfig struct {

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
@@ -48,11 +48,15 @@ func GetMigrationVersion() uint32 {
 	return cast.ToUint32(configEntity.Config)
 }
 
-func SyncMigrationVersion(version uint32) {
+func SyncMigrationVersion(version uint32) error {
 	configEntity := GetByPageType(Migration)
 	configEntity.PageType = Migration
 	configEntity.Config = cast.ToString(version)
-	CreateOrSave(&configEntity)
+	if configEntity.Id == 0 {
+		result := builder().Create(&configEntity)
+		return result.Error
+	}
+	return builder().Save(&configEntity).Error
 }
 
 // wikiSyncSettingsMu 序列化 WikiSyncSettings 的读改写：webhook secret 与

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfig_test.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfig_test.go
@@ -6,6 +6,25 @@ import (
 	"testing"
 )
 
+func TestRateLimitActionIndexPreservesFirstDuplicate(t *testing.T) {
+	cfg := RateLimitConfig{Actions: []RateLimitRule{
+		{Action: "login", WindowSeconds: 60, LimitPerIp: 1},
+		{Action: "login", WindowSeconds: 3600, LimitPerIp: 99},
+		{Action: "register", WindowSeconds: 120, LimitPerIp: 2},
+	}}
+	cfg.BuildActionIndex()
+
+	if got, ok := cfg.RuleForAction("login"); !ok || got.WindowSeconds != 60 || got.LimitPerIp != 1 {
+		t.Fatalf("login rule = %+v, %v; want first duplicate", got, ok)
+	}
+	if got, ok := cfg.RuleForAction("register"); !ok || got.LimitPerIp != 2 {
+		t.Fatalf("register rule = %+v, %v; want configured rule", got, ok)
+	}
+	if _, ok := cfg.RuleForAction("missing"); ok {
+		t.Fatal("missing action should not be found")
+	}
+}
+
 // TestOneSystemSettingsConfigJSONOmitsCiphertext 验证领域结构不随 JSON 序列化泄漏密文，
 // 落库形状保留密文（review MEDIUM）。
 func TestOneSystemSettingsConfigJSONOmitsCiphertext(t *testing.T) {

--- a/apps/gooseforum/app/models/forum/posts/posts_rep.go
+++ b/apps/gooseforum/app/models/forum/posts/posts_rep.go
@@ -1,6 +1,7 @@
 package posts
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -44,6 +45,12 @@ func SaveTx(tx *gorm.DB, entity *Entity) error {
 
 func Get(id uint64) (entity Entity) {
 	builder().First(&entity, id)
+	return
+}
+
+// GetWithContext is the cancellable worker/request variant of Get.
+func GetWithContext(ctx context.Context, id uint64) (entity Entity, err error) {
+	err = db.ConnectContext(ctx).Table(tableName).First(&entity, id).Error
 	return
 }
 
@@ -91,6 +98,12 @@ func GetMapByIdsUnscoped(ids []uint64) map[uint64]*Entity {
 
 func UpdateProcessStatus(id uint64, processStatus int8) error {
 	return builder().Where(queryopt.Eq("id", id)).Update("process_status", processStatus).Error
+}
+
+// UpdateProcessStatusTx updates moderation state inside a caller-owned
+// transaction.
+func UpdateProcessStatusTx(tx *gorm.DB, id uint64, processStatus int8) error {
+	return tx.Table(tableName).Where(queryopt.Eq("id", id)).Update("process_status", processStatus).Error
 }
 
 // ResetPendingReview 作废待审状态：将 process_status 复位为正常。
@@ -502,6 +515,18 @@ func GetByTopicPostNoBefore(topicId uint64, postNo uint64, limit int) (entities 
 func GetByTopicPostNoAtOrAfter(topicId uint64, postNo uint64) (entity Entity, ok bool) {
 	err := builder().
 		Where(queryopt.Eq("topic_id", topicId)).
+		Where(queryopt.Ge("post_no", postNo)).
+		Order(queryopt.Asc("post_no")).
+		Order(queryopt.Asc("id")).
+		First(&entity).Error
+	return entity, err == nil
+}
+
+// GetByTopicPostNoAtOrAfterContext is the cancellable variant used by search
+// projection workers when a topic has no valid first-post pointer.
+func GetByTopicPostNoAtOrAfterContext(ctx context.Context, topicID uint64, postNo uint64) (entity Entity, ok bool) {
+	err := db.ConnectContext(ctx).Table(tableName).
+		Where(queryopt.Eq("topic_id", topicID)).
 		Where(queryopt.Ge("post_no", postNo)).
 		Order(queryopt.Asc("post_no")).
 		Order(queryopt.Asc("id")).

--- a/apps/gooseforum/app/models/forum/topics/topics_rep.go
+++ b/apps/gooseforum/app/models/forum/topics/topics_rep.go
@@ -1,8 +1,10 @@
 package topics
 
 import (
+	"context"
 	"time"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/jsonopt"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/pageutil"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
@@ -74,6 +76,15 @@ func UpdateTopicEditableTx(tx *gorm.DB, entity *Entity) error {
 		}).Error
 }
 
+// UpdateCategoryIDsTx changes only the topic category payload inside a
+// caller-owned transaction.
+func UpdateCategoryIDsTx(tx *gorm.DB, id uint64, categoryIDs []uint64) error {
+	return tx.Table(tableName).Where(queryopt.Eq("id", id)).Updates(map[string]any{
+		"category_id": jsonopt.Encode(categoryIDs),
+		"updated_at":  time.Now(),
+	}).Error
+}
+
 // UpdateWikiSyncedMetaTx 事务内只更新由 wiki 修订派生的话题字段
 // （标题/摘要/首图/水印/更新时间）。不触碰并发回复/点赞/浏览维护的统计与
 // 指针字段——整行 Save 会把 post_count/post_seq/posters/last_post_id/
@@ -101,6 +112,12 @@ func Get(id uint64) (entity Entity) {
 // GetWithError 返回实体与查询错误，供需要区分“记录不存在”与“查询失败”的调用方使用。
 func GetWithError(id uint64) (entity Entity, err error) {
 	err = builder().First(&entity, id).Error
+	return
+}
+
+// GetWithContext is the cancellable worker/request variant of GetWithError.
+func GetWithContext(ctx context.Context, id uint64) (entity Entity, err error) {
+	err = dbconnect.ConnectContext(ctx).Table(tableName).First(&entity, id).Error
 	return
 }
 
@@ -469,6 +486,17 @@ func UpdateProcessStatus(id uint64, processStatus int8) error {
 	return builder().Where(queryopt.Eq("id", id)).UpdateColumn("process_status", processStatus).Error
 }
 
+// UpdateProcessStatusTx updates moderation state and lets callers enqueue an
+// outbox task in the same transaction.
+func UpdateProcessStatusTx(tx *gorm.DB, id uint64, processStatus int8) error {
+	return tx.Table(tableName).Where(queryopt.Eq("id", id)).UpdateColumn("process_status", processStatus).Error
+}
+
+// UpdateStatusTx updates publish status inside a caller-owned transaction.
+func UpdateStatusTx(tx *gorm.DB, id uint64, status int8) error {
+	return tx.Table(tableName).Where(queryopt.Eq("id", id)).UpdateColumn("status", status).Error
+}
+
 // ResetPendingReview 作废待审状态：将 process_status 复位为正常。
 // 内容被删除后不应继续停留在管理审核队列（PRD R1），避免"已删除+待审"
 // 语义叠加导致审核队列出现幽灵项。
@@ -478,6 +506,13 @@ func ResetPendingReview(id uint64) error {
 
 func UpdatePinWeight(id uint64, pinWeight int) error {
 	return builder().Where(queryopt.Eq("id", id)).Updates(map[string]any{
+		"pin_weight": pinWeight,
+	}).Error
+}
+
+// UpdatePinWeightTx updates pin weight inside a caller-owned transaction.
+func UpdatePinWeightTx(tx *gorm.DB, id uint64, pinWeight int) error {
+	return tx.Table(tableName).Where(queryopt.Eq("id", id)).Updates(map[string]any{
 		"pin_weight": pinWeight,
 	}).Error
 }

--- a/apps/gooseforum/app/models/forum/topics/topics_test.go
+++ b/apps/gooseforum/app/models/forum/topics/topics_test.go
@@ -1,6 +1,7 @@
 package topics
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -11,6 +12,20 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
+
+func TestGetWithContextHonorsCancellation(t *testing.T) {
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&Entity{}); err != nil {
+		t.Fatalf("migrate topics table: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := GetWithContext(ctx, 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetWithContext() err=%v, want context.Canceled", err)
+	}
+}
 
 func TestTopicAndPostSchemaMigrates(t *testing.T) {
 	conn, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})

--- a/apps/gooseforum/app/models/forum/users/users_rep.go
+++ b/apps/gooseforum/app/models/forum/users/users_rep.go
@@ -1,6 +1,7 @@
 package users
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/algorithm"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/pageutil"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/queryopt"
 	"github.com/samber/lo"
@@ -35,6 +37,12 @@ var ErrInvalidCredentials = errors.New("invalid username or password")
 
 func Get(id any) (entity EntityComplete, err error) {
 	err = builder().Where(pid, id).First(&entity).Error
+	return
+}
+
+// GetWithContext is the cancellable worker/request variant of Get.
+func GetWithContext(ctx context.Context, id any) (entity EntityComplete, err error) {
+	err = dbconnect.ConnectContext(ctx).Table(tableName).Where(pid, id).First(&entity).Error
 	return
 }
 

--- a/apps/gooseforum/app/models/hotdataserve/config_cache.go
+++ b/apps/gooseforum/app/models/hotdataserve/config_cache.go
@@ -195,6 +195,7 @@ func GetRateLimitConfigCache() pageConfig.RateLimitConfig {
 	return rateLimitConfigCache.GetOrLoad("", func() (pageConfig.RateLimitConfig, error) {
 		cfg := pageConfig.GetConfigByPageType(pageConfig.RateLimitSettings, defaultconfig.GetDefaultRateLimitConfig())
 		mergeDefaultRateLimitActions(&cfg)
+		cfg.BuildActionIndex()
 		return cfg, nil
 	}, configFastCacheTTL)
 }

--- a/apps/gooseforum/app/models/hotdataserve/config_cache_test.go
+++ b/apps/gooseforum/app/models/hotdataserve/config_cache_test.go
@@ -17,6 +17,7 @@ func TestMergeDefaultRateLimitActionsAddsRewardAbuseGuards(t *testing.T) {
 		}},
 	}
 	mergeDefaultRateLimitActions(&cfg)
+	cfg.BuildActionIndex()
 
 	found := map[string]pageConfig.RateLimitRule{}
 	for _, rule := range cfg.Actions {
@@ -29,5 +30,11 @@ func TestMergeDefaultRateLimitActionsAddsRewardAbuseGuards(t *testing.T) {
 	}
 	if got := found["topic.write"].WindowSeconds; got != 999 {
 		t.Errorf("existing topic.write window = %d, want 999", got)
+	}
+	if rule, ok := cfg.RuleForAction("topic.write"); !ok || rule.WindowSeconds != 999 {
+		t.Fatalf("indexed topic.write rule = %+v, %v; want first configured rule", rule, ok)
+	}
+	if _, ok := cfg.RuleForAction("unknown"); ok {
+		t.Fatal("unknown action should not be indexed")
 	}
 }

--- a/apps/gooseforum/app/models/hotdataserve/topic_list_cache.go
+++ b/apps/gooseforum/app/models/hotdataserve/topic_list_cache.go
@@ -16,6 +16,8 @@ const (
 	topicListCacheTTL  = 5 * time.Second
 )
 
+var topicListSorts = [...]string{"latest", "hot", "popular", "new"}
+
 type TopicSimpleVoPage struct {
 	Topics  []*vo.TopicsSimpleVo
 	HasNext bool
@@ -29,7 +31,7 @@ func GetLatestTopicsSimpleVoPaginated(page int, sort string) TopicSimpleVoPage {
 	if !shouldCacheTopicPage(page) {
 		return loadLatestTopicsSimpleVoPaginated(page, sort)
 	}
-	key := "home:GetLatestTopics:" + sort + ":" + strconv.Itoa(page)
+	key := latestTopicsCacheKey(sort, page)
 	return topicSimpleVoCache.GetOrLoad(key, func() (TopicSimpleVoPage, error) {
 		return loadLatestTopicsSimpleVoPaginated(page, sort), nil
 	}, topicListCacheTTL)
@@ -41,7 +43,7 @@ func GetTopicsByCategorySimpleVo(categoryId uint64, sort string, page int) Topic
 	if !shouldCacheTopicPage(page) {
 		return loadTopicsByCategorySimpleVo(categoryId, sort, page)
 	}
-	key := "GetTopicsByCategory:" + strconv.FormatUint(categoryId, 10) + ":" + sort + ":" + strconv.Itoa(page)
+	key := topicsByCategoryCacheKey(categoryId, sort, page)
 	return topicSimpleVoCache.GetOrLoad(key, func() (TopicSimpleVoPage, error) {
 		return loadTopicsByCategorySimpleVo(categoryId, sort, page), nil
 	}, topicListCacheTTL)
@@ -65,6 +67,14 @@ func normalizeTopicSort(sort string) string {
 
 func shouldCacheTopicPage(page int) bool {
 	return page <= maxCachedTopicPage
+}
+
+func latestTopicsCacheKey(sort string, page int) string {
+	return "home:GetLatestTopics:" + sort + ":" + strconv.Itoa(page)
+}
+
+func topicsByCategoryCacheKey(categoryID uint64, sort string, page int) string {
+	return "GetTopicsByCategory:" + strconv.FormatUint(categoryID, 10) + ":" + sort + ":" + strconv.Itoa(page)
 }
 
 func loadLatestTopicsSimpleVoPaginated(page int, sort string) TopicSimpleVoPage {
@@ -106,4 +116,31 @@ func topicEntitiesToPointers(data []topics.Entity) []*topics.Entity {
 
 func ClearTopicListCache() {
 	topicSimpleVoCache.Clear()
+}
+
+// InvalidateTopicListCacheForCategories invalidates home pages and category
+// pages for categories touched by a topic mutation. Other category pages stay
+// warm and are still protected from stale in-flight loads by localcache.
+func InvalidateTopicListCacheForCategories(categoryIDs ...uint64) {
+	for page := 1; page <= maxCachedTopicPage; page++ {
+		for _, sort := range topicListSorts {
+			topicSimpleVoCache.Delete(latestTopicsCacheKey(sort, page))
+		}
+	}
+
+	seen := make(map[uint64]struct{}, len(categoryIDs))
+	for _, categoryID := range categoryIDs {
+		if categoryID == 0 {
+			continue
+		}
+		if _, ok := seen[categoryID]; ok {
+			continue
+		}
+		seen[categoryID] = struct{}{}
+		for page := 1; page <= maxCachedTopicPage; page++ {
+			for _, sort := range topicListSorts {
+				topicSimpleVoCache.Delete(topicsByCategoryCacheKey(categoryID, sort, page))
+			}
+		}
+	}
 }

--- a/apps/gooseforum/app/models/hotdataserve/topic_list_cache_test.go
+++ b/apps/gooseforum/app/models/hotdataserve/topic_list_cache_test.go
@@ -66,34 +66,45 @@ func TestInvalidateTopicListCacheForCategories(t *testing.T) {
 	ClearTopicListCache()
 	defer ClearTopicListCache()
 
-	homeKey := latestTopicsCacheKey("latest", 1)
-	categoryKey := topicsByCategoryCacheKey(3, "latest", 1)
-	otherCategoryKey := topicsByCategoryCacheKey(4, "latest", 1)
-	topicSimpleVoCache.Set(homeKey, TopicSimpleVoPage{}, time.Minute)
-	topicSimpleVoCache.Set(categoryKey, TopicSimpleVoPage{}, time.Minute)
-	topicSimpleVoCache.Set(otherCategoryKey, TopicSimpleVoPage{}, time.Minute)
+	for page := 1; page <= maxCachedTopicPage; page++ {
+		for _, sort := range topicListSorts {
+			topicSimpleVoCache.Set(latestTopicsCacheKey(sort, page), TopicSimpleVoPage{}, time.Minute)
+			topicSimpleVoCache.Set(topicsByCategoryCacheKey(3, sort, page), TopicSimpleVoPage{}, time.Minute)
+			topicSimpleVoCache.Set(topicsByCategoryCacheKey(4, sort, page), TopicSimpleVoPage{}, time.Minute)
+		}
+	}
 
 	InvalidateTopicListCacheForCategories(3, 3, 0)
 
-	for _, key := range []string{homeKey, categoryKey} {
-		loaded := false
-		if _, err := topicSimpleVoCache.GetOrLoadE(key, func() (TopicSimpleVoPage, error) {
-			loaded = true
-			return TopicSimpleVoPage{}, nil
-		}, time.Minute); err != nil {
-			t.Fatalf("reload invalidated key %q: %v", key, err)
-		} else if !loaded {
-			t.Fatalf("key %q remained cached after topic invalidation", key)
+	for page := 1; page <= maxCachedTopicPage; page++ {
+		for _, sort := range topicListSorts {
+			for _, key := range []string{latestTopicsCacheKey(sort, page), topicsByCategoryCacheKey(3, sort, page)} {
+				loaded := false
+				if _, err := topicSimpleVoCache.GetOrLoadE(key, func() (TopicSimpleVoPage, error) {
+					loaded = true
+					return TopicSimpleVoPage{}, nil
+				}, time.Minute); err != nil {
+					t.Fatalf("reload invalidated key %q: %v", key, err)
+				} else if !loaded {
+					t.Fatalf("key %q remained cached after topic invalidation", key)
+				}
+			}
 		}
 	}
-	loaded := false
-	if _, err := topicSimpleVoCache.GetOrLoadE(otherCategoryKey, func() (TopicSimpleVoPage, error) {
-		loaded = true
-		return TopicSimpleVoPage{}, nil
-	}, time.Minute); err != nil {
-		t.Fatalf("read unaffected category key: %v", err)
-	} else if loaded {
-		t.Fatal("unaffected category page was invalidated")
+
+	for page := 1; page <= maxCachedTopicPage; page++ {
+		for _, sort := range topicListSorts {
+			key := topicsByCategoryCacheKey(4, sort, page)
+			loaded := false
+			if _, err := topicSimpleVoCache.GetOrLoadE(key, func() (TopicSimpleVoPage, error) {
+				loaded = true
+				return TopicSimpleVoPage{}, nil
+			}, time.Minute); err != nil {
+				t.Fatalf("read unaffected category key: %v", err)
+			} else if loaded {
+				t.Fatalf("unaffected category page was invalidated: %q", key)
+			}
+		}
 	}
 }
 

--- a/apps/gooseforum/app/models/hotdataserve/topic_list_cache_test.go
+++ b/apps/gooseforum/app/models/hotdataserve/topic_list_cache_test.go
@@ -62,6 +62,41 @@ func TestTopicListCacheReadsTopics(t *testing.T) {
 	}
 }
 
+func TestInvalidateTopicListCacheForCategories(t *testing.T) {
+	ClearTopicListCache()
+	defer ClearTopicListCache()
+
+	homeKey := latestTopicsCacheKey("latest", 1)
+	categoryKey := topicsByCategoryCacheKey(3, "latest", 1)
+	otherCategoryKey := topicsByCategoryCacheKey(4, "latest", 1)
+	topicSimpleVoCache.Set(homeKey, TopicSimpleVoPage{}, time.Minute)
+	topicSimpleVoCache.Set(categoryKey, TopicSimpleVoPage{}, time.Minute)
+	topicSimpleVoCache.Set(otherCategoryKey, TopicSimpleVoPage{}, time.Minute)
+
+	InvalidateTopicListCacheForCategories(3, 3, 0)
+
+	for _, key := range []string{homeKey, categoryKey} {
+		loaded := false
+		if _, err := topicSimpleVoCache.GetOrLoadE(key, func() (TopicSimpleVoPage, error) {
+			loaded = true
+			return TopicSimpleVoPage{}, nil
+		}, time.Minute); err != nil {
+			t.Fatalf("reload invalidated key %q: %v", key, err)
+		} else if !loaded {
+			t.Fatalf("key %q remained cached after topic invalidation", key)
+		}
+	}
+	loaded := false
+	if _, err := topicSimpleVoCache.GetOrLoadE(otherCategoryKey, func() (TopicSimpleVoPage, error) {
+		loaded = true
+		return TopicSimpleVoPage{}, nil
+	}, time.Minute); err != nil {
+		t.Fatalf("read unaffected category key: %v", err)
+	} else if loaded {
+		t.Fatal("unaffected category page was invalidated")
+	}
+}
+
 func TestCategoryCacheReadsCleanCategories(t *testing.T) {
 	conn := dbconnect.Connect()
 	if err := conn.AutoMigrate(&category.Entity{}); err != nil {

--- a/apps/gooseforum/app/service/backgroundservice/worker.go
+++ b/apps/gooseforum/app/service/backgroundservice/worker.go
@@ -39,12 +39,10 @@ type TaskHandler func(ctx context.Context, task *taskQueue.Entity) error
 // RunWorker starts a polling worker for tasks whose type starts with
 // typePrefix. The worker stops when the process closer fires.
 func RunWorker(name, typePrefix string, handler TaskHandler) {
-	stopCh := make(chan struct{})
-	closer.RegisterPriority(closer.PriorityProducer, func() error {
-		close(stopCh)
-		return nil
-	})
+	workerCtx, cancel := context.WithCancel(context.Background())
+	workerDone := make(chan struct{})
 	go func() {
+		defer close(workerDone)
 		defer paniclog.Recover(name)
 		ticker := time.NewTicker(pollInterval)
 		defer ticker.Stop()
@@ -55,22 +53,31 @@ func RunWorker(name, typePrefix string, handler TaskHandler) {
 			if err := taskQueue.RecoverStaleRunning(typePrefix, taskQueue.LeaseDuration); err != nil {
 				slog.Error("background: recover stale running tasks failed", "worker", typePrefix, "err", err)
 			}
-			if !drainTasks(stopCh, typePrefix, handler) {
+			if !drainTasks(workerCtx, typePrefix, handler) {
 				return
 			}
 			select {
 			case <-ticker.C:
-			case <-stopCh:
+			case <-workerCtx.Done():
 				return
 			}
 		}
 	}()
+	closer.RegisterPriorityContext(closer.PriorityProducer, func(shutdownCtx context.Context) error {
+		cancel()
+		select {
+		case <-workerDone:
+			return nil
+		case <-shutdownCtx.Done():
+			return shutdownCtx.Err()
+		}
+	})
 }
 
-func drainTasks(stopCh <-chan struct{}, typePrefix string, handler TaskHandler) bool {
+func drainTasks(ctx context.Context, typePrefix string, handler TaskHandler) bool {
 	for {
 		select {
-		case <-stopCh:
+		case <-ctx.Done():
 			return false
 		default:
 		}
@@ -82,18 +89,18 @@ func drainTasks(stopCh <-chan struct{}, typePrefix string, handler TaskHandler) 
 		slog.Debug("background: pulled tasks", "worker", typePrefix, "count", len(tasks))
 
 		for _, task := range tasks {
-			if !processTask(stopCh, typePrefix, task, handler) {
+			if !processTask(ctx, typePrefix, task, handler) {
 				return false
 			}
 		}
 	}
 }
 
-// processTask 处理单个任务并返回 continue 布尔：false = stop（stopCh 已
+// processTask 处理单个任务并返回 continue 布尔：false = stop（ctx 已
 // 关闭，worker 应退出），true = continue。注意与 mail worker 的
 // processClaimedEmailTask 语义相反（后者 true = stop）——两处各自调用方
 // 匹配了约定，修改时勿混用。
-func processTask(stopCh <-chan struct{}, typePrefix string, task *taskQueue.Entity, handler TaskHandler) bool {
+func processTask(workerCtx context.Context, typePrefix string, task *taskQueue.Entity, handler TaskHandler) bool {
 	// 原子领取（issue #138）：pending/retrying → running 的 CAS 更新，
 	// 并发 worker 中只有一个能成功，其余直接跳过，杜绝重复执行外部副作用。
 	running, claimed, err := taskQueue.ClaimTask(task.Id)
@@ -108,7 +115,7 @@ func processTask(stopCh <-chan struct{}, typePrefix string, task *taskQueue.Enti
 
 	// 处理期间心跳续租；租约丢失（任务被回收重领）时取消 ctx，终止 handler。
 	guard := NewLeaseGuard(running.LeaseToken)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(workerCtx)
 	defer cancel()
 	heartbeatDone := StartLeaseHeartbeat(ctx, cancel, running.Id, guard)
 
@@ -149,7 +156,7 @@ func processTask(stopCh <-chan struct{}, typePrefix string, task *taskQueue.Enti
 			select {
 			case <-time.After(retryInterval):
 				return true
-			case <-stopCh:
+			case <-workerCtx.Done():
 				return false
 			}
 		}

--- a/apps/gooseforum/app/service/backgroundservice/worker_test.go
+++ b/apps/gooseforum/app/service/backgroundservice/worker_test.go
@@ -102,7 +102,7 @@ func TestProcessTaskRetryThenFail(t *testing.T) {
 	}
 
 	// 第一次：失败 → 进入重试
-	if !processTask(make(chan struct{}), "export", task, handler) {
+	if !processTask(context.Background(), "export", task, handler) {
 		t.Fatal("processTask returned stop=true on first attempt, want continue")
 	}
 	updated := mustGetTask(t, task.Id)
@@ -114,7 +114,7 @@ func TestProcessTaskRetryThenFail(t *testing.T) {
 	}
 
 	// 第二次：成功 → 标记成功
-	if !processTask(make(chan struct{}), "export", task, handler) {
+	if !processTask(context.Background(), "export", task, handler) {
 		t.Fatal("processTask returned stop=true on success, want continue")
 	}
 	updated = mustGetTask(t, task.Id)
@@ -142,7 +142,6 @@ func TestClaimTaskAtomicity(t *testing.T) {
 	if err := taskQueue.Create(task); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-
 
 	const workers = 8
 	var claimed atomic.Int32
@@ -195,7 +194,7 @@ func TestProcessTaskConcurrentSingleExecution(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			processTask(make(chan struct{}), "export", task, handler)
+			processTask(context.Background(), "export", task, handler)
 		}()
 	}
 	wg.Wait()
@@ -243,7 +242,7 @@ func TestProcessTaskWritesExportProgressThroughRealChain(t *testing.T) {
 	}
 
 	// 真实 worker 链路：processTask 内部 ClaimTask → handler(&running)
-	if !processTask(make(chan struct{}), dataservice.TaskTypeExport, task, dataservice.RunExportTask) {
+	if !processTask(context.Background(), dataservice.TaskTypeExport, task, dataservice.RunExportTask) {
 		t.Fatal("processTask returned stop=true, want continue")
 	}
 
@@ -575,7 +574,7 @@ func TestProcessTaskStatusFailedAfterMaxRetries(t *testing.T) {
 	}
 
 	start := time.Now()
-	if !processTask(make(chan struct{}), "export", task, handler) {
+	if !processTask(context.Background(), "export", task, handler) {
 		t.Fatal("processTask returned stop=true, want continue")
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
@@ -664,10 +663,9 @@ func TestProcessTaskCleanupRetryThenFail(t *testing.T) {
 		t.Fatalf("create task: %v", err)
 	}
 
-
 	for i := 1; i <= maxRetries; i++ {
 		reload := mustGetTask(t, task.Id)
-		if !processTask(make(chan struct{}), "course-review-cleanup", &reload, courseservice.RunCleanupTask) {
+		if !processTask(context.Background(), "course-review-cleanup", &reload, courseservice.RunCleanupTask) {
 			t.Fatalf("processTask attempt %d returned stop=true, want continue", i)
 		}
 		updated := mustGetTask(t, task.Id)
@@ -684,7 +682,7 @@ func TestProcessTaskCleanupRetryThenFail(t *testing.T) {
 
 	// 第 4 次（超过 maxRetries）：failed + LastError
 	reload := mustGetTask(t, task.Id)
-	processTask(make(chan struct{}), "course-review-cleanup", &reload, courseservice.RunCleanupTask)
+	processTask(context.Background(), "course-review-cleanup", &reload, courseservice.RunCleanupTask)
 	updated := mustGetTask(t, task.Id)
 	if updated.Status != taskQueue.StatusFailed {
 		t.Fatalf("final status = %d, want %d (failed)", updated.Status, taskQueue.StatusFailed)

--- a/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
@@ -167,7 +167,7 @@ func DeleteTopicAs(topic topics.Entity, operatorID uint64, visibility string, re
 	}
 
 	// 删除立即生效：全渠道清除 + 通知预览置空 + 附件转入受限恢复态。
-	clearTopicCaches(topic.Id)
+	clearTopicCaches(topic.Id, topic.CategoryIds...)
 	notificationservice.NullifyContentPreviews(topic.Id, 0)
 	fileusageservice.HardenTargetFiles(topicsTarget(topic.Id), time.Now().Add(RecoveryWindow))
 	eventbus.Publish(context.Background(), &eventhandlers.ContentDeletedEvent{
@@ -209,8 +209,8 @@ func markTopicDeleted(topicID uint64, visibility string, operatorID uint64, reas
 	}
 }
 
-func clearTopicCaches(topicID uint64) {
-	hotdataserve.ClearTopicListCache()
+func clearTopicCaches(topicID uint64, categoryIDs ...uint64) {
+	hotdataserve.InvalidateTopicListCacheForCategories(categoryIDs...)
 	llmsservice.ClearCache()
 	slog.Debug("topic delete caches cleared", "topicId", topicID)
 }
@@ -275,7 +275,7 @@ func DeletePostByUser(userID uint64, postID uint64) (DeletePostResult, error) {
 	topicEntity := topics.GetSimple(post.TopicId)
 	if topicEntity.Id > 0 {
 		postservice.SyncTopicPostStats(topicEntity, post, true)
-		hotdataserve.ClearTopicListCache()
+		hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		llmsservice.ClearCache()
 	}
 	fileusageservice.HardenTargetFiles(postsTarget(postID), time.Now().Add(RecoveryWindow))
@@ -339,7 +339,7 @@ func DeletePostAsModerator(moderatorID uint64, postID uint64, reason string) err
 	topicEntity := topics.GetSimple(post.TopicId)
 	if topicEntity.Id > 0 {
 		postservice.SyncTopicPostStats(topicEntity, post, true)
-		hotdataserve.ClearTopicListCache()
+		hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		llmsservice.ClearCache()
 	}
 	notificationservice.NullifyContentPreviews(post.TopicId, postID)
@@ -371,9 +371,8 @@ func RestoreContent(userID uint64, contentType ContentType, contentID uint64) er
 		}
 		restoreTopicPosts(topic.Id, userID)
 		restoreWikiTopicPages(topic)
-		rebuildTopicSearchIndex(contentID)
 		fileusageservice.RecoverTargetFiles(topicsTarget(contentID))
-		hotdataserve.ClearTopicListCache()
+		hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 		llmsservice.ClearCache()
 		eventbus.Publish(context.Background(), &eventhandlers.ContentRestoredEvent{
 			ContentType: string(ContentTypeTopic),
@@ -413,7 +412,7 @@ func RestoreContent(userID uint64, contentType ContentType, contentID uint64) er
 			if err := posts.ListByTopicID(topicEntity.Id, &activePosts); err == nil {
 				_ = postservice.RebuildTopicPostStats(topicEntity, activePosts)
 			}
-			hotdataserve.ClearTopicListCache()
+			hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 			llmsservice.ClearCache()
 		}
 		fileusageservice.RecoverTargetFiles(postsTarget(post.Id))
@@ -523,9 +522,8 @@ func RestoreTopicAsModerator(moderatorID uint64, topicID uint64) error {
 	}
 	restoreModeratorRemovedTopicPosts(topic, moderatorID)
 	restoreWikiTopicPages(topic)
-	rebuildTopicSearchIndex(topicID)
 	fileusageservice.RecoverTargetFiles(topicsTarget(topicID))
-	hotdataserve.ClearTopicListCache()
+	hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 	llmsservice.ClearCache()
 	eventbus.Publish(context.Background(), &eventhandlers.ContentRestoredEvent{
 		ContentType: string(ContentTypeTopic),
@@ -565,17 +563,6 @@ func restoreModeratorRemovedTopicPosts(topic topics.Entity, moderatorID uint64) 
 
 func topicDeleteCascadeReason(topicID uint64) string {
 	return "topic_delete:" + fmt.Sprint(topicID)
-}
-
-func rebuildTopicSearchIndex(topicID uint64) {
-	topic := topics.Get(topicID)
-	if topic.Id == 0 {
-		return
-	}
-	firstPost := posts.Get(topic.FirstPostId)
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Error("failed to rebuild topic search document after restore", "topicId", topicID, "err", err)
-	}
 }
 
 // PurgeContent 永久删除（R4）：置 PURGED、清理附件引用、通知预览置空。
@@ -633,7 +620,7 @@ func PurgeContent(userID uint64, contentType ContentType, contentID uint64, reas
 		notificationservice.NullifyContentPreviews(post.TopicId, contentID)
 		topicEntity := topics.GetSimple(post.TopicId)
 		if topicEntity.Id > 0 {
-			hotdataserve.ClearTopicListCache()
+			hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 			llmsservice.ClearCache()
 		}
 		eventbus.Publish(context.Background(), &eventhandlers.ContentDeletedEvent{
@@ -806,7 +793,7 @@ func ExpireRecoverableBatch(limit int) error {
 		purgeTopicPosts(topic.Id, topic.UserId)
 		fileusageservice.PurgeTargetFiles(topicsTarget(topic.Id))
 		notificationservice.NullifyContentPreviews(topic.Id, 0)
-		hotdataserve.ClearTopicListCache()
+		hotdataserve.InvalidateTopicListCacheForCategories(topic.CategoryIds...)
 		llmsservice.ClearCache()
 		slog.Info("retention: topic purged after recovery window", "topicId", topic.Id)
 	}

--- a/apps/gooseforum/app/service/courseservice/course_ai_summary.go
+++ b/apps/gooseforum/app/service/courseservice/course_ai_summary.go
@@ -193,18 +193,18 @@ var (
 // 不消耗任何名额；LLM 失败/未配置/落库失败返还单课名额（全局名额保留——
 // 确实发生了调用，防刷语义不变）。
 func GetAiSummary(courseId uint64, refresh bool) (AiSummaryResult, error) {
-	ctx, cancel := context.WithTimeoutCause(context.Background(), aiSummaryTimeout, context.DeadlineExceeded)
-	defer cancel()
-	return GetAiSummaryContext(ctx, courseId, refresh)
+	return GetAiSummaryContext(context.Background(), courseId, refresh)
 }
 
 // GetAiSummaryContext keeps request cancellation attached to the provider
-// call. The legacy wrapper above supplies a bounded context for non-HTTP
-// callers; background jobs should pass their own worker context.
+// call and applies the service-level upper bound for every caller. Background
+// jobs should still pass their own worker context so shutdown can cancel it.
 func GetAiSummaryContext(ctx context.Context, courseId uint64, refresh bool) (AiSummaryResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	ctx, cancel := context.WithTimeoutCause(ctx, aiSummaryTimeout, context.DeadlineExceeded)
+	defer cancel()
 	if err := ctx.Err(); err != nil {
 		return AiSummaryResult{}, ErrAiSummaryGenerationFailed
 	}

--- a/apps/gooseforum/app/service/courseservice/course_ai_summary.go
+++ b/apps/gooseforum/app/service/courseservice/course_ai_summary.go
@@ -85,6 +85,7 @@ const (
 	aiSummaryCourseWindow    = 10 * time.Minute
 	aiSummaryGlobalKey       = "ai.summary.global"
 	aiSummaryCourseKeyPrefix = "ai.summary.course:"
+	aiSummaryTimeout         = 30 * time.Second
 )
 
 // aiSummaryGlobalLimit 全局每分钟生成上限；0 表示用默认值（成本护栏，
@@ -192,6 +193,21 @@ var (
 // 不消耗任何名额；LLM 失败/未配置/落库失败返还单课名额（全局名额保留——
 // 确实发生了调用，防刷语义不变）。
 func GetAiSummary(courseId uint64, refresh bool) (AiSummaryResult, error) {
+	ctx, cancel := context.WithTimeoutCause(context.Background(), aiSummaryTimeout, context.DeadlineExceeded)
+	defer cancel()
+	return GetAiSummaryContext(ctx, courseId, refresh)
+}
+
+// GetAiSummaryContext keeps request cancellation attached to the provider
+// call. The legacy wrapper above supplies a bounded context for non-HTTP
+// callers; background jobs should pass their own worker context.
+func GetAiSummaryContext(ctx context.Context, courseId uint64, refresh bool) (AiSummaryResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return AiSummaryResult{}, ErrAiSummaryGenerationFailed
+	}
 	// 1. 课程存在且可见。
 	entity := course.GetCourse(courseId)
 	if entity.Id == 0 || entity.Status != course.StatusVisible {
@@ -310,7 +326,7 @@ func GetAiSummary(courseId uint64, refresh bool) (AiSummaryResult, error) {
 		return AiSummaryResult{}, ErrAiSummaryGenerationFailed
 	}
 	prompt := buildAiSummaryPrompt(entity.Name, entity.PrimaryCode, reviews)
-	raw, err := llmChat(context.Background(), cfg, prompt)
+	raw, err := llmChat(ctx, cfg, prompt)
 	if err != nil {
 		slog.Error("ai_summary_generation_failed", "courseId", courseId, "error", err)
 		store.Reset(courseKey)

--- a/apps/gooseforum/app/service/courseservice/course_ai_summary_test.go
+++ b/apps/gooseforum/app/service/courseservice/course_ai_summary_test.go
@@ -665,3 +665,34 @@ func TestResolveAiSummaryConfigFallsBackToToml(t *testing.T) {
 		t.Fatalf("cfg = %#v, want toml baseURL/model with trailing slash trimmed", cfg)
 	}
 }
+
+func TestGetAiSummaryContextCancelsLLM(t *testing.T) {
+	courseID := setupAiSummaryTest(t)
+	seedAiSummaryReviews(t, courseID, 10)
+	preferences.Set("ai_summary.base_url", "http://fake.local/v1")
+	preferences.Set("ai_summary.model", "fake-model")
+	started := make(chan struct{})
+	original := llmChat
+	llmChat = func(ctx context.Context, _ llmprovider.Config, _ string) (string, error) {
+		close(started)
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	t.Cleanup(func() { llmChat = original })
+
+	timeoutErr := errors.New("test llm timeout")
+	ctx, cancel := context.WithTimeoutCause(context.Background(), 20*time.Millisecond, timeoutErr)
+	defer cancel()
+	_, err := GetAiSummaryContext(ctx, courseID, false)
+	if !errors.Is(err, ErrAiSummaryGenerationFailed) {
+		t.Fatalf("GetAiSummaryContext() error = %v, want generation failure", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("LLM was not called")
+	}
+	if !errors.Is(context.Cause(ctx), timeoutErr) {
+		t.Fatalf("context cause = %v, want %v", context.Cause(ctx), timeoutErr)
+	}
+}

--- a/apps/gooseforum/app/service/datamigration/wiki_git_ssot_backfill.go
+++ b/apps/gooseforum/app/service/datamigration/wiki_git_ssot_backfill.go
@@ -3,6 +3,7 @@ package datamigration
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"log/slog"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -72,7 +73,7 @@ func BackfillWikiGitSSOTWithDB(conn *gorm.DB) WikiGitSSOTBackfillResult {
 				Order("id DESC").
 				First(&latest).Error
 			if err != nil {
-				if err == gorm.ErrRecordNotFound {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
 					result.PagesSkipped++
 					continue
 				}

--- a/apps/gooseforum/app/service/datamigration/wiki_single_source_backfill.go
+++ b/apps/gooseforum/app/service/datamigration/wiki_single_source_backfill.go
@@ -1,6 +1,7 @@
 package datamigration
 
 import (
+	"errors"
 	"log/slog"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
@@ -73,7 +74,7 @@ func BackfillWikiSingleSourceWithDB(conn *gorm.DB) WikiSingleSourceBackfillResul
 				Order("id DESC").
 				First(&latest).Error
 			if err != nil {
-				if err == gorm.ErrRecordNotFound {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
 					result.Skipped++
 					continue
 				}

--- a/apps/gooseforum/app/service/dataservice/dataservice_test.go
+++ b/apps/gooseforum/app/service/dataservice/dataservice_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -133,8 +134,9 @@ func TestExportRunAndFile(t *testing.T) {
 		t.Fatalf("export file missing: %v", err)
 	}
 	// issue #324 S4：导出文件含用户 PII，权限必须为 0600（仅属主可读写）。
-	if perm := info.Mode().Perm(); perm != 0o600 {
-		t.Fatalf("export file mode = %o, want 600", perm)
+	// Windows does not expose POSIX permission bits through os.FileMode.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Fatalf("export file mode = %o, want 600", info.Mode().Perm())
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -292,7 +294,8 @@ func TestEnqueueImportIsIdempotentAndRemovesStagingFileAfterSuccess(t *testing.T
 	if err != nil {
 		t.Fatalf("stat staged import: %v", err)
 	}
-	if info.Mode().Perm() != 0o600 {
+	// Windows does not expose POSIX permission bits through os.FileMode.
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
 		t.Fatalf("staged import mode = %o, want 600", info.Mode().Perm())
 	}
 	running, claimed, err := taskQueue.ClaimTask(task.Id)

--- a/apps/gooseforum/app/service/dataservice/dataservice_test.go
+++ b/apps/gooseforum/app/service/dataservice/dataservice_test.go
@@ -3,6 +3,7 @@ package dataservice
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -231,6 +232,112 @@ func TestImportDataForeignKeyFailure(t *testing.T) {
 	}
 	if len(report.Errors) != 1 || report.Errors[0].Table != "topics" {
 		t.Fatalf("ImportData() errors = %+v, want one topics error", report.Errors)
+	}
+}
+
+func TestImportDataRollsBackAllRowsOnValidationFailure(t *testing.T) {
+	setupDataTestDB(t)
+	jsonData := []byte(`{"users":[{"id":901001,"username":"atomic-user"},{"id":901002,"username":""}]}`)
+
+	report, err := ImportData(context.Background(), jsonData, "json")
+	if err != nil {
+		t.Fatalf("ImportData() error = %v", err)
+	}
+	if report.Failed != 1 || report.Success != 1 {
+		t.Fatalf("report = %+v, want one success and one failed row", report)
+	}
+	var user users.EntityComplete
+	if err := dbconnect.Connect().Where("username = ?", "atomic-user").First(&user).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("rolled-back user lookup error = %v, want record not found", err)
+	}
+}
+
+func TestEnqueueImportIsIdempotentAndRemovesStagingFileAfterSuccess(t *testing.T) {
+	setupDataTestDB(t)
+	restoreImportDir := SetImportDirForTest(t.TempDir())
+	defer restoreImportDir()
+	data := []byte(`{"users":[]}`)
+
+	first, err := EnqueueImport(context.Background(), data, "json")
+	if err != nil {
+		t.Fatalf("first EnqueueImport() error = %v", err)
+	}
+	second, err := EnqueueImport(context.Background(), data, "json")
+	if err != nil {
+		t.Fatalf("duplicate EnqueueImport() error = %v", err)
+	}
+	if first.TaskID == 0 || first.TaskID != second.TaskID || first.Status != "pending" {
+		t.Fatalf("first=%+v second=%+v, want one pending task", first, second)
+	}
+	var count int64
+	if err := dbconnect.Connect().Model(&taskQueue.Entity{}).Where("type = ?", TaskTypeImport).Count(&count).Error; err != nil {
+		t.Fatalf("count import tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("import task count = %d, want 1", count)
+	}
+	var task taskQueue.Entity
+	if err := dbconnect.Connect().First(&task, first.TaskID).Error; err != nil {
+		t.Fatalf("load import task: %v", err)
+	}
+	var payload ImportTask
+	if err := json.Unmarshal([]byte(task.TaskJson), &payload); err != nil {
+		t.Fatalf("decode import task: %v", err)
+	}
+	path, err := importFilePath(payload.FileName)
+	if err != nil {
+		t.Fatalf("importFilePath() error = %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat staged import: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("staged import mode = %o, want 600", info.Mode().Perm())
+	}
+	running, claimed, err := taskQueue.ClaimTask(task.Id)
+	if err != nil || !claimed {
+		t.Fatalf("claim import task: claimed=%v err=%v", claimed, err)
+	}
+	if err := RunImportTask(context.Background(), &running); err != nil {
+		t.Fatalf("RunImportTask() error = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("staged import stat error = %v, want not exist", err)
+	}
+}
+
+func TestReplayImportTaskKeepsStagedFile(t *testing.T) {
+	setupDataTestDB(t)
+	restoreImportDir := SetImportDirForTest(t.TempDir())
+	defer restoreImportDir()
+
+	task, err := EnqueueImport(context.Background(), []byte(`{"users":[]}`), "json")
+	if err != nil {
+		t.Fatalf("EnqueueImport() error = %v", err)
+	}
+	if err := dbconnect.Connect().Model(&taskQueue.Entity{}).Where("id = ?", task.TaskID).
+		Updates(map[string]any{"status": taskQueue.StatusFailed, "last_error": "test failure"}).Error; err != nil {
+		t.Fatalf("mark import task failed: %v", err)
+	}
+
+	replayed, err := ReplayImportTask(task.TaskID)
+	if err != nil {
+		t.Fatalf("ReplayImportTask() error = %v", err)
+	}
+	if replayed.Status != taskQueue.StatusPending || replayed.RetryCount != 0 || replayed.LastError != "" {
+		t.Fatalf("replayed task = %+v, want clean pending task", replayed)
+	}
+	var payload ImportTask
+	if err := json.Unmarshal([]byte(replayed.TaskJson), &payload); err != nil {
+		t.Fatalf("decode replayed payload: %v", err)
+	}
+	path, err := importFilePath(payload.FileName)
+	if err != nil {
+		t.Fatalf("importFilePath() error = %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("replay removed staging file: %v", err)
 	}
 }
 

--- a/apps/gooseforum/app/service/dataservice/export.go
+++ b/apps/gooseforum/app/service/dataservice/export.go
@@ -1,6 +1,6 @@
 // Package dataservice provides admin data export/import for users, topics
-// and posts. Export runs as a taskQueue background task; import is a
-// synchronous, validated JSON import with idempotent skip.
+// and posts. Export and import both run as taskQueue background tasks; import
+// uses a staged, validated JSON body with idempotent replay.
 package dataservice
 
 import (

--- a/apps/gooseforum/app/service/dataservice/import.go
+++ b/apps/gooseforum/app/service/dataservice/import.go
@@ -3,8 +3,8 @@ package dataservice
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
@@ -35,6 +35,8 @@ type ImportReport struct {
 	Failed   int           `json:"failed"`
 	Errors   []ImportError `json:"errors"`
 	Imported []string      `json:"importedTables"`
+	TaskID   uint64        `json:"taskId,omitempty"`
+	Status   string        `json:"status,omitempty"`
 }
 
 // ImportData 导入 JSON 数据（仅支持 JSON 格式）。
@@ -43,7 +45,12 @@ type ImportReport struct {
 // 导入完成后重建话题 invariants（首末帖指针、计数、post_seq、参与者统计、
 // 分类索引），保证 round-trip 后结构与源库一致且可继续回复（issue #135）。
 // postRevisions 依赖 posts 存在（外键校验），在 posts 之后导入。
-func ImportData(_ context.Context, data []byte, format string) (*ImportReport, error) {
+var errImportRowsFailed = errors.New("导入存在失败行，事务已回滚")
+
+func ImportData(ctx context.Context, data []byte, format string) (*ImportReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if format != "json" {
 		return nil, fmt.Errorf("导入仅支持 JSON 格式")
 	}
@@ -55,23 +62,26 @@ func ImportData(_ context.Context, data []byte, format string) (*ImportReport, e
 		Errors:   []ImportError{},
 		Imported: []string{},
 	}
-	importUsers(parsed["users"], report)
-	importTopics(parsed["topics"], report)
-	importPosts(parsed["posts"], report)
-	importPostRevisions(parsed["postRevisions"], report)
-	importTopicCategoryIndexes(parsed["topicCategoryIndex"], report)
-	importTopicUserStats(parsed["topicUserStat"], report)
-	// 显式主键写入不会推进 PostgreSQL sequence，必须先推进序列再重建派生数据：
-	// rebuild 期间 ensureTopicCategoryIndexes / rebuildTopicUserStats 会用自增 ID
-	// 创建新行，若序列仍停在导入前小值，新行可能复用已导入显式 ID 撞主键，
-	// 分类索引/参与者统计行被静默丢弃（PR #160 复审 🟠）。
-	resetPostgresSequences()
-	// 话题 invariants 需要 posts 全部落库后才能推导，必须在 posts 导入之后执行。
-	// 仅当本次导入涉及非空 topics 且无失败行时才全库重建：失败导入的数据可能
-	// 不完整，重建会产生误导性结果；仅导入 users 或空 topics 时也跳过全库扫描
-	// 与副作用（PR #160 review, suggestion 3 / 复审 🟡）。
-	if len(parsed["topics"]) > 0 && report.Failed == 0 {
-		rebuildTopicInvariants()
+	txErr := dbconnect.ConnectContext(ctx).Transaction(func(tx *gorm.DB) error {
+		importUsers(tx, parsed["users"], report)
+		importTopics(tx, parsed["topics"], report)
+		importPosts(tx, parsed["posts"], report)
+		importPostRevisions(tx, parsed["postRevisions"], report)
+		importTopicCategoryIndexes(tx, parsed["topicCategoryIndex"], report)
+		importTopicUserStats(tx, parsed["topicUserStat"], report)
+		if report.Failed > 0 {
+			return errImportRowsFailed
+		}
+		if err := resetPostgresSequences(tx); err != nil {
+			return err
+		}
+		if len(parsed["topics"]) > 0 {
+			return rebuildTopicInvariants(tx)
+		}
+		return nil
+	})
+	if txErr != nil && !errors.Is(txErr, errImportRowsFailed) {
+		return nil, txErr
 	}
 	for _, t := range []string{"users", "topics", "posts", "postRevisions", "topicCategoryIndex", "topicUserStat"} {
 		if _, ok := parsed[t]; ok {
@@ -86,19 +96,19 @@ func ImportData(_ context.Context, data []byte, format string) (*ImportReport, e
 // topic_user_stat（均 autoIncrement 主键，PR #160 review, warning 1）：PG 上
 // 显式主键写入不推进序列，若漏推，下一次 INSERT 可能复用已导入 ID 触发
 // 主键冲突。SQLite 无 sequence 概念，无需处理。
-func resetPostgresSequences() {
+func resetPostgresSequences(db *gorm.DB) error {
 	if dbconnect.IsSqlite() {
-		return
+		return nil
 	}
-	db := dbconnect.Connect()
 	for _, table := range []string{"users", "topics", "posts", "post_revisions", "topic_category_index", "topic_user_stat"} {
 		if err := db.Exec(fmt.Sprintf(
 			`SELECT setval(pg_get_serial_sequence('%s', 'id'), GREATEST((SELECT COALESCE(MAX(id), 1) FROM %s), 1), true)`,
 			table, table,
 		)).Error; err != nil {
-			slog.Error("resetPostgresSequences: 推进序列失败", "table", table, "err", err)
+			return fmt.Errorf("resetPostgresSequences: 推进 %s 序列失败: %w", table, err)
 		}
 	}
+	return nil
 }
 
 // parseImportJSON 解析导入 JSON 为按表分组的行。
@@ -141,8 +151,7 @@ func parseImportJSON(data []byte) (map[string][]map[string]any, error) {
 	return result, nil
 }
 
-func importUsers(rows []map[string]any, report *ImportReport) {
-	db := dbconnect.Connect()
+func importUsers(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 	for i, row := range rows {
 		line := i + 1
 		report.Total++
@@ -201,8 +210,7 @@ func importUsers(rows []map[string]any, report *ImportReport) {
 	}
 }
 
-func importTopics(rows []map[string]any, report *ImportReport) {
-	db := dbconnect.Connect()
+func importTopics(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 	for i, row := range rows {
 		line := i + 1
 		report.Total++
@@ -236,7 +244,8 @@ func importTopics(rows []map[string]any, report *ImportReport) {
 			_ = json.Unmarshal([]byte(cats), &categoryIDs)
 		}
 		for _, cid := range categoryIDs {
-			if category.Get(cid).Id == 0 {
+			var cat category.Entity
+			if err := db.First(&cat, cid).Error; err != nil {
 				report.Failed++
 				report.Errors = append(report.Errors, ImportError{Line: line, Table: "topics", Reason: fmt.Sprintf("分类 %d 不存在", cid)})
 				categoryIDs = nil
@@ -297,8 +306,7 @@ func importTopics(rows []map[string]any, report *ImportReport) {
 	}
 }
 
-func importTopicCategoryIndexes(rows []map[string]any, report *ImportReport) {
-	db := dbconnect.Connect()
+func importTopicCategoryIndexes(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 	for i, row := range rows {
 		line := i + 1
 		report.Total++
@@ -343,8 +351,7 @@ func importTopicCategoryIndexes(rows []map[string]any, report *ImportReport) {
 	}
 }
 
-func importTopicUserStats(rows []map[string]any, report *ImportReport) {
-	db := dbconnect.Connect()
+func importTopicUserStats(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 	for i, row := range rows {
 		line := i + 1
 		report.Total++
@@ -408,12 +415,10 @@ func importTopicUserStats(rows []map[string]any, report *ImportReport) {
 //     指针但仍需重建统计，PR #160 review, warning 2）。
 //
 // 仅当话题缺失关键字段时补算指针，避免覆盖新导出格式中导出的精确值。
-func rebuildTopicInvariants() {
-	db := dbconnect.Connect()
+func rebuildTopicInvariants(db *gorm.DB) error {
 	var list []topics.Entity
 	if err := db.Find(&list).Error; err != nil {
-		slog.Error("rebuildTopicInvariants: 加载话题列表失败", "err", err)
-		return
+		return fmt.Errorf("rebuildTopicInvariants: 加载话题列表失败: %w", err)
 	}
 	for _, topic := range list {
 		// 判断该话题是否需要按 posts 回填指针：invariants 缺失（旧格式导出，
@@ -423,8 +428,12 @@ func rebuildTopicInvariants() {
 			// 新格式导出：指针/计数已精确恢复，仅补齐缺失的派生表。
 			// 分类索引缺失时按 topics.categoryIds 补齐；
 			// 参与者统计缺失（默认 UI 路径不导出该表）时从 posts 重建。
-			ensureTopicCategoryIndexes(db, topic.Id)
-			ensureTopicUserStats(db, topic.Id)
+			if err := ensureTopicCategoryIndexes(db, topic.Id); err != nil {
+				return err
+			}
+			if err := ensureTopicUserStats(db, topic.Id); err != nil {
+				return err
+			}
 			continue
 		}
 		var postList []*posts.Entity
@@ -433,8 +442,7 @@ func rebuildTopicInvariants() {
 		if err := db.Where("topic_id = ? AND visibility_status = ?", topic.Id, posts.VisibilityActive).
 			Order("post_no asc").Order("id asc").
 			Find(&postList).Error; err != nil {
-			slog.Error("rebuildTopicInvariants: 加载话题 posts 失败", "topicId", topic.Id, "err", err)
-			continue
+			return fmt.Errorf("rebuildTopicInvariants: 加载话题 %d posts 失败: %w", topic.Id, err)
 		}
 		// 无 posts 的话题（空话题在源库不存在）跳过，避免全 0 误判后白扫
 		if len(postList) == 0 {
@@ -484,26 +492,30 @@ func rebuildTopicInvariants() {
 			updates["last_posted_at"] = *lastTime
 		}
 		if err := db.Model(&topics.Entity{}).Where("id = ?", topic.Id).Updates(updates).Error; err != nil {
-			slog.Error("rebuildTopicInvariants: 更新话题 invariants 失败", "topicId", topic.Id, "err", err)
-			continue
+			return fmt.Errorf("rebuildTopicInvariants: 更新话题 %d invariants 失败: %w", topic.Id, err)
 		}
 		// 参与者统计：导入文件带 topicUserStat 时保留导出值，缺失时从 posts 重建
-		ensureTopicUserStats(db, topic.Id)
-		ensureTopicCategoryIndexes(db, topic.Id)
+		if err := ensureTopicUserStats(db, topic.Id); err != nil {
+			return err
+		}
+		if err := ensureTopicCategoryIndexes(db, topic.Id); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // ensureTopicUserStats 话题参与者统计缺失（count==0）时从 posts 重建。
 // 导入文件显式携带 topicUserStat 时保留导出值（count>0 不重建）。
-func ensureTopicUserStats(db *gorm.DB, topicID uint64) {
+func ensureTopicUserStats(db *gorm.DB, topicID uint64) error {
 	var count int64
 	if err := db.Model(&topicUserStat.Entity{}).Where("topic_id = ?", topicID).Count(&count).Error; err != nil {
-		slog.Error("ensureTopicUserStats: 统计失败", "topicId", topicID, "err", err)
-		return
+		return fmt.Errorf("ensureTopicUserStats: 统计话题 %d 失败: %w", topicID, err)
 	}
 	if count == 0 {
-		rebuildTopicUserStats(db, topicID)
+		return rebuildTopicUserStats(db, topicID)
 	}
+	return nil
 }
 
 // rebuildPosters 从 posts 重建话题参与者列表：话题作者置前，其余按出现顺序。
@@ -525,11 +537,10 @@ func rebuildPosters(topicUserID uint64, postList []*posts.Entity) []topics.Poste
 }
 
 // ensureTopicCategoryIndexes 为话题补齐分类索引行（issue #135）。
-func ensureTopicCategoryIndexes(db *gorm.DB, topicID uint64) {
+func ensureTopicCategoryIndexes(db *gorm.DB, topicID uint64) error {
 	var topic topics.Entity
 	if err := db.First(&topic, topicID).Error; err != nil {
-		slog.Error("ensureTopicCategoryIndexes: 加载话题失败", "topicId", topicID, "err", err)
-		return
+		return fmt.Errorf("ensureTopicCategoryIndexes: 加载话题 %d 失败: %w", topicID, err)
 	}
 	for _, cid := range topic.CategoryIds {
 		if cid == 0 {
@@ -539,8 +550,7 @@ func ensureTopicCategoryIndexes(db *gorm.DB, topicID uint64) {
 		if err := db.Model(&topicCategoryIndex.Entity{}).
 			Where("topic_id = ? AND category_id = ?", topicID, cid).
 			Count(&count).Error; err != nil {
-			slog.Error("ensureTopicCategoryIndexes: 统计分类索引失败", "topicId", topicID, "categoryId", cid, "err", err)
-			continue
+			return fmt.Errorf("ensureTopicCategoryIndexes: 统计话题 %d 分类 %d 失败: %w", topicID, cid, err)
 		}
 		if count > 0 {
 			continue
@@ -550,21 +560,21 @@ func ensureTopicCategoryIndexes(db *gorm.DB, topicID uint64) {
 			CategoryId: cid,
 			Effective:  1,
 		}).Error; err != nil {
-			slog.Error("ensureTopicCategoryIndexes: 创建分类索引失败", "topicId", topicID, "categoryId", cid, "err", err)
+			return fmt.Errorf("ensureTopicCategoryIndexes: 创建话题 %d 分类 %d 索引失败: %w", topicID, cid, err)
 		}
 	}
+	return nil
 }
 
 // rebuildTopicUserStats 从 posts 重建话题参与者统计（reply_count/last_reply_at）。
 // 与 postservice.RebuildTopicPostStats 语义一致：仅统计 visibility_status=ACTIVE
 // 的回复（PR #160 review, suggestion 7）。
-func rebuildTopicUserStats(db *gorm.DB, topicID uint64) {
+func rebuildTopicUserStats(db *gorm.DB, topicID uint64) error {
 	var postList []*posts.Entity
 	if err := db.Where("topic_id = ?", topicID).
 		Order("post_no asc").Order("id asc").
 		Find(&postList).Error; err != nil {
-		slog.Error("rebuildTopicUserStats: 加载话题 posts 失败", "topicId", topicID, "err", err)
-		return
+		return fmt.Errorf("rebuildTopicUserStats: 加载话题 %d posts 失败: %w", topicID, err)
 	}
 	byUser := map[uint64]uint32{}
 	lastByUser := map[uint64]time.Time{}
@@ -585,16 +595,16 @@ func rebuildTopicUserStats(db *gorm.DB, topicID uint64) {
 			ReplyCount:  count,
 			LastReplyAt: last,
 		}).Error; err != nil {
-			slog.Error("rebuildTopicUserStats: 创建参与者统计失败", "topicId", topicID, "userId", userID, "err", err)
+			return fmt.Errorf("rebuildTopicUserStats: 创建话题 %d 用户 %d 统计失败: %w", topicID, userID, err)
 		}
 	}
+	return nil
 }
 
 // importPostRevisions 导入帖子版本快照（首楼编辑 PR 新增的表）。
 // 依赖 posts 存在：postId 对应的帖子必须已导入，否则跳过该行并报错。
 // 与导出顺序一致，在 posts 之后调用；已存在记录跳过（幂等）。
-func importPostRevisions(rows []map[string]any, report *ImportReport) {
-	db := dbconnect.Connect()
+func importPostRevisions(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 	for i, row := range rows {
 		line := i + 1
 		report.Total++
@@ -650,8 +660,7 @@ func importPostRevisions(rows []map[string]any, report *ImportReport) {
 	}
 }
 
-func importPosts(rows []map[string]any, report *ImportReport) {
-	db := dbconnect.Connect()
+func importPosts(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 	for i, row := range rows {
 		line := i + 1
 		report.Total++

--- a/apps/gooseforum/app/service/dataservice/import.go
+++ b/apps/gooseforum/app/service/dataservice/import.go
@@ -52,11 +52,11 @@ func ImportData(ctx context.Context, data []byte, format string) (*ImportReport,
 		ctx = context.Background()
 	}
 	if format != "json" {
-		return nil, fmt.Errorf("导入仅支持 JSON 格式")
+		return nil, fmt.Errorf("%w: 导入仅支持 JSON 格式", ErrImportInvalidFormat)
 	}
 	parsed, err := parseImportJSON(data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrImportInvalidFormat, err)
 	}
 	report := &ImportReport{
 		Errors:   []ImportError{},
@@ -247,7 +247,11 @@ func importTopics(db *gorm.DB, rows []map[string]any, report *ImportReport) {
 			var cat category.Entity
 			if err := db.First(&cat, cid).Error; err != nil {
 				report.Failed++
-				report.Errors = append(report.Errors, ImportError{Line: line, Table: "topics", Reason: fmt.Sprintf("分类 %d 不存在", cid)})
+				reason := fmt.Sprintf("分类 %d 不存在", cid)
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					reason = "分类校验失败"
+				}
+				report.Errors = append(report.Errors, ImportError{Line: line, Table: "topics", Reason: reason})
 				categoryIDs = nil
 				break
 			}
@@ -328,7 +332,11 @@ func importTopicCategoryIndexes(db *gorm.DB, rows []map[string]any, report *Impo
 		var cat category.Entity
 		if err := db.First(&cat, categoryID).Error; err != nil {
 			report.Failed++
-			report.Errors = append(report.Errors, ImportError{Line: line, Table: "topicCategoryIndex", Reason: "categoryId 不存在"})
+			reason := "categoryId 不存在"
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				reason = "categoryId 校验失败"
+			}
+			report.Errors = append(report.Errors, ImportError{Line: line, Table: "topicCategoryIndex", Reason: reason})
 			continue
 		}
 		var existing topicCategoryIndex.Entity

--- a/apps/gooseforum/app/service/dataservice/import_task.go
+++ b/apps/gooseforum/app/service/dataservice/import_task.go
@@ -25,6 +25,9 @@ const TaskTypeImport = "import"
 
 var importDir = "data/import"
 
+// ErrImportInvalidFormat identifies client-correctable import input errors.
+var ErrImportInvalidFormat = errors.New("invalid import format")
+
 // ImportTask is the small task payload. The import body stays in a mode-0600
 // staging file instead of being copied into task_queue.task_json.
 type ImportTask struct {
@@ -44,19 +47,19 @@ func SetImportDirForTest(dir string) func() {
 // task. A repeated identical body reuses an existing active/success/failed
 // task, so a client retry cannot create duplicate imports. Failed tasks keep
 // their staging file and must be replayed explicitly.
-func EnqueueImport(ctx context.Context, data []byte, format string) (*ImportReport, error) {
+func EnqueueImport(ctx context.Context, data []byte, format string) (*ImportTaskAcceptedResult, error) {
 	if format != "json" {
-		return nil, fmt.Errorf("导入仅支持 JSON 格式")
+		return nil, fmt.Errorf("%w: 导入仅支持 JSON 格式", ErrImportInvalidFormat)
 	}
 	if len(data) == 0 {
-		return nil, fmt.Errorf("导入文件为空")
+		return nil, fmt.Errorf("%w: 导入文件为空", ErrImportInvalidFormat)
 	}
 	if len(data) > MaxImportSize {
-		return nil, fmt.Errorf("导入文件超过 %d MB 限制", MaxImportSize>>20)
+		return nil, fmt.Errorf("%w: 导入文件超过 %d MB 限制", ErrImportInvalidFormat, MaxImportSize>>20)
 	}
 	parsed, err := parseImportJSON(data)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", ErrImportInvalidFormat, err)
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -100,12 +103,22 @@ func EnqueueImport(ctx context.Context, data []byte, format string) (*ImportRepo
 	}
 
 	status := importTaskStatus(task.Status)
-	return &ImportReport{
+	return &ImportTaskAcceptedResult{
 		Status:   status,
 		TaskID:   task.Id,
 		Errors:   []ImportError{},
 		Imported: importTableNames(parsed),
 	}, nil
+}
+
+// ImportTaskAcceptedResult is the stable HTTP result returned when an import
+// has been staged and queued. Row-level totals are available from the task
+// status endpoint after the worker processes the staged body.
+type ImportTaskAcceptedResult struct {
+	TaskID   uint64        `json:"taskId"`
+	Status   string        `json:"status"`
+	Errors   []ImportError `json:"errors"`
+	Imported []string      `json:"importedTables"`
 }
 
 func stageImportFile(path string, data []byte) error {
@@ -205,8 +218,16 @@ func isWithinDirectory(base, path string) bool {
 // ReplayImportTask puts a failed import back into the pending state without
 // replacing its retained, checksum-addressed staging file.
 func ReplayImportTask(id uint64) (taskQueue.Entity, error) {
+	return ReplayImportTaskContext(context.Background(), id)
+}
+
+// ReplayImportTaskContext requeues a failed import using the caller's context.
+func ReplayImportTaskContext(ctx context.Context, id uint64) (taskQueue.Entity, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var task taskQueue.Entity
-	err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
+	err := dbconnect.ConnectContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("id = ? AND type = ?", id, TaskTypeImport).First(&task).Error; err != nil {
 			return err
 		}
@@ -239,6 +260,7 @@ func ReplayImportTask(id uint64) (taskQueue.Entity, error) {
 		if result.RowsAffected != 1 {
 			return fmt.Errorf("导入任务 %d 状态已变化", id)
 		}
+		task = taskQueue.Entity{}
 		return tx.Where("id = ?", id).First(&task).Error
 	})
 	return task, err

--- a/apps/gooseforum/app/service/dataservice/import_task.go
+++ b/apps/gooseforum/app/service/dataservice/import_task.go
@@ -1,0 +1,289 @@
+package dataservice
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
+	"gorm.io/gorm"
+)
+
+// MaxImportSize bounds both the multipart request and the staged task file.
+const MaxImportSize = 50 << 20
+
+// TaskTypeImport identifies asynchronous data import tasks.
+const TaskTypeImport = "import"
+
+var importDir = "data/import"
+
+// ImportTask is the small task payload. The import body stays in a mode-0600
+// staging file instead of being copied into task_queue.task_json.
+type ImportTask struct {
+	FileName string `json:"fileName"`
+	SHA256   string `json:"sha256"`
+	Format   string `json:"format"`
+}
+
+// SetImportDirForTest redirects staged imports for tests.
+func SetImportDirForTest(dir string) func() {
+	old := importDir
+	importDir = dir
+	return func() { importDir = old }
+}
+
+// EnqueueImport validates and stages a JSON import, then creates an idempotent
+// task. A repeated identical body reuses an existing active/success/failed
+// task, so a client retry cannot create duplicate imports. Failed tasks keep
+// their staging file and must be replayed explicitly.
+func EnqueueImport(ctx context.Context, data []byte, format string) (*ImportReport, error) {
+	if format != "json" {
+		return nil, fmt.Errorf("导入仅支持 JSON 格式")
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("导入文件为空")
+	}
+	if len(data) > MaxImportSize {
+		return nil, fmt.Errorf("导入文件超过 %d MB 限制", MaxImportSize>>20)
+	}
+	parsed, err := parseImportJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	digest := sha256.Sum256(data)
+	hexDigest := hex.EncodeToString(digest[:])
+	payload := ImportTask{
+		FileName: hexDigest + ".json",
+		SHA256:   hexDigest,
+		Format:   format,
+	}
+	taskJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("编码导入任务失败: %w", err)
+	}
+	path := filepath.Join(importDir, payload.FileName)
+	if err := stageImportFile(path, data); err != nil {
+		return nil, err
+	}
+
+	var task taskQueue.Entity
+	txErr := dbconnect.ConnectContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing taskQueue.Entity
+		err := tx.Where("type = ? AND task_json = ? AND status IN ?", TaskTypeImport, string(taskJSON),
+			[]int{taskQueue.StatusPending, taskQueue.StatusRunning, taskQueue.StatusRetrying, taskQueue.StatusSuccess, taskQueue.StatusFailed}).
+			Order("id desc").First(&existing).Error
+		if err == nil {
+			task = existing
+			return nil
+		}
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		task = taskQueue.Entity{Type: TaskTypeImport, Status: taskQueue.StatusPending, TaskJson: string(taskJSON)}
+		return taskQueue.CreateTx(tx, &task)
+	})
+	if txErr != nil {
+		_ = os.Remove(path)
+		return nil, txErr
+	}
+
+	status := importTaskStatus(task.Status)
+	return &ImportReport{
+		Status:   status,
+		TaskID:   task.Id,
+		Errors:   []ImportError{},
+		Imported: importTableNames(parsed),
+	}, nil
+}
+
+func stageImportFile(path string, data []byte) error {
+	if err := os.MkdirAll(importDir, 0o700); err != nil {
+		return fmt.Errorf("创建导入暂存目录失败: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("创建导入暂存文件失败: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	if err := file.Chmod(0o600); err != nil {
+		return fmt.Errorf("设置导入暂存文件权限失败: %w", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		return fmt.Errorf("写入导入暂存文件失败: %w", err)
+	}
+	return file.Sync()
+}
+
+// RunImportTask consumes a staged import under the worker lease. The source
+// file is retained on failure so an operator can replay the task after fixing
+// the underlying issue; successful imports remove it after the DB transaction.
+func RunImportTask(ctx context.Context, task *taskQueue.Entity) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if task == nil {
+		return errors.New("import task is nil")
+	}
+	var payload ImportTask
+	if err := json.Unmarshal([]byte(task.TaskJson), &payload); err != nil {
+		return fmt.Errorf("解码导入任务失败: %w", err)
+	}
+	path, err := importFilePath(payload.FileName)
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("打开导入暂存文件失败: %w", err)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, MaxImportSize+1))
+	closeErr := file.Close()
+	if readErr != nil {
+		return fmt.Errorf("读取导入暂存文件失败: %w", readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("关闭导入暂存文件失败: %w", closeErr)
+	}
+	if len(data) > MaxImportSize {
+		return fmt.Errorf("导入暂存文件超过 %d MB 限制", MaxImportSize>>20)
+	}
+	digest := sha256.Sum256(data)
+	if hex.EncodeToString(digest[:]) != payload.SHA256 {
+		return errors.New("导入暂存文件校验失败")
+	}
+	report, err := ImportData(ctx, data, payload.Format)
+	if err != nil {
+		return err
+	}
+	if report.Failed > 0 {
+		return fmt.Errorf("导入存在 %d 个失败行，任务保留以便重放", report.Failed)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("删除已完成导入暂存文件失败: %w", err)
+	}
+	return nil
+}
+
+func importFilePath(fileName string) (string, error) {
+	if fileName == "" || filepath.Base(fileName) != fileName {
+		return "", errors.New("非法的导入暂存文件路径")
+	}
+	base, err := filepath.Abs(importDir)
+	if err != nil {
+		return "", err
+	}
+	path, err := filepath.Abs(filepath.Join(importDir, fileName))
+	if err != nil {
+		return "", err
+	}
+	if path != base && !isWithinDirectory(base, path) {
+		return "", errors.New("非法的导入暂存文件路径")
+	}
+	return path, nil
+}
+
+func isWithinDirectory(base, path string) bool {
+	rel, err := filepath.Rel(base, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
+// ReplayImportTask puts a failed import back into the pending state without
+// replacing its retained, checksum-addressed staging file.
+func ReplayImportTask(id uint64) (taskQueue.Entity, error) {
+	var task taskQueue.Entity
+	err := dbconnect.Connect().Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("id = ? AND type = ?", id, TaskTypeImport).First(&task).Error; err != nil {
+			return err
+		}
+		if task.Status != taskQueue.StatusFailed {
+			return fmt.Errorf("导入任务 %d 当前不可重放", id)
+		}
+		var payload ImportTask
+		if err := json.Unmarshal([]byte(task.TaskJson), &payload); err != nil {
+			return fmt.Errorf("解码导入任务失败: %w", err)
+		}
+		path, err := importFilePath(payload.FileName)
+		if err != nil {
+			return err
+		}
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("导入暂存文件不可重放: %w", err)
+		}
+		result := tx.Model(&taskQueue.Entity{}).
+			Where("id = ? AND type = ? AND status = ?", id, TaskTypeImport, taskQueue.StatusFailed).
+			Updates(map[string]any{
+				"status":       taskQueue.StatusPending,
+				"retry_count":  0,
+				"last_error":   "",
+				"processed_at": nil,
+				"lease_token":  "",
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return fmt.Errorf("导入任务 %d 状态已变化", id)
+		}
+		return tx.Where("id = ?", id).First(&task).Error
+	})
+	return task, err
+}
+
+func importTaskStatus(status uint8) string {
+	switch status {
+	case taskQueue.StatusPending:
+		return "pending"
+	case taskQueue.StatusRunning:
+		return "running"
+	case taskQueue.StatusRetrying:
+		return "retrying"
+	case taskQueue.StatusSuccess:
+		return "success"
+	case taskQueue.StatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// ListImportTasks returns recent import task rows for the admin status view.
+func ListImportTasks(limit int) ([]taskQueue.Entity, error) {
+	if limit <= 0 || limit > 50 {
+		limit = 20
+	}
+	var list []taskQueue.Entity
+	if err := taskQueue.QueryByTypeDesc(TaskTypeImport, limit).Find(&list).Error; err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+// RecoverImportTasks restores expired import leases after a process restart.
+func RecoverImportTasks() error {
+	return taskQueue.RecoverStaleRunning(TaskTypeImport, taskQueue.LeaseDuration)
+}
+
+func importTableNames(parsed map[string][]map[string]any) []string {
+	result := make([]string, 0, len(parsed))
+	for _, table := range []string{"users", "topics", "posts", "postRevisions", "topicCategoryIndex", "topicUserStat"} {
+		if _, ok := parsed[table]; ok {
+			result = append(result, table)
+		}
+	}
+	return result
+}

--- a/apps/gooseforum/app/service/eventhandlers/content_delete_handler.go
+++ b/apps/gooseforum/app/service/eventhandlers/content_delete_handler.go
@@ -2,12 +2,10 @@ package eventhandlers
 
 import (
 	"context"
-	"log/slog"
 
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/llmsservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/searchservice"
+	"gorm.io/gorm"
 )
 
 // ContentDeletedEvent 内容删除事件（Issue #94）：话题/回复删除后广播，
@@ -30,14 +28,9 @@ func handleContentDeleted(ctx context.Context, event *ContentDeletedEvent) error
 	llmsservice.ClearCache()
 
 	if event.ContentType == "topic" {
-		topic := topics.UnscopedGet(event.TopicId)
-		if topic.Id == 0 {
-			return nil
-		}
-		if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, nil); err != nil {
-			slog.Error("failed to sync search document on content deleted", "topicId", topic.Id, "err", err)
-			return err
-		}
+		return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+			return searchservice.EnqueueTopicSearchTask(tx, event.TopicId)
+		})
 	}
 	return nil
 }
@@ -57,15 +50,9 @@ func handleContentRestored(ctx context.Context, event *ContentRestoredEvent) err
 	llmsservice.ClearCache()
 
 	if event.ContentType == "topic" {
-		topic := topics.Get(event.TopicId)
-		if topic.Id == 0 {
-			return nil
-		}
-		firstPost := posts.Get(topic.FirstPostId)
-		if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-			slog.Error("failed to rebuild search document on content restore", "topicId", topic.Id, "err", err)
-			return err
-		}
+		return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+			return searchservice.EnqueueTopicSearchTask(tx, event.TopicId)
+		})
 	}
 	return nil
 }

--- a/apps/gooseforum/app/service/eventhandlers/search_handler.go
+++ b/apps/gooseforum/app/service/eventhandlers/search_handler.go
@@ -2,15 +2,20 @@ package eventhandlers
 
 import (
 	"context"
-	"errors"
 
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/category"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/searchservice"
 	"gorm.io/gorm"
 )
+
+func enqueueSearchProjection(ctx context.Context, enqueue func(*gorm.DB) error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return dbconnect.Connect().WithContext(ctx).Transaction(enqueue)
+}
 
 // TopicPublishedEvent 主题发布事件
 type TopicPublishedEvent struct {
@@ -30,14 +35,12 @@ func (event *TopicPublishedEvent) Subject() (uint64, uint64, string) {
 
 // handleTopicPublished 更新已发布主题搜索索引
 func handleTopicPublished(ctx context.Context, event *TopicPublishedEvent) error {
-	if event == nil {
+	if event == nil || event.Topic == nil {
 		return nil
 	}
-	if event.Topic != nil {
-		_, err := searchservice.BuildSingleTopicSearchDocument(event.Topic, event.FirstPost)
-		return err
-	}
-	return nil
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueTopicSearchTask(tx, event.Topic.Id)
+	})
 }
 
 // TopicUpdatedEvent 主题更新事件
@@ -48,14 +51,12 @@ type TopicUpdatedEvent struct {
 
 // handleTopicUpdated 更新主题搜索索引
 func handleTopicUpdated(ctx context.Context, event *TopicUpdatedEvent) error {
-	if event == nil {
+	if event == nil || event.Topic == nil {
 		return nil
 	}
-	if event.Topic != nil {
-		_, err := searchservice.BuildSingleTopicSearchDocument(event.Topic, event.FirstPost)
-		return err
-	}
-	return nil
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueTopicSearchTask(tx, event.Topic.Id)
+	})
 }
 
 // TopicDeletedEvent 主题删除事件
@@ -78,8 +79,9 @@ func handleTopicDeleted(ctx context.Context, event *TopicDeletedEvent) error {
 	if event == nil || event.Topic == nil {
 		return nil
 	}
-	_, err := searchservice.BuildSingleTopicSearchDocument(event.Topic, nil)
-	return err
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueTopicSearchTask(tx, event.Topic.Id)
+	})
 }
 
 // UserSearchIndexUpdatedEvent 用户可搜字段变更（昵称/简介/用户名）后更新搜索索引
@@ -99,18 +101,9 @@ func handleUserSearchIndexUpdated(ctx context.Context, event *UserSearchIndexUpd
 	if event == nil || event.UserId == 0 {
 		return nil
 	}
-	user, err := users.Get(event.UserId)
-	if err != nil {
-		// 仅当用户确实不存在（软删/删除）时移除索引文档；
-		// 瞬态 DB 错误不删除，避免误删有效用户的搜索结果。
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			_, delErr := searchservice.DeleteUserSearchDocument(event.UserId)
-			return delErr
-		}
-		return err
-	}
-	_, err = searchservice.BuildSingleUserSearchDocument(&user)
-	return err
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueUserSearchTask(tx, event.UserId)
+	})
 }
 
 // handleUserSignUpSearchIndex 注册事件后把新用户加入搜索索引
@@ -119,15 +112,9 @@ func handleUserSignUpSearchIndex(ctx context.Context, event *UserSignUpEvent) er
 	if event == nil || event.UserId == 0 {
 		return nil
 	}
-	user, err := users.Get(event.UserId)
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil
-		}
-		return err
-	}
-	_, err = searchservice.BuildSingleUserSearchDocument(&user)
-	return err
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueUserSearchTask(tx, event.UserId)
+	})
 }
 
 // CategorySearchIndexUpdatedEvent 分类新增/更新后同步搜索索引
@@ -147,12 +134,9 @@ func handleCategorySearchIndexUpdated(ctx context.Context, event *CategorySearch
 	if event == nil || event.CategoryId == 0 {
 		return nil
 	}
-	entity := category.Get(event.CategoryId)
-	if entity.Id == 0 {
-		return nil
-	}
-	_, err := searchservice.BuildSingleCategorySearchDocument(&entity)
-	return err
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueCategorySearchTask(tx, event.CategoryId)
+	})
 }
 
 // CategorySearchIndexDeletedEvent 分类删除后移除搜索索引
@@ -172,6 +156,7 @@ func handleCategorySearchIndexDeleted(ctx context.Context, event *CategorySearch
 	if event == nil || event.CategoryId == 0 {
 		return nil
 	}
-	_, err := searchservice.DeleteCategorySearchDocument(event.CategoryId)
-	return err
+	return enqueueSearchProjection(ctx, func(tx *gorm.DB) error {
+		return searchservice.EnqueueCategorySearchTask(tx, event.CategoryId)
+	})
 }

--- a/apps/gooseforum/app/service/eventhandlers/search_handler_test.go
+++ b/apps/gooseforum/app/service/eventhandlers/search_handler_test.go
@@ -5,9 +5,22 @@ import (
 	"testing"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"gorm.io/gorm"
 )
+
+func setupSearchOutboxDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&taskQueue.Entity{}); err != nil {
+		t.Fatalf("migrate task queue: %v", err)
+	}
+	if err := conn.Unscoped().Where("1 = 1").Delete(&taskQueue.Entity{}).Error; err != nil {
+		t.Fatalf("clear task queue: %v", err)
+	}
+	return conn
+}
 
 func TestTopicDeletedEventSubject(t *testing.T) {
 	if id, userId, title := (*TopicDeletedEvent)(nil).Subject(); id != 0 || userId != 0 || title != "" {
@@ -25,6 +38,7 @@ func TestTopicDeletedEventSubject(t *testing.T) {
 
 func TestHandleTopicDeleted(t *testing.T) {
 	ctx := context.Background()
+	conn := setupSearchOutboxDB(t)
 	if err := handleTopicDeleted(ctx, nil); err != nil {
 		t.Fatalf("handleTopicDeleted(nil) error = %v, want nil", err)
 	}
@@ -36,6 +50,13 @@ func TestHandleTopicDeleted(t *testing.T) {
 	}}
 	if err := handleTopicDeleted(ctx, event); err != nil {
 		t.Fatalf("handleTopicDeleted(event) error = %v, want nil", err)
+	}
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "topic-search.sync").Count(&count).Error; err != nil {
+		t.Fatalf("count topic outbox tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("topic outbox task count = %d, want 1", count)
 	}
 }
 
@@ -71,70 +92,81 @@ func TestCategorySearchIndexDeletedEventSubject(t *testing.T) {
 
 func TestHandleUserSearchIndexUpdated(t *testing.T) {
 	ctx := context.Background()
+	conn := setupSearchOutboxDB(t)
 	if err := handleUserSearchIndexUpdated(ctx, nil); err != nil {
 		t.Fatalf("handleUserSearchIndexUpdated(nil) error = %v, want nil", err)
 	}
-	// 建表使 users.Get 对不存在用户返回 RecordNotFound（而非 no such table）
-	conn := dbconnect.Connect()
-	if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
-		t.Fatalf("migrate users table: %v", err)
-	}
-	// 用户不存在（RecordNotFound）→ 删除分支 → 无 Meilisearch 返回 nil
 	if err := handleUserSearchIndexUpdated(ctx, &UserSearchIndexUpdatedEvent{UserId: 999999}); err != nil {
 		t.Fatalf("handleUserSearchIndexUpdated(event) error = %v, want nil", err)
+	}
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "user-search.sync").Count(&count).Error; err != nil {
+		t.Fatalf("count user outbox tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("user outbox task count = %d, want 1", count)
 	}
 }
 
 func TestHandleUserSignUpSearchIndex(t *testing.T) {
 	ctx := context.Background()
+	conn := setupSearchOutboxDB(t)
 	if err := handleUserSignUpSearchIndex(ctx, nil); err != nil {
 		t.Fatalf("handleUserSignUpSearchIndex(nil) error = %v, want nil", err)
 	}
-	conn := dbconnect.Connect()
-	if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
-		t.Fatalf("migrate users table: %v", err)
+	if err := handleUserSignUpSearchIndex(ctx, &UserSignUpEvent{UserId: 999999}); err != nil {
+		t.Fatalf("handleUserSignUpSearchIndex(event) error = %v, want nil", err)
 	}
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "user-search.sync").Count(&count).Error; err != nil {
+		t.Fatalf("count signup outbox tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("signup outbox task count = %d, want 1", count)
+	}
+}
+
+func TestHandleUserSignUpSearchIndexDoesNotReadDatabase(t *testing.T) {
+	ctx := context.Background()
+	setupSearchOutboxDB(t)
+
 	if err := handleUserSignUpSearchIndex(ctx, &UserSignUpEvent{UserId: 999999}); err != nil {
 		t.Fatalf("handleUserSignUpSearchIndex(event) error = %v, want nil", err)
 	}
 }
 
-func TestHandleUserSignUpSearchIndexReturnsDatabaseError(t *testing.T) {
-	ctx := context.Background()
-	conn := dbconnect.Connect()
-	if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
-		t.Fatalf("migrate users table: %v", err)
-	}
-	if err := conn.Migrator().DropTable(&users.EntityComplete{}); err != nil {
-		t.Fatalf("drop users table: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := conn.AutoMigrate(&users.EntityComplete{}); err != nil {
-			t.Errorf("restore users table: %v", err)
-		}
-	})
-
-	if err := handleUserSignUpSearchIndex(ctx, &UserSignUpEvent{UserId: 999999}); err == nil {
-		t.Fatal("handleUserSignUpSearchIndex(event) error = nil, want database error")
-	}
-}
-
 func TestHandleCategorySearchIndexUpdated(t *testing.T) {
 	ctx := context.Background()
+	conn := setupSearchOutboxDB(t)
 	if err := handleCategorySearchIndexUpdated(ctx, nil); err != nil {
 		t.Fatalf("handleCategorySearchIndexUpdated(nil) error = %v, want nil", err)
 	}
 	if err := handleCategorySearchIndexUpdated(ctx, &CategorySearchIndexUpdatedEvent{CategoryId: 999999}); err != nil {
 		t.Fatalf("handleCategorySearchIndexUpdated(event) error = %v, want nil", err)
 	}
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "category-search.sync").Count(&count).Error; err != nil {
+		t.Fatalf("count category outbox tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("category outbox task count = %d, want 1", count)
+	}
 }
 
 func TestHandleCategorySearchIndexDeleted(t *testing.T) {
 	ctx := context.Background()
+	conn := setupSearchOutboxDB(t)
 	if err := handleCategorySearchIndexDeleted(ctx, nil); err != nil {
 		t.Fatalf("handleCategorySearchIndexDeleted(nil) error = %v, want nil", err)
 	}
 	if err := handleCategorySearchIndexDeleted(ctx, &CategorySearchIndexDeletedEvent{CategoryId: 999999}); err != nil {
 		t.Fatalf("handleCategorySearchIndexDeleted(event) error = %v, want nil", err)
+	}
+	var count int64
+	if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "category-search.sync").Count(&count).Error; err != nil {
+		t.Fatalf("count category delete outbox tasks: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("category delete outbox task count = %d, want 1", count)
 	}
 }

--- a/apps/gooseforum/app/service/eventhandlers/search_handler_test.go
+++ b/apps/gooseforum/app/service/eventhandlers/search_handler_test.go
@@ -60,6 +60,34 @@ func TestHandleTopicDeleted(t *testing.T) {
 	}
 }
 
+func TestHandleTopicPublishedAndUpdated(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		handler func(context.Context, *TopicPublishedEvent) error
+	}{
+		{name: "published", handler: handleTopicPublished},
+		{name: "updated", handler: func(ctx context.Context, event *TopicPublishedEvent) error {
+			return handleTopicUpdated(ctx, (*TopicUpdatedEvent)(event))
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+			conn := setupSearchOutboxDB(t)
+			event := &TopicPublishedEvent{Topic: &topics.Entity{Id: 321, UserId: 654, Title: "published topic"}}
+			if err := test.handler(ctx, event); err != nil {
+				t.Fatalf("handle topic %s error = %v", test.name, err)
+			}
+			var count int64
+			if err := conn.Model(&taskQueue.Entity{}).Where("type = ?", "topic-search.sync").Count(&count).Error; err != nil {
+				t.Fatalf("count topic outbox tasks: %v", err)
+			}
+			if count != 1 {
+				t.Fatalf("topic outbox task count = %d, want 1", count)
+			}
+		})
+	}
+}
+
 func TestUserSearchIndexUpdatedEventSubject(t *testing.T) {
 	if id, userId, title := (*UserSearchIndexUpdatedEvent)(nil).Subject(); id != 0 || userId != 0 || title != "" {
 		t.Fatalf("nil event Subject() = (%d, %d, %q), want (0, 0, \"\")", id, userId, title)

--- a/apps/gooseforum/app/service/kvstore/kv.go
+++ b/apps/gooseforum/app/service/kvstore/kv.go
@@ -1,15 +1,16 @@
 package kvstore
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/v4"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
+	"github.com/dgraph-io/badger/v4"
 )
 
 var (
@@ -78,7 +79,7 @@ func connect() (*store, error) {
 	current = instance
 	currentMu.Unlock()
 
-	closer.RegisterPriority(closer.PriorityDatabase, func() error {
+	closer.RegisterPriorityContext(closer.PriorityDatabase, func(context.Context) error {
 		instance.close()
 		return nil
 	})

--- a/apps/gooseforum/app/service/mailservice/queue.go
+++ b/apps/gooseforum/app/service/mailservice/queue.go
@@ -66,7 +66,9 @@ func AddToQueue(task EmailTask) error {
 // StartEmailProcessor starts the background email queue worker.
 func StartEmailProcessor() {
 	emailProcessor.once.Do(func() {
-		closer.RegisterPriority(closer.PriorityProducer, StopEmailProcessor)
+		closer.RegisterPriorityContext(closer.PriorityProducer, func(context.Context) error {
+			return StopEmailProcessor()
+		})
 		emailProcessor.wg.Go(func() {
 			defer paniclog.Recover("mail_processor")
 			ticker := time.NewTicker(5 * time.Second)

--- a/apps/gooseforum/app/service/mcpservice/mcpservice_test.go
+++ b/apps/gooseforum/app/service/mcpservice/mcpservice_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/postRevisions"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicCategoryIndex"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userStatistics"
@@ -42,6 +43,7 @@ func setupMCPServiceTestDB(t *testing.T) *gorm.DB {
 		&posts.Entity{},
 		&category.Entity{},
 		&topicCategoryIndex.Entity{},
+		&taskQueue.Entity{},
 		&pageConfig.Entity{},
 	); err != nil {
 		t.Fatalf("migrate mcp tables: %v", err)
@@ -62,6 +64,7 @@ func cleanMCPServiceTables(conn *gorm.DB) {
 	conn.Where("1 = 1").Delete(&topicCategoryIndex.Entity{})
 	conn.Where("1 = 1").Delete(&postRevisions.Entity{})
 	conn.Where("1 = 1").Delete(&topics.Entity{})
+	conn.Where("1 = 1").Delete(&taskQueue.Entity{})
 	conn.Where("1 = 1").Delete(&category.Entity{})
 	conn.Where("1 = 1").Delete(&agents.Entity{})
 	conn.Where("1 = 1").Delete(&userStatistics.Entity{})

--- a/apps/gooseforum/app/service/mcpservice/tools.go
+++ b/apps/gooseforum/app/service/mcpservice/tools.go
@@ -178,7 +178,7 @@ func registerCreateTopic(s *mcp.Server, svc *Service) {
 		Name:        "create_topic",
 		Description: "以当前 Agent 身份发布一个主题（创建即发布）。受 topic.write 限流约束。",
 		InputSchema: objectSchema(props, required),
-	}, recoverToolHandler("create_topic", func(_ context.Context, req *mcp.CallToolRequest, in map[string]any) (*mcp.CallToolResult, map[string]any, error) {
+	}, recoverToolHandler("create_topic", func(ctx context.Context, req *mcp.CallToolRequest, in map[string]any) (*mcp.CallToolResult, map[string]any, error) {
 		agentID, err := svc.userID(req)
 		if err != nil {
 			return nil, nil, err
@@ -191,7 +191,7 @@ func registerCreateTopic(s *mcp.Server, svc *Service) {
 			Content:    asString(in["content"]),
 			CategoryId: asUintSlice(in["categoryId"]),
 		}
-		resp := api.AgentWriteTopic(component.BetterRequest[api.AgentWriteTopicReq]{Params: params, UserId: agentID})
+		resp := api.AgentWriteTopic(component.BetterRequest[api.AgentWriteTopicReq]{Params: params, UserId: agentID, Context: ctx})
 		v, err := serviceResult(resp)
 		if err != nil {
 			return nil, nil, err
@@ -257,7 +257,7 @@ func registerCreatePost(s *mcp.Server, svc *Service) {
 		Name:        "create_post",
 		Description: "以当前 Agent 身份在指定主题下发帖（回复）。受 post.create 限流约束。",
 		InputSchema: objectSchema(props, required),
-	}, recoverToolHandler("create_post", func(_ context.Context, req *mcp.CallToolRequest, in map[string]any) (*mcp.CallToolResult, map[string]any, error) {
+	}, recoverToolHandler("create_post", func(ctx context.Context, req *mcp.CallToolRequest, in map[string]any) (*mcp.CallToolResult, map[string]any, error) {
 		agentID, err := svc.userID(req)
 		if err != nil {
 			return nil, nil, err
@@ -270,7 +270,7 @@ func registerCreatePost(s *mcp.Server, svc *Service) {
 			Content:       asString(in["content"]),
 			ReplyToPostId: asUint(in["replyToPostId"]),
 		}
-		resp := api.AgentCreatePost(component.BetterRequest[api.AgentCreatePostReq]{Params: params, UserId: agentID})
+		resp := api.AgentCreatePost(component.BetterRequest[api.AgentCreatePostReq]{Params: params, UserId: agentID, Context: ctx})
 		v, err := serviceResult(resp)
 		if err != nil {
 			return nil, nil, err

--- a/apps/gooseforum/app/service/mcpservice/tools.go
+++ b/apps/gooseforum/app/service/mcpservice/tools.go
@@ -9,16 +9,15 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/ratelimit"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/recovery"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/api"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/forum"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -323,8 +322,8 @@ func (s *Service) checkWriteRateLimit(action string, req *mcp.CallToolRequest, u
 	if !cfg.Enabled {
 		return nil
 	}
-	rule := findRateLimitRule(cfg.Actions, action)
-	if rule == nil || (rule.LimitPerIp <= 0 && rule.LimitPerUser <= 0) {
+	rule, ok := cfg.RuleForAction(action)
+	if !ok || (rule.LimitPerIp <= 0 && rule.LimitPerUser <= 0) {
 		return nil
 	}
 
@@ -393,17 +392,6 @@ func (s *Service) checkWriteRateLimit(action string, req *mcp.CallToolRequest, u
 			"window", rule.WindowSeconds,
 		)
 		return fmt.Errorf("rate limited (%s): retry after %ds", action, seconds)
-	}
-	return nil
-}
-
-// findRateLimitRule returns the quota for an action, or nil if none is
-// configured. Mirrors the lookup in middleware/rateLimit.go.
-func findRateLimitRule(rules []pageConfig.RateLimitRule, action string) *pageConfig.RateLimitRule {
-	for i := range rules {
-		if rules[i].Action == action {
-			return &rules[i]
-		}
 	}
 	return nil
 }

--- a/apps/gooseforum/app/service/searchservice/categorysearch.go
+++ b/apps/gooseforum/app/service/searchservice/categorysearch.go
@@ -1,16 +1,35 @@
 package searchservice
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/meiliconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/category"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/spf13/cast"
 	"gorm.io/gorm"
 )
+
+// TaskTypeCategorySearch is the category-search outbox task type prefix.
+const TaskTypeCategorySearch = "category-search."
+
+type CategorySearchTask struct {
+	CategoryId uint64 `json:"categoryId"`
+}
+
+// EnqueueCategorySearchTask adds a category projection task to the caller's
+// transaction. The worker reads the current row, so updates are idempotent.
+func EnqueueCategorySearchTask(tx *gorm.DB, categoryID uint64) error {
+	if categoryID == 0 {
+		return errors.New("category search task requires category id")
+	}
+	return enqueueSearchTask(tx, TaskTypeCategorySearch, "sync", CategorySearchTask{CategoryId: categoryID})
+}
 
 // CategorySearchDocument 分类搜索文档结构（只含公开可搜字段 + 拼音辅助字段）
 type CategorySearchDocument struct {
@@ -37,6 +56,12 @@ func convertCategoryToSearchDocument(entity *category.Entity) CategorySearchDocu
 
 // BuildSingleCategorySearchDocument upserts a category document.
 func BuildSingleCategorySearchDocument(entity *category.Entity) (*meilisearch.TaskInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), searchTaskWaitTimeout)
+	defer cancel()
+	return BuildSingleCategorySearchDocumentContext(ctx, entity)
+}
+
+func BuildSingleCategorySearchDocumentContext(ctx context.Context, entity *category.Entity) (*meilisearch.TaskInfo, error) {
 	if !meiliconnect.IsAvailable() {
 		return nil, nil
 	}
@@ -47,7 +72,7 @@ func BuildSingleCategorySearchDocument(entity *category.Entity) (*meilisearch.Ta
 	index := client.Index(CategoryIndex)
 	pk := "id"
 	doc := convertCategoryToSearchDocument(entity)
-	task, err := index.AddDocuments(doc, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	task, err := index.AddDocumentsWithContext(ctx, doc, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 	if err != nil {
 		slog.Warn(fmt.Sprintf("Meilisearch 处理分类 ID:%v 失败: %v\n", doc.ID, err))
 		return nil, fmt.Errorf("add category search document: %w", err)
@@ -58,18 +83,76 @@ func BuildSingleCategorySearchDocument(entity *category.Entity) (*meilisearch.Ta
 
 // DeleteCategorySearchDocument removes a category document by id.
 func DeleteCategorySearchDocument(categoryID uint64) (*meilisearch.TaskInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), searchTaskWaitTimeout)
+	defer cancel()
+	return DeleteCategorySearchDocumentContext(ctx, categoryID)
+}
+
+func DeleteCategorySearchDocumentContext(ctx context.Context, categoryID uint64) (*meilisearch.TaskInfo, error) {
 	if !meiliconnect.IsAvailable() {
 		return nil, nil
 	}
 	client := meiliconnect.GetClient()
 	index := client.Index(CategoryIndex)
-	task, err := index.DeleteDocument(cast.ToString(categoryID), nil)
+	task, err := index.DeleteDocumentWithContext(ctx, cast.ToString(categoryID), nil)
 	if err != nil {
 		slog.Warn(fmt.Sprintf("Meilisearch 删除分类文档失败: %v, Error: %v\n", categoryID, err))
 		return nil, fmt.Errorf("delete category search document: %w", err)
 	}
 	slog.Info(fmt.Sprintf("删除分类 ID:%v, TaskUID: %v\n", categoryID, getTaskUID(task)))
 	return task, nil
+}
+
+// RunCategorySearchTask rebuilds or removes the latest category search
+// document. A missing category is an explicit delete operation.
+func RunCategorySearchTask(ctx context.Context, task *taskQueue.Entity) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if task == nil {
+		return errors.New("category search task is nil")
+	}
+	var payload CategorySearchTask
+	if err := json.Unmarshal([]byte(task.TaskJson), &payload); err != nil {
+		return err
+	}
+	if payload.CategoryId == 0 {
+		return errors.New("category search task requires category id")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !meiliconnect.IsAvailable() {
+		return errors.New("meilisearch 服务不可用")
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, searchTaskWaitTimeout)
+	defer cancel()
+	client := meiliconnect.GetClient()
+	entity, err := category.GetWithContext(operationCtx, payload.CategoryId)
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		deleteTask, deleteErr := client.Index(CategoryIndex).DeleteDocumentWithContext(operationCtx, cast.ToString(payload.CategoryId), nil)
+		if deleteErr != nil {
+			return deleteErr
+		}
+		return waitForTaskCheckedContext(operationCtx, client, deleteTask.TaskUID, searchTaskWaitTimeout)
+	}
+	searchTask, err := BuildSingleCategorySearchDocumentContext(operationCtx, &entity)
+	if err != nil {
+		return err
+	}
+	if searchTask == nil {
+		return errors.New("meilisearch returned no category task")
+	}
+	return waitForTaskCheckedContext(operationCtx, client, searchTask.TaskUID, searchTaskWaitTimeout)
+}
+
+// RecoverCategorySearchTasks restores expired category projection leases after
+// a process restart.
+func RecoverCategorySearchTasks() error {
+	return taskQueue.RecoverStaleRunning(TaskTypeCategorySearch, taskQueue.LeaseDuration)
 }
 
 // BuildCategoryIndex rebuilds the whole Meilisearch category index.

--- a/apps/gooseforum/app/service/searchservice/coursesearch.go
+++ b/apps/gooseforum/app/service/searchservice/coursesearch.go
@@ -282,7 +282,11 @@ func shouldIndexCourse(entity course.Entity) bool {
 // 只检查 error 会把索引拒绝/内部失败当作成功，导致 outbox 永不重试。
 // 这里显式检查 task.Status 与 task.Error，失败即返回错误。
 func waitForTaskChecked(client meilisearch.ServiceManager, taskUID int64, interval time.Duration) error {
-	task, err := client.WaitForTask(taskUID, interval)
+	return waitForTaskCheckedContext(context.Background(), client, taskUID, interval)
+}
+
+func waitForTaskCheckedContext(ctx context.Context, client meilisearch.ServiceManager, taskUID int64, interval time.Duration) error {
+	task, err := client.WaitForTaskWithContext(ctx, taskUID, interval)
 	if err != nil {
 		return err
 	}

--- a/apps/gooseforum/app/service/searchservice/coursesearch_test.go
+++ b/apps/gooseforum/app/service/searchservice/coursesearch_test.go
@@ -151,6 +151,45 @@ func TestEnqueueCourseSearchTaskTxBound(t *testing.T) {
 	}
 }
 
+func TestEnqueueTopicSearchTaskTxBoundAndDeduplicated(t *testing.T) {
+	setupCourseSearchTestDB(t)
+	conn := dbconnect.Connect()
+	countTasks := func() int64 {
+		var n int64
+		if err := conn.Model(&taskQueue.Entity{}).Where("type LIKE ?", TaskTypeTopicSearch+"%").Count(&n).Error; err != nil {
+			t.Fatalf("count topic tasks: %v", err)
+		}
+		return n
+	}
+
+	if err := conn.Transaction(func(tx *gorm.DB) error {
+		return EnqueueTopicSearchTask(tx, 42)
+	}); err != nil {
+		t.Fatalf("enqueue topic task: %v", err)
+	}
+	if err := conn.Transaction(func(tx *gorm.DB) error {
+		return EnqueueTopicSearchTask(tx, 42)
+	}); err != nil {
+		t.Fatalf("deduplicate topic task: %v", err)
+	}
+	if got := countTasks(); got != 1 {
+		t.Fatalf("duplicate topic task count = %d, want 1", got)
+	}
+
+	rollbackErr := conn.Transaction(func(tx *gorm.DB) error {
+		if err := EnqueueTopicSearchTask(tx, 43); err != nil {
+			return err
+		}
+		return errors.New("rollback")
+	})
+	if rollbackErr == nil || rollbackErr.Error() != "rollback" {
+		t.Fatalf("expected rollback error, got %v", rollbackErr)
+	}
+	if got := countTasks(); got != 1 {
+		t.Fatalf("rolled-back topic task count = %d, want 1", got)
+	}
+}
+
 // TestBuildCourseIndexPagesConvertFailure 任一页转换失败必须整体返回错误：
 // 索引已在此前清空，若只累计 FailedCount 继续，该批课程会永久丢失且 CLI 仍报成功。
 func TestBuildCourseIndexPagesConvertFailure(t *testing.T) {

--- a/apps/gooseforum/app/service/searchservice/indexservice.go
+++ b/apps/gooseforum/app/service/searchservice/indexservice.go
@@ -1,6 +1,8 @@
 package searchservice
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -9,12 +11,60 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/meiliconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/markdown2html"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/samber/lo"
 	"github.com/spf13/cast"
 	"gorm.io/gorm"
 )
+
+const searchTaskWaitTimeout = 30 * time.Second
+
+// enqueueSearchTask writes an idempotent search projection task inside the
+// caller's business transaction. The task row is the local outbox boundary;
+// Meilisearch is only contacted after the transaction commits by a worker.
+func enqueueSearchTask(tx *gorm.DB, typePrefix, operation string, payload any) error {
+	taskJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	var count int64
+	if err := tx.Table((&taskQueue.Entity{}).TableName()).
+		Where("type LIKE ?", typePrefix+"%").
+		Where("status IN ?", []int{taskQueue.StatusPending, taskQueue.StatusRetrying}).
+		Where("task_json = ?", string(taskJSON)).
+		Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+	return taskQueue.CreateTx(tx, &taskQueue.Entity{
+		Type:     typePrefix + operation,
+		Status:   taskQueue.StatusPending,
+		TaskJson: string(taskJSON),
+	})
+}
+
+// TopicSearchTask identifies the current topic projection to rebuild. The
+// worker reads the latest database row so repeated writes coalesce naturally.
+type TopicSearchTask struct {
+	TopicId uint64 `json:"topicId"`
+}
+
+// TaskTypeTopicSearch is the topic-search outbox task type prefix.
+const TaskTypeTopicSearch = "topic-search."
+
+// EnqueueTopicSearchTask adds a topic projection task to the caller's
+// transaction. A missing topic is also valid: the worker then removes its
+// stale search document by id.
+func EnqueueTopicSearchTask(tx *gorm.DB, topicID uint64) error {
+	if topicID == 0 {
+		return errors.New("topic search task requires topic id")
+	}
+	return enqueueSearchTask(tx, TaskTypeTopicSearch, "sync", TopicSearchTask{TopicId: topicID})
+}
 
 // IndexBuildResult summarizes a Meilisearch rebuild.
 type IndexBuildResult struct {
@@ -59,6 +109,15 @@ func isTopicPubliclySearchable(topic *topics.Entity) bool {
 }
 
 func BuildSingleTopicSearchDocument(topic *topics.Entity, firstPost *posts.Entity) (*meilisearch.TaskInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), searchTaskWaitTimeout)
+	defer cancel()
+	return BuildSingleTopicSearchDocumentContext(ctx, topic, firstPost)
+}
+
+// BuildSingleTopicSearchDocumentContext is the cancellable form used by
+// background projection workers. The legacy wrapper above preserves callers
+// that do not yet own a context.
+func BuildSingleTopicSearchDocumentContext(ctx context.Context, topic *topics.Entity, firstPost *posts.Entity) (*meilisearch.TaskInfo, error) {
 	if !meiliconnect.IsAvailable() {
 		return nil, nil
 	}
@@ -84,7 +143,7 @@ func BuildSingleTopicSearchDocument(topic *topics.Entity, firstPost *posts.Entit
 		firstPost.VisibilityStatus == posts.VisibilityActive
 	if isIndexable {
 		doc := convertTopicToSearchDocument(topic, firstPost)
-		task, err = index.AddDocuments(doc, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+		task, err = index.AddDocumentsWithContext(ctx, doc, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 		if err != nil {
 			slog.Warn(fmt.Sprintf("Meilisearch 处理主题 ID:%v 失败: %v\n", doc.ID, err))
 			return nil, fmt.Errorf("add search document: %w", err)
@@ -92,7 +151,7 @@ func BuildSingleTopicSearchDocument(topic *topics.Entity, firstPost *posts.Entit
 		slog.Info(fmt.Sprintf("处理主题 ID:%v, TaskUID: %v\n", doc.ID, getTaskUID(task)))
 	} else {
 		// DeleteDocument 删除单个文档；index.Delete(uid) 会误删整个索引
-		task, err = index.DeleteDocument(cast.ToString(topic.Id), nil)
+		task, err = index.DeleteDocumentWithContext(ctx, cast.ToString(topic.Id), nil)
 		if err != nil {
 			slog.Warn(fmt.Sprintf("Meilisearch 删除文档失败: %v, Error: %v\n", topic.Id, err))
 			return nil, fmt.Errorf("delete search document: %w", err)
@@ -100,6 +159,65 @@ func BuildSingleTopicSearchDocument(topic *topics.Entity, firstPost *posts.Entit
 		slog.Info(fmt.Sprintf("删除主题 ID:%v, TaskUID: %v\n", topic.Id, getTaskUID(task)))
 	}
 	return task, nil
+}
+
+// RunTopicSearchTask projects the latest topic state after the business
+// transaction has committed. Missing topics are explicit delete operations.
+func RunTopicSearchTask(ctx context.Context, task *taskQueue.Entity) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if task == nil {
+		return errors.New("topic search task is nil")
+	}
+	var payload TopicSearchTask
+	if err := json.Unmarshal([]byte(task.TaskJson), &payload); err != nil {
+		return err
+	}
+	if payload.TopicId == 0 {
+		return errors.New("topic search task requires topic id")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !meiliconnect.IsAvailable() {
+		return errors.New("meilisearch 服务不可用")
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, searchTaskWaitTimeout)
+	defer cancel()
+	client := meiliconnect.GetClient()
+	topic, err := topics.GetWithContext(operationCtx, payload.TopicId)
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		deleteTask, deleteErr := client.Index(TopicIndex).DeleteDocumentWithContext(operationCtx, cast.ToString(payload.TopicId), nil)
+		if deleteErr != nil {
+			return fmt.Errorf("delete missing topic search document: %w", deleteErr)
+		}
+		return waitForTaskCheckedContext(operationCtx, client, deleteTask.TaskUID, searchTaskWaitTimeout)
+	}
+	firstPost, firstPostErr := posts.GetWithContext(operationCtx, topic.FirstPostId)
+	if firstPostErr != nil && !errors.Is(firstPostErr, gorm.ErrRecordNotFound) {
+		return firstPostErr
+	}
+	if firstPost.Id == 0 {
+		firstPost, _ = posts.GetByTopicPostNoAtOrAfterContext(operationCtx, topic.Id, 1)
+	}
+	searchTask, err := BuildSingleTopicSearchDocumentContext(operationCtx, &topic, &firstPost)
+	if err != nil {
+		return err
+	}
+	if searchTask == nil {
+		return errors.New("meilisearch returned no topic task")
+	}
+	return waitForTaskCheckedContext(operationCtx, client, searchTask.TaskUID, searchTaskWaitTimeout)
+}
+
+// RecoverTopicSearchTasks restores expired topic projection leases after a
+// process restart.
+func RecoverTopicSearchTasks() error {
+	return taskQueue.RecoverStaleRunning(TaskTypeTopicSearch, taskQueue.LeaseDuration)
 }
 
 // BuildMeilisearchIndex rebuilds the Meilisearch topic index.

--- a/apps/gooseforum/app/service/searchservice/usersearch.go
+++ b/apps/gooseforum/app/service/searchservice/usersearch.go
@@ -1,16 +1,35 @@
 package searchservice
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/meiliconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/meilisearch/meilisearch-go"
 	"github.com/spf13/cast"
 	"gorm.io/gorm"
 )
+
+// TaskTypeUserSearch is the user-search outbox task type prefix.
+const TaskTypeUserSearch = "user-search."
+
+type UserSearchTask struct {
+	UserId uint64 `json:"userId"`
+}
+
+// EnqueueUserSearchTask adds a user projection task to the caller's
+// transaction. The worker reads the current row, so updates are idempotent.
+func EnqueueUserSearchTask(tx *gorm.DB, userID uint64) error {
+	if userID == 0 {
+		return errors.New("user search task requires user id")
+	}
+	return enqueueSearchTask(tx, TaskTypeUserSearch, "sync", UserSearchTask{UserId: userID})
+}
 
 // UserSearchDocument 用户搜索文档结构（只含公开可搜字段 + 拼音辅助字段）
 type UserSearchDocument struct {
@@ -46,6 +65,12 @@ func shouldIndexUser(user *users.EntityComplete) bool {
 // BuildSingleUserSearchDocument upserts a human user document, or deletes it
 // when the user is missing from the public index, soft-deleted, or a bot.
 func BuildSingleUserSearchDocument(user *users.EntityComplete) (*meilisearch.TaskInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), searchTaskWaitTimeout)
+	defer cancel()
+	return BuildSingleUserSearchDocumentContext(ctx, user)
+}
+
+func BuildSingleUserSearchDocumentContext(ctx context.Context, user *users.EntityComplete) (*meilisearch.TaskInfo, error) {
 	if !meiliconnect.IsAvailable() {
 		return nil, nil
 	}
@@ -57,7 +82,7 @@ func BuildSingleUserSearchDocument(user *users.EntityComplete) (*meilisearch.Tas
 	pk := "id"
 	if shouldIndexUser(user) {
 		doc := convertUserToSearchDocument(user)
-		task, err := index.AddDocuments(doc, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+		task, err := index.AddDocumentsWithContext(ctx, doc, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 		if err != nil {
 			slog.Warn(fmt.Sprintf("Meilisearch 处理用户 ID:%v 失败: %v\n", doc.ID, err))
 			return nil, fmt.Errorf("add user search document: %w", err)
@@ -65,7 +90,7 @@ func BuildSingleUserSearchDocument(user *users.EntityComplete) (*meilisearch.Tas
 		slog.Info(fmt.Sprintf("处理用户 ID:%v, TaskUID: %v\n", doc.ID, getTaskUID(task)))
 		return task, nil
 	}
-	task, err := index.DeleteDocument(cast.ToString(user.Id), nil)
+	task, err := index.DeleteDocumentWithContext(ctx, cast.ToString(user.Id), nil)
 	if err != nil {
 		slog.Warn(fmt.Sprintf("Meilisearch 删除用户文档失败: %v, Error: %v\n", user.Id, err))
 		return nil, fmt.Errorf("delete user search document: %w", err)
@@ -76,18 +101,75 @@ func BuildSingleUserSearchDocument(user *users.EntityComplete) (*meilisearch.Tas
 
 // DeleteUserSearchDocument removes a user document by id.
 func DeleteUserSearchDocument(userID uint64) (*meilisearch.TaskInfo, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), searchTaskWaitTimeout)
+	defer cancel()
+	return DeleteUserSearchDocumentContext(ctx, userID)
+}
+
+func DeleteUserSearchDocumentContext(ctx context.Context, userID uint64) (*meilisearch.TaskInfo, error) {
 	if !meiliconnect.IsAvailable() {
 		return nil, nil
 	}
 	client := meiliconnect.GetClient()
 	index := client.Index(UserIndex)
-	task, err := index.DeleteDocument(cast.ToString(userID), nil)
+	task, err := index.DeleteDocumentWithContext(ctx, cast.ToString(userID), nil)
 	if err != nil {
 		slog.Warn(fmt.Sprintf("Meilisearch 删除用户文档失败: %v, Error: %v\n", userID, err))
 		return nil, fmt.Errorf("delete user search document: %w", err)
 	}
 	slog.Info(fmt.Sprintf("删除用户 ID:%v, TaskUID: %v\n", userID, getTaskUID(task)))
 	return task, nil
+}
+
+// RunUserSearchTask rebuilds or removes the latest user search document.
+func RunUserSearchTask(ctx context.Context, task *taskQueue.Entity) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if task == nil {
+		return errors.New("user search task is nil")
+	}
+	var payload UserSearchTask
+	if err := json.Unmarshal([]byte(task.TaskJson), &payload); err != nil {
+		return err
+	}
+	if payload.UserId == 0 {
+		return errors.New("user search task requires user id")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !meiliconnect.IsAvailable() {
+		return errors.New("meilisearch 服务不可用")
+	}
+	operationCtx, cancel := context.WithTimeout(ctx, searchTaskWaitTimeout)
+	defer cancel()
+	client := meiliconnect.GetClient()
+	user, err := users.GetWithContext(operationCtx, payload.UserId)
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		deleteTask, deleteErr := client.Index(UserIndex).DeleteDocumentWithContext(operationCtx, cast.ToString(payload.UserId), nil)
+		if deleteErr != nil {
+			return deleteErr
+		}
+		return waitForTaskCheckedContext(operationCtx, client, deleteTask.TaskUID, searchTaskWaitTimeout)
+	}
+	searchTask, err := BuildSingleUserSearchDocumentContext(operationCtx, &user)
+	if err != nil {
+		return err
+	}
+	if searchTask == nil {
+		return errors.New("meilisearch returned no user task")
+	}
+	return waitForTaskCheckedContext(operationCtx, client, searchTask.TaskUID, searchTaskWaitTimeout)
+}
+
+// RecoverUserSearchTasks restores expired user projection leases after a
+// process restart.
+func RecoverUserSearchTasks() error {
+	return taskQueue.RecoverStaleRunning(TaskTypeUserSearch, taskQueue.LeaseDuration)
 }
 
 // BuildUserIndex rebuilds the whole Meilisearch user index.

--- a/apps/gooseforum/app/service/topicviewservice/view_counter.go
+++ b/apps/gooseforum/app/service/topicviewservice/view_counter.go
@@ -1,6 +1,7 @@
 package topicviewservice
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"sync"
@@ -39,7 +40,9 @@ func GetViewCounter() *ViewCounter {
 			flushFn:   topics.IncrementViews,
 		}
 		counter.start()
-		closer.RegisterPriority(closer.PriorityFlush, CloseViewCounter)
+		closer.RegisterPriorityContext(closer.PriorityFlush, func(context.Context) error {
+			return CloseViewCounter()
+		})
 		slog.Info("topic view counter started", "flushInterval", viewFlushInterval.String(), "queueSize", viewQueueSize)
 	})
 	return counter

--- a/apps/gooseforum/app/service/userservice/updateUserLastActiveTime.go
+++ b/apps/gooseforum/app/service/userservice/updateUserLastActiveTime.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jellydator/ttlcache/v3"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/cacheconfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userStatistics"
+	"github.com/jellydator/ttlcache/v3"
 )
 
 type userActivity struct {
@@ -49,7 +49,9 @@ func (store *userActivityStore) init() {
 		})
 		go store.cache.Start()
 		if store.registerCloser {
-			closer.RegisterPriority(closer.PriorityFlush, CloseUpdateUserLastActiveTime)
+			closer.RegisterPriorityContext(closer.PriorityFlush, func(context.Context) error {
+				return CloseUpdateUserLastActiveTime()
+			})
 		}
 	})
 }

--- a/apps/gooseforum/app/service/wikiservice/sync.go
+++ b/apps/gooseforum/app/service/wikiservice/sync.go
@@ -668,12 +668,31 @@ type SyncAccepted struct {
 // Sync 执行一次 GitHub → 论坛投影同步（webhook / 定时 / 手动共用）。
 // 幂等：内容 hash 不变则跳过（重复同步零变更）。
 func Sync(trigger string) (*SyncResult, error) {
-	return SyncWithConfig(LoadGitConfig(), trigger)
+	return SyncContext(context.Background(), trigger)
+}
+
+// SyncContext runs a sync with an explicit lifecycle context. The context is
+// checked before acquiring the process/database lock so detached jobs can be
+// abandoned without starting new work after their owner has gone away.
+func SyncContext(ctx context.Context, trigger string) (*SyncResult, error) {
+	return SyncWithConfigContext(ctx, LoadGitConfig(), trigger)
 }
 
 // SyncWithConfig 使用显式配置执行一次同步（测试注入本地仓库用；
 // 生产路径 Sync 内部读取 [wiki.git] 配置）。
 func SyncWithConfig(cfg GitConfig, trigger string) (*SyncResult, error) {
+	return SyncWithConfigContext(context.Background(), cfg, trigger)
+}
+
+// SyncWithConfigContext is the cancellable form used by request-launched jobs
+// and tests that inject a local repository configuration.
+func SyncWithConfigContext(ctx context.Context, cfg GitConfig, trigger string) (*SyncResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if !cfg.Enabled() {
 		return nil, fmt.Errorf("wiki git sync not configured ([wiki.git].repo empty)")
 	}
@@ -1344,16 +1363,16 @@ func createPageFromRepo(cfg GitConfig, wp wantedPage) error {
 			ContentHash:         sha256Hex(wp.body),
 			PublishedRevisionNo: 1,
 		}
-		return wikiPages.CreateTx(tx, &page)
+		if err := wikiPages.CreateTx(tx, &page); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
 	})
 	if err != nil {
 		return err
 	}
 	// 提交后副作用：文件引用 + 搜索索引（话题索引 + wiki 段落索引） + 发布事件 + git 溯源快照。
 	fileusageservice.ReplaceTopic(topic.Id, wikiSystemUserID, wp.body)
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Warn("wiki sync: search index failed", "topicId", topic.Id, "error", err)
-	}
 	if err := searchservice.IndexWikiPageDocuments(page.Id); err != nil {
 		slog.Warn("wiki sync: wiki page index failed", "pageId", page.Id, "error", err)
 	}
@@ -1417,16 +1436,16 @@ func updatePageFromRepo(cfg GitConfig, page *wikiPages.Entity, wp wantedPage, cu
 		firstPost.RenderedHTML = rendered
 		firstPost.RenderedVersion = markdown2html.GetPostVersion()
 		firstPost.ProcessStatus = posts.ProcessStatusNormal
-		return posts.UpdateWikiSyncedContentTx(tx, &firstPost)
+		if err := posts.UpdateWikiSyncedContentTx(tx, &firstPost); err != nil {
+			return err
+		}
+		return searchservice.EnqueueTopicSearchTask(tx, topic.Id)
 	})
 	if err != nil {
 		return err
 	}
 	// 提交后副作用：文件引用 + 搜索（话题索引 + wiki 段落索引） + git 溯源快照 + watcher 通知。
 	fileusageservice.ReplaceTopic(topic.Id, wikiSystemUserID, wp.body)
-	if _, err := searchservice.BuildSingleTopicSearchDocument(&topic, &firstPost); err != nil {
-		slog.Warn("wiki sync: search index failed", "topicId", topic.Id, "error", err)
-	}
 	if err := searchservice.IndexWikiPageDocuments(page.Id); err != nil {
 		slog.Warn("wiki sync: wiki page index failed", "pageId", page.Id, "error", err)
 	}

--- a/apps/gooseforum/app/service/wikiservice/sync_test.go
+++ b/apps/gooseforum/app/service/wikiservice/sync_test.go
@@ -1,7 +1,9 @@
 package wikiservice
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -22,6 +24,16 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/datamigration"
 )
+
+func TestSyncWithConfigContextHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := SyncWithConfigContext(ctx, GitConfig{}, "manual")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("SyncWithConfigContext() err=%v, want context.Canceled", err)
+	}
+}
 
 func TestApplyRepoToDBRewritesRelativeReferences(t *testing.T) {
 	setupWikiTestDB(t)

--- a/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
+++ b/apps/gooseforum/app/service/wikiservice/wikiservice_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/eventNotification"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/rolePermissionRs"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserAction"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
@@ -38,6 +39,7 @@ func setupWikiTestDB(t *testing.T) {
 		&wikiNamespaceEditors.Entity{},
 		&wikiPages.Entity{},
 		&wikiSyncRuns.Entity{},
+		&taskQueue.Entity{},
 	}
 	if err := conn.AutoMigrate(models...); err != nil {
 		t.Fatalf("migrate wiki schema: %v", err)

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -4651,11 +4651,11 @@ export interface paths {
          *     at 50MB); only JSON is accepted — either an object keyed by table name
          *     (`users`/`topics`/`posts`/`postRevisions`/`topicCategoryIndex`/
          *     `topicUserStat`) or an array of row objects with an optional `table`
-         *     field (defaulting to `users`). Import is idempotent (existing rows are
-         *     skipped and counted), runs in users → topics → posts → postRevisions →
-         *     derived-tables order, and rebuilds topic invariants afterwards. The
-         *     response report counts total/success/skipped/failed rows with per-row
-         *     error details. Failure responses use real HTTP statuses: missing
+         *     field (defaulting to `users`). The request only stages a deduplicated
+         *     `import` task and returns its id/status; the worker performs the
+         *     idempotent import in users → topics → posts → postRevisions →
+         *     derived-tables order and rebuilds topic invariants in one transaction.
+         *     Failure responses use real HTTP statuses: missing
          *     `file` field → HTTP 400 `admin.data.importFailed` (params.error
          *     `未获取到上传文件`); unparsable content, an empty file, a payload
          *     without known tables, or an unknown table name → HTTP 400
@@ -4664,6 +4664,53 @@ export interface paths {
          *     inside `result.failed`/`result.errors`.
          */
         post: operations["adminImportData"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/data/import/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List recent data-import tasks
+         * @description Admin console operation gated by the `SiteManager` role permission.
+         *     Returns up to 20 most recent `import` task_queue rows, newest id first.
+         *     The task payload contains only the staged filename, format, and SHA-256;
+         *     the imported body is never returned by this endpoint.
+         */
+        get: operations["adminListImportTasks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/admin/data/import/tasks/{taskId}/replay": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Replay a failed data-import task
+         * @description Admin console operation gated by the `SiteManager` role permission.
+         *     Only a failed `import` task with an intact checksum-addressed staging
+         *     file can be replayed. The source file is not replaced and the task is
+         *     reset to `pending`; active or successful tasks are rejected as a
+         *     business failure using the standard HTTP 200 failure envelope.
+         */
+        post: operations["adminReplayImportTask"];
         delete?: never;
         options?: never;
         head?: never;
@@ -7944,11 +7991,11 @@ export interface components {
         AdminTaskQueueItem: {
             /** Format: uint64 */
             id: number;
-            /** @description Task type prefix (`export` for data exports, `file-migrate` for storage migrations). */
+            /** @description Task type prefix (`export`, `import`, `file-migrate`, or a search projection prefix). */
             type: string;
             /** @description 0=pending, 1=running, 2=success, 3=failed, 4=retrying. */
             status: number;
-            /** @description Serialized task payload (JSON text; export payloads carry tables/format/fileName/progress/errorCount, migrate payloads carry lastId/total/processed/failed/clearAfterMigrate). */
+            /** @description Serialized task payload (JSON text; import payloads carry only fileName/format/sha256; export payloads carry tables/format/fileName/progress/errorCount; migrate payloads carry lastId/total/processed/failed/clearAfterMigrate). */
             taskJson: string;
             retryCount: number;
             lastError: string;
@@ -8185,7 +8232,7 @@ export interface components {
             importedTables: string[];
         };
         AdminImportDataResponse: (components["schemas"]["ApiSuccess"] & {
-            result: components["schemas"]["AdminImportReport"];
+            result: components["schemas"]["AdminImportTaskAcceptedResult"];
         }) | components["schemas"]["ApiFailure"];
         TopicAuthorPayload: {
             /** Format: uint64 */
@@ -9391,6 +9438,24 @@ export interface components {
             secretKeyConfigured: boolean;
             publicUrlPrefix: string;
         };
+        AdminImportTaskAcceptedResult: {
+            /**
+             * Format: uint64
+             * @description Enqueued import task id.
+             */
+            taskId: number;
+            /** @enum {string} */
+            status: "pending" | "running" | "retrying" | "failed" | "success";
+            errors: components["schemas"]["AdminImportReportError"][];
+            importedTables: string[];
+        };
+        AdminImportTaskListResponse: components["schemas"]["ApiSuccess"] & {
+            /** @description Up to 20 most recent import tasks, newest id first. */
+            result: components["schemas"]["AdminTaskQueueItem"][];
+        };
+        AdminImportTaskReplayResponse: (components["schemas"]["ApiSuccess"] & {
+            result: components["schemas"]["AdminTaskQueueItem"];
+        }) | components["schemas"]["ApiFailure"];
         /** @description Page-level wiki search result (aggregates the paragraph hits of one wiki page). */
         WikiSearchItem: {
             /** @description Display name of the namespace (fallback: URL key). */
@@ -17046,7 +17111,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Import finished; `result` is the per-table report (may still contain per-row failures). */
+            /** @description Import task accepted; poll adminListImportTasks for worker status. */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -17056,6 +17121,93 @@ export interface operations {
                 };
             };
             /** @description Missing file or unimportable payload. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Missing, invalid, expired, or revoked access token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+        };
+    };
+    adminListImportTasks: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Recent data-import tasks. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminImportTaskListResponse"];
+                };
+            };
+            /** @description Missing, invalid, expired, or revoked access token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+        };
+    };
+    adminReplayImportTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                taskId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Requeued task, or a business failure when it is not replayable. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminImportTaskReplayResponse"];
+                };
+            };
+            /** @description Missing or malformed task id path parameter. */
             400: {
                 headers: {
                     [name: string]: unknown;

--- a/apps/gooseforum/resource/src/admin/pages/management/DataManagementPage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/management/DataManagementPage.vue
@@ -16,7 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/admin/components/ui/table'
-import { createExportTask, downloadExportTask, getExportTasks, importData } from '@/admin/runtime/api'
+import { createExportTask, downloadExportTask, getExportTasks, getImportTasks, importData, replayImportTask } from '@/admin/runtime/api'
 import { adminToast } from '@/admin/runtime/toast'
 import type { AdminPayload, AdminTaskRow, ImportReport, ManageHomeProps } from '@/admin/types'
 
@@ -29,6 +29,10 @@ const exportFormat = ref<'json' | 'csv'>('json')
 const exportTasks = ref<AdminTaskRow[]>([])
 const tasksLoading = ref(false)
 const tasksError = ref('')
+const importTasks = ref<AdminTaskRow[]>([])
+const importTasksLoading = ref(false)
+const importTasksError = ref('')
+const replayingImportTask = ref<number | null>(null)
 const creating = ref(false)
 const createConfirm = ref(false)
 
@@ -67,7 +71,19 @@ function taskStatusText(status: number) {
 }
 
 function hasActiveTasks() {
-  return exportTasks.value.some(task => task.status !== 2 && task.status !== 3)
+  return [...exportTasks.value, ...importTasks.value].some(task => task.status !== 2 && task.status !== 3)
+}
+
+async function loadImportTasks() {
+  importTasksLoading.value = true
+  importTasksError.value = ''
+  try {
+    importTasks.value = await getImportTasks()
+  } catch (err) {
+    importTasksError.value = err instanceof Error ? err.message : adminText('k00hk')
+  } finally {
+    importTasksLoading.value = false
+  }
 }
 
 async function loadExportTasks() {
@@ -86,7 +102,7 @@ function startPolling() {
   stopPolling()
   pollTimer = setInterval(() => {
     if (!hasActiveTasks()) return
-    void loadExportTasks()
+    void Promise.all([loadExportTasks(), loadImportTasks()])
   }, 5000)
 }
 
@@ -138,6 +154,8 @@ async function submitImport() {
   importing.value = true
   try {
     importReport.value = await importData(importFile.value)
+    await loadImportTasks()
+    startPolling()
     adminToast.success(adminText('k00id'))
   } catch (err) {
     importReport.value = null
@@ -145,6 +163,31 @@ async function submitImport() {
   } finally {
     importing.value = false
   }
+}
+
+async function replayImport(taskId: number) {
+  replayingImportTask.value = taskId
+  try {
+    await replayImportTask(taskId)
+    await loadImportTasks()
+    startPolling()
+    adminToast.success(adminText('k00id'))
+  } catch (err) {
+    adminToast.error(err, adminText('k00hk'))
+  } finally {
+    replayingImportTask.value = null
+  }
+}
+
+function importStatusText(status: ImportReport['status']) {
+  const statusKey: Record<ImportReport['status'], string> = {
+    pending: 'k00i0',
+    running: 'k00i1',
+    success: 'k00i2',
+    failed: 'k00i3',
+    retrying: 'k00i4',
+  }
+  return adminText(statusKey[status])
 }
 
 function formatTime(value: string) {
@@ -157,6 +200,7 @@ function formatTime(value: string) {
 
 onMounted(() => {
   void loadExportTasks()
+  void loadImportTasks()
   startPolling()
 })
 
@@ -280,24 +324,14 @@ onUnmounted(stopPolling)
           </div>
 
           <div v-if="importReport" class="space-y-3 rounded-lg border bg-muted/10 p-4">
-            <div class="flex flex-wrap items-center gap-2 text-sm font-semibold"><CheckCircle2 class="size-4 text-emerald-600" />{{ adminText('k00hf') }}</div>
-            <div class="grid grid-cols-2 gap-3 sm:grid-cols-4">
-              <div class="rounded-md border bg-background p-3">
-                <div class="text-xs text-muted-foreground">{{ adminText('k00hg') }}</div>
-                <div class="mt-1 text-lg font-semibold">{{ importReport.total }}</div>
-              </div>
-              <div class="rounded-md border bg-background p-3">
-                <div class="text-xs text-muted-foreground">{{ adminText('k00hh') }}</div>
-                <div class="mt-1 text-lg font-semibold text-emerald-600">{{ importReport.success }}</div>
-              </div>
-              <div class="rounded-md border bg-background p-3">
-                <div class="text-xs text-muted-foreground">{{ adminText('k00hi') }}</div>
-                <div class="mt-1 text-lg font-semibold text-muted-foreground">{{ importReport.skipped }}</div>
-              </div>
-              <div class="rounded-md border bg-background p-3">
-                <div class="text-xs text-muted-foreground">{{ adminText('k00hj') }}</div>
-                <div class="mt-1 text-lg font-semibold text-destructive">{{ importReport.failed }}</div>
-              </div>
+            <div class="flex flex-wrap items-center gap-2 text-sm font-semibold">
+              <CheckCircle2 class="size-4 text-emerald-600" />
+              {{ adminText('k00hf') }}
+              <Badge variant="secondary">{{ importStatusText(importReport.status) }}</Badge>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <span class="font-mono text-xs">#{{ importReport.taskId }}</span>
+              <span v-if="importReport.importedTables.length">{{ importReport.importedTables.join(', ') }}</span>
             </div>
             <div v-if="importReport.importedTables.length" class="flex flex-wrap items-center gap-2 text-sm">
               <span class="text-muted-foreground">{{ adminText('k00hp') }}:</span>
@@ -322,6 +356,27 @@ onUnmounted(stopPolling)
                     </tr>
                   </tbody>
                 </table>
+              </div>
+            </div>
+          </div>
+
+          <div class="space-y-2 border-t pt-4">
+            <div class="flex items-center gap-2 text-sm font-semibold"><Database class="size-4 text-muted-foreground" />{{ adminText('k00h8') }}</div>
+            <div v-if="importTasksLoading && importTasks.length === 0" class="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">{{ adminText('k0046') }}</div>
+            <div v-else-if="importTasksError" class="rounded-lg border border-dashed p-4 text-center text-sm text-destructive">{{ importTasksError }}</div>
+            <div v-else-if="importTasks.length === 0" class="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">{{ adminText('k00hq') }}</div>
+            <div v-else class="space-y-2">
+              <div v-for="task in importTasks" :key="task.id" class="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-background p-3 text-sm">
+                <div class="flex min-w-0 flex-wrap items-center gap-2">
+                  <span class="font-mono text-xs text-muted-foreground">#{{ task.id }}</span>
+                  <Badge :variant="task.status === 2 ? 'default' : task.status === 3 ? 'destructive' : 'secondary'" class="px-2 py-0 text-xs">{{ taskStatusText(task.status) }}</Badge>
+                  <span class="truncate text-xs text-muted-foreground">{{ formatTime(task.createdAt) }}</span>
+                </div>
+                <Button v-if="task.status === 3" type="button" size="sm" variant="outline" class="h-7 text-xs" :disabled="replayingImportTask === task.id" @click="replayImport(task.id)">
+                  <Loader2 v-if="replayingImportTask === task.id" class="size-3.5 animate-spin" />
+                  <RefreshCw v-else class="size-3.5" />
+                  {{ adminText('k004q') }}
+                </Button>
               </div>
             </div>
           </div>

--- a/apps/gooseforum/resource/src/admin/runtime/api.ts
+++ b/apps/gooseforum/resource/src/admin/runtime/api.ts
@@ -500,6 +500,10 @@ export function importData(file: File) {
   return postForm<ImportReport>('/api/admin/data/import', body, adminText('k00hk'))
 }
 
+export function getImportTasks() {
+  return getJson<AdminTaskRow[]>('/api/admin/data/import/tasks', adminText('k00hk'))
+}
+
 export function getAgentList() {
   return postJson<AdminAgent[]>('/api/admin/agent-list', {}, adminText('k00k2'))
 }

--- a/apps/gooseforum/resource/src/admin/runtime/api.ts
+++ b/apps/gooseforum/resource/src/admin/runtime/api.ts
@@ -504,6 +504,10 @@ export function getImportTasks() {
   return getJson<AdminTaskRow[]>('/api/admin/data/import/tasks', adminText('k00hk'))
 }
 
+export function replayImportTask(taskId: number) {
+  return postJson<AdminTaskRow>(`/api/admin/data/import/tasks/${taskId}/replay`, {}, adminText('k00hk'))
+}
+
 export function getAgentList() {
   return postJson<AdminAgent[]>('/api/admin/agent-list', {}, adminText('k00k2'))
 }

--- a/apps/gooseforum/resource/src/admin/types.ts
+++ b/apps/gooseforum/resource/src/admin/types.ts
@@ -370,6 +370,8 @@ export interface ImportReport {
   failed: number
   errors: Array<{ line: number; table: string; reason: string }>
   importedTables: string[]
+  taskId?: number
+  status?: 'pending' | 'running' | 'retrying' | 'success' | 'failed'
 }
 
 export interface PostingSettings {

--- a/apps/gooseforum/resource/src/admin/types.ts
+++ b/apps/gooseforum/resource/src/admin/types.ts
@@ -364,14 +364,10 @@ export interface ReviewQueueItem {
 }
 
 export interface ImportReport {
-  total: number
-  success: number
-  skipped: number
-  failed: number
+  taskId: number
+  status: 'pending' | 'running' | 'retrying' | 'success' | 'failed'
   errors: Array<{ line: number; table: string; reason: string }>
   importedTables: string[]
-  taskId?: number
-  status?: 'pending' | 'running' | 'retrying' | 'success' | 'failed'
 }
 
 export interface PostingSettings {

--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -29,6 +29,10 @@ backupDir = "./storage/databasebackup/"
 keep = 7
 spec = "0 3 * * *"
 
+[cron]
+# 应用内定时任务开关；关闭后持久化 worker 与手动 CLI 仍可用。
+enabled = true
+
 [db.default]
 # 主库连接类型: postgres（部署默认）/ sqlite（本地开发；文件库 [db.file] 固定 sqlite）
 connection = "postgres"

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -163,7 +163,9 @@ complete operation coverage and the precondition for such a gate is met.
   across handlers:
   - `email.*` (activation/reset_password; legacy `activation` / `reset_password` rows are whitelisted)
   - `export` (data export)
+  - `import` (staged, checksum-addressed JSON import)
   - `file-migrate` (BLOB → object storage migration)
+  - `topic-search.*`, `user-search.*`, `category-search.*`, and `course-search.*` (search projections)
 - Task claiming is **atomic with a lease** (issue #138): a worker claims a row via a CAS update
   (`pending/retrying → running`, `RowsAffected = 1`), so concurrent workers/processes never execute
   the same task simultaneously from the queue's perspective. Each claim generates a fresh,
@@ -181,6 +183,15 @@ complete operation coverage and the precondition for such a gate is met.
   only prevents the stale worker from writing terminal state over the new owner.
 - Export and migration tasks update `task_json` with progress payloads (`processed/total/errorCount`,
   cursor `lastId`) so the admin panel can render live progress and resume after restarts.
+- Import requests are bounded at 50 MiB and staged with mode `0600`; the task payload stores only the
+  filename, format, and SHA-256. The worker rechecks the digest, runs row validation and invariant
+  rebuilding in one transaction, and keeps the source file on failure. `POST
+  /api/admin/data/import/tasks/{taskId}/replay` resets a failed task after the operator has fixed the
+  cause. Identical uploads reuse the same task instead of overwriting a failed task's source.
+- Search projection rows are enqueued in the same transaction as topic/user/category mutations.
+  A worker re-reads current database state before upserting or deleting the external document, so
+  rollback cannot leave a committed-looking projection task behind and an unavailable Meilisearch
+  instance only delays a rebuildable projection.
 - Export files land in `data/export/` and are retained 7 days (daily cron cleanup).
 
 ## Config-driven features (pageConfig)

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -188,10 +188,11 @@ complete operation coverage and the precondition for such a gate is met.
   rebuilding in one transaction, and keeps the source file on failure. `POST
   /api/admin/data/import/tasks/{taskId}/replay` resets a failed task after the operator has fixed the
   cause. Identical uploads reuse the same task instead of overwriting a failed task's source.
-- Search projection rows are enqueued in the same transaction as topic/user/category mutations.
-  A worker re-reads current database state before upserting or deleting the external document, so
-  rollback cannot leave a committed-looking projection task behind and an unavailable Meilisearch
-  instance only delays a rebuildable projection.
+- Search projection rows are transaction-bound for the main topic/category/wiki write paths. User
+  profile, likes/follows, and content delete/restore event paths enqueue after the business commit;
+  they therefore have a short crash window but remain idempotent, retryable, and rebuildable. A
+  worker re-reads current database state before upserting or deleting the external document, so an
+  unavailable Meilisearch instance only delays a rebuildable projection.
 - Export files land in `data/export/` and are retained 7 days (daily cron cleanup).
 
 ## Config-driven features (pageConfig)

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -82,9 +82,29 @@
 
 - Meilisearch optionally enabled (config [meilisearch]). Aggregate search (one box covering
   topics/users/categories with scope tabs; pinyin/initials matching for users and categories) landed
-  in issue #22. Index sync is event-driven (topic/user/category events). When Meilisearch is
-  unavailable the search page shows a full unavailable state; per-index failures degrade partially
-  via `failedScopes`. The index is a rebuildable projection (`rebuild-search-index` CLI).
+  in issue #22. Index sync is event-driven (topic/user/category events) through transaction-bound
+  `task_queue` outbox rows. Workers read the latest committed database state, use a lease and
+  retry/recovery path, and keep Meilisearch as a rebuildable projection (`rebuild-search-index` CLI).
+  When Meilisearch is unavailable the search page shows a full unavailable state; per-index failures
+  degrade partially via `failedScopes`.
+
+### Async boundaries and consistency
+
+- A request-scoped database, HTTP, or LLM operation receives the incoming request context and must
+  stop on cancellation/deadline. Post-commit notifications use the explicit
+  `eventbus.DetachedContext` boundary, while workers receive their own lifetime context; legacy
+  synchronous wrappers retain bounded timeouts for compatibility.
+- Admin JSON import is accepted only up to 50 MiB, staged as an owner-readable (`0600`) file, and
+  represented by a deduplicated `import` task. The worker validates the SHA-256 payload and applies
+  all rows plus invariant rebuilding in one database transaction; failures retain the staging file
+  and can be replayed from the admin task endpoint.
+- Course AI summary remains synchronous at the public API boundary for wire compatibility, but the
+  provider call is cancellable and capped at 30 seconds. Database caching and rate limits remain the
+  cost and duplicate-generation guard; moving this API to an asynchronous response is a separate
+  contract change.
+- Topic-list cache invalidation is keyed to the changed category set; the cache is process-local.
+  Redis or another shared cache is deliberately deferred until deployment has a measured
+  multi-instance requirement and an explicit rollback plan.
 
 ### Wiki 分站 (Current)
 
@@ -132,5 +152,9 @@ Wiki 内容由公开 GitHub 仓库 `YourTongji/YourTJ-Wiki` 维护（PR 协作�
   rebuildable projections.
 - Critical side effects (notifications, index sync, points distribution) are idempotent, retryable,
   observable.
+- The transaction outbox is the reliability seam for this single-binary deployment; adding a broker
+  is not implied by the current architecture. Connection-pool sizing and query-cache/projection
+  changes require measurements from the target PostgreSQL deployment (CPU, concurrency, p95 latency,
+  and memory) before changing defaults.
 - For OpenAPI-covered operations, contract changes ship in the same PR: Go behavior/struct →
   `openapi.yaml` → generated TypeScript output → fixture tests. Dart generation remains Planned.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -82,9 +82,11 @@
 
 - Meilisearch optionally enabled (config [meilisearch]). Aggregate search (one box covering
   topics/users/categories with scope tabs; pinyin/initials matching for users and categories) landed
-  in issue #22. Index sync is event-driven (topic/user/category events) through transaction-bound
-  `task_queue` outbox rows. Workers read the latest committed database state, use a lease and
-  retry/recovery path, and keep Meilisearch as a rebuildable projection (`rebuild-search-index` CLI).
+  in issue #22. Index sync is event-driven (topic/user/category events) through `task_queue` outbox
+  rows. Main topic/category/wiki writes enqueue in their transaction; post-commit user/profile and
+  lifecycle events enqueue asynchronously. Workers read the latest committed database state, use a
+  lease and retry/recovery path, and keep Meilisearch as a rebuildable projection
+  (`rebuild-search-index` CLI).
   When Meilisearch is unavailable the search page shows a full unavailable state; per-index failures
   degrade partially via `failedScopes`.
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -465,6 +465,10 @@ CLI 同步（运维 cron 等自动化场景）：
   30 2 * * * cd /srv/yourtj-hub && ONESYSTEM_COOKIE='JWTUser=…; JSESSIONID=…' ./bin/yourtj-hub course-pk-sync 121
   ```
 
+应用内定时任务默认开启。若实例只运行持久化 worker、由外部 cron 触发维护命令，
+可在 `config.toml` 设置 `[cron].enabled = false`；该开关只停止应用内 scheduler，
+不会停用 task queue worker 或手动 CLI。
+
 - 行为保证：同一学期重复执行先清空再全量重写（幂等，不翻倍）；同步中断后重跑从失败批次
   续跑（`pk_fetch_log` 游标），不回滚已成功批次；Cookie 失效时报 HTTP 状态与提示并标记
   fetchlog `failed`，且不删除存量数据；无效 Cookie 不会破坏已同步数据。
@@ -622,6 +626,10 @@ curl -fsS -H "Host: forum.yourtj.de" http://127.0.0.1/ | head -5   # 经 1Panel 
   4. 再切 DNS 回旧机。
   - 若回滚发生在切换后很短时间内且写入量可忽略，可接受不回灌，但文档不承诺"数据无损"。
 - Meilisearch 索引不迁移，首次启动后由 `rebuild-search-index` 重建（ADR-003：索引是可重建投影）。
+- 搜索投影任务采用有界重试；Meilisearch 短时不可用时，`topic-search.*`、
+  `user-search.*` 或 `category-search.*` 任务可能进入 `failed`，不会自动无限重试。
+  Meilisearch 恢复后检查 `task_queue`，并运行 `rebuild-search-index` 做一次全量对账；
+  该命令是运维恢复动作，不依赖旧任务仍处于 pending。
 
 ## Runbooks to write
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -405,8 +405,13 @@ instance:
 
 - Admin panel (数据管理): export users/topics/posts (plus derived topic_category_index /
   topic_user_stat when selected) as JSON or CSV via a background task, then download;
-  import JSON with a per-row validation report and idempotent skip; topic invariants
-  (post_seq, first/last post pointers, counts, posters) are preserved and rebuilt on import.
+  upload JSON (maximum 50 MiB) into a staged background task. The task is checksum-addressed and
+  idempotent; identical uploads reuse the same task. The worker applies all rows and topic
+  invariants (post_seq, first/last post pointers, counts, posters) in one database transaction,
+  so validation failures roll back the batch rather than leaving partial data. Staged files use
+  mode `0600`, are deleted after success, and are retained for an explicit replay after failure.
+  Administrators can inspect `GET /api/admin/data/import/tasks` and replay a failed task with
+  `POST /api/admin/data/import/tasks/:taskId/replay`.
 - Export files are written to `data/export/` inside the storage dir with mode 0600
   (owner-only) and cleaned up after 7 days (daily cron). Export contains user emails —
   treat downloads as sensitive. Export creation and download are recorded in the

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -7210,13 +7210,13 @@ AdminTaskQueueItem:
       format: uint64
     type:
       type: string
-      description: Task type prefix (`export` for data exports, `file-migrate` for storage migrations).
+      description: Task type prefix (`export`, `import`, `file-migrate`, or a search projection prefix).
     status:
       type: integer
       description: "0=pending, 1=running, 2=success, 3=failed, 4=retrying."
     taskJson:
       type: string
-      description: Serialized task payload (JSON text; export payloads carry tables/format/fileName/progress/errorCount, migrate payloads carry lastId/total/processed/failed/clearAfterMigrate).
+      description: Serialized task payload (JSON text; import payloads carry only fileName/format/sha256; export payloads carry tables/format/fileName/progress/errorCount; migrate payloads carry lastId/total/processed/failed/clearAfterMigrate).
     retryCount:
       type: integer
     lastError:
@@ -7777,7 +7777,52 @@ AdminImportDataResponse:
           required: [result]
           properties:
             result:
-              $ref: '#/AdminImportReport'
+              $ref: '#/AdminImportTaskAcceptedResult'
+    - $ref: '#/ApiFailure'
+
+AdminImportTaskAcceptedResult:
+  type: object
+  required: [taskId, status, errors, importedTables]
+  properties:
+    taskId:
+      type: integer
+      format: uint64
+      minimum: 1
+      description: Enqueued import task id.
+    status:
+      type: string
+      enum: [pending, running, retrying, failed, success]
+    errors:
+      type: array
+      items:
+        $ref: '#/AdminImportReportError'
+    importedTables:
+      type: array
+      items:
+        type: string
+  additionalProperties: false
+
+AdminImportTaskListResponse:
+  allOf:
+    - $ref: '#/ApiSuccess'
+    - type: object
+      required: [result]
+      properties:
+        result:
+          type: array
+          items:
+            $ref: '#/AdminTaskQueueItem'
+          description: Up to 20 most recent import tasks, newest id first.
+
+AdminImportTaskReplayResponse:
+  oneOf:
+    - allOf:
+        - $ref: '#/ApiSuccess'
+        - type: object
+          required: [result]
+          properties:
+            result:
+              $ref: '#/AdminTaskQueueItem'
     - $ref: '#/ApiFailure'
 
 # --- User content lifecycle (issue #94) and forum read ops (issue #277) ---

--- a/packages/api-contract/coverage-matrix.md
+++ b/packages/api-contract/coverage-matrix.md
@@ -4,11 +4,11 @@
 
 路由快照来自 `TestRoutesSnapshot`（`fixtures/routes-snapshot.json`，默认配置装配，不含 OIDC `/api/oauth/*` 端点——OIDC 另有专项）。
 
-- 快照路由总数：270
-- /api JSON 路由：214，已入契约：212（99%），已知未覆盖：0
+- 快照路由总数：272
+- /api JSON 路由：216，已入契约：214（99%），已知未覆盖：0
 - 非 API 排除路由：58
 
-## 已覆盖（212）
+## 已覆盖（214）
 
 | Method | Path | operationId |
 | --- | --- | --- |
@@ -20,6 +20,7 @@
 | GET | `/api/admin/badges` | `adminListBadges` |
 | GET | `/api/admin/data/export/download/:taskId` | `adminDownloadExportTask` |
 | GET | `/api/admin/data/export/tasks` | `adminListExportTasks` |
+| GET | `/api/admin/data/import/tasks` | `adminListImportTasks` |
 | GET | `/api/admin/friend-links` | `adminGetFriendLinks` |
 | GET | `/api/admin/get-all-role-item` | `adminGetAllRoleItem` |
 | GET | `/api/admin/http-notify-settings` | `adminGetHttpNotifySettings` |
@@ -93,6 +94,7 @@
 | POST | `/api/admin/category-save` | `adminCategorySave` |
 | POST | `/api/admin/data/export` | `adminCreateExportTask` |
 | POST | `/api/admin/data/import` | `adminImportData` |
+| POST | `/api/admin/data/import/tasks/:taskId/replay` | `adminReplayImportTask` |
 | POST | `/api/admin/file-resources` | `adminListFileResources` |
 | POST | `/api/admin/get-permission-list` | `adminGetPermissionList` |
 | POST | `/api/admin/global-moderator-add` | `adminGlobalModeratorAdd` |

--- a/packages/api-contract/fixtures/admin-data-import-invalid-format.json
+++ b/packages/api-contract/fixtures/admin-data-import-invalid-format.json
@@ -3,6 +3,6 @@
   "code": 1,
   "messageCode": "admin.data.importInvalidFormat",
   "params": {
-    "error": "JSON 解析失败: invalid character 'h' looking for beginning of value"
+    "error": "导入文件格式无效"
   }
 }

--- a/packages/api-contract/fixtures/admin-data-import-replay-failed.json
+++ b/packages/api-contract/fixtures/admin-data-import-replay-failed.json
@@ -1,0 +1,8 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "common.operation.failed",
+  "params": {
+    "error": "导入任务当前不可重放"
+  }
+}

--- a/packages/api-contract/fixtures/admin-data-import-replay-success.json
+++ b/packages/api-contract/fixtures/admin-data-import-replay-success.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "id": 990020,
+    "type": "import",
+    "status": 0,
+    "taskJson": "{\"fileName\":\"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f.json\",\"sha256\":\"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f\",\"format\":\"json\"}",
+    "retryCount": 0,
+    "lastError": "",
+    "createdAt": "2026-02-03T04:05:06Z",
+    "processedAt": "0001-01-01T00:00:00Z"
+  },
+  "code": 0
+}

--- a/packages/api-contract/fixtures/admin-data-import-success.json
+++ b/packages/api-contract/fixtures/admin-data-import-success.json
@@ -1,9 +1,7 @@
 {
   "result": {
-    "total": 0,
-    "success": 0,
-    "skipped": 0,
-    "failed": 0,
+    "taskId": 123456,
+    "status": "pending",
     "errors": [],
     "importedTables": [
       "users"

--- a/packages/api-contract/fixtures/admin-data-import-tasks-success.json
+++ b/packages/api-contract/fixtures/admin-data-import-tasks-success.json
@@ -1,0 +1,15 @@
+{
+  "result": [
+    {
+      "id": 990007,
+      "type": "import",
+      "status": 3,
+      "taskJson": "{\"fileName\":\"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f.json\",\"sha256\":\"adac7b84dc3b7394d8385aa0c65fe27a19915d6ab4b0e0d826d34fb439541d3f\",\"format\":\"json\"}",
+      "retryCount": 2,
+      "lastError": "temporary failure",
+      "createdAt": "2026-02-03T04:05:06Z",
+      "processedAt": "2026-02-03T04:06:06Z"
+    }
+  ],
+  "code": 0
+}

--- a/packages/api-contract/fixtures/routes-snapshot.json
+++ b/packages/api-contract/fixtures/routes-snapshot.json
@@ -57,6 +57,10 @@
   },
   {
     "method": "GET",
+    "path": "/api/admin/data/import/tasks"
+  },
+  {
+    "method": "GET",
     "path": "/api/admin/friend-links"
   },
   {
@@ -538,6 +542,10 @@
   {
     "method": "POST",
     "path": "/api/admin/data/import"
+  },
+  {
+    "method": "POST",
+    "path": "/api/admin/data/import/tasks/:taskId/replay"
   },
   {
     "method": "POST",

--- a/packages/api-contract/openapi.yaml
+++ b/packages/api-contract/openapi.yaml
@@ -422,6 +422,10 @@ paths:
     $ref: ./paths/admin-data.yaml#/adminDownloadExportTask
   /api/admin/data/import:
     $ref: ./paths/admin-data.yaml#/adminImportData
+  /api/admin/data/import/tasks:
+    $ref: ./paths/admin-data.yaml#/adminListImportTasks
+  /api/admin/data/import/tasks/{taskId}/replay:
+    $ref: ./paths/admin-data.yaml#/adminReplayImportTask
   /api/wiki/search:
     get:
       $ref: ./paths/wiki.yaml#/searchWikiSearch/get

--- a/packages/api-contract/paths/admin-data.yaml
+++ b/packages/api-contract/paths/admin-data.yaml
@@ -75,6 +75,104 @@ adminUploadImage:
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
 
+adminListImportTasks:
+  get:
+    tags: [Admin]
+    summary: List recent data-import tasks
+    operationId: adminListImportTasks
+    description: |
+      Admin console operation gated by the `SiteManager` role permission.
+      Returns up to 20 most recent `import` task_queue rows, newest id first.
+      The task payload contains only the staged filename, format, and SHA-256;
+      the imported body is never returned by this endpoint.
+    security:
+      - bearerAuth: []
+      - accessTokenCookie: []
+    responses:
+      '200':
+        description: Recent data-import tasks.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/AdminImportTaskListResponse
+      '401':
+        description: Missing, invalid, expired, or revoked access token.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              unauthenticated:
+                externalValue: ../fixtures/auth-required.json
+      '403':
+        description: Frozen account, or caller lacks the SiteManager permission.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              frozenAccount:
+                externalValue: ../fixtures/account-frozen.json
+              permissionDenied:
+                externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+
+adminReplayImportTask:
+  post:
+    tags: [Admin]
+    summary: Replay a failed data-import task
+    operationId: adminReplayImportTask
+    description: |
+      Admin console operation gated by the `SiteManager` role permission.
+      Only a failed `import` task with an intact checksum-addressed staging
+      file can be replayed. The source file is not replaced and the task is
+      reset to `pending`; active or successful tasks are rejected as a
+      business failure using the standard HTTP 200 failure envelope.
+    security:
+      - bearerAuth: []
+      - accessTokenCookie: []
+    parameters:
+      - name: taskId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: uint64
+          minimum: 1
+          description: Failed import task id.
+    responses:
+      '200':
+        description: Requeued task, or a business failure when it is not replayable.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/AdminImportTaskReplayResponse
+      '400':
+        description: Missing or malformed task id path parameter.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+      '401':
+        description: Missing, invalid, expired, or revoked access token.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              unauthenticated:
+                externalValue: ../fixtures/auth-required.json
+      '403':
+        description: Frozen account, or caller lacks the SiteManager permission.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              frozenAccount:
+                externalValue: ../fixtures/account-frozen.json
+              permissionDenied:
+                externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+
 adminCreateExportTask:
   post:
     tags: [Admin]
@@ -277,11 +375,11 @@ adminImportData:
       at 50MB); only JSON is accepted — either an object keyed by table name
       (`users`/`topics`/`posts`/`postRevisions`/`topicCategoryIndex`/
       `topicUserStat`) or an array of row objects with an optional `table`
-      field (defaulting to `users`). Import is idempotent (existing rows are
-      skipped and counted), runs in users → topics → posts → postRevisions →
-      derived-tables order, and rebuilds topic invariants afterwards. The
-      response report counts total/success/skipped/failed rows with per-row
-      error details. Failure responses use real HTTP statuses: missing
+      field (defaulting to `users`). The request only stages a deduplicated
+      `import` task and returns its id/status; the worker performs the
+      idempotent import in users → topics → posts → postRevisions →
+      derived-tables order and rebuilds topic invariants in one transaction.
+      Failure responses use real HTTP statuses: missing
       `file` field → HTTP 400 `admin.data.importFailed` (params.error
       `未获取到上传文件`); unparsable content, an empty file, a payload
       without known tables, or an unknown table name → HTTP 400
@@ -305,7 +403,7 @@ adminImportData:
                 description: JSON export file produced by adminCreateExportTask (object or array form).
     responses:
       '200':
-        description: Import finished; `result` is the per-table report (may still contain per-row failures).
+        description: Import task accepted; poll adminListImportTasks for worker status.
         content:
           application/json:
             schema:


### PR DESCRIPTION
## 变更概览

以单一事务 outbox、可取消上下文和最小化实现完成 Issue #351 及全部子 issue：

- #352：移除低价值 lo/错误比较与一次性初始化改造。
- #353：完善关闭、事件总线、后台 worker、cron 与迁移锁生命周期。
- #354：按分类精准失效话题列表缓存，并补充查询基线验证。
- #355：预计算限流规则索引，补充重复/未知 action 语义与多实例设计文档。
- #356：导入改为受限 staging + 可重试任务，AI 请求绑定超时与取消。
- #357：请求/后台 job 明确 context 边界，DB/HTTP/LLM 入口支持取消。
- #358：topic/user/category 搜索投影统一使用事务 outbox、幂等、租约恢复和 worker。

同时更新 OpenAPI、生成客户端、覆盖矩阵和架构/运维文档。

## 验证

- `GOTOOLCHAIN=go1.26.0 go test ./...`
- `GOTOOLCHAIN=go1.26.0 go vet ./...`
- `GOTOOLCHAIN=go1.26.0 go test -race ./app/service/wikiservice/`
- `GOTOOLCHAIN=go1.26.0 go build .` 与 `make build`
- `pnpm typecheck`、`pnpm test --run`（43 files / 296 tests）、`pnpm check:i18n`、`pnpm build`
- `make contract-check`：864 fixtures、272 routes、生成代码一致性通过

本机未启动 PostgreSQL，CI PG 专项未在本地复现。

Fixes #351
Fixes #352
Fixes #353
Fixes #354
Fixes #355
Fixes #356
Fixes #357
Fixes #358