### PR TITLE
fix(schedule): prevent semester select text overflow in SiteSelect

### DIFF
--- a/apps/gooseforum/resource/src/site/components/SiteSelect.vue
+++ b/apps/gooseforum/resource/src/site/components/SiteSelect.vue
@@ -114,10 +114,13 @@ function handleContentKeydown(event: KeyboardEvent) {
       :class="triggerClass"
       :aria-label="props.label || undefined"
     >
-      <SelectValue :placeholder="props.placeholder ?? ''">
+      <!-- SelectValue 根 span 是 trigger(flex) 的子项：flex-1 撑开可用宽度，
+           min-w-0 允许其收缩到内容宽度以下，否则长学期名会把 trigger 撑破溢出。 -->
+      <SelectValue :placeholder="props.placeholder ?? ''" class="min-w-0 flex-1">
         <template #default="{ selectedLabel }">
+          <!-- 内层文本 span 必须是 block：inline 元素上 text-overflow: ellipsis 不生效 -->
           <span
-            class="min-w-0 truncate"
+            class="block truncate"
             :class="selectedLabel.length ? 'text-base-content' : 'text-base-content/45'"
           >
             {{ selectedLabel[0] ?? props.placeholder ?? '' }}

--- a/apps/gooseforum/resource/test/site-select.test.ts
+++ b/apps/gooseforum/resource/test/site-select.test.ts
@@ -274,3 +274,24 @@ describe('SiteSelect 可搜索模式', () => {
     wrapper.unmount()
   })
 })
+
+// 排课器学期选择：学期名可能很长（如「2026-2027 学年第一学期」），
+// SelectValue 根 span 是 trigger(flex) 的子项，默认 min-width:auto 拒绝收缩，
+// 长文本会把 trigger 撑破溢出；内层文本 span 必须是 block，truncate 才生效。
+describe('SiteSelect 长文本溢出', () => {
+  test('长标签下 SelectValue 容器可收缩(min-w-0)且文本 span 为 block', () => {
+    const longLabel = '2026-2027 学年第一学期（同济大学一系统排课数据）'
+    const wrapper = mount(SiteSelect, {
+      props: { modelValue: '2026-1', options: [{ value: '2026-1', label: longLabel }] },
+      attachTo: document.body,
+    })
+    const trigger = wrapper.get('[role="combobox"]')
+    const labelSpan = trigger.element.querySelector('span.truncate')
+    expect(labelSpan).not.toBeNull()
+    // 文本 span 的父级 = SelectValue 根 span，必须是可收缩的 flex 子项
+    expect(labelSpan!.parentElement!.classList.contains('min-w-0')).toBe(true)
+    // inline 元素上 text-overflow: ellipsis 不生效，文本 span 必须为 block
+    expect(labelSpan!.classList.contains('block')).toBe(true)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Problem

排课器学期选择(以及年级、校区等所有走 `SiteSelect` 的下拉)在选项标签很长时(例如「2026-2027 学年第一学期」)文本溢出触发器,把整行撑破。

## Cause

`SiteSelect` 的触发器是 flex 容器。reka-ui `SelectValue` 渲染为根 `<span>`,作为 flex 子项其默认 `min-width: auto` 拒绝收缩到内容宽度以下;且内层文本 `<span>` 是 inline,`text-overflow: ellipsis` 对 inline 元素不生效——长标签直接溢出。

## Fix

- `SelectValue` 容器加 `min-w-0 flex-1`:允许收缩,撑开可用宽度。
- 内层文本 span 改为 `block truncate`:block 上 `text-overflow` 才生效,长学期名以省略号截断。

## Verification

- 回归测试 `SiteSelect 长文本溢出`(先红后绿):断言触发器内文本 span 的父级含 `min-w-0`、文本 span 含 `block`。
- `pnpm test`:306/306 通过(44 个文件)。
- `pnpm typecheck`:通过(exit 0)。
- 未改动任何其他调用方;`SiteSelect` 为共享组件,修复惠及学期/年级/专业/校区等所有下拉。
