### PR TITLE
[Upstream Sync] 增加数据库迁移启动门闸与 migrate 命令 (#370)

### DIFF
--- a/apps/gooseforum/AGENTS.md
+++ b/apps/gooseforum/AGENTS.md
@@ -56,6 +56,7 @@ cd resource && npx vitest run
 ### CLI 命令
 ```bash
 ./gooseforum serve                 # 启动服务
+./gooseforum migrate               # 显式执行数据库迁移（部署前运行）
 ./gooseforum set-user-admin <userId>  # 设置管理员
 ./gooseforum set-user-email <userId> <email>  # 设置用户邮箱
 ./gooseforum set-user-password <userId> <password>  # 重置用户密码

--- a/apps/gooseforum/README.md
+++ b/apps/gooseforum/README.md
@@ -76,6 +76,7 @@ See [configuration documentation](docs/user/configuration.md) for PostgreSQL, SQ
 ### Admin Commands
 
 ```bash
+./yourtj-hub migrate
 ./yourtj-hub set-user-admin <userId>
 ./yourtj-hub set-user-email <userId> <email>
 ./yourtj-hub set-user-password <userId> <password>

--- a/apps/gooseforum/README_ZH.md
+++ b/apps/gooseforum/README_ZH.md
@@ -76,6 +76,7 @@ PostgreSQL、SQLite、邮件、备份、安全和站点配置见 [配置文档](
 ### 管理命令
 
 ```bash
+./yourtj-hub migrate
 ./yourtj-hub set-user-admin <用户ID>
 ./yourtj-hub set-user-email <用户ID> <邮箱>
 ./yourtj-hub set-user-password <用户ID> <密码>

--- a/apps/gooseforum/app/console/cmd/migrate.go
+++ b/apps/gooseforum/app/console/cmd/migrate.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/migration"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	appendCommand(&cobra.Command{
+		Use:   "migrate",
+		Short: "Run database schema and versioned data migrations",
+		Args:  cobra.NoArgs,
+		RunE:  runMigrate,
+	})
+}
+
+// runMigrate applies migrations so a deployment can run them explicitly before
+// starting serve. Deferred (retry-later) and lock-held states are non-fatal:
+// they preserve the historical log-and-proceed behavior and exit successfully
+// with an actionable message rather than failing a release pipeline.
+func runMigrate(_ *cobra.Command, _ []string) error {
+	err := migration.M()
+	if err == nil {
+		fmt.Println("Database migrations completed.")
+		return nil
+	}
+	if migration.Deferred(err) {
+		fmt.Println("Database migrations deferred (will retry on next run):", err)
+		return nil
+	}
+	slog.Error("database migrations failed", "err", err)
+	return fmt.Errorf("run migrations: %w", err)
+}

--- a/apps/gooseforum/app/console/cmd/rebuildSqliteIndexes.go
+++ b/apps/gooseforum/app/console/cmd/rebuildSqliteIndexes.go
@@ -66,7 +66,9 @@ AND name NOT LIKE 'sqlite_autoindex%'
 	printStepDuration("drop indexes", stepStart)
 
 	stepStart = time.Now()
-	migration.M()
+	if err := migration.M(); err != nil {
+		return fmt.Errorf("rerun migrations after index drop: %w", err)
+	}
 	printStepDuration("rerun migrations", stepStart)
 
 	var afterCount int64

--- a/apps/gooseforum/app/console/root.go
+++ b/apps/gooseforum/app/console/root.go
@@ -1,6 +1,9 @@
 package console
 
 import (
+	"log/slog"
+	"os"
+
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/closer"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/eventbus"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/console/cmd"
@@ -15,11 +18,38 @@ var rootCmd = &cobra.Command{
 	Short: "GooseForum command line tools",
 	Long:  `GooseForum`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		migration.M()
+		// `serve` runs migrations itself, behind the startup gate, so it is
+		// skipped here; every other command keeps the historical behavior of
+		// migrating synchronously before touching the database.
+		//
+		// For `serve` this starts the event bus before migrations run. That
+		// inversion is safe only while no data migration publishes events —
+		// if a future backfill publishes, it must move behind the startup gate
+		// (see serve.go runStartup) instead of running before the bus is up.
+		if cmd.Name() != "serve" {
+			runMigrationForCommand()
+		}
 		// 初始化并启动事件总线
 		eventbus.Start(eventhandlers.Handlers()...)
 	},
 	// Run: runWeb,
+}
+
+// runMigrationForCommand applies migrations before a CLI command runs.
+// Sentinels (retry-later, lock held by another instance) are non-fatal and
+// preserve the historical log-and-proceed behavior; any hard migration failure
+// aborts with a message and a non-zero exit so the command never runs against
+// a partial schema or incomplete data migration.
+func runMigrationForCommand() {
+	err := migration.M()
+	if err == nil || migration.Deferred(err) {
+		if err != nil {
+			slog.Warn("migration deferred; continuing", "err", err)
+		}
+		return
+	}
+	slog.Error("migration failed", "err", err)
+	os.Exit(1)
 }
 
 func init() {
@@ -30,6 +60,11 @@ func init() {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	defer closer.CloseAll() // 执行所有注册的关闭逻辑
-	cobra.CheckErr(rootCmd.Execute())
+	err := rootCmd.Execute()
+	// Close registered resources before any CheckErr os.Exit (the defers would
+	// be skipped by cobra.CheckErr's os.Exit(1) on error paths).
+	if closeErr := closer.CloseAll(); closeErr != nil {
+		slog.Error("closer: resources closed with errors", "err", closeErr)
+	}
+	cobra.CheckErr(err)
 }

--- a/apps/gooseforum/app/console/serve.go
+++ b/apps/gooseforum/app/console/serve.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"net/url"
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/captchaOpt"
@@ -21,7 +23,9 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/setting"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/signalwatch"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/console/job"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/routes"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/migration"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/backgroundservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/courseservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/dataservice"
@@ -42,11 +46,11 @@ import (
 var CmdServe = &cobra.Command{
 	Use:   "serve",
 	Short: "Start web server",
-	Run:   runWeb,
+	RunE:  runWeb,
 	Args:  cobra.NoArgs,
 }
 
-func runWeb(_ *cobra.Command, _ []string) {
+func runWeb(_ *cobra.Command, _ []string) error {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	slog.Info("GooseForum:start")
@@ -54,7 +58,7 @@ func runWeb(_ *cobra.Command, _ []string) {
 
 	warnInsecureServerURL()
 	startDebugServices()
-	ginServe()
+	return ginServe()
 }
 
 // warnInsecureServerURL logs a startup warning when a non-local deployment is
@@ -133,7 +137,7 @@ func pprofMux() *http.ServeMux {
 	return mux
 }
 
-func ginServe() {
+func ginServe() error {
 	// fail-closed：拒绝在不安全的 JWT 签名密钥下启动。空值、内置公开默认值
 	// 与部署模板占位符都可使攻击者伪造密码重置令牌（见 issue #106），因此
 	// 配置错误必须以非零退出码终止——否则 systemd/docker 会把"配置错误"
@@ -143,7 +147,119 @@ func ginServe() {
 			"hint", "请配置一个随机密钥（例如 openssl rand -base64 32）后重试")
 		os.Exit(1)
 	}
+	// prepareServeRuntime 只配置与数据库无关的启动态，可在迁移门闸开启前安全执行。
+	prepareServeRuntime()
+	port := preferences.GetString("server.port", 8080)
+	serverRuntime, err := newServeRuntime(port)
+	if err != nil {
+		return fmt.Errorf("create serve runtime: %w", err)
+	}
+	serverRuntime.start()
+
+	slog.Info("GooseForum:listen " + port)
+	slog.Info("use port:" + port)
+	slog.Info("start use:" + cast.ToString(setting.GetUnitTime()))
+	fmt.Println("if in local you can http://localhost:" + port)
+
+	return serverRuntime.wait()
+}
+
+// prepareServeRuntime 只配置与数据库无关的启动态，可在迁移门闸开启前安全执行。
+func prepareServeRuntime() {
 	preferences.OpenConfigChangeEvent()
+}
+
+type serveRuntime struct {
+	server        *http.Server
+	startupGate   *middleware.StartupGate
+	listener      net.Listener
+	quit          chan os.Signal
+	shutdownOnce  sync.Once
+	fatalMu       sync.Mutex
+	fatalErr      error
+	migrate       func() error
+	startBusiness func()
+}
+
+func newServeRuntime(port string) (*serveRuntime, error) {
+	engine := newGinEngine()
+	// 启动门闸必须是第一个中间件，且在 RegisterByGin 之前注册：gin 在路由
+	// 注册时快照处理器链，gate 注册晚了会静默失效；gate 前置保证迁移期间
+	// 没有任何 DB 依赖的中间件/控制器被执行。
+	startupGate := middleware.NewStartupGate()
+	engine.Use(startupGate.Handler)
+	routes.RegisterByGin(engine)
+	host := preferences.GetString("server.host", "")
+	if host == "" && setting.IsLocal() {
+		host = `127.0.0.1`
+	}
+	address := fmt.Sprintf("%v:%v", host, port)
+	srv := newHTTPServer(address, engine)
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("listen on %s: %w", address, err)
+	}
+	return &serveRuntime{
+		server:        srv,
+		startupGate:   startupGate,
+		listener:      listener,
+		quit:          make(chan os.Signal, 1),
+		migrate:       migration.M,
+		startBusiness: startBusinessServices,
+	}, nil
+}
+
+func (r *serveRuntime) start() {
+	signalwatch.ListenSignal(r.quit)
+	go func() {
+		defer paniclog.Recover("http_server")
+		if err := r.server.Serve(r.listener); !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("http serve ", "err", err)
+			fmt.Println("http serve ", "err", err)
+			r.requestShutdown()
+		}
+	}()
+	// 迁移完成前监听器已就绪并只返回 503（StartupGate），完成后才启动
+	// 业务服务并放行流量；worker/cron 全部在成功路径内启动，避免半迁移
+	// 实例处理业务请求。
+	go func() {
+		if err := r.runStartup(); err != nil {
+			r.setFatal(err)
+			r.requestShutdown()
+		}
+	}()
+}
+
+// runStartup applies migrations and, on success, boots the business services
+// and opens the startup gate. A hard migration error or a panic in the
+// migration path (e.g. dbconnect.Connect panics on an unreachable database)
+// returns an error so the instance exits non-zero instead of staying on the
+// 503 loading page forever.
+func (r *serveRuntime) runStartup() (fatalErr error) {
+	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			paniclog.LogPanic("startup_migration", panicValue)
+			fatalErr = fmt.Errorf("startup migration panicked: %v", panicValue)
+		}
+	}()
+	err := r.migrate()
+	if err != nil {
+		if migration.Deferred(err) {
+			slog.Warn("startup migration deferred, serving with degraded state", "err", err)
+		} else {
+			slog.Error("startup migration failed", "err", err)
+			return err
+		}
+	}
+	r.startBusiness()
+	r.startupGate.Complete()
+	return nil
+}
+
+// startBusinessServices boots every business-facing component that reads or
+// writes the database (or depends on a migrated schema). It runs only after
+// migration succeeds or defers via a non-fatal sentinel.
+func startBusinessServices() {
 	// 初始化OAuth配置
 	oauthservice.InitOAuth()
 	oidcservice.InitOIDC()
@@ -205,43 +321,47 @@ func ginServe() {
 			}
 		}()
 	}
+}
 
-	port := preferences.GetString("server.port", 8080)
-	engine := newGinEngine()
-	routes.RegisterByGin(engine)
-	// local 模式默认只绑定回环地址（安全），配置 server.host 可覆盖为 0.0.0.0 以允许局域网访问
-	host := preferences.GetString("server.host", "")
-	if host == "" && setting.IsLocal() {
-		host = `127.0.0.1`
-	}
-	address := fmt.Sprintf("%v:%v", host, port)
-	srv := newHTTPServer(address, engine)
+// setFatal records a startup failure that must be surfaced as a non-zero exit
+// code; wait reads it after the graceful shutdown completes. The mutex keeps
+// this race-free when an external signal (not requestShutdown) wakes wait.
+func (r *serveRuntime) setFatal(err error) {
+	r.fatalMu.Lock()
+	defer r.fatalMu.Unlock()
+	r.fatalErr = err
+}
 
-	quit := make(chan os.Signal, 1)
-	signalwatch.ListenSignal(quit)
-	go func() {
-		defer paniclog.Recover("http_server")
-		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("http serve ", "err", err)
-			fmt.Println("http serve ", "err", err)
-			quit <- os.Interrupt
+// fatal returns the recorded startup failure, or nil on a normal run.
+func (r *serveRuntime) fatal() error {
+	r.fatalMu.Lock()
+	defer r.fatalMu.Unlock()
+	return r.fatalErr
+}
+
+// requestShutdown asks the event loop to stop, idempotently and without
+// blocking: an external signal may already be queued, and signal.Notify
+// panics on a closed channel so the channel is never closed.
+func (r *serveRuntime) requestShutdown() {
+	r.shutdownOnce.Do(func() {
+		select {
+		case r.quit <- os.Interrupt:
+		default:
 		}
-	}()
+	})
+}
 
-	slog.Info("GooseForum:listen " + port)
-	slog.Info("use port:" + port)
-	slog.Info("start use:" + cast.ToString(setting.GetUnitTime()))
-	fmt.Println("if in local you can http://localhost:" + port)
-
-	data := <-quit
-	slog.Info("Shutdown Server ...", "signal", data)
+func (r *serveRuntime) wait() error {
+	signal := <-r.quit
+	slog.Info("Shutdown Server ...", "signal", signal)
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
-	if err := srv.Shutdown(shutdownCtx); err != nil {
+	if err := r.server.Shutdown(shutdownCtx); err != nil {
 		slog.Info("Server Shutdown", "err", err)
 	}
 
 	slog.Info("Server exiting")
+	return r.fatal()
 }
 
 func newHTTPServer(address string, handler http.Handler) *http.Server {

--- a/apps/gooseforum/app/console/serve_runtime_test.go
+++ b/apps/gooseforum/app/console/serve_runtime_test.go
@@ -1,0 +1,159 @@
+package console
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/migration"
+	"github.com/gin-gonic/gin"
+)
+
+// newTestServeRuntime builds a serveRuntime bound to an ephemeral port so
+// tests do not collide with the running instance or each other. The migration
+// function is stubbed by the caller via withMigrate and defaults to success.
+func newTestServeRuntime(t *testing.T) *serveRuntime {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on ephemeral port: %v", err)
+	}
+	engine := newGinEngine()
+	gate := middleware.NewStartupGate()
+	engine.Use(gate.Handler)
+	engine.GET("/ready", func(c *gin.Context) { c.Status(http.StatusOK) })
+	rt := &serveRuntime{
+		server:        newHTTPServer(listener.Addr().String(), engine),
+		startupGate:   gate,
+		listener:      listener,
+		quit:          make(chan os.Signal, 1),
+		migrate:       func() error { return nil },
+		startBusiness: func() {},
+	}
+	t.Cleanup(func() {
+		_ = rt.listener.Close()
+	})
+	return rt
+}
+
+// TestServeRuntimeWaitsForQuit verifies the normal shutdown path: an external
+// signal wakes wait and the recorded fatal error is nil.
+func TestServeRuntimeNormalShutdownReturnsNil(t *testing.T) {
+	rt := newTestServeRuntime(t)
+	rt.start()
+
+	rt.requestShutdown()
+	errCh := make(chan error, 1)
+	go func() { errCh <- rt.wait() }()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("wait() after normal shutdown = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait() did not return after requestShutdown")
+	}
+}
+
+// TestServeRuntimeFatalMigrationSurfaces verifies the acceptance criterion
+// "migration failure does not report ready": the gate never completes, the
+// server keeps answering 503 until shutdown, and wait() surfaces the fatal
+// error for a non-zero exit.
+func TestServeRuntimeFatalMigrationSurfaces(t *testing.T) {
+	rt := newTestServeRuntime(t)
+	boom := errors.New("schema migration failed: simulate")
+	rt.migrate = func() error { return boom }
+	rt.start()
+
+	assertPendingGate(t, rt)
+
+	rt.requestShutdown()
+	errCh := make(chan error, 1)
+	go func() { errCh <- rt.wait() }()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, boom) {
+			t.Fatalf("wait() after fatal migration = %v, want %v", err, boom)
+		}
+		if rt.startupGate.Ready() {
+			t.Fatal("startup gate reported ready after a fatal migration failure")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait() did not return after fatal shutdown")
+	}
+}
+
+// TestServeRuntimePanickingMigrationSurfaces verifies the panic path: a panic
+// inside the migration (e.g. an unreachable database panics in dbconnect) must
+// be treated as a fatal startup failure, not swallowed leaving the instance on
+// the 503 loading page forever.
+func TestServeRuntimePanickingMigrationSurfaces(t *testing.T) {
+	rt := newTestServeRuntime(t)
+	rt.migrate = func() error { panic("db unreachable") }
+	rt.start()
+
+	assertPendingGate(t, rt)
+
+	rt.requestShutdown()
+	errCh := make(chan error, 1)
+	go func() { errCh <- rt.wait() }()
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("wait() after panicking migration = nil, want a fatal error")
+		}
+		if rt.startupGate.Ready() {
+			t.Fatal("startup gate reported ready after a panicking migration")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait() did not return after panicking migration shutdown")
+	}
+}
+
+// TestServeRuntimeDeferredMigrationBoots verifies the sentinel path: a
+// deferred migration (Meilisearch unavailable, or the lock held) must NOT block
+// startup — the gate opens and the instance serves.
+func TestServeRuntimeDeferredMigrationBoots(t *testing.T) {
+	rt := newTestServeRuntime(t)
+	rt.migrate = func() error { return migration.ErrRetryLater }
+	rt.start()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get("http://" + rt.listener.Addr().String() + "/ready")
+		if err != nil {
+			t.Fatalf("get during deferred startup: %v", err)
+		}
+		if resp.StatusCode == http.StatusOK {
+			_ = resp.Body.Close()
+			return
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("gate status = %d, want 503 while booting", resp.StatusCode)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("gate never opened after a deferred migration")
+}
+
+func assertPendingGate(t *testing.T, rt *serveRuntime) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://" + rt.listener.Addr().String() + "/ready")
+	if err != nil {
+		t.Fatalf("get during migration: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("gate status during migration = %d, want 503", resp.StatusCode)
+	}
+	if resp.Header.Get("Retry-After") != "5" {
+		t.Fatalf("Retry-After during migration = %q, want 5", resp.Header.Get("Retry-After"))
+	}
+}

--- a/apps/gooseforum/app/console/serve_signing_key_test.go
+++ b/apps/gooseforum/app/console/serve_signing_key_test.go
@@ -57,6 +57,6 @@ func TestServeSigningKeyHelperProcess(t *testing.T) {
 	if os.Getenv(serveSigningKeyHelperEnv) != "1" {
 		return
 	}
-	ginServe()
+	_ = ginServe()
 	os.Exit(0) // 守卫被绕过才到达这里：弱密钥下服务不应启动
 }

--- a/apps/gooseforum/app/http/middleware/startup.go
+++ b/apps/gooseforum/app/http/middleware/startup.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	_ "embed"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/gin-gonic/gin"
+)
+
+//go:embed startup.html
+var startupHTML []byte
+
+// StartupGate keeps every request on a temporary loading page until the
+// startup work (database migration and dependent service boot) completes.
+// Load balancers and health probes observe 503 + Retry-After, so a
+// half-migrated instance is never treated as available.
+type StartupGate struct {
+	ready atomic.Int32
+}
+
+func NewStartupGate() *StartupGate {
+	return &StartupGate{}
+}
+
+// Complete marks the instance as ready to serve business traffic.
+func (g *StartupGate) Complete() {
+	g.ready.Store(1)
+}
+
+// Ready reports whether the startup gate has been opened.
+func (g *StartupGate) Ready() bool {
+	return g.ready.Load() == 1
+}
+
+// Handler returns the loading page until Complete is called, then passes
+// through. It must be registered before any empty routes so nothing
+// DB-dependent runs while the schema/data migrations are still in progress.
+func (g *StartupGate) Handler(c *gin.Context) {
+	if g.ready.Load() == 1 {
+		c.Next()
+		return
+	}
+	c.Header("Retry-After", "5")
+	c.Header("Cache-Control", "no-store, no-cache, must-revalidate")
+	c.Data(http.StatusServiceUnavailable, "text/html; charset=utf-8", startupHTML)
+	c.Abort()
+}

--- a/apps/gooseforum/app/http/middleware/startup.html
+++ b/apps/gooseforum/app/http/middleware/startup.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex,nofollow">
+    <title>系统初始化中</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --ink: #172033;
+            --muted: #697386;
+            --accent: #f5a524;
+        }
+
+        * { box-sizing: border-box; }
+
+        html, body { min-height: 100vh; min-height: 100dvh; }
+
+        body {
+            margin: 0;
+            display: grid;
+            place-items: center;
+            overflow: hidden;
+            background: #fffdf7;
+            color: var(--ink);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif;
+        }
+
+        main {
+            width: min(220px, calc(100vw - 48px));
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 18px;
+        }
+
+        .label {
+            color: var(--muted);
+            font-size: 13px;
+            letter-spacing: .08em;
+        }
+
+        .signal {
+            width: 100%;
+            height: 2px;
+            overflow: hidden;
+            background: #eee8dc;
+        }
+
+        .signal::after {
+            content: "";
+            display: block;
+            width: 34%;
+            height: 100%;
+            background: var(--accent);
+            animation: progress 1.6s ease-in-out infinite;
+        }
+
+        @keyframes progress {
+            from { transform: translateX(-100%); }
+            to { transform: translateX(300%); }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after { animation-duration: 2.5s !important; }
+        }
+    </style>
+</head>
+<body>
+    <main aria-label="系统正在初始化">
+        <div class="label">Loading</div>
+        <div class="signal" aria-hidden="true"></div>
+    </main>
+    <script>
+        window.setTimeout(function () {
+            window.location.reload();
+        }, 3000 + Math.random() * 3000);
+    </script>
+</body>
+</html>

--- a/apps/gooseforum/app/http/middleware/startup_test.go
+++ b/apps/gooseforum/app/http/middleware/startup_test.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestStartupGateBlocksUntilComplete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gate := NewStartupGate()
+	router := gin.New()
+	router.Use(gate.Handler)
+	router.GET("/", func(c *gin.Context) { c.String(http.StatusOK, "ready") })
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusServiceUnavailable ||
+		response.Header().Get("Retry-After") != "5" ||
+		response.Header().Get("Cache-Control") != "no-store, no-cache, must-revalidate" ||
+		!strings.Contains(response.Body.String(), `class="signal"`) {
+		t.Fatalf("pending response = %d %q", response.Code, response.Body.String())
+	}
+
+	gate.Complete()
+	response = httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusOK || response.Body.String() != "ready" {
+		t.Fatalf("ready response = %d %q", response.Code, response.Body.String())
+	}
+}
+
+func TestStartupGateRemainsPendingUntilComplete(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	gate := NewStartupGate()
+	router := gin.New()
+	router.Use(gate.Handler)
+	router.GET("/", func(c *gin.Context) { c.String(http.StatusOK, "ready") })
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	if response.Code != http.StatusServiceUnavailable || !strings.Contains(response.Body.String(), `class="signal"`) {
+		t.Fatalf("pending response = %d %q", response.Code, response.Body.String())
+	}
+}

--- a/apps/gooseforum/app/migration/app_migration.go
+++ b/apps/gooseforum/app/migration/app_migration.go
@@ -1,23 +1,24 @@
 package migration
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/datamigration"
 )
 
-func runVersionedDataMigrations() {
+func runVersionedDataMigrations() error {
 	unlock, err := acquireVersionedMigrationLock()
 	if err != nil {
-		slog.Error("app migration lock unavailable", "err", err)
-		return
+		slog.Warn("app migration lock unavailable; data migrations deferred to a later start", "err", err)
+		return fmt.Errorf("%w: %w", ErrLockUnavailable, err)
 	}
 	defer unlock()
 
 	currentVersion := pageConfig.GetMigrationVersion()
 	if currentVersion >= pageConfig.AppMigrationVersion {
-		return
+		return nil
 	}
 
 	slog.Info("app migration start", "currentVersion", currentVersion, "targetVersion", pageConfig.AppMigrationVersion)
@@ -26,8 +27,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.RebuildReplyMarkdown()
 		slog.Info("app migration rebuild reply markdown done", "processed", result.Processed, "skipped", result.Skipped, "failed", result.Failed)
 		if result.Failed > 0 {
-			slog.Error("app migration rebuild reply markdown has failures", "failed", result.Failed)
-			return
+			return dataMigrationError("rebuild reply markdown", 1, result.Failed, "")
 		}
 		pageConfig.SyncMigrationVersion(1)
 		currentVersion = 1
@@ -36,8 +36,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.BackfillReplySequence()
 		slog.Info("app migration backfill reply sequence done", "articles", result.Articles, "replies", result.Replies, "skipped", result.Skipped, "failed", result.Failed)
 		if result.Failed > 0 {
-			slog.Error("app migration backfill reply sequence has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("backfill reply sequence", 2, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(2)
 		currentVersion = 2
@@ -46,8 +45,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.BackfillArticleUserAction()
 		slog.Info("app migration backfill article user action done", "processed", result.Processed, "skipped", result.Skipped, "failed", result.Failed)
 		if result.Failed > 0 {
-			slog.Error("app migration backfill article user action has failures", "failed", result.Failed)
-			return
+			return dataMigrationError("backfill article user action", 3, result.Failed, "")
 		}
 		pageConfig.SyncMigrationVersion(3)
 		currentVersion = 3
@@ -56,8 +54,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.MigrateSiteChromeContent()
 		slog.Info("app migration site chrome content done", "migrated", result.Migrated, "failed", result.Failed)
 		if result.Failed > 0 {
-			slog.Error("app migration site chrome content has failures", "failed", result.Failed)
-			return
+			return dataMigrationError("site chrome content", 4, result.Failed, "")
 		}
 		pageConfig.SyncMigrationVersion(4)
 		currentVersion = 4
@@ -66,8 +63,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.BackfillTopicPostModel()
 		slog.Info("app migration topic post model done", "topics", result.Topics, "posts", result.Posts, "categories", result.Categories, "topicCategoryIndexes", result.TopicCategoryIndexes, "topicUserActions", result.TopicUserActions, "topicUserStats", result.TopicUserStats, "mappings", result.Mappings, "notifications", result.Notifications, "reportsChecked", result.ReportsChecked, "reportsMissing", result.ReportsMissing, "moderationLogs", result.ModerationLogs, "moderationLogsMissing", result.ModerationLogsMissing, "skipped", result.Skipped, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration topic post model has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("topic post model", 5, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(5)
 		currentVersion = 5
@@ -76,8 +72,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.BackfillModerationLogsTopicPost()
 		slog.Info("app migration moderation log topic post migration done", "moderationLogs", result.ModerationLogs, "moderationLogsMissing", result.ModerationLogsMissing, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration moderation log topic post migration has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("moderation log topic post", 6, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(6)
 		currentVersion = 6
@@ -86,8 +81,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.BackfillFileUsagesTopicPost()
 		slog.Info("app migration file usage topic post migration done", "fileUsages", result.FileUsages, "fileUsagesMissing", result.FileUsagesMissing, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration file usage topic post migration has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("file usage topic post", 7, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(7)
 		currentVersion = 7
@@ -96,8 +90,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.MigrateTopicCountNaming()
 		slog.Info("app migration topic count naming done", "userStatisticsMigrated", result.UserStatisticsMigrated, "dailyStatsMigrated", result.DailyStatsMigrated, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration topic count naming has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("topic count naming", 8, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(8)
 		currentVersion = 8
@@ -107,7 +100,7 @@ func runVersionedDataMigrations() {
 		slog.Info("app migration topic search index done", "skipped", result.Skipped, "rebuilt", result.Rebuilt, "processed", result.ProcessedCount, "failedCount", result.FailedCount, "legacyIndexDeleteTried", result.LegacyIndexDeleteTried, "legacyIndexDeleted", result.LegacyIndexDeleted, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 || result.FailedCount > 0 {
 			slog.Error("app migration topic search index has failures", "failed", result.Failed, "failedCount", result.FailedCount, "lastFailed", result.LastFailed)
-			return
+			return fmt.Errorf("app migration v9 topic search index: %d failed (lastFailed: %s)", result.Failed+result.FailedCount, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(9)
 		currentVersion = 9
@@ -116,8 +109,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.DropReportLegacyColumns()
 		slog.Info("app migration report legacy columns done", "articleIDColumnDropped", result.ArticleIDColumnDropped, "statusArticleIndexDrop", result.StatusArticleIndexDrop, "articleIndexDrop", result.ArticleIndexDrop, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration report legacy columns has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("report legacy columns", 10, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(10)
 		currentVersion = 10
@@ -126,8 +118,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.MigratePointsRecordAction()
 		slog.Info("app migration points record action done", "backfilled", result.Backfilled, "changeReasonColumnDropped", result.ChangeReasonColumnDropped, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration points record action has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("points record action", 11, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(11)
 		currentVersion = 11
@@ -136,8 +127,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.RebuildPostMarkdown()
 		slog.Info("app migration rebuild post markdown done", "processed", result.Processed, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration rebuild post markdown has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("rebuild post markdown", 12, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(12)
 		currentVersion = 12
@@ -148,11 +138,10 @@ func runVersionedDataMigrations() {
 		if result.Skipped {
 			// Meilisearch 不可用：不推进版本，下次启动重试（避免永久跳过索引构建）
 			slog.Warn("app migration aggregate search indexes skipped (meilisearch unavailable), will retry on next start")
-			return
+			return fmt.Errorf("%w: v13 aggregate search indexes (meilisearch unavailable)", ErrRetryLater)
 		}
 		if result.Failed > 0 {
-			slog.Error("app migration aggregate search indexes has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("aggregate search indexes", 13, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(13)
 		currentVersion = 13
@@ -162,8 +151,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.BackfillMissingUserPoints()
 		slog.Info("app migration user points backfill done", "backfilled", result.Backfilled, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration user points backfill has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("user points backfill", 14, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(14)
 		currentVersion = 14
@@ -174,8 +162,7 @@ func runVersionedDataMigrations() {
 		deleteResult := datamigration.BackfillDeleteLifecycle()
 		slog.Info("app migration delete lifecycle backfill done", "topics", deleteResult.TopicsBackfilled, "posts", deleteResult.PostsBackfilled, "failed", deleteResult.Failed, "lastFailed", deleteResult.LastFailed)
 		if deleteResult.Failed > 0 {
-			slog.Error("app migration delete lifecycle backfill has failures", "failed", deleteResult.Failed, "lastFailed", deleteResult.LastFailed)
-			return
+			return dataMigrationError("delete lifecycle backfill", 15, deleteResult.Failed, deleteResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(15)
 		currentVersion = 15
@@ -185,8 +172,7 @@ func runVersionedDataMigrations() {
 		result := datamigration.DropUserOAuthTokenColumns()
 		slog.Info("app migration user oauth credentials drop done", "dropped", result.Dropped, "failed", result.Failed, "lastFailed", result.LastFailed)
 		if result.Failed > 0 {
-			slog.Error("app migration user oauth credentials drop has failures", "failed", result.Failed, "lastFailed", result.LastFailed)
-			return
+			return dataMigrationError("user oauth credentials drop", 16, result.Failed, result.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(16)
 		currentVersion = 16
@@ -198,8 +184,7 @@ func runVersionedDataMigrations() {
 		anchorResult := datamigration.BackfillCourseReviewDeleteAnchors()
 		slog.Info("app migration course review delete anchor backfill done", "backfilled", anchorResult.Backfilled, "failed", anchorResult.Failed, "lastFailed", anchorResult.LastFailed)
 		if anchorResult.Failed > 0 {
-			slog.Error("app migration course review delete anchor backfill has failures", "failed", anchorResult.Failed, "lastFailed", anchorResult.LastFailed)
-			return
+			return dataMigrationError("course review delete anchor backfill", 17, anchorResult.Failed, anchorResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(17)
 		currentVersion = 17
@@ -211,8 +196,7 @@ func runVersionedDataMigrations() {
 		backfillResult := datamigration.BackfillPostRevisionSeeds()
 		slog.Info("app migration post revision seed backfill done", "seeded", backfillResult.Seeded, "skipped", backfillResult.Skipped, "failed", backfillResult.Failed, "lastFailed", backfillResult.LastFailed)
 		if backfillResult.Failed > 0 {
-			slog.Error("app migration post revision seed backfill has failures", "failed", backfillResult.Failed, "lastFailed", backfillResult.LastFailed)
-			return
+			return dataMigrationError("post revision seed backfill", 18, backfillResult.Failed, backfillResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(18)
 		currentVersion = 18
@@ -232,8 +216,7 @@ func runVersionedDataMigrations() {
 			"failed", singleSourceResult.Failed,
 			"lastFailed", singleSourceResult.LastFailed)
 		if singleSourceResult.Failed > 0 {
-			slog.Error("app migration wiki single source backfill has failures", "failed", singleSourceResult.Failed, "lastFailed", singleSourceResult.LastFailed)
-			return
+			return dataMigrationError("wiki single source backfill", 19, singleSourceResult.Failed, singleSourceResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(19)
 		currentVersion = 19
@@ -253,11 +236,11 @@ func runVersionedDataMigrations() {
 			"lastFailed", topicIndexResult.LastFailed)
 		if topicIndexResult.Skipped {
 			slog.Warn("app migration topic search index topicType rebuild skipped (meilisearch unavailable), will retry on next start")
-			return
+			return fmt.Errorf("%w: v20 topic search index topicType rebuild (meilisearch unavailable)", ErrRetryLater)
 		}
 		if topicIndexResult.Failed > 0 || topicIndexResult.FailedCount > 0 {
 			slog.Error("app migration topic search index topicType rebuild has failures", "failed", topicIndexResult.Failed, "failedCount", topicIndexResult.FailedCount, "lastFailed", topicIndexResult.LastFailed)
-			return
+			return fmt.Errorf("app migration v20 topic search index topicType rebuild: %d failed (lastFailed: %s)", topicIndexResult.Failed+topicIndexResult.FailedCount, topicIndexResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(20)
 		currentVersion = 20
@@ -274,8 +257,7 @@ func runVersionedDataMigrations() {
 			"failed", gitSSOTResult.Failed,
 			"lastFailed", gitSSOTResult.LastFailed)
 		if gitSSOTResult.Failed > 0 {
-			slog.Error("app migration wiki git ssot backfill has failures", "failed", gitSSOTResult.Failed, "lastFailed", gitSSOTResult.LastFailed)
-			return
+			return dataMigrationError("wiki git ssot backfill", 21, gitSSOTResult.Failed, gitSSOTResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(21)
 		currentVersion = 21
@@ -297,8 +279,7 @@ func runVersionedDataMigrations() {
 			"failed", sourcePathResult.Failed,
 			"lastFailed", sourcePathResult.LastFailed)
 		if sourcePathResult.Failed > 0 {
-			slog.Error("app migration wiki page source_path backfill has failures", "failed", sourcePathResult.Failed, "lastFailed", sourcePathResult.LastFailed)
-			return
+			return dataMigrationError("wiki page source_path backfill", 23, sourcePathResult.Failed, sourcePathResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(23)
 		currentVersion = 23
@@ -317,8 +298,7 @@ func runVersionedDataMigrations() {
 			"failed", slugRemoval.Failed,
 			"lastFailed", slugRemoval.LastFailed)
 		if slugRemoval.Failed > 0 {
-			slog.Error("app migration wiki slug removal has failures", "failed", slugRemoval.Failed, "lastFailed", slugRemoval.LastFailed)
-			return
+			return dataMigrationError("wiki slug removal", 24, slugRemoval.Failed, slugRemoval.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(24)
 		currentVersion = 24
@@ -336,11 +316,16 @@ func runVersionedDataMigrations() {
 			"failed", secretResult.Failed,
 			"lastFailed", secretResult.LastFailed)
 		if secretResult.Failed > 0 {
-			slog.Error("app migration admin secret plaintext encryption has failures", "failed", secretResult.Failed, "lastFailed", secretResult.LastFailed)
-			return
+			return dataMigrationError("admin secret plaintext encryption", 25, secretResult.Failed, secretResult.LastFailed)
 		}
 		pageConfig.SyncMigrationVersion(25)
 		currentVersion = 25
 	}
 	slog.Info("app migration end", "version", currentVersion)
+	return nil
+}
+
+func dataMigrationError(name string, version int, failed int, lastFailed any) error {
+	slog.Error("app migration "+name+" has failures", "failed", failed, "lastFailed", lastFailed)
+	return fmt.Errorf("app migration v%d %s: %d failed (lastFailed: %v)", version, name, failed, lastFailed)
 }

--- a/apps/gooseforum/app/migration/errors.go
+++ b/apps/gooseforum/app/migration/errors.go
@@ -1,0 +1,23 @@
+package migration
+
+import "errors"
+
+// ErrLockUnavailable reports that the versioned data migration lock could not
+// be acquired because another instance is (or recently was) migrating. It is
+// non-fatal: schema has already been applied and data migrations will retry on
+// a later start, so serve proceeds and the standalone migrate command reports
+// "skipped" and exits successfully.
+var ErrLockUnavailable = errors.New("migration: versioned migration lock unavailable")
+
+// ErrRetryLater reports that a versioned data migration was deferred (e.g.
+// Meilisearch unavailable) and the migration version was intentionally not
+// advanced. It is non-fatal: serve proceeds with degraded functionality and
+// the standalone migrate command reports "deferred" and exits successfully.
+var ErrRetryLater = errors.New("migration: deferred, will retry on next run")
+
+// Deferred reports whether err is a non-fatal migration outcome that must not
+// block startup or fail a release step: either the versioned migration lock is
+// held by another instance, or a data migration was deferred to a later run.
+func Deferred(err error) bool {
+	return errors.Is(err, ErrRetryLater) || errors.Is(err, ErrLockUnavailable)
+}

--- a/apps/gooseforum/app/migration/errors_test.go
+++ b/apps/gooseforum/app/migration/errors_test.go
@@ -1,0 +1,30 @@
+package migration
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestDeferredClassifiesMigrationOutcomes(t *testing.T) {
+	hard := errors.New("app migration v25 admin secret plaintext encryption: 3 failed")
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "hard failure", err: hard, want: false},
+		{name: "generic error", err: errors.New("boom"), want: false},
+		{name: "lock unavailable", err: fmt.Errorf("%w: sqlite lock still held", ErrLockUnavailable), want: true},
+		{name: "retry later", err: fmt.Errorf("%w: v13 aggregate search indexes", ErrRetryLater), want: true},
+		{name: "wrapped hard failure", err: fmt.Errorf("run migrations: %w", hard), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Deferred(tt.err); got != tt.want {
+				t.Fatalf("Deferred(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/gooseforum/app/migration/migration.go
+++ b/apps/gooseforum/app/migration/migration.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
-	"os"
 	"regexp"
 	"strings"
 
@@ -64,52 +63,53 @@ import (
 	"gorm.io/gorm"
 )
 
-func M() {
+// M runs the schema migration and versioned data migration, returning an
+// error on any failure. It does not decide process policy: callers choose
+// whether a returned error is fatal (serve via the startup gate, the standalone
+// migrate command) or tolerated (other CLI commands). Sentinels let callers
+// distinguish "deferred, retry later" (ErrRetryLater) and
+// "another instance holds the migration lock" (ErrLockUnavailable) from a hard
+// failure.
+func M() error {
 	if !setting.UseMigration() {
-		return
+		return nil
 	}
-	migrateSchema()
-	runVersionedDataMigrations()
+	if err := migrateSchema(); err != nil {
+		return err
+	}
+	return runVersionedDataMigrations()
 }
 
-func migrateSchema() {
+func migrateSchema() error {
 	var err error
 
 	db := dbconnect.Connect()
 	if err = validateUniqueUserEmails(db); err != nil {
-		slog.Error("dbconnect migration email uniqueness preflight failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect migration email uniqueness preflight failed: %w", err)
 	}
 	if err = validateUniqueUsernames(db); err != nil {
-		slog.Error("dbconnect migration preflight failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect migration preflight failed: %w", err)
 	}
 	if err = upgradeCourseReviewLegacySchema(db); err != nil {
-		slog.Error("dbconnect course_review legacy upgrade failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect course_review legacy upgrade failed: %w", err)
 	}
 	if err = dedupeWikiRevisionNumbers(db); err != nil {
-		slog.Error("dbconnect wiki revision dedupe failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect wiki revision dedupe failed: %w", err)
 	}
 	if err = upgradeImportRunCompositeIndex(db); err != nil {
-		slog.Error("dbconnect course_import_run index upgrade failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect course_import_run index upgrade failed: %w", err)
 	}
 	if err = upgradeCourseTeacherIdentity(db); err != nil {
-		slog.Error("dbconnect course teacher identity upgrade failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect course teacher identity upgrade failed: %w", err)
 	}
 	if err = upgradeCourseAiSummaryStatusIndex(db); err != nil {
-		slog.Error("dbconnect course_ai_summary status index upgrade failed", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect course_ai_summary status index upgrade failed: %w", err)
 	}
 	if err = db.AutoMigrate(SchemaModels()...); err != nil {
-		// 迁移失败必须立即退出（非零码），否则服务会带着残缺 schema 继续启动，
+		// 迁移失败必须上层按非零码退出，否则服务会带着残缺 schema 继续启动，
 		// 登录/注册等依赖新表的接口在运行期才会报错，故障被发现时已影响线上。
 		// 进程管理器会因此把实例标记为启动失败，触发回滚或告警。
-		slog.Error("dbconnect migration err", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("dbconnect migration err: %w", err)
 	}
 	slog.Info("dbconnect migration end")
 
@@ -117,10 +117,10 @@ func migrateSchema() {
 	if err = db4file.AutoMigrate(
 		&filedata.Entity{},
 	); err != nil {
-		slog.Error("db4fileconnect migration err", "err", err)
-		os.Exit(1)
+		return fmt.Errorf("db4fileconnect migration err: %w", err)
 	}
 	slog.Info("db4fileconnect migration end")
+	return nil
 }
 
 type duplicateUsername struct {

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -48,7 +48,7 @@
 
 | Layer | Responsibility |
 |---|---|
-| `app/console` | cobra CLI (serve / mock / rebuild-search-index / migrate-files ...) |
+| `app/console` | cobra CLI (serve / migrate / mock / rebuild-search-index / migrate-files ...) |
 | `app/bundles` | Utilities (connect/eventbus/jwtopt/i18n/captcha/logging/cache ...) |
 | `app/models` | GORM models + migrations (app/migration) |
 | `app/service` | Business logic (users/topics/mail/oauth/theme/wikiservice ...) |

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -209,13 +209,27 @@ make build     # cd apps/gooseforum/resource && pnpm build → cd apps/gooseforu
 
 ## DB migration execution and rollback
 
-- Migrations run at startup (`[db] migration = "on"`); append-only upstream style.
-- **Migration failures now abort startup** (since the issue #8 PG fix): if `AutoMigrate` errors,
-  `serve` exits non-zero instead of continuing with a partial schema. This makes deploy.sh's
-  health-check rollback and container restart policies catch schema problems immediately instead of
-  surfacing as runtime API failures (the original issue #8 login/register outage). It also means a
-  deploy with an incompatible schema change will roll back — rehearse on dev (which syncs main's db)
-  before main.
+- Migrations run at service startup behind a **startup gate** (`[db] migration = "on"`, the default):
+  the HTTP listener binds immediately but every request — including `GET /health` — receives
+  `503 Service Unavailable` with `Retry-After: 5` and the loading page until the schema migration
+  (`app/migration` AutoMigrate) and versioned data migrations complete. Only after success does
+  `serve` boot the business services (workers, cron, OAuth/OIDC init, wiki sync) and open the gate.
+- **Migration failures abort startup** (since the issue #8 PG fix, extended by #370): if `AutoMigrate`
+  or any versioned data migration errors, `serve` reports the error, never opens the gate, shuts down
+  gracefully and **exits non-zero**. exit semantics: a hard failure is fatal (non-zero exit, gate never
+  opened); a deferred data migration (e.g. Meilisearch unavailable, or the cross-instance migration
+  lock held by another instance) is non-fatal — the gate opens and the instance serves with degraded
+  state, retrying deferred migrations on the next start. This makes deploy.sh's health-check rollback
+  and container restart policies catch schema problems immediately instead of surfacing as runtime API
+  failures (the original issue #8 login/register outage). It also means a deploy with an incompatible
+  schema change will roll back — rehearse on dev (which syncs main's db) before main.
+- **Standalone `migrate` command**: `./yourtj-hub migrate` runs schema + versioned data migrations
+  explicitly, so a release step can apply them before traffic-bearing instances start. It exits with
+  a non-zero code on a hard migration failure (with an actionable `lastFailed` message), and exits 0
+  with a "deferred / will retry on next run" message for deferred or lock-held states.
+- **`[db] migration = "off"`**: the operator owns schema. `serve` opens the startup gate immediately
+  (readiness is not gated on migration) and the `migrate` command reports migrations are disabled and
+  exits 0.
 - Rollback: `deploy.sh` tags the previous image `ghcr.io/yourtongji/yourtj-hub:prev` and re-points
   the instance on health-check failure; forward-compatible migrations mean an older binary can still start.
 


### PR DESCRIPTION
Closes #370

## 上游依据

同步 [leancodebox/GooseForum c431384a · feat: gate server startup on database migration](https://github.com/leancodebox/GooseForum/commit/c431384a)，结合 YourTJ-Hub 现有单二进制部署、OIDC/搜索/worker 启动序列与 `db.migration = on/off` 语义做兼容设计。

## 变更内容

### 启动门闸（startup gate）

- 新增 `StartupGate` 中间件（`app/http/middleware/startup.go`）：在数据库 Schema + 版本化数据迁移完成前，**所有请求**（含 `GET /health`）返回 `503` + `Retry-After: 5` + 初始化加载页，负载均衡器不会把半迁移实例当作可用实例。
- `serve` 重构为 `prepareServeRuntime → newServeRuntime → start → wait`：监听器先绑定（加载页可达），迁移成功后才启动 worker/cron/OAuth/OIDC/wiki 同步等全部 DB 依赖业务服务并打开门闸。
- 中间件注册顺序关键点（gin 路由注册时快照处理器链）：gate 必须在 `RegisterByGin` 之前作为第一个中间件注册，否则静默失效。

### 非零退出语义

- `migration.M()` / `migrateSchema()` / `runVersionedDataMigrations()` 改为返回 `error`，移除包内 `os.Exit`。
- Schema 或版本化数据迁移**硬失败**（以及迁移路径 panic，如 `dbconnect.Connect` 对不可达库直接 panic）：记录 fatal、优雅关闭后 **exit 1**，门闸永不打开。
- 非致命 sentinel（`ErrLockUnavailable` 另一实例持锁、`ErrRetryLater` Meilisearch 不可用等重试场景）：保持历史 log-and-proceed 行为，门闸照常打开、以降级状态服务。
- `Execute()` 调整：`closer.CloseAll()` 在 `cobra.CheckErr` 之前执行（原 `defer` 在错误路径会被 `os.Exit` 跳过）。

### `migrate` 命令

- 新增 `./yourtj-hub migrate`：部署前显式执行迁移；硬失败非零退出并输出可操作 `lastFailed` 信息，deferred/持锁状态退出 0 并给出明确消息。

### 现有 CLI 命令兼容

- `root.go` `PersistentPreRun` 按命令名分发：仅 `serve` 跳过（由门闸 goroutine 管理），其余命令（`set-user-admin`、`seed-demo`、`course-import` 等约 15 个依赖 DB 的命令）保持「启动即同步迁移」的既有行为，避免全新库上缺表回归。

### `[db] migration = off`

- 门闸立即打开（operator 自管 schema），`migrate` 命令输出 disabled 信息并退出 0。

## 验证（本地实际执行）

- `cd apps/gooseforum && go vet ./...` — 通过
- `go test ./...` — 93 个包全部通过，0 失败
- PG 迁移门禁：`YOURTJ_TEST_PG_URL=... go test ./app/migration/ -run TestSchema` — 通过
- `golangci-lint run --new-from-rev=origin/dev` — 0 issues
- `git diff --check` — 通过
- pre-push hooks（lefthook）：`go vet` + `golangci-lint` + `pnpm typecheck` — 全部通过
- 端到端 smoke（本地 SQLite）：`serve` 启动后 `/health` 在迁移窗口返回 503（加载页），迁移完成（Meili deferred）后 gate 打开返回 200，SIGTERM 优雅退出；`migrate` 命令输出 deferred 消息并退出 0
- 新增测试：`startup_test.go`（gate 503→200）、`serve_runtime_test.go`（正常关闭/fatal/panic/deferred 四路径，`-race` 通过）、`errors_test.go`（sentinel 分类）

## 契约影响

无。未新增任何 `/api` 路由；`migrate` 为 CLI 命令；`/health` 迁移期间的瞬时 503 不属于契约变更。路由覆盖率门禁不受影响。

## 文档

- `docs/operations/deployment.md`：启动门闸/503 语义、`migrate` 命令、off 模式 readiness、与 deploy.sh 180s 健康窗口的交互
- `docs/architecture/system-overview.md`：CLI 命令清单
- `apps/gooseforum/README(.ZH).md` + 内部 `AGENTS.md`：CLI 命令清单

## 关注点（供 reviewer）

- 迁移期间 `/health` 返回 503 是**有意为之**：`deploy.sh` 的 180s 健康等待窗口本就预算了 AutoMigrate 时间，出口语义与现状兼容且更明确（conn-refused → 503）。
- `eventbus.Start`（PersistentPreRun）先于 serve 的迁移 goroutine：仅当数据迁移发布事件时才需要移动，已在 root.go 注释中记录该不变量。