### PR TITLE
fix(migration): 课评聚合回填 FindInBatches 需声明主键，修复真实数据量下启动崩溃

### DIFF
--- a/apps/gooseforum/app/migration/course_aggregation_upgrade_test.go
+++ b/apps/gooseforum/app/migration/course_aggregation_upgrade_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -239,4 +240,98 @@ func TestCourseAggregationUpgradeFromLegacySchemaOnPostgreSQL(t *testing.T) {
 		}
 	}
 	exerciseCourseAggregationUpgrade(t, db)
+}
+
+// TestCourseAggregationUpgradeLargeBatch 回归: 真实库 course_source_ref 超过
+// FindInBatches 批大小(500)时, 无主键裸结构体分页报 "primary key required"
+// (dev 部署事故根因: offering 21941 / instructor 4318 行, 均 > 500)。
+// 修复后升级必须完整成功且回填正确(offering.teaching_class_id / instructor.teacher_code)。
+func TestCourseAggregationUpgradeLargeBatch(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	const n = 1100 // > 500, 强制走 keyset 分页分支
+	if err := db.AutoMigrate(
+		&legacyAggregationCourseEntity{},
+		&legacyAggregationOfferingEntity{},
+		&legacyAggregationInstructorEntity{},
+		&course.SourceRefEntity{},
+	); err != nil {
+		t.Fatalf("migrate legacy schema: %v", err)
+	}
+	courseRow := legacyAggregationCourseEntity{PrimaryCode: "12200402", Name: "高等数学(B)上", Status: 0}
+	if err := db.Create(&courseRow).Error; err != nil {
+		t.Fatalf("seed legacy course: %v", err)
+	}
+	offerings := make([]legacyAggregationOfferingEntity, n)
+	for i := range offerings {
+		offerings[i] = legacyAggregationOfferingEntity{CourseId: courseRow.Id, TermId: 1, Status: 0}
+	}
+	if err := db.Create(&offerings).Error; err != nil {
+		t.Fatalf("seed legacy offerings: %v", err)
+	}
+	offeringRefs := make([]course.SourceRefEntity, n)
+	for i := range offeringRefs {
+		offeringRefs[i] = course.SourceRefEntity{
+			Source: "jcourse-snapshot-20260814", EntityType: course.EntityTypeOffering,
+			ExternalId: fmt.Sprintf("%d-42", 100000+i), LocalId: offerings[i].Id,
+			Checksum: fmt.Sprintf("offering-%d", i),
+		}
+	}
+	if err := db.Create(&offeringRefs).Error; err != nil {
+		t.Fatalf("seed offering source_refs: %v", err)
+	}
+	instructors := make([]legacyAggregationInstructorEntity, n)
+	for i := range instructors {
+		instructors[i] = legacyAggregationInstructorEntity{
+			Name: fmt.Sprintf("教师%04d", i), NormalizedName: fmt.Sprintf("教师%04d", i),
+			Department: "数学科学学院",
+		}
+	}
+	if err := db.Create(&instructors).Error; err != nil {
+		t.Fatalf("seed legacy instructors: %v", err)
+	}
+	instructorRefs := make([]course.SourceRefEntity, n)
+	for i := range instructorRefs {
+		instructorRefs[i] = course.SourceRefEntity{
+			Source: "jcourse-snapshot-20260814", EntityType: course.EntityTypeInstructor,
+			ExternalId: fmt.Sprintf("T%05d", 10000+i), LocalId: instructors[i].Id,
+			Checksum: fmt.Sprintf("instructor-%d", i),
+		}
+	}
+	if err := db.Create(&instructorRefs).Error; err != nil {
+		t.Fatalf("seed instructor source_refs: %v", err)
+	}
+
+	if err := upgradeCourseAggregation(db); err != nil {
+		t.Fatalf("upgrade aggregation on >500-row backfill: %v", err)
+	}
+	// 与 migrateSchema 一致: upgrade* 后统一 AutoMigrate 新模型。
+	if err := db.AutoMigrate(
+		&course.Entity{},
+		&course.OfferingEntity{},
+		&course.InstructorEntity{},
+		&course.RelationEntity{},
+	); err != nil {
+		t.Fatalf("migrate new course models: %v", err)
+	}
+
+	// 抽样断言: 跨批次边界(499/500/501)与尾部行回填正确。
+	for _, i := range []int{0, 499, 500, 777, 1099} {
+		var got course.OfferingEntity
+		if err := db.First(&got, "id = ?", offerings[i].Id).Error; err != nil {
+			t.Fatalf("load offering %d: %v", i, err)
+		}
+		if want := uint64(100000 + i); got.TeachingClassId != want {
+			t.Fatalf("offering %d teaching_class_id = %d, want %d", i, got.TeachingClassId, want)
+		}
+		var ins course.InstructorEntity
+		if err := db.First(&ins, "id = ?", instructors[i].Id).Error; err != nil {
+			t.Fatalf("load instructor %d: %v", i, err)
+		}
+		if want := fmt.Sprintf("T%05d", 10000+i); ins.TeacherCode != want {
+			t.Fatalf("instructor %d teacher_code = %q, want %q", i, ins.TeacherCode, want)
+		}
+	}
 }

--- a/apps/gooseforum/app/migration/migration.go
+++ b/apps/gooseforum/app/migration/migration.go
@@ -311,15 +311,18 @@ func backfillOfferingTeachingClass(db *gorm.DB) error {
 		return nil
 	}
 	type refRow struct {
+		Id         uint64 `gorm:"primaryKey"`
 		ExternalId string
 		LocalId    uint64
 	}
 	var rows []refRow
 	backfilled := 0
 	// 分批处理（review nit：整表全量读入内存后逐行 UPDATE → FindInBatches 分批，
-	// 课程域量级上涨时不占峰值内存）。
+	// 课程域量级上涨时不占峰值内存）。refRow 必须声明主键: GORM FindInBatches
+	// 在批次打满后按主键 keyset 分页, 无主键结构体报 ErrPrimaryKeyRequired
+	// （真实库 course_source_ref 行数 > 批大小 500 时触发, dev 部署事故根因）。
 	if err := db.Table("course_source_ref").
-		Select("external_id, local_id").
+		Select("id, external_id, local_id").
 		Where("entity_type = ?", course.EntityTypeOffering).
 		Where("external_id <> ''").
 		Order("id ASC").
@@ -367,13 +370,15 @@ func backfillInstructorTeacherCode(db *gorm.DB) error {
 		return nil
 	}
 	type refRow struct {
+		Id         uint64 `gorm:"primaryKey"`
 		ExternalId string
 		LocalId    uint64
 	}
 	var rows []refRow
 	backfilled := 0
+	// 同 backfillOfferingTeachingClass: FindInBatches keyset 分页要求 dest 声明主键。
 	if err := db.Table("course_source_ref").
-		Select("external_id, local_id").
+		Select("id, external_id, local_id").
 		Where("entity_type = ?", course.EntityTypeInstructor).
 		Where("external_id <> ''").
 		Order("id ASC").


### PR DESCRIPTION
## 背景

dev 部署连续失败（run #33598978043 / #33598694720）：新镜像启动后 `/health` 60/60 探测失败 → 自动回滚 → 回滚目标同样带坏迁移 → dev 容器 crash loop 31 次，**dev 实例约 2 小时不可用**。

## 根因

PR #361 引入的 `upgradeCourseAggregation` 启动迁移（serve 门禁内、HTTP 监听前执行）中，两个回填（`backfillOfferingTeachingClass` / `backfillInstructorTeacherCode`）用 GORM `FindInBatches` 扫 `course_source_ref`，但 dest `refRow` 是**无主键裸结构体**：

- GORM `FindInBatches` 每批打满 500 行后走 keyset 分页优化，要求 dest 有主键读取末行主键（`gorm.io/gorm@v1.30.1/finisher_api.go:232` → `ErrPrimaryKeyRequired`）；
- 线上报错：`dbconnect course aggregation upgrade failed: backfill course_offering.teaching_class_id: primary key required`；
- **CI 未抓到的原因**：测试 fixture < 500 行，单批 `RowsAffected < batchSize` 直接 break，永不进入分页分支；真实 dev 库（从 main 同步快照）`course_source_ref` offering 21,941 行 / instructor 4,318 行，首批发满即确定性崩溃，与方言无关。

## 修复

- `apps/gooseforum/app/migration/migration.go`：两个回填的 `refRow` 声明 `Id uint64 \`gorm:"primaryKey"\`` 并 `Select("id, external_id, local_id")`，使 keyset 分页可用；
- `apps/gooseforum/app/migration/course_aggregation_upgrade_test.go`：新增回归测试 `TestCourseAggregationUpgradeLargeBatch`（1100 行 > 批大小 500，覆盖批次边界与尾部抽样断言）。

## 验证

- 回归测试修复前精确复现 `primary key required`（红），修复后 PASS（绿）；
- `go test ./app/migration/`（SQLite 全量）PASS；
- PG 迁移测试 `TestSchemaMigratesOnPostgreSQL` / `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL` PASS；
- `go vet` / `go build` / gofmt（改动文件）干净。

## 线上处置（已单独完成）

dev 已回滚到最后一个健康镜像 `dev-0cc2b48b`（pre-#361）并恢复 healthy（`/health` 200）；DB 重同步为 main 纯净快照，无部分回填残留。本 PR 合入 dev 后，CI 将自动重新部署，21,941 行回填在真实数据上跑通即最终验证点。