### PR TITLE
fix(forum): 恢复首楼编辑跳转发布页编辑态（issue #379）

### DIFF
--- a/apps/gooseforum/resource/src/site/components/PostStream.vue
+++ b/apps/gooseforum/resource/src/site/components/PostStream.vue
@@ -1281,6 +1281,12 @@ function canDeleteRenderedPost(post: PostPayload) {
 
 function startEditPost(post: PostPayload) {
   if (savingEditPostId.value || deletingPostId.value === post.id) return
+  // 首楼本质上是话题本体，其编辑应进入“发布话题”编辑态（可改标题/分类/正文），
+  // 而不是回复楼层那样就地编辑正文。此分支在 PR #217 中被误删，属行为回归（issue #379）。
+  if (isFirstPost(post)) {
+    window.location.href = `/publish?id=${props.topicId}`
+    return
+  }
   if (!editingPostId.value) {
     postDraftBeforeEdit.value = postContent.value
     targetPostBeforeEdit.value = targetPostId.value

--- a/apps/gooseforum/resource/test/post-stream-first-post-edit.test.ts
+++ b/apps/gooseforum/resource/test/post-stream-first-post-edit.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import type { PostPayload, PostWindowPayload, ViewerPayload } from '@gooseforum/client'
+import { i18n } from '../src/runtime/i18n'
+import PostStream from '../src/site/components/PostStream.vue'
+
+// PostComposer 是重型异步组件（vditor/prosemirror），与本回归无关，stub 掉以隔离。
+// 断言依赖其 props（mode 表示就地编辑态），故 stub 需透出 props。
+vi.mock('@/site/components/PostComposer.vue', () => ({
+  // Vue 的 async loader 依赖 __esModule 决定取 mod.default 作为组件；
+  // 缺省时会把整个 mock 命名空间当组件，test-utils 对 vitest 代理访问未声明属性会抛错。
+  __esModule: true,
+  default: {
+    name: 'PostComposerStub',
+    props: ['open', 'mode'],
+    template: '<div data-test="post-composer" />',
+  },
+}))
+
+const TOPIC_ID = 42
+const ORIGINAL_HREF = `http://localhost:5234/p/topic/${TOPIC_ID}`
+
+let locationMock: { href: string; pathname: string; hash: string }
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(window, 'location')!
+
+function makePost(overrides: Partial<PostPayload> & { id: number; postNo: number }): PostPayload {
+  return {
+    topicId: TOPIC_ID,
+    content: '正文内容',
+    renderedContent: '<p>正文内容</p>',
+    processStatus: 0,
+    isHidden: false,
+    isAuthorDeleted: false,
+    isModeratorRemoved: false,
+    canModerate: false,
+    author: { id: 7, username: 'author', avatarUrl: '' },
+    createdAt: '2026-09-02 10:00:00',
+    isOwnPost: true,
+    updatedAt: '2026-09-02 10:00:00',
+    revisionCount: 0,
+    likeCount: 0,
+    isLiked: false,
+    isBookmarked: false,
+    ...overrides,
+  }
+}
+
+const viewer: ViewerPayload = {
+  id: 7,
+  username: 'author',
+  email: 'author@example.com',
+  avatarUrl: '',
+  isAuthenticated: true,
+  canAccessAdmin: false,
+  isModerator: false,
+  requiresEmailVerification: false,
+  adminPermissions: [],
+}
+
+const editButtonTitle = i18n.global.t('common.edit')
+
+function mountStream() {
+  const postStream: PostWindowPayload = {
+    posts: [
+      makePost({ id: 101, postNo: 1 }),
+      makePost({ id: 102, postNo: 2 }),
+    ],
+    replyTargets: [],
+    hasBefore: false,
+    hasAfter: false,
+    total: 2,
+    maxPostNo: 2,
+  }
+  return mount(PostStream, {
+    props: {
+      topicId: TOPIC_ID,
+      topicTitle: '测试话题',
+      initialPostStream: postStream,
+      viewer,
+      canPost: true,
+      syncUrl: false,
+    },
+    global: { plugins: [i18n] },
+    attachTo: document.body,
+  })
+}
+
+// 首楼点击编辑应导航到 /publish?id=<topicId>（发布页编辑态），回复楼层不跳转、走就地编辑。
+// 回归：PR #217（b8cb1ff0）误删首楼分支，导致首楼只能就地改正文、无法改标题/分类（issue #379）。
+describe('PostStream 首楼编辑跳发布页（issue #379 回归）', () => {
+  beforeEach(() => {
+    locationMock = { href: ORIGINAL_HREF, pathname: `/p/topic/${TOPIC_ID}`, hash: '' }
+    Object.defineProperty(window, 'location', { configurable: true, value: locationMock })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', originalLocationDescriptor)
+    vi.restoreAllMocks()
+  })
+
+  test('首楼（postNo === 1）点击编辑笔跳转 /publish?id=<topicId>', async () => {
+    const wrapper = mountStream()
+    await flushPromises()
+
+    const firstPostArticle = wrapper.get('article[data-post-no="1"]')
+    await firstPostArticle.get(`button[title="${editButtonTitle}"]`).trigger('click')
+    await flushPromises()
+
+    expect(locationMock.href).toBe(`/publish?id=${TOPIC_ID}`)
+    wrapper.unmount()
+  })
+
+  test('回复楼层（postNo > 1）点击编辑笔不跳转，进入就地编辑态', async () => {
+    const wrapper = mountStream()
+    await flushPromises()
+
+    const replyArticle = wrapper.get('article[data-post-no="2"]')
+    await replyArticle.get(`button[title="${editButtonTitle}"]`).trigger('click')
+    await flushPromises()
+
+    expect(locationMock.href).toBe(ORIGINAL_HREF)
+    const composer = wrapper.findComponent({ name: 'PostComposerStub' })
+    expect(composer.exists()).toBe(true)
+    expect(composer.props('open')).toBe(true)
+    expect(composer.props('mode')).toBe('edit')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 背景

修复 issue #379：帖子首楼（postNo===1）的编辑被 PR #217（`b8cb1ff0`）改为与回复楼层相同的「回复式就地编辑器」，作者无法再编辑话题标题/分类，只能就地改正文。这是行为回归。

## 根因

`b8cb1ff0` 在 `startEditPost` 中删除了首楼分支：

```ts
// 回归前
function startEditPost(post) {
  if (isFirstPost(post)) {
    window.location.href = `/publish?id=${page.props.topic.id}`  // 1楼走发布页编辑态
    return
  }
  // …回复楼层就地编辑
}
```

该分支后由 `d25cab15` 随代码从 `TopicPage.vue` 拆入 `PostStream.vue`，但首楼分支未恢复。

## 改动

`apps/gooseforum/resource/src/site/components/PostStream.vue`：在 `startEditPost` 恢复首楼分支——首楼点击编辑铅笔跳转 `/publish?id=<topicId>`（发布页编辑态，可改标题/分类/正文）；回复楼层（postNo>1）仍走就地编辑。**不**回滚 #217 的整体功能（版本历史、last editor、`post_revisions`、编辑限流均保留）。

仅 6 行前端改动，无后端/契约/数据库/文档影响。

## 验证

- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test`：299 passed / 8 failed —— 8 个失败均为 **pre-existing**（`schedule-rough-list-drop.test.ts` 等 PK 课程退课持久化，与本次改动无关，基线上同样失败 8 个）
- `git diff --check` ✅

Closes #379（PR 合并后自动关闭；按用户要求，当前 Issue 保持打开）