### PR TITLE
fix(schedule): 修复「我的方案」删除唯一方案后序号循环自增，并限制方案数量上限（issue #378）

### DIFF
--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -517,6 +517,7 @@ export default {
     // ---- v2: multi-plan / week view / tolerant conflicts / custom placeholders ----
     myPlans: 'My Plans',
     planAdd: 'Add plan',
+    planLimitReached: 'Up to {n} plans',
     planDefaultName: 'Plan {n}',
     planDelete: 'Delete plan',
     planDeleteConfirm: 'Delete "{name}"? Courses and custom placeholders in this plan will be removed.',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -517,6 +517,7 @@ export default {
     // ---- v2: piani multipli / vista settimanale / conflitti tollerati / segnaposto ----
     myPlans: 'I miei piani',
     planAdd: 'Aggiungi piano',
+    planLimitReached: 'Massimo {n} piani',
     planDefaultName: 'Piano {n}',
     planDelete: 'Elimina piano',
     planDeleteConfirm: 'Eliminare "{name}"? I corsi e i segnaposto di questo piano verranno rimossi.',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -517,6 +517,7 @@ export default {
     // ---- v2：複数プラン / 週表示 / 許容型の重複 / カスタム予定 ----
     myPlans: 'マイプラン',
     planAdd: 'プランを追加',
+    planLimitReached: 'プランは最大 {n} 件まで作成できます',
     planDefaultName: 'プラン {n}',
     planDelete: 'プランを削除',
     planDeleteConfirm: '「{name}」を削除しますか？このプランの科目とカスタム予定も削除されます。',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -520,6 +520,7 @@ export default {
     myPlans: '我的方案',
     planDefaultName: '方案 {n}',
     planAdd: '新增方案',
+    planLimitReached: '最多可创建 {n} 个方案',
     planDelete: '删除方案',
     planDeleteConfirm: '确定删除「{name}」？该方案内的课程与自定义占位将一并删除。',
     planMore: '更多操作',

--- a/apps/gooseforum/resource/src/site/components/schedule/SchedulePlanBar.vue
+++ b/apps/gooseforum/resource/src/site/components/schedule/SchedulePlanBar.vue
@@ -6,7 +6,7 @@ import { useI18n } from 'vue-i18n'
 import { MoreHorizontal, Plus, Trash2 } from '@lucide/vue'
 import { DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui'
 import SiteSelect from '@/site/components/SiteSelect.vue'
-import { useScheduleStore } from '@/site/composables/useScheduleStore'
+import { MAX_PLANS, useScheduleStore } from '@/site/composables/useScheduleStore'
 
 const { t } = useI18n()
 const store = useScheduleStore()
@@ -14,6 +14,9 @@ const store = useScheduleStore()
 const planOptions = computed(() =>
   store.state.plans.map((plan) => ({ value: plan.id, label: plan.name })),
 )
+
+/** 达到方案数量上限：禁用「新增方案」并给出提示。 */
+const planLimitReached = computed(() => store.state.plans.length >= MAX_PLANS)
 
 const planValue = computed({
   get: () => store.state.activePlanId,
@@ -29,6 +32,7 @@ const confirmClear = ref(false)
 
 function handleAdd() {
   const plan = store.createPlan()
+  if (!plan) return
   store.switchPlan(plan.id)
 }
 </script>
@@ -46,9 +50,10 @@ function handleAdd() {
     </div>
     <button
       type="button"
-      class="gf-icon-button shrink-0"
-      :aria-label="t('schedule.planAdd')"
-      :title="t('schedule.planAdd')"
+      class="gf-icon-button shrink-0 disabled:cursor-not-allowed disabled:opacity-50"
+      :disabled="planLimitReached"
+      :aria-label="planLimitReached ? t('schedule.planLimitReached', { n: MAX_PLANS }) : t('schedule.planAdd')"
+      :title="planLimitReached ? t('schedule.planLimitReached', { n: MAX_PLANS }) : t('schedule.planAdd')"
       @click="handleAdd"
     >
       <Plus class="h-4 w-4" />

--- a/apps/gooseforum/resource/src/site/composables/useScheduleStore.ts
+++ b/apps/gooseforum/resource/src/site/composables/useScheduleStore.ts
@@ -62,6 +62,9 @@ export const COURSE_STATUS = {
   SELECTED: 2,
 } as const
 
+/** 方案数量上限：防无限创建拖垮 localStorage；达到上限时 UI 禁用「新增方案」。 */
+export const MAX_PLANS = 10
+
 interface CommonLists {
   /** 必修课（按年级分组展示） */
   compulsoryCourses: PkCourse[]
@@ -135,8 +138,27 @@ function genId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${planSeq.toString(36)}`
 }
 
-function nextPlanName(): string {
-  return i18n.global.t('schedule.planDefaultName', { n: state.plans.length + 1 })
+/** 从默认方案名（如「方案 {n}」）提取序号；自定义名/旧数据不匹配时返回 0。 */
+function planNameIndex(name: string): number {
+  const template = i18n.global.t('schedule.planDefaultName', { n: '{n}' })
+  const [prefix, suffix] = template.split('{n}')
+  if (!name.startsWith(prefix) || !name.endsWith(suffix)) return 0
+  const digits = name.slice(prefix.length, name.length - suffix.length)
+  return /^\d+$/.test(digits) ? Number(digits) : 0
+}
+
+/**
+ * 推导下一个方案名：取现存方案序号最大值 +1（无匹配序号时从 1 开始）。
+ * plans 传「保留后」的方案集合：删最后一个时传空数组 → 新方案回到「方案 1」，
+ * 避免历史实现「方案数 +1」在删除后持续自增，以及删除中间方案后与现存方案重名。
+ */
+function nextPlanName(plans: PkPlan[] = state.plans): string {
+  let max = 0
+  for (const plan of plans) {
+    const index = planNameIndex(plan.name)
+    if (index > max) max = index
+  }
+  return i18n.global.t('schedule.planDefaultName', { n: max + 1 })
 }
 
 function createEmptyPlan(name?: string): PkPlan {
@@ -625,7 +647,9 @@ export function useScheduleStore() {
 
   // ---- 方案 CRUD ----
 
-  function createPlan(): PkPlan {
+  /** 新增方案；达到 MAX_PLANS 上限时返回 null（UI 禁用按钮兜底）。 */
+  function createPlan(): PkPlan | null {
+    if (state.plans.length >= MAX_PLANS) return null
     const plan = createEmptyPlan(nextPlanName())
     state.plans = [...state.plans, plan]
     return plan
@@ -642,8 +666,8 @@ export function useScheduleStore() {
   function deletePlan(planId: string): void {
     const remaining = state.plans.filter((plan) => plan.id !== planId)
     if (remaining.length === 0) {
-      // 删最后一个：自动建空方案，保证始终至少一个。
-      const fresh = createEmptyPlan(nextPlanName())
+      // 删最后一个：自动建空方案，保证始终至少一个；remaining 为空 → 名称回到「方案 1」。
+      const fresh = createEmptyPlan(nextPlanName(remaining))
       state.plans = [fresh]
       state.activePlanId = fresh.id
     } else {

--- a/apps/gooseforum/resource/test/useScheduleStore.test.ts
+++ b/apps/gooseforum/resource/test/useScheduleStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { useScheduleStore } from '../src/site/composables/useScheduleStore'
+import { i18n } from '../src/runtime/i18n'
+import { MAX_PLANS, useScheduleStore } from '../src/site/composables/useScheduleStore'
 import {
   CUSTOM_EVENT_CODE_PREFIX,
   conflictBaseOf,
@@ -9,11 +10,16 @@ import {
   getCourseBaseCode,
 } from '../src/site/utils/pkConflict'
 import { currentWeekForDate, formatWeeksText } from '../src/site/utils/pkArrange'
-import type { PkArrangement, PkCourseDetail, PkStagedCourse } from '../src/site/types/pk'
+import type { PkArrangement, PkCourseDetail, PkPlan, PkStagedCourse } from '../src/site/types/pk'
 
 /** 展开的周次区间（如 range(1, 8) = [1..8]），对齐「1-8周」语义。 */
 function range(from: number, to: number): number[] {
   return Array.from({ length: to - from + 1 }, (_, i) => from + i)
+}
+
+/** 与 store 同源的默认方案名（如「方案 {n}」），断言名称不依赖测试环境 locale。 */
+function planName(n: number): string {
+  return i18n.global.t('schedule.planDefaultName', { n })
 }
 
 function makeDetail(code: string, day: number, time: number[], weeks: number[]): PkCourseDetail {
@@ -80,7 +86,10 @@ describe('useScheduleStore（v2 多方案 + 容忍式冲突）', () => {
     const store = useScheduleStore()
     store.clearStagedAndSelectedCourses()
     store.setMajorInfo({ calendarId: undefined, grade: undefined, major: undefined })
-    // 重置为单方案初始态。
+    // 重置为单方案初始态（清掉上一用例遗留的多方案，再删最后一个触发自动补建）。
+    while (store.state.plans.length > 1) {
+      store.deletePlan(store.state.plans[0].id)
+    }
     store.deletePlan(store.state.plans[0].id)
     store.setWeekView({ week: null, useCurrent: false })
   })
@@ -244,7 +253,7 @@ describe('useScheduleStore（v2 多方案 + 容忍式冲突）', () => {
     expect(store.state.commonLists.stagedCourses).toHaveLength(1)
 
     // 新建方案二并切换：镜像清空。
-    const second = store.createPlan()
+    const second = store.createPlan()!
     store.switchPlan(second.id)
     expect(store.state.activePlanId).toBe(second.id)
     expect(store.state.commonLists.stagedCourses).toHaveLength(0)
@@ -279,6 +288,65 @@ describe('useScheduleStore（v2 多方案 + 容忍式冲突）', () => {
     expect(store.state.plans).toHaveLength(1)
     expect(store.state.plans[0].id).not.toBe(only.id)
     expect(store.state.activePlanId).toBe(store.state.plans[0].id)
+  })
+
+  test('删除唯一方案后自动补建回到「方案 1」（序号不再自增）', () => {
+    const store = useScheduleStore()
+    expect(store.state.plans).toHaveLength(1)
+    expect(store.state.plans[0].name).toBe(planName(1))
+
+    // 删除唯一的「方案 1」→ 自动补建仍为「方案 1」，而非「方案 2」。
+    store.deletePlan(store.state.plans[0].id)
+    expect(store.state.plans).toHaveLength(1)
+    expect(store.state.plans[0].name).toBe(planName(1))
+
+    // 再次删除 → 序号继续回落，不再循环自增。
+    store.deletePlan(store.state.plans[0].id)
+    expect(store.state.plans[0].name).toBe(planName(1))
+  })
+
+  test('新增方案序号取现存最大值 +1：删除中间方案后不与现存方案重名', () => {
+    const store = useScheduleStore()
+    const first = store.state.plans[0]
+    expect(first.name).toBe(planName(1))
+
+    const second = store.createPlan()
+    expect(second).not.toBeNull()
+    expect(second!.name).toBe(planName(2))
+
+    const third = store.createPlan()
+    expect(third).not.toBeNull()
+    expect(third!.name).toBe(planName(3))
+
+    // 已有 方案1/2/3，删除中间的「方案 2」→ 剩余 方案1/3 → 再新增应为「方案 4」。
+    store.deletePlan(second!.id)
+    const fourth = store.createPlan()
+    expect(fourth).not.toBeNull()
+    expect(fourth!.name).toBe(planName(4))
+    // 新方案不与现存方案重名。
+    expect(store.state.plans.map((plan) => plan.name).filter((name) => name === fourth!.name)).toHaveLength(1)
+  })
+
+  test('方案数量达到上限后 createPlan 返回 null（不再创建）', () => {
+    const store = useScheduleStore()
+    const created: PkPlan[] = []
+    // 预置到 MAX_PLANS 个方案（含初始 1 个）。
+    for (let i = 1; i < MAX_PLANS; i++) {
+      const plan = store.createPlan()
+      expect(plan).not.toBeNull()
+      created.push(plan!)
+    }
+    expect(store.state.plans).toHaveLength(MAX_PLANS)
+
+    // 到达上限：拒绝新增且不改变状态。
+    expect(store.createPlan()).toBeNull()
+    expect(store.state.plans).toHaveLength(MAX_PLANS)
+
+    // 删除一个后可继续新增。
+    store.deletePlan(created[0].id)
+    expect(store.state.plans).toHaveLength(MAX_PLANS - 1)
+    expect(store.createPlan()).not.toBeNull()
+    expect(store.state.plans).toHaveLength(MAX_PLANS)
   })
 
   test('学期/年级/专业变更清空所有方案（防跨学期污染）', () => {
@@ -410,7 +478,7 @@ describe('useScheduleStore（v2 多方案 + 容忍式冲突）', () => {
     store.pushStagedCourse(makeStaged('122004', [makeDetail('122004.01', 1, [3], [1, 8])]))
     store.stageCourse(makeDetail('122004.01', 1, [3], [1, 8])) // status=1
 
-    const second = store.createPlan()
+    const second = store.createPlan()!
     store.switchPlan(second.id)
     store.setClickedCourseInfo({ courseCode: '122004', courseName: '高数' })
     store.pushStagedCourse(makeStaged('122004', [makeDetail('122004.01', 1, [3], [1, 8])]))
@@ -447,7 +515,7 @@ describe('useScheduleStore（v2 多方案 + 容忍式冲突）', () => {
     expect(details[1].status).toBe(1)
 
     // 切走再切回（触发纯重建）：只有新班在表。
-    const other = store.createPlan()
+    const other = store.createPlan()!
     store.switchPlan(other.id)
     store.switchPlan(store.state.plans.find((plan) => plan.stagedCourses.length > 0)!.id)
     expect(store.state.timeTableData.map((row) => row.code)).toEqual(['122004.02'])


### PR DESCRIPTION
## 问题（issue #378）

排课器「我的方案」在仅剩一个方案时删除该方案，自动补建的空方案序号持续自增（方案1→方案2→方案3…），永不回落；且「新增方案」无数量上限，可无限创建拖垮 localStorage。

根因：
- `nextPlanName()` 用「当前方案数 + 1」命名，删除时 `state.plans.length` 仍为 1 → 新方案名即「方案2」，再删又变「方案3」；
- 删除中间方案后新增也会与现存方案重名（如 1/2/3 删 2 后再新增算出「方案3」）；
- `createPlan()` 无数量上限。

## 修复

1. **命名改为基于现有序号推导**（`useScheduleStore.ts`）：
   - 新增 `planNameIndex()` 从默认方案名（如「方案 {n}」）提取序号，自定义名/旧数据不匹配返回 0；
   - `nextPlanName(plans)` 取保留方案中序号最大值 +1；删除最后一个方案时传空数组 → 自动补建回到「方案 1」；
   - `deletePlan()` 删唯一方案后补建名称回落「方案 1」，不再循环自增。
2. **引入方案数量上限 `MAX_PLANS = 10`**：
   - store 层 `createPlan()` 达到上限返回 `null`（兜底不创建）；
   - `SchedulePlanBar.vue` 达到上限禁用「新增方案」按钮，`aria-label`/`title` 给出「最多可创建 {n} 个方案」提示；
   - 四语言（zh/en/ja/it）新增 `schedule.planLimitReached` 键。

## 测试

`resource/test/useScheduleStore.test.ts` 新增 3 个用例（先红后绿）：
- 删除唯一方案后自动补建回到「方案 1」（序号不再自增）；
- 新增方案序号取现存最大值 +1：删除中间方案后不与现存方案重名；
- 方案数量达到上限后 `createPlan` 返回 null，删除一个后可继续新增。

测试框架的 `beforeEach` 重置逻辑同步强化为真正回到单方案初始态（清掉遗留多方案）。

## 验证

- `cd apps/gooseforum/resource && pnpm test`：302 passed / 8 failed（8 个失败为本地既有 happy-dom 环境问题，在干净 `origin/dev` 基线上同样失败，与本 PR 无关；`useScheduleStore.test.ts` 29/29 通过）
- `pnpm typecheck`：EXIT=0
- `pnpm check:i18n`：1728 keys × 4 locales 一致
- `pnpm build`：EXIT=0
- `git diff --check`：OK

Refs #378（不自动关闭，人工确认后处理）