### PR TITLE
fix: 登录/注册/重置密码表单密码框增加明文切换按钮 (issue #375)

### DIFF
--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -145,6 +145,8 @@ export default {
     password: 'Password',
     newPassword: 'New password',
     confirmPassword: 'Confirm password',
+    showPassword: 'Show password',
+    hidePassword: 'Hide password',
     captcha: 'Captcha',
     captchaAlt: 'Captcha',
     forgotPassword: 'Forgot password?',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -145,6 +145,8 @@ export default {
     password: 'Password',
     newPassword: 'Nuova password',
     confirmPassword: 'Conferma password',
+    showPassword: 'Mostra password',
+    hidePassword: 'Nascondi password',
     captcha: 'Captcha',
     captchaAlt: 'Captcha',
     forgotPassword: 'Password dimenticata?',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -145,6 +145,8 @@ export default {
     password: 'パスワード',
     newPassword: '新しいパスワード',
     confirmPassword: 'パスワード確認',
+    showPassword: 'パスワードを表示',
+    hidePassword: 'パスワードを隠す',
     captcha: '認証コード',
     captchaAlt: '認証コード',
     forgotPassword: 'パスワードを忘れましたか？',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -145,6 +145,8 @@ export default {
     password: '密码',
     newPassword: '新密码',
     confirmPassword: '确认密码',
+    showPassword: '显示密码',
+    hidePassword: '隐藏密码',
     captcha: '验证码',
     captchaAlt: '验证码',
     forgotPassword: '忘记密码？',

--- a/apps/gooseforum/resource/src/site/components/PasswordInput.vue
+++ b/apps/gooseforum/resource/src/site/components/PasswordInput.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Eye, EyeOff, LockKeyhole } from '@lucide/vue'
+import { useI18n } from 'vue-i18n'
+
+/**
+ * 带左侧锁图标与右侧明文/密文切换按钮的密码输入框（issue #375）。
+ * 兼容现有内联写法：外层 relative block 包裹、左侧图标绝对定位，
+ * 右侧切换按钮不干扰左侧定位与表单提交。v-model 绑定到输入值。
+ */
+const model = defineModel<string>({ default: '' })
+
+defineProps<{
+  placeholder?: string
+  autocomplete?: string
+  /** 可访问名称（sr-only label 的文本），同时作为切换按钮的 aria-label 来源 */
+  label?: string
+}>()
+
+const { t } = useI18n()
+const show = ref(false)
+</script>
+
+<template>
+  <span class="relative block">
+    <LockKeyhole class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
+    <input
+      v-model="model"
+      :type="show ? 'text' : 'password'"
+      class="gf-input pl-10 pr-11"
+      :placeholder="placeholder"
+      :autocomplete="autocomplete"
+      :aria-label="label"
+    />
+    <button
+      type="button"
+      class="absolute right-2 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-md text-base-content/55 transition-colors duration-150 hover:bg-base-300/60 hover:text-base-content focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-primary"
+      :aria-label="show ? t('auth.hidePassword') : t('auth.showPassword')"
+      :title="show ? t('auth.hidePassword') : t('auth.showPassword')"
+      :aria-pressed="show"
+      @click="show = !show"
+    >
+      <EyeOff v-if="show" class="h-4 w-4" />
+      <Eye v-else class="h-4 w-4" />
+    </button>
+  </span>
+</template>

--- a/apps/gooseforum/resource/src/site/pages/LoginPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/LoginPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref } from 'vue'
-import { LoaderCircle, Languages, LockKeyhole, Mail, Moon, ShieldCheck, Sun, UserRound } from '@lucide/vue'
+import { LoaderCircle, Languages, Mail, Moon, ShieldCheck, Sun, UserRound } from '@lucide/vue'
 import { useI18n } from 'vue-i18n'
+import PasswordInput from '@/site/components/PasswordInput.vue'
 import { forgotPassword, getCaptcha, login, register, verifyTotp } from '@/runtime/api'
 import { queueFlashMessage } from '@/runtime/flash-message'
 import { setLocale, supportedLocales, type Locale } from '@/runtime/i18n'
@@ -355,10 +356,7 @@ function onToggleTheme(event: MouseEvent) {
             </label>
             <label class="block">
               <span class="sr-only">{{ t('auth.password') }}</span>
-              <span class="relative block">
-                <LockKeyhole class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
-                <input v-model="loginForm.password" type="password" class="gf-input pl-10" :placeholder="t('auth.password')" autocomplete="current-password" />
-              </span>
+              <PasswordInput v-model="loginForm.password" :placeholder="t('auth.password')" autocomplete="current-password" :label="t('auth.password')" />
             </label>
             <div class="flex gap-3">
               <input v-model.trim="loginForm.captcha" class="gf-input min-w-0 flex-1" :placeholder="t('auth.captcha')" />
@@ -393,17 +391,11 @@ function onToggleTheme(event: MouseEvent) {
             </label>
             <label class="block">
               <span class="sr-only">{{ t('auth.password') }}</span>
-              <span class="relative block">
-                <LockKeyhole class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
-                <input v-model="registerForm.password" type="password" class="gf-input pl-10" :placeholder="t('auth.password')" autocomplete="new-password" />
-              </span>
+              <PasswordInput v-model="registerForm.password" :placeholder="t('auth.password')" autocomplete="new-password" :label="t('auth.password')" />
             </label>
             <label class="block">
               <span class="sr-only">{{ t('auth.confirmPassword') }}</span>
-              <span class="relative block">
-                <LockKeyhole class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
-                <input v-model="registerForm.confirmPassword" type="password" class="gf-input pl-10" :placeholder="t('auth.confirmPassword')" autocomplete="new-password" />
-              </span>
+              <PasswordInput v-model="registerForm.confirmPassword" :placeholder="t('auth.confirmPassword')" autocomplete="new-password" :label="t('auth.confirmPassword')" />
             </label>
             <div class="flex gap-3">
               <span class="relative min-w-0 flex-1">

--- a/apps/gooseforum/resource/src/site/pages/ResetPasswordPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/ResetPasswordPage.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { Check, LoaderCircle, LockKeyhole } from '@lucide/vue'
+import { Check, LoaderCircle } from '@lucide/vue'
 import { resetPassword } from '@/runtime/api'
+import PasswordInput from '@/site/components/PasswordInput.vue'
 import type { LayoutPayload, ResetPasswordPageProps } from '@gooseforum/client'
 
 const page = defineProps<{
@@ -77,17 +78,11 @@ async function submit() {
           <form class="space-y-3.5" @submit.prevent="submit">
             <label class="block">
               <span class="sr-only">{{ t('auth.newPassword') }}</span>
-              <span class="relative block">
-                <LockKeyhole class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
-                <input v-model="form.password" type="password" class="gf-input pl-10" :placeholder="t('auth.newPassword')" autocomplete="new-password" />
-              </span>
+              <PasswordInput v-model="form.password" :placeholder="t('auth.newPassword')" autocomplete="new-password" :label="t('auth.newPassword')" />
             </label>
             <label class="block">
               <span class="sr-only">{{ t('auth.confirmPassword') }}</span>
-              <span class="relative block">
-                <LockKeyhole class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
-                <input v-model="form.confirmPassword" type="password" class="gf-input pl-10" :placeholder="t('auth.confirmPassword')" autocomplete="new-password" />
-              </span>
+              <PasswordInput v-model="form.confirmPassword" :placeholder="t('auth.confirmPassword')" autocomplete="new-password" :label="t('auth.confirmPassword')" />
             </label>
             <button type="submit" class="gf-button gf-button-xl gf-button-primary w-full" :disabled="!canSubmit">
               <LoaderCircle v-if="loading" class="h-4 w-4 animate-spin" />

--- a/apps/gooseforum/resource/test/password-input.test.ts
+++ b/apps/gooseforum/resource/test/password-input.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+import { describe, expect, test } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { i18n } from '../src/runtime/i18n'
+import PasswordInput from '../src/site/components/PasswordInput.vue'
+
+function mountInput() {
+  return mount(PasswordInput, {
+    props: { placeholder: '密码', label: '密码' },
+    global: { plugins: [i18n] },
+    attachTo: document.body,
+  })
+}
+
+describe('PasswordInput 明文/密文切换（issue #375）', () => {
+  test('默认密文输入，切换按钮 aria 状态为“显示密码”', () => {
+    const wrapper = mountInput()
+    const input = wrapper.find('input')
+    expect(input.attributes('type')).toBe('password')
+    const toggle = wrapper.find('button')
+    expect(toggle.attributes('aria-label')).toBe(i18n.global.t('auth.showPassword'))
+    expect(toggle.attributes('aria-pressed')).toBe('false')
+  })
+
+  test('点击切换按钮后输入框变为明文，图标状态同步为“隐藏密码”', async () => {
+    const wrapper = mountInput()
+    const toggle = wrapper.find('button')
+    await toggle.trigger('click')
+    expect(wrapper.find('input').attributes('type')).toBe('text')
+    expect(toggle.attributes('aria-label')).toBe(i18n.global.t('auth.hidePassword'))
+    expect(toggle.attributes('aria-pressed')).toBe('true')
+    // 再点一次恢复密文
+    await toggle.trigger('click')
+    expect(wrapper.find('input').attributes('type')).toBe('password')
+  })
+
+  test('v-model 双向绑定输入值', async () => {
+    const wrapper = mountInput()
+    await wrapper.find('input').setValue('secret')
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['secret'])
+  })
+})


### PR DESCRIPTION
## 背景

Issue #375：登录、注册、重置密码页面的所有密码输入框均为纯 `type="password"`，无明文/密文切换按钮。移动端键盘与自动纠错环境下长/随机密码极易输入失败，且确认密码无法临时明文核对。

## 变更

- 新增共享组件 `PasswordInput.vue`（`apps/gooseforum/resource/src/site/components/`）：左侧锁图标 + 右侧 `Eye`/`EyeOff` 明文切换按钮，`v-model` 绑定输入值。
  - 点击在 `password` / `text` 间切换，图标状态同步（`Eye` ↔ `EyeOff`）。
  - 按钮提供 i18n 化的 `aria-label`/`title`（`auth.showPassword` / `auth.hidePassword`）及 `aria-pressed` 状态。
  - `type="button"`，不干扰左侧图标定位与表单提交。
- 统一应用到 5 处密码输入框：
  - 登录页：登录密码、注册密码、注册确认密码（`LoginPage.vue`）
  - 重置密码页：新密码、确认密码（`ResetPasswordPage.vue`）
- 新增 i18n 键 `auth.showPassword` / `auth.hidePassword` 至 zh/en/ja/it 四种语言。
- 新增组件单元测试 `password-input.test.ts`，覆盖默认密文、点击切换、图标状态同步与 v-model 双向绑定。

## 验证

- `pnpm typecheck` ✅（含 `@gooseforum/client` 构建）
- `pnpm vitest run test/password-input.test.ts` ✅（3 个用例全过）
- `pnpm build` ✅
- `pnpm test` 全量：290 passed；8 failed 均为 `schedule-major-selector` / `schedule-rough-list-drop` 中 `localStorage.clear()` 环境问题（happy-dom 未注入 localStorage），与本改动无关、属于既有环境失败。
- pre-push hook：`go vet` / `golangci-lint` / `frontend typecheck` 全部通过。

## 文档影响

本改动为既有 `Current` 能力（密码登录/注册/重置）的 UI 缺陷修复，不改变任何能力状态词或访问语义，无需 docs center 变更；组件内含说明注释。

## 备注

未关闭 Issue #375。