### PR TITLE
feat(deploy): config as artifact — 模板渲染 + Environments secrets + CI 下发 + 漂移守卫

### DIFF
--- a/.github/actions/render-config/action.yml
+++ b/.github/actions/render-config/action.yml
@@ -1,0 +1,55 @@
+name: render-config
+description: >-
+  把 deploy/config.toml.tmpl + deploy/instances/<env>.json + Environments secrets
+  渲染成实例 config.toml 产物（deploy/rendered/config-<env>.toml）。
+  渲染 fail-closed：残留占位符 / 必需 secret 为空 / TOML 解析失败即步骤失败，不产出。
+inputs:
+  env:
+    description: 实例环境（main|dev）
+    required: true
+  signing-key:
+    description: SIGNING_KEY（app.signingKey，与存量一致，会话不中断）
+    required: true
+  pg-dsn:
+    description: PG_DSN（db.default.url，实例库 DSN）
+    required: true
+  meili-master-key:
+    description: MEILI_MASTER_KEY（meilisearch.masterkey）
+    required: true
+  wiki-webhook-secret:
+    description: WIKI_WEBHOOK_SECRET（wiki.git.webhook_secret）
+    required: true
+  gh-client-id:
+    description: GH_CLIENT_ID（github.client_id；dev 可空）
+    required: false
+    default: ""
+  gh-client-secret:
+    description: GH_CLIENT_SECRET（github.client_secret；dev 可空）
+    required: false
+    default: ""
+  ai-api-key:
+    description: AI_API_KEY（ai_summary.api_key；可空，AI 总结默认关闭）
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Render instance config
+      shell: bash
+      env:
+        RENDER_ENV: ${{ inputs.env }}
+        SIGNING_KEY: ${{ inputs.signing-key }}
+        PG_DSN: ${{ inputs.pg-dsn }}
+        MEILI_MASTER_KEY: ${{ inputs.meili-master-key }}
+        WIKI_WEBHOOK_SECRET: ${{ inputs.wiki-webhook-secret }}
+        GH_CLIENT_ID: ${{ inputs.gh-client-id }}
+        GH_CLIENT_SECRET: ${{ inputs.gh-client-secret }}
+        AI_API_KEY: ${{ inputs.ai-api-key }}
+      run: |
+        set -euo pipefail
+        mkdir -p deploy/rendered
+        python3 deploy/render_config.py render \
+          --env "$RENDER_ENV" \
+          --out "deploy/rendered/config-$RENDER_ENV.toml"
+        echo "render-config: 产物 deploy/rendered/config-$RENDER_ENV.toml"

--- a/.github/workflows/apply-config.yml
+++ b/.github/workflows/apply-config.yml
@@ -1,0 +1,64 @@
+name: Apply / instance config
+
+on:
+  workflow_dispatch:
+    inputs:
+      env:
+        description: "目标实例环境"
+        required: true
+        type: choice
+        options:
+          - dev
+          - main
+
+concurrency:
+  # 与同实例 code deploy 串行, 防 config.prev 单槽互相覆盖
+  group: apply-config-${{ github.event.inputs.env }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.env }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render ${{ github.event.inputs.env }} config
+        uses: ./.github/actions/render-config
+        with:
+          env: ${{ github.event.inputs.env }}
+          signing-key: ${{ secrets.SIGNING_KEY }}
+          pg-dsn: ${{ secrets.PG_DSN }}
+          meili-master-key: ${{ secrets.MEILI_MASTER_KEY }}
+          wiki-webhook-secret: ${{ secrets.WIKI_WEBHOOK_SECRET }}
+          # main 才配 GitHub 凭据; dev 渲染时为空（render action 内 allow-empty）
+          gh-client-id: ${{ secrets.GH_CLIENT_ID }}
+          gh-client-secret: ${{ secrets.GH_CLIENT_SECRET }}
+          ai-api-key: ${{ secrets.AI_API_KEY }}
+
+      - name: Upload rendered config + apply script
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          source: "deploy/rendered/config-${{ github.event.inputs.env }}.toml,deploy/scripts/apply-config.sh,deploy/scripts/pgdsn.sh"
+          target: "/tmp/yourtj-deploy-${{ github.run_id }}"
+          strip_components: 2
+
+      - name: Apply config on server
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          script: |
+            set -e
+            RUN_DIR=/tmp/yourtj-deploy-${{ github.run_id }}
+            install -m 0755 "$RUN_DIR/apply-config.sh" /opt/yourtj/scripts/apply-config.sh
+            # apply-config.sh: 备份 → 原子替换 → force-recreate 重挂 → 健康检查 → 失败恢复
+            /opt/yourtj/scripts/apply-config.sh ${{ github.event.inputs.env }} \
+              "$RUN_DIR/config-${{ github.event.inputs.env }}.toml"

--- a/.github/workflows/apply-config.yml
+++ b/.github/workflows/apply-config.yml
@@ -62,3 +62,5 @@ jobs:
             # apply-config.sh: 备份 → 原子替换 → force-recreate 重挂 → 健康检查 → 失败恢复
             /opt/yourtj/scripts/apply-config.sh ${{ github.event.inputs.env }} \
               "$RUN_DIR/config-${{ github.event.inputs.env }}.toml"
+            # 清理本 run 上传的临时文件（含明文渲染 config）
+            rm -rf "$RUN_DIR"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -14,6 +14,11 @@ on:
       - "apps/gooseforum/testdata/markdown-compat/**"
       - "packages/api-contract/**"
       - "deploy/scripts/**"
+      - "deploy/*.py"
+      - "deploy/instances/**"
+      - "deploy/config.toml.tmpl"
+      - "deploy/config.toml.example"
+      - ".github/actions/render-config/**"
       - ".github/workflows/ci-backend.yml"
   # PR 无条件触发, 保证 required status check 稳定存在(不会被 paths 跳过卡死)
   pull_request:
@@ -63,7 +68,12 @@ jobs:
               - '.github/workflows/ci-backend.yml'
             deploy_scripts:
               - 'deploy/scripts/**'
+              - 'deploy/*.py'
+              - 'deploy/instances/**'
+              - 'deploy/config.toml.tmpl'
+              - 'deploy/config.toml.example'
               - '.github/workflows/ci-backend.yml'
+              - '.github/actions/render-config/**'
 
       - uses: actions/setup-go@v5
         if: steps.filter.outputs.backend == 'true'
@@ -83,15 +93,17 @@ jobs:
         run: go build .
 
       # deploy 运维脚本测试(issue #134): DSN 解析支持 URL/key=value 两种格式,
-      # 非法 DSN 在调用侧于任何 DB 操作前报错; 仅脚本变更时运行。
-      - name: Deploy scripts (bash syntax + DSN parser tests)
+      # 非法 DSN 在调用侧于任何 DB 操作前报错; 渲染器 fail-closed(配置治理);
+      # 仅 deploy 脚本/模板/渲染器变更时运行。
+      - name: Deploy scripts (bash syntax + DSN parser + render config tests)
         if: steps.filter.outputs.deploy_scripts == 'true'
         run: |
           # bash -n 只语法检查第一个文件参数, 多文件写法会静默跳过其余文件, 必须逐个检查
-          for f in deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh deploy/scripts/init-server.sh deploy/scripts/deploy.sh; do
+          for f in deploy/scripts/pgdsn.sh deploy/scripts/pgdsn_test.sh deploy/scripts/backup-db.sh deploy/scripts/sync-db-from-main.sh deploy/scripts/init-server.sh deploy/scripts/deploy.sh deploy/scripts/apply-config.sh deploy/scripts/verify-instance.sh; do
             bash -n "$f"
           done
           bash deploy/scripts/pgdsn_test.sh
+          python3 deploy/render_config_test.py
 
   # wiki 同步锁并发测试（#285 回归）必须通过竞态检测。PR #297 描述引用过
   # "ci-backend-race"，但此前该 job 不存在；此处落地为真实 job，与

--- a/.github/workflows/config-drift-check.yml
+++ b/.github/workflows/config-drift-check.yml
@@ -55,3 +55,5 @@ jobs:
             EXPECT_SERVER_URL="${{ steps.expected.outputs.exp_server_url }}" \
             EXPECT_DBNAME="${{ steps.expected.outputs.exp_dbname }}" \
               /opt/yourtj/scripts/verify-instance.sh ${{ matrix.env }}
+            # 清理本 run 上传的临时脚本
+            rm -rf "$RUN_DIR"

--- a/.github/workflows/config-drift-check.yml
+++ b/.github/workflows/config-drift-check.yml
@@ -1,0 +1,57 @@
+name: Config / drift check
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 每日 04:00 UTC（12:00 北京时间）巡检漂移
+    - cron: "0 4 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [dev, main]
+    environment: ${{ matrix.env }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # 期望值在 runner 上从仓库 instances JSON 读取（服务器不需要 python）
+      - name: Read expected values from instances JSON
+        id: expected
+        shell: bash
+        run: |
+          echo "exp_server_url=$(python3 -c "import json;print(json.load(open('deploy/instances/${{ matrix.env }}.json'))['server_url'])")" >> "$GITHUB_OUTPUT"
+          echo "exp_dbname=$(python3 -c "import json;print(json.load(open('deploy/instances/${{ matrix.env }}.json'))['pg_dbname'])")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload verify scripts to host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          source: "deploy/scripts/verify-instance.sh,deploy/scripts/pgdsn.sh"
+          target: "/tmp/yourtj-drift-${{ github.run_id }}"
+          strip_components: 2
+
+      - name: Verify ${{ matrix.env }} instance config drift
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          script: |
+            set -e
+            RUN_DIR=/tmp/yourtj-drift-${{ github.run_id }}
+            install -m 0755 "$RUN_DIR/verify-instance.sh" /opt/yourtj/scripts/verify-instance.sh
+            install -m 0755 "$RUN_DIR/pgdsn.sh" /opt/yourtj/scripts/pgdsn.sh
+            EXPECT_SERVER_URL="${{ steps.expected.outputs.exp_server_url }}" \
+            EXPECT_DBNAME="${{ steps.expected.outputs.exp_dbname }}" \
+              /opt/yourtj/scripts/verify-instance.sh ${{ matrix.env }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -81,7 +81,7 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "deploy/rendered/config-dev.toml"
           target: "/tmp/yourtj-deploy-${{ github.run_id }}"
-          strip_components: 1
+          strip_components: 2
       # compose 由 init-server.sh 一次性安装到服务器, dev 部署不更新它,
       # 避免 dev 分支的 compose 变更影响共享的生产实例(PR review #3)。
       # 部署只需 pull 镜像 + up 已有 compose 中的服务
@@ -109,3 +109,5 @@ jobs:
             #    CONFIG_FILE 携带渲染 config: 与镜像同一回滚事务原子替换
             IMAGE_KEEP_N=3 CONFIG_FILE="$RUN_DIR/config-dev.toml" \
               /opt/yourtj/scripts/deploy.sh dev dev-${{ github.sha }} 5235
+            # 3. 部署成功/失败后清理本 run 上传的临时文件(含明文渲染 config)
+            rm -rf "$RUN_DIR"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -43,9 +43,23 @@ jobs:
   deploy:
     needs: [build, build-image]
     runs-on: ubuntu-latest
+    environment: dev
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+      # 渲染实例 config（dev 环境 secrets; dev GitHub 凭据留空 → 渲染 allow-empty）
+      - name: Render dev config
+        uses: ./.github/actions/render-config
+        with:
+          env: dev
+          signing-key: ${{ secrets.SIGNING_KEY }}
+          pg-dsn: ${{ secrets.PG_DSN }}
+          meili-master-key: ${{ secrets.MEILI_MASTER_KEY }}
+          wiki-webhook-secret: ${{ secrets.WIKI_WEBHOOK_SECRET }}
+          # dev 有意不设 GitHub 凭据(DB siteUrl 无环境隔离); gh inputs 留空
+          gh-client-id: ""
+          gh-client-secret: ""
+          ai-api-key: ""
       # 上传到 run-specific 路径, 避免与 deploy-main 并发部署时
       # 互相覆盖 /tmp 下的同名文件(见 PR review #1)
       - name: Upload deploy scripts to dev host
@@ -55,9 +69,19 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/sync-db-from-main.sh,deploy/scripts/pgdsn.sh,deploy/scripts/apply-config.sh"
           target: "/tmp/yourtj-deploy-${{ github.run_id }}"
           strip_components: 2
+      - name: Upload rendered dev config to dev host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          source: "deploy/rendered/config-dev.toml"
+          target: "/tmp/yourtj-deploy-${{ github.run_id }}"
+          strip_components: 1
       # compose 由 init-server.sh 一次性安装到服务器, dev 部署不更新它,
       # 避免 dev 分支的 compose 变更影响共享的生产实例(PR review #3)。
       # 部署只需 pull 镜像 + up 已有 compose 中的服务
@@ -70,14 +94,18 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
+            RUN_DIR=/tmp/yourtj-deploy-${{ github.run_id }}
             # 0. 同步仓库最新脚本到服务器(install 保证可执行位)。
             #    sync-db-from-main.sh source pgdsn.sh, 必须一并下发, 否则
             #    set -e 下 source 失败阻断部署(review W2)。
-            install -m 0755 /tmp/yourtj-deploy-${{ github.run_id }}/deploy.sh /opt/yourtj/scripts/deploy.sh
-            install -m 0755 /tmp/yourtj-deploy-${{ github.run_id }}/sync-db-from-main.sh /opt/yourtj/scripts/sync-db-from-main.sh
-            install -m 0755 /tmp/yourtj-deploy-${{ github.run_id }}/pgdsn.sh /opt/yourtj/scripts/pgdsn.sh
+            install -m 0755 "$RUN_DIR/deploy.sh" /opt/yourtj/scripts/deploy.sh
+            install -m 0755 "$RUN_DIR/sync-db-from-main.sh" /opt/yourtj/scripts/sync-db-from-main.sh
+            install -m 0755 "$RUN_DIR/pgdsn.sh" /opt/yourtj/scripts/pgdsn.sh
+            install -m 0755 "$RUN_DIR/apply-config.sh" /opt/yourtj/scripts/apply-config.sh
             # 1. 同步 main 数据库一致性快照(dev 用 main 真实数据预演迁移)
             /opt/yourtj/scripts/sync-db-from-main.sh
             # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), dev 对外端口 5235
             #    dev 部署频繁, 镜像只保留最近 3 个(含当前) + prev
-            IMAGE_KEEP_N=3 /opt/yourtj/scripts/deploy.sh dev dev-${{ github.sha }} 5235
+            #    CONFIG_FILE 携带渲染 config: 与镜像同一回滚事务原子替换
+            IMAGE_KEEP_N=3 CONFIG_FILE="$RUN_DIR/config-dev.toml" \
+              /opt/yourtj/scripts/deploy.sh dev dev-${{ github.sha }} 5235

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -65,7 +65,7 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "deploy/rendered/config-main.toml"
           target: "/tmp/yourtj-deploy-${{ github.run_id }}"
-          strip_components: 1
+          strip_components: 2
       # docker-compose.yaml 只有两层路径, strip_components: 2 会把它剥没
       # (scp-action 丢弃空路径), 必须单独上传不 strip
       - name: Upload compose file to prod host
@@ -111,3 +111,5 @@ jobs:
               /opt/yourtj/scripts/deploy.sh main main-${{ github.sha }} 5234
             # 3. 部署成功后清理备份(失败时 deploy.sh 已恢复 compose)
             rm -f /opt/yourtj/docker-compose.yaml.prev
+            # 4. 清理本 run 上传的临时文件(含明文渲染 config)
+            rm -rf "$RUN_DIR"

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -32,6 +32,18 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
+      # 渲染实例 config（production 环境 secrets; GitHub 凭据生产必填）
+      - name: Render main config
+        uses: ./.github/actions/render-config
+        with:
+          env: main
+          signing-key: ${{ secrets.SIGNING_KEY }}
+          pg-dsn: ${{ secrets.PG_DSN }}
+          meili-master-key: ${{ secrets.MEILI_MASTER_KEY }}
+          wiki-webhook-secret: ${{ secrets.WIKI_WEBHOOK_SECRET }}
+          gh-client-id: ${{ secrets.GH_CLIENT_ID }}
+          gh-client-secret: ${{ secrets.GH_CLIENT_SECRET }}
+          ai-api-key: ${{ secrets.AI_API_KEY }}
       # 上传到 run-specific 路径, 避免与 deploy-dev 并发部署时
       # 互相覆盖 /tmp 下的同名文件(见 PR review #1)
       - name: Upload deploy scripts to prod host
@@ -41,9 +53,19 @@ jobs:
           username: ${{ secrets.VM_USER }}
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
-          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh"
+          source: "deploy/scripts/deploy.sh,deploy/scripts/backup-db.sh,deploy/scripts/pgdsn.sh,deploy/scripts/apply-config.sh"
           target: "/tmp/yourtj-deploy-${{ github.run_id }}"
           strip_components: 2
+      - name: Upload rendered main config to prod host
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VM_HOST }}
+          username: ${{ secrets.VM_USER }}
+          key: ${{ secrets.VM_SSH_KEY }}
+          port: ${{ secrets.VM_SSH_PORT || '22' }}
+          source: "deploy/rendered/config-main.toml"
+          target: "/tmp/yourtj-deploy-${{ github.run_id }}"
+          strip_components: 1
       # docker-compose.yaml 只有两层路径, strip_components: 2 会把它剥没
       # (scp-action 丢弃空路径), 必须单独上传不 strip
       - name: Upload compose file to prod host
@@ -72,6 +94,7 @@ jobs:
             install -m 0755 "$RUN_DIR/deploy.sh" /opt/yourtj/scripts/deploy.sh
             install -m 0755 "$RUN_DIR/backup-db.sh" /opt/yourtj/scripts/backup-db.sh
             install -m 0755 "$RUN_DIR/pgdsn.sh" /opt/yourtj/scripts/pgdsn.sh
+            install -m 0755 "$RUN_DIR/apply-config.sh" /opt/yourtj/scripts/apply-config.sh
             # 0.5 更新 compose(仅 main 部署更新共享 compose, 生产为权威):
             #   - 先备份现有 compose, 部署失败时由 deploy.sh 恢复(PR review #4)
             if [ -f /opt/yourtj/docker-compose.yaml ]; then
@@ -83,6 +106,8 @@ jobs:
             /opt/yourtj/scripts/backup-db.sh main
             # 2. 拉取 GHCR 镜像 + 部署 + 健康检查(失败自动回滚), main 对外端口 5234
             #    生产保留更多回滚候选, 镜像保留最近 5 个(含当前) + prev
-            IMAGE_KEEP_N=5 /opt/yourtj/scripts/deploy.sh main main-${{ github.sha }} 5234
+            #    CONFIG_FILE 携带渲染 config: 与镜像同一回滚事务原子替换
+            IMAGE_KEEP_N=5 CONFIG_FILE="$RUN_DIR/config-main.toml" \
+              /opt/yourtj/scripts/deploy.sh main main-${{ github.sha }} 5234
             # 3. 部署成功后清理备份(失败时 deploy.sh 已恢复 compose)
             rm -f /opt/yourtj/docker-compose.yaml.prev

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ apps/mobile/.packages
 .env
 deploy/.env
 
+# 配置治理渲染产物（CI 下发用, 不入库）
+deploy/rendered/
+deploy/__pycache__/
+
 # OS
 .DS_Store
 

--- a/deploy/config.toml.tmpl
+++ b/deploy/config.toml.tmpl
@@ -1,0 +1,130 @@
+# yourtj-hub 实例配置模板（配置治理，唯一权威）
+# 本文件不直接使用：由 deploy/render_config.py 读取本模板 + deploy/instances/<env>.json
+# （实例差异、非敏感）+ GitHub Environments secrets（敏感值），渲染成实例 config.toml。
+# 占位符形如双花括号包大写下划线标识符（见下方各处）；值为字符串时输出 TOML basic
+# string，值为数组时输出 inline array。
+# 渲染后必须通过 tomllib 解析且不含未替换占位符，才会被 CI 下发到服务器。
+# 服务器 config 由 CI apply-config.sh 原子替换，禁止人工 SSH 修改（漂移守卫会告警）。
+[app]
+env = "production"
+maintenance = false
+# 由 init-server.sh 生成随机密钥替换；迁移后由 CI 从 SIGNING_KEY secret 注入，
+# 值必须与存量一致，否则现有 JWT 会话全部失效。
+signingKey = {{SIGNING_KEY}}
+cdn_url = ""
+
+[server]
+# 容器内固定; 对外端口由 compose 的 MAIN_PORT/DEV_PORT 决定
+url = {{SERVER_URL}}
+port = 5234
+accessLog = false
+gzip = true
+# 信任的反向代理网段: nginx 容器在 compose 网络(默认 172.16.0.0/12)内访问本服务,
+# 必须信任该网段才能正确解析 X-Forwarded-For(限流按真实客户端 IP 归并)
+trusted_proxies = {{TRUSTED_PROXIES}}
+
+[jwtopt]
+validTime = 604800
+
+[db]
+migration = "on"
+backupSqlite = true
+backupDir = "./storage/databasebackup/"
+keep = 7
+spec = "0 3 * * *"
+
+[db.default]
+# 主库连接类型: postgres（部署默认）/ sqlite（本地开发；文件库 [db.file] 固定 sqlite）
+connection = "postgres"
+# 实例数据库 DSN 由 CI 从 PG_DSN secret 注入（main/dev 分别指向 yourtj_main / yourtj_dev）。
+# postgres: "host=postgres user=... password=... dbname=... port=5432 sslmode=disable"
+url = {{PG_DSN}}
+path = "./storage/database/sqlite.db"
+maxIdleConnections = 3
+maxOpenConnections = 5
+maxLifeSeconds = 300
+
+[db.file]
+connection = "sqlite"
+path = "./storage/database/file.db"
+maxIdleConnections = 3
+maxOpenConnections = 5
+maxLifeSeconds = 300
+
+
+[meilisearch]
+url = "http://meilisearch:7700"
+masterkey = {{MEILI_MASTER_KEY}}
+
+[wiki.git]
+repo = "https://github.com/YourTongji/YourTJ-Wiki.git"
+branch = "main"
+clone_dir = "./storage/wiki-repo"
+schedule = "0 3 * * *"
+webhook_secret = {{WIKI_WEBHOOK_SECRET}}
+
+[log]
+type = "file"
+path = "./storage/logs/run.log"
+rolling = true
+maxage = 10
+maxsize = 256
+maxBackUps = 30
+# 日志级别 debug/info/warn/error，默认 info
+level = "info"
+# 日志格式 json/console，默认 json
+format = "json"
+# ERROR/WARNING 独立轮转文件（便于告警采集），留空则不单独拆分
+errorPath = "./storage/logs/run.error.log"
+# 访问日志是否记录客户端 IP，默认关闭（隐私最小化）
+logIp = false
+slowSQL = true
+slowSQLThreshold = "200ms"
+
+[github]
+# GitHub OAuth 登录（goth）。production 从 GH_CLIENT_ID / GH_CLIENT_SECRET secret 注入；
+# dev 因 DB 站点设置无环境隔离（siteUrl 跟随 main 快照）保持空凭据（optional，渲染为空）。
+client_id = {{GH_CLIENT_ID}}
+client_secret = {{GH_CLIENT_SECRET}}
+
+[oidc]
+enabled = false
+# issuer 默认取 site_url + /api/oauth；显式配置可覆盖
+# issuer = "https://forum.example.com/api/oauth"
+# RS256 签名私钥：内联 PEM 或密钥文件（二者都为空时自动生成并持久化到 signing_key_file）
+# signing_key = ""
+signing_key_file = "./storage/oidc/signing_key.pem"
+access_token_ttl = 3600
+auth_request_ttl = 600
+id_token_ttl = 3600
+# 第一方客户端（public 客户端不填 secret，PKCE 强制；confidential 客户端用 client_secret_basic）
+# redirect_uris 精确匹配；回调带动态 query/路径段时用 redirect_uris_globs
+# 兜底(doublestar pattern, 配置加载时校验, 非法 pattern 拒绝整个 OIDC 配置)。
+# 示例：第三方客户端授权回调带动态 redirect query（授权后回跳应用深层页）时用 globs 兜底。
+# 注意(zitadel/oidc v3.49 实测): 匹配前会再 QueryUnescape 一次 redirect_uri,
+# 实际匹配串中内层页面 URL 的 %2F 已是字面 /; doublestar 的 * 嵌在 query
+# 值中不能跨 /, 只有 ** 作为末尾 segment 可以。因此按"钉死站点域名前缀"
+# 拆两条。\? 转义匹配字面 ?; TOML 单引号字面串保证反斜杠原样传给解析器
+# redirect_uris_globs = [
+#   'https://app.example.com/api/oauth\?redirect=https://app.example.com/**',
+#   'https://app.example.com/api/oauth\?redirect=/**',
+# ]
+[[oidc.clients]]
+id = "yourtj-mobile"
+name = "yourtj 移动端"
+redirect_uris = ["yourtj://callback"]
+# secret = ""
+
+# AI 课程总结（B7，issue #181）：OpenAI-compatible /chat/completions 端点。
+# qwen（DashScope compatible-mode）/OpenRouter/本地 Ollama 均走同一协议，
+# 切换只改 base_url/model/api_key，输出 schema 不变。
+# 开关与全局每分钟生成上限在管理面板「AI 总结」设置中（DB 存储、热生效），
+# 默认关闭；部署需在此配好端点与模型并开启开关后生效。
+# api_key 由 CI 从 AI_API_KEY secret 注入（未配置时渲染为空，属 optional）。
+[ai_summary]
+provider = "qwen"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+api_key = {{AI_API_KEY}}
+model = "qwen3.6-flash-2026-04-16"
+temperature = 0.3
+max_tokens = 1024

--- a/deploy/instances/dev.json
+++ b/deploy/instances/dev.json
@@ -1,0 +1,6 @@
+{
+  "instance": "dev",
+  "server_url": "https://dev.yourtj.de",
+  "trusted_proxies": ["172.16.0.0/12"],
+  "pg_dbname": "yourtj_dev"
+}

--- a/deploy/instances/main.json
+++ b/deploy/instances/main.json
@@ -1,0 +1,6 @@
+{
+  "instance": "main",
+  "server_url": "https://f.yourtj.de",
+  "trusted_proxies": ["172.16.0.0/12"],
+  "pg_dbname": "yourtj_main"
+}

--- a/deploy/render_config.py
+++ b/deploy/render_config.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""render_config.py — 把 deploy/config.toml.tmpl 渲染成实例 config.toml（配置治理）。
+
+模板占位符 {{TOKEN}} 的值来源：
+  - 实例差异（非敏感）: deploy/instances/<env>.json 提供 SERVER_URL / TRUSTED_PROXIES；
+  - 敏感值: 同名环境变量（GitHub Actions 里由 Environments secrets 注入）。
+
+安全契约（fail-closed）:
+  - 值经 json.dumps 编码为 TOML basic string / inline array（引号、反斜杠、换行安全）;
+  - 渲染后仍残留 {{ 或 }}（未知 token）→ 拒绝输出;
+  - 必需 token 为空 → 拒绝输出。allow-empty 按环境收紧:
+      main: 仅 AI_API_KEY 允许为空（GitHub 凭据生产必须非空）;
+      dev:  AI_API_KEY + GH_CLIENT_ID/GH_CLIENT_SECRET 允许为空
+            （dev 因 DB 站点设置无环境隔离保持 GitHub 登录关闭）;
+  - 产物必须能被 tomllib 解析;
+  - 摘要只回显 token 名与值长度/前 4 字符，绝不打印 secret 值。
+
+用法:
+  SIGNING_KEY=... PG_DSN=... python3 deploy/render_config.py --env dev \
+      --out deploy/rendered/config-dev.toml
+  python3 deploy/render_config.py --compare-example   # example 键集 ⊇ tmpl 键集断言
+
+仅依赖 python3.11+ 标准库（tomllib），无第三方。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+
+TOKEN_RE = re.compile(r"\{\{\s*([A-Z][A-Z0-9_]*)\s*\}\}")
+
+# 由实例 JSON 提供的非敏感 token；其余 token 一律视为 secret（从环境变量读取）。
+INSTANCE_TOKENS = {"SERVER_URL", "TRUSTED_PROXIES"}
+
+# 全部环境都允许为空的 token（可选功能，未配置即关闭）。
+BASE_OPTIONAL_TOKENS = {"AI_API_KEY"}
+
+DEFAULT_TMPL = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "config.toml.tmpl"
+)
+DEFAULT_INSTANCES_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "instances"
+)
+DEFAULT_EXAMPLE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "config.toml.example"
+)
+
+
+def optional_tokens(env):
+    """按环境返回允许为空的 token 集合。"""
+    s = set(BASE_OPTIONAL_TOKENS)
+    if env == "dev":
+        # dev GitHub 登录关闭（DB siteUrl 无环境隔离，回调会指回生产）。
+        s |= {"GH_CLIENT_ID", "GH_CLIENT_SECRET"}
+    return s
+
+
+def flatten_keys(data, prefix=""):
+    """把 tomllib 解析结果转成 {'sec.key'} 键集；[[数组]] 内 dict 以其键并入。"""
+    keys = set()
+    if isinstance(data, dict):
+        for k, v in data.items():
+            key = f"{prefix}.{k}" if prefix else k
+            keys.add(key)
+            if isinstance(v, dict):
+                keys |= flatten_keys(v, key)
+            elif isinstance(v, list):
+                for item in v:
+                    if isinstance(item, dict):
+                        keys |= flatten_keys(item, key)
+    return keys
+
+
+def tokens_in(text):
+    """模板中出现的全部 token 名。"""
+    return set(TOKEN_RE.findall(text))
+
+
+def load_instance(env, instances_dir):
+    path = os.path.join(instances_dir, f"{env}.json")
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    if data.get("instance") != env:
+        raise SystemExit(
+            f"render: {path} instance 字段 {data.get('instance')!r} != env {env!r}"
+        )
+    return data
+
+
+def render(text, values):
+    """把模板中的 {{TOKEN}} 全部替换为 TOML 编码后的值；出现未知 token 即失败。"""
+    out = text
+    for tok in sorted(tokens_in(text)):
+        if tok not in values:
+            raise SystemExit(
+                f"render: token {tok} 无值来源（instance JSON 或 secret 缺失）"
+            )
+        # json.dumps → TOML basic string（字符串）或 inline array（列表），
+        # 天然转义引号/反斜杠/换行/控制字符。
+        out = out.replace("{{%s}}" % tok, json.dumps(values[tok]))
+    if "{{" in out or "}}" in out:
+        raise SystemExit("render: 渲染后仍残留 {{ 或 }}（占位符未全部替换）")
+    return out
+
+
+def build_values(env, instance, environ, tokens, allow_empty):
+    """组装 token → 值。返回 (values, summary)；空必需值即失败。"""
+    instance_token_map = {
+        "SERVER_URL": str(instance["server_url"]),
+        "TRUSTED_PROXIES": list(instance["trusted_proxies"]),
+    }
+    values = {}
+    summary = []
+    for tok in sorted(tokens):
+        if tok in instance_token_map:
+            values[tok] = instance_token_map[tok]
+            summary.append((tok, values[tok], "instance"))
+            continue
+        raw = environ.get(tok, "")
+        if raw == "":
+            if tok in allow_empty:
+                values[tok] = ""
+                summary.append((tok, "", "secret-optional-empty"))
+                continue
+            raise SystemExit(
+                f"render: 必需 secret {tok} 为空（{env} 环境未设置或为必填）"
+            )
+        values[tok] = raw
+        summary.append((tok, raw, "secret"))
+    return values, summary
+
+
+def summarize(summary):
+    """只输出键名、来源、值长度与前 4 字符，绝不打印完整 secret。"""
+    for tok, val, src in summary:
+        if isinstance(val, list):
+            print(f"  {tok}: {src} (array len={len(val)})")
+        else:
+            head = val[:4] if val else "(empty)"
+            print(f"  {tok}: {src} len={len(val)} head={head!r}")
+
+
+def cmd_render(args):
+    text = ""
+    with open(args.tmpl, encoding="utf-8") as f:
+        text = f.read()
+    tokens = tokens_in(text)
+    instance = load_instance(args.env, args.instances_dir)
+    allow = optional_tokens(args.env)
+    if args.allow_empty_extra:
+        allow |= {x.strip() for x in args.allow_empty_extra.split(",") if x.strip()}
+    values, summary = build_values(args.env, instance, os.environ, tokens, allow)
+    rendered = render(text, values)
+    try:
+        tomllib.loads(rendered)
+    except tomllib.TOMLDecodeError as e:
+        raise SystemExit(f"render: 产物 TOML 解析失败（fail-closed，不输出）: {e}")
+    print(f"render: {args.env} 渲染校验通过，token 清单:")
+    summarize(summary)
+    out = args.out
+    if out == "-":
+        sys.stdout.write(rendered)
+    else:
+        os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
+        with open(out, "w", encoding="utf-8") as f:
+            f.write(rendered)
+        print(f"render: 已写入 {out}")
+
+
+def cmd_compare_example(args):
+    """断言 example 键集 ⊇ tmpl 键集（tmpl 所有键在 example 都有对应说明）。
+
+    example 允许额外携带可选功能节（如 [cron]、[pk.semester_dates]）作人类参考，
+    但 tmpl 新增的任何键必须同步进 example，防止模板漂移。
+    """
+    with open(args.tmpl, encoding="utf-8") as f:
+        text = f.read()
+    with open(args.example, encoding="utf-8") as f:
+        example_text = f.read()
+    # 哑渲染: 所有 token 替换为合法值（tomllib 不做类型语义检查）
+    for tok in sorted(tokens_in(text)):
+        text = text.replace("{{%s}}" % tok, json.dumps("x"))
+    try:
+        tmpl_keys = flatten_keys(tomllib.loads(text))
+        example_keys = flatten_keys(tomllib.loads(example_text))
+    except tomllib.TOMLDecodeError as e:
+        raise SystemExit(f"compare: 解析失败: {e}")
+    missing = sorted(tmpl_keys - example_keys)
+    if missing:
+        print(f"compare: FAIL — tmpl 有以下键未在 example 出现: {missing}")
+        return 1
+    extra = sorted(example_keys - tmpl_keys)
+    print(
+        f"compare: OK — example 键集覆盖 tmpl ({len(tmpl_keys)} 键)；example 额外可选键 {len(extra)}: {extra}"
+    )
+    return 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="渲染实例 config.toml（配置治理）")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pr = sub.add_parser("render", help="渲染实例 config")
+    pr.add_argument(
+        "--env", required=True, choices=["main", "dev"], help="实例: main|dev"
+    )
+    pr.add_argument("--tmpl", default=DEFAULT_TMPL)
+    pr.add_argument("--instances-dir", default=DEFAULT_INSTANCES_DIR)
+    pr.add_argument("--out", default="-", help="输出路径（默认 stdout）")
+    pr.add_argument(
+        "--allow-empty-extra", default="", help="额外允许为空的 token（逗号分隔）"
+    )
+    pr.set_defaults(func=cmd_render)
+
+    pc = sub.add_parser(
+        "compare-example", help="断言 config.toml.example 键集覆盖 tmpl"
+    )
+    pc.add_argument("--tmpl", default=DEFAULT_TMPL)
+    pc.add_argument("--example", default=DEFAULT_EXAMPLE)
+    pc.set_defaults(func=cmd_compare_example)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/render_config.py
+++ b/deploy/render_config.py
@@ -12,8 +12,10 @@
       main: 仅 AI_API_KEY 允许为空（GitHub 凭据生产必须非空）;
       dev:  AI_API_KEY + GH_CLIENT_ID/GH_CLIENT_SECRET 允许为空
             （dev 因 DB 站点设置无环境隔离保持 GitHub 登录关闭）;
+  - PG_DSN 的 dbname 必须等于实例期望 pg_dbname（防跨库连错: dev 配到 yourtj_main 即拒绝）;
   - 产物必须能被 tomllib 解析;
-  - 摘要只回显 token 名与值长度/前 4 字符，绝不打印 secret 值。
+  - 诊断信息只输出键名/来源/长度，绝不打印 secret 值或前缀；stdout 模式（--out -）下
+    stdout 只含 TOML 文档，诊断一律走 stderr。
 
 用法:
   SIGNING_KEY=... PG_DSN=... python3 deploy/render_config.py --env dev \
@@ -31,6 +33,7 @@ import os
 import re
 import sys
 import tomllib
+import urllib.parse
 
 TOKEN_RE = re.compile(r"\{\{\s*([A-Z][A-Z0-9_]*)\s*\}\}")
 
@@ -108,6 +111,50 @@ def render(text, values):
     return out
 
 
+def dsn_dbname(dsn):
+    """从 libpq key=value 或 postgres:// URL DSN 提取 dbname；解析失败返回 None。
+
+    支持两种格式（与 deploy/scripts/pgdsn.sh 语义一致）:
+      postgres://user:pass@host:port/dbname?sslmode=disable
+      host=postgres user=u password=p dbname=xxx port=5432 sslmode=disable
+    """
+    dsn = dsn.strip()
+    if not dsn:
+        return None
+    if re.match(r"^[a-z]+://", dsn, re.IGNORECASE):
+        rest = dsn.split("://", 1)[1]
+        # 去掉 authority（host[:port][@userinfo] 前的部分），取首个 / 后的路径段
+        if "/" not in rest:
+            return None
+        path_query = rest.split("/", 1)[1]
+        db = path_query.split("?")[0].split("#")[0]
+        return urllib.parse.unquote(db) if db else None
+    # key=value 格式（dbname 值不含空格/引号——本仓库 DSN 由 init-server 生成，值无空格）
+    for tok in dsn.split():
+        if tok.startswith("dbname="):
+            v = tok[len("dbname=") :]
+            if len(v) >= 2 and v[0] in "\"'" and v[-1] == v[0]:
+                v = v[1:-1]
+            return v or None
+    return None
+
+
+def validate_pg_dsn(values, instance):
+    """fail-closed: PG_DSN 的 dbname 必须与实例期望一致（防跨库连错生产库）。"""
+    pg_val = values.get("PG_DSN")
+    expect_db = instance.get("pg_dbname")
+    if not pg_val or not expect_db:
+        return
+    actual = dsn_dbname(pg_val)
+    if not actual:
+        raise SystemExit("render: PG_DSN 无法解析 dbname（fail-closed，拒绝输出）")
+    if actual != expect_db:
+        raise SystemExit(
+            f"render: PG_DSN dbname='{actual}' ≠ 实例期望 '{expect_db}'"
+            "（疑似跨库连错，拒绝输出）"
+        )
+
+
 def build_values(env, instance, environ, tokens, allow_empty):
     """组装 token → 值。返回 (values, summary)；空必需值即失败。"""
     instance_token_map = {
@@ -136,13 +183,12 @@ def build_values(env, instance, environ, tokens, allow_empty):
 
 
 def summarize(summary):
-    """只输出键名、来源、值长度与前 4 字符，绝不打印完整 secret。"""
+    """向 stderr 输出键名/来源/长度，绝不打印 secret 值或其前缀。"""
     for tok, val, src in summary:
         if isinstance(val, list):
-            print(f"  {tok}: {src} (array len={len(val)})")
+            print(f"  {tok}: {src} (array len={len(val)})", file=sys.stderr)
         else:
-            head = val[:4] if val else "(empty)"
-            print(f"  {tok}: {src} len={len(val)} head={head!r}")
+            print(f"  {tok}: {src} len={len(val)}", file=sys.stderr)
 
 
 def cmd_render(args):
@@ -155,21 +201,24 @@ def cmd_render(args):
     if args.allow_empty_extra:
         allow |= {x.strip() for x in args.allow_empty_extra.split(",") if x.strip()}
     values, summary = build_values(args.env, instance, os.environ, tokens, allow)
+    # 跨库防护: DSN dbname 必须匹配实例
+    validate_pg_dsn(values, instance)
     rendered = render(text, values)
     try:
         tomllib.loads(rendered)
     except tomllib.TOMLDecodeError as e:
         raise SystemExit(f"render: 产物 TOML 解析失败（fail-closed，不输出）: {e}")
-    print(f"render: {args.env} 渲染校验通过，token 清单:")
+    print(f"render: {args.env} 渲染校验通过，token 清单:", file=sys.stderr)
     summarize(summary)
     out = args.out
     if out == "-":
+        # stdout 是产物通道：只写 TOML，诊断已走 stderr
         sys.stdout.write(rendered)
-    else:
-        os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
-        with open(out, "w", encoding="utf-8") as f:
-            f.write(rendered)
-        print(f"render: 已写入 {out}")
+        return
+    os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(rendered)
+    print(f"render: 已写入 {out}")
 
 
 def cmd_compare_example(args):
@@ -211,7 +260,7 @@ def main(argv=None):
     )
     pr.add_argument("--tmpl", default=DEFAULT_TMPL)
     pr.add_argument("--instances-dir", default=DEFAULT_INSTANCES_DIR)
-    pr.add_argument("--out", default="-", help="输出路径（默认 stdout）")
+    pr.add_argument("--out", default="-", help="输出路径（默认 stdout，纯 TOML）")
     pr.add_argument(
         "--allow-empty-extra", default="", help="额外允许为空的 token（逗号分隔）"
     )

--- a/deploy/render_config_test.py
+++ b/deploy/render_config_test.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""render_config_test.py — deploy/render_config.py 的单元测试（assert 风格，仿 pgdsn_test.sh）。
+
+运行: python3 deploy/render_config_test.py  （退出码非 0 = 失败，无需外部依赖）
+覆盖: token 解析 / 占位替换 / TOML 转义 / 残留拒绝 / 空必需值拒绝 / allow-empty 白名单 /
+      example↔tmpl 键集一致性 / dev 端到端渲染产物可解析。
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import tomllib
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import render_config as rc  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(desc, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"ok  - {desc}")
+    else:
+        FAIL += 1
+        print(f"FAIL- {desc}")
+
+
+def check_eq(desc, want, got):
+    check(f"{desc}: want {want!r}, got {got!r}", want == got)
+
+
+def expect_exit(desc, fn):
+    try:
+        fn()
+        check(desc, False)
+    except SystemExit:
+        check(desc, True)
+
+
+# --- 1. token 解析与渲染（string / array / 转义） ---
+tmpl_src = "url = {{SERVER_URL}}\narr = {{TRUSTED_PROXIES}}\ntxt = {{GH_SECRET}}\n"
+check_eq(
+    "tokens_in 收集",
+    {"SERVER_URL", "TRUSTED_PROXIES", "GH_SECRET"},
+    rc.tokens_in(tmpl_src),
+)
+
+out = rc.render(
+    tmpl_src,
+    {
+        "SERVER_URL": "https://f.yourtj.de",
+        "TRUSTED_PROXIES": ["172.16.0.0/12", "::1"],
+        "GH_SECRET": 'p"a\\b\nc',
+    },
+)
+parsed = tomllib.loads(out)
+check_eq("string 渲染", "https://f.yourtj.de", parsed["url"])
+check_eq("array 渲染", ["172.16.0.0/12", "::1"], parsed["arr"])
+check_eq("转义保留(引号/反斜杠/换行)", 'p"a\\b\nc', parsed["txt"])
+
+# --- 2. 残留 / 未知 token 拒绝 ---
+expect_exit(
+    "未知 token 应失败",
+    lambda: rc.render("a = {{SERVER_URL}}\nbad = {{UNKNOWN}}", {"SERVER_URL": "x"}),
+)
+expect_exit("残留 {{ 应失败", lambda: rc.render('a = "x{{BROKEN"', {}))
+expect_exit(
+    "渲染后仍含 }} 应失败",
+    lambda: rc.render("a = {{SERVER_URL}} }}\n", {"SERVER_URL": "x"}),
+)
+
+# --- 3. 真实模板 token 分类与空值 fail-closed ---
+fake_instance = {
+    "instance": "dev",
+    "server_url": "https://dev.yourtj.de",
+    "trusted_proxies": ["172.16.0.0/12"],
+    "pg_dbname": "yourtj_dev",
+}
+with open(rc.DEFAULT_TMPL, encoding="utf-8") as f:
+    real_tmpl = f.read()
+real_tokens = rc.tokens_in(real_tmpl)
+required_nonempty = sorted(real_tokens - rc.INSTANCE_TOKENS - rc.optional_tokens("dev"))
+check(
+    "模板必需非空 secret 含 SIGNING_KEY/PG_DSN/MEILI/WIKI",
+    {"SIGNING_KEY", "PG_DSN", "MEILI_MASTER_KEY", "WIKI_WEBHOOK_SECRET"}
+    <= set(required_nonempty),
+)
+check(
+    "main 的 GH_CLIENT_ID 必填（不在 allow-empty）",
+    "GH_CLIENT_ID" not in rc.optional_tokens("main"),
+)
+check("dev 的 GH_CLIENT_ID 允许空", "GH_CLIENT_ID" in rc.optional_tokens("dev"))
+
+env_empty = {tok: "" for tok in real_tokens}
+expect_exit(
+    "空必需 secret 应拒绝（dev）",
+    lambda: rc.build_values(
+        "dev", fake_instance, env_empty, real_tokens, rc.optional_tokens("dev")
+    ),
+)
+
+# --- 4. allow-empty 白名单生效 + main GH 必填 ---
+env_partial = dict(env_empty)
+env_partial.update(
+    {
+        "SIGNING_KEY": "s" * 32,
+        "PG_DSN": "host=postgres user=yourtj dbname=yourtj_dev port=5432 sslmode=disable",
+        "MEILI_MASTER_KEY": "m" * 32,
+        "WIKI_WEBHOOK_SECRET": "w" * 64,
+    }
+)
+values, summary = rc.build_values(
+    "dev", fake_instance, env_partial, real_tokens, rc.optional_tokens("dev")
+)
+check_eq("dev 空 GH_CLIENT_ID 渲染为空串", "", values.get("GH_CLIENT_ID", "<missing>"))
+check_eq("dev 空 AI_API_KEY 渲染为空串", "", values.get("AI_API_KEY", "<missing>"))
+check_eq("dev 渲染 signingKey 正确", "s" * 32, values["SIGNING_KEY"])
+secret_toks = {t for t, _, src in summary if src == "secret"}
+check(
+    "summary 标记 secret",
+    "SIGNING_KEY" in secret_toks and "GH_CLIENT_ID" not in secret_toks,
+)
+
+# main 场景: GH 凭据未设 → 必须失败（fail-closed 生产）
+fake_main = {
+    "instance": "main",
+    "server_url": "https://f.yourtj.de",
+    "trusted_proxies": ["172.16.0.0/12"],
+    "pg_dbname": "yourtj_main",
+}
+expect_exit(
+    "main 缺 GH_CLIENT_SECRET 应拒绝",
+    lambda: rc.build_values(
+        "main", fake_main, env_partial, real_tokens, rc.optional_tokens("main")
+    ),
+)
+
+# --- 5. example ↔ tmpl 键集一致性（仓库实际文件） ---
+rc_ok = rc.main(["compare-example"])
+check("compare-example: example 键集覆盖 tmpl", rc_ok == 0)
+
+# --- 6. dev 端到端渲染（CLI 子进程, 注入完整 env）: 产物可解析、值正确、无残留 ---
+with tempfile.TemporaryDirectory() as td:
+    out_path = os.path.join(td, "config.toml")
+    env_full = dict(os.environ)
+    env_full.update(
+        {
+            "SIGNING_KEY": "k" * 32,
+            "PG_DSN": "host=postgres user=yourtj password=x dbname=yourtj_dev port=5432 sslmode=disable",
+            "MEILI_MASTER_KEY": "m" * 32,
+            "WIKI_WEBHOOK_SECRET": "w" * 64,
+        }
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(HERE, "render_config.py"),
+            "render",
+            "--env",
+            "dev",
+            "--out",
+            out_path,
+        ],
+        env=env_full,
+        capture_output=True,
+        text=True,
+    )
+    check(
+        f"dev 渲染 exit 0（stderr: {proc.stderr.strip()[:60]}）", proc.returncode == 0
+    )
+    if proc.returncode == 0:
+        with open(out_path, encoding="utf-8") as f:
+            cfg = tomllib.loads(f.read())
+        check_eq("dev server_url", "https://dev.yourtj.de", cfg["server"]["url"])
+        check_eq("dev github client_id 空", "", cfg["github"]["client_id"])
+        check_eq("dev signingKey", "k" * 32, cfg["app"]["signingKey"])
+        dbname = cfg["db"]["default"]["url"].split("dbname=")[1].split()[0]
+        check_eq("dev dsn dbname", "yourtj_dev", dbname)
+        rendered_txt = open(out_path, encoding="utf-8").read()
+        check(
+            "dev 产物无 {{ 残留", "{{" not in rendered_txt and "}}" not in rendered_txt
+        )
+
+# --- 7. 坏模板端到端拒绝（fail-closed 不产文件） ---
+with tempfile.TemporaryDirectory() as td:
+    bad_tmpl = os.path.join(td, "bad.tmpl")
+    with open(bad_tmpl, "w", encoding="utf-8") as f:
+        f.write("url = {{SERVER_URL}}\nleftover = {{STRAY}}\n")
+    env_bad = dict(os.environ)
+    env_bad.update({"SERVER_URL": "https://x.de"})
+    bad_out = os.path.join(td, "out.toml")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(HERE, "render_config.py"),
+            "render",
+            "--env",
+            "dev",
+            "--tmpl",
+            bad_tmpl,
+            "--out",
+            bad_out,
+        ],
+        env=env_bad,
+        capture_output=True,
+        text=True,
+    )
+    check("坏模板端到端拒绝（exit != 0）", proc.returncode != 0)
+    check("坏模板不产出文件", not os.path.exists(bad_out))
+
+print(f"\n{'-' * 40}\nrender_config_test: {PASS} passed, {FAIL} failed")
+raise SystemExit(1 if FAIL else 0)

--- a/deploy/render_config_test.py
+++ b/deploy/render_config_test.py
@@ -3,7 +3,7 @@
 
 运行: python3 deploy/render_config_test.py  （退出码非 0 = 失败，无需外部依赖）
 覆盖: token 解析 / 占位替换 / TOML 转义 / 残留拒绝 / 空必需值拒绝 / allow-empty 白名单 /
-      example↔tmpl 键集一致性 / dev 端到端渲染产物可解析。
+      PG_DSN dbname 跨库校验 / stdout 纯 TOML / example↔tmpl 键集一致性 / dev 端到端渲染。
 """
 
 from __future__ import annotations
@@ -77,6 +77,36 @@ expect_exit(
     lambda: rc.render("a = {{SERVER_URL}} }}\n", {"SERVER_URL": "x"}),
 )
 
+# --- 2.5 PG_DSN dbname 解析与跨库校验 ---
+check_eq(
+    "dsn key=value 解析",
+    "yourtj_dev",
+    rc.dsn_dbname(
+        "host=postgres user=yourtj password=x dbname=yourtj_dev port=5432 sslmode=disable"
+    ),
+)
+check_eq(
+    "dsn URL 解析",
+    "yourtj_main",
+    rc.dsn_dbname("postgres://yourtj:x@postgres:5432/yourtj_main?sslmode=disable"),
+)
+check_eq(
+    "dsn URL 空库返回 None", None, rc.dsn_dbname("postgres://yourtj:x@postgres:5432")
+)
+check_eq("dsn 空串返回 None", None, rc.dsn_dbname(""))
+check_eq("dsn 无 dbname 返回 None", None, rc.dsn_dbname("host=postgres user=yourtj"))
+
+inst_dev = {"pg_dbname": "yourtj_dev"}
+rc.validate_pg_dsn({"PG_DSN": "host=x dbname=yourtj_dev"}, inst_dev)  # 不抛
+expect_exit(
+    "PG_DSN dbname 与实例不符应拒绝",
+    lambda: rc.validate_pg_dsn({"PG_DSN": "host=x dbname=yourtj_main"}, inst_dev),
+)
+expect_exit(
+    "PG_DSN 无法解析 dbname 应拒绝",
+    lambda: rc.validate_pg_dsn({"PG_DSN": "host=x port=5432"}, inst_dev),
+)
+
 # --- 3. 真实模板 token 分类与空值 fail-closed ---
 fake_instance = {
     "instance": "dev",
@@ -128,6 +158,19 @@ check(
     "summary 标记 secret",
     "SIGNING_KEY" in secret_toks and "GH_CLIENT_ID" not in secret_toks,
 )
+# summarize() 输出（stderr）不得含任何 secret 值或前缀（防日志泄露部分密钥）
+import contextlib
+import io
+
+buf = io.StringIO()
+with contextlib.redirect_stderr(buf):
+    rc.summarize(summary)
+sum_text = buf.getvalue()
+check(
+    "summarize 输出不含 secret 值前缀",
+    "s" * 4 not in sum_text and "Ov23" not in sum_text,
+)
+check("summarize 输出含键名与长度", "SIGNING_KEY" in sum_text and "len=32" in sum_text)
 
 # main 场景: GH 凭据未设 → 必须失败（fail-closed 生产）
 fake_main = {
@@ -188,6 +231,57 @@ with tempfile.TemporaryDirectory() as td:
         check(
             "dev 产物无 {{ 残留", "{{" not in rendered_txt and "}}" not in rendered_txt
         )
+    # stderr 诊断不得包含 secret 值前缀
+    check(
+        "stderr 不含 secret 前缀",
+        "k" * 4 not in proc.stderr and "Ov23" not in proc.stderr,
+    )
+
+    # 6.5 stdout 模式（--out -）: stdout 只含 TOML, 诊断全在 stderr
+    proc_stdout = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(HERE, "render_config.py"),
+            "render",
+            "--env",
+            "dev",
+            "--out",
+            "-",
+        ],
+        env=env_full,
+        capture_output=True,
+        text=True,
+    )
+    check("stdout 模式 exit 0", proc_stdout.returncode == 0)
+    if proc_stdout.returncode == 0:
+        stdout_cfg = tomllib.loads(proc_stdout.stdout)
+        check(
+            "stdout 是纯 TOML（可解析）",
+            stdout_cfg["server"]["url"] == "https://dev.yourtj.de",
+        )
+    check("stdout 模式诊断在 stderr", "render:" in proc_stdout.stderr)
+
+    # 6.6 跨库 DSN（dev 指向 yourtj_main）端到端拒绝
+    env_cross = dict(env_full)
+    env_cross["PG_DSN"] = (
+        "host=postgres user=yourtj password=x dbname=yourtj_main port=5432 sslmode=disable"
+    )
+    proc_cross = subprocess.run(
+        [
+            sys.executable,
+            os.path.join(HERE, "render_config.py"),
+            "render",
+            "--env",
+            "dev",
+            "--out",
+            "-",
+        ],
+        env=env_cross,
+        capture_output=True,
+        text=True,
+    )
+    check("跨库 DSN 端到端拒绝（exit != 0）", proc_cross.returncode != 0)
+    check("跨库错误信息含 dbname", "dbname" in proc_cross.stderr)
 
 # --- 7. 坏模板端到端拒绝（fail-closed 不产文件） ---
 with tempfile.TemporaryDirectory() as td:

--- a/deploy/scripts/apply-config.sh
+++ b/deploy/scripts/apply-config.sh
@@ -33,7 +33,7 @@ INST_DIR="$ROOT/$INSTANCE"
 CFG="$INST_DIR/config.toml"
 MARKER="$INST_DIR/.config.sha256"
 PREV="$CFG.prev"
-
+LOCK_DIR="$INST_DIR/.config.lock"
 PORT_VAR="$([ "$INSTANCE" = "main" ] && echo MAIN_PORT || echo DEV_PORT)"
 PORT="5234"
 [ "$INSTANCE" = "dev" ] && PORT="5235"
@@ -68,15 +68,22 @@ if [ -n "$CUR_SHA" ] && [ "$CUR_SHA" = "$NEW_SHA" ]; then
   exit 0
 fi
 
-# --- 备份（单槽 prev; 并发/残留防护） ---
+# --- 持锁（与 deploy.sh 同一把锁, mkdir 原子; 防止并发互相覆盖回滚点） ---
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  log "FATAL: config 锁 $LOCK_DIR 已存在（另一 apply/deploy 正在进行）"
+  log "       确认无并发后: rm -rf $LOCK_DIR 再重试"
+  exit 1
+fi
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+
+# --- 备份（单槽 prev; 残留防护） ---
 if [ -e "$PREV" ]; then
-  log "FATAL: $PREV 已存在（并发 apply 或上次失败残留），拒绝覆盖回滚点"
+  log "FATAL: $PREV 已存在（上次失败残留），拒绝覆盖回滚点"
   log "       确认无并发后: rm -f $PREV 再重试"
   exit 1
 fi
 cp -f "$CFG" "$PREV" || { log "FATAL: 备份现网 config 失败"; exit 1; }
 log "已备份现网 config → $PREV"
-
 # --- 原子替换（同目录 .new + mv = rename 原子） ---
 cp -f "$RENDERED" "$CFG.new" || { log "FATAL: 写入 $CFG.new 失败"; rm -f "$CFG.new"; exit 1; }
 mv -f "$CFG.new" "$CFG" || { log "FATAL: mv 替换 config 失败"; rm -f "$CFG.new"; exit 1; }

--- a/deploy/scripts/apply-config.sh
+++ b/deploy/scripts/apply-config.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# apply-config.sh — 原子替换实例 config.toml（配置治理 CI 下发入口）。
+#
+# 语义（与 deploy.sh 同一回滚体系）:
+#   1. 校验渲染产物（存在、无未替换占位符）;
+#   2. 计算现网 config 当前 SHA-256，与 .config.sha256 marker 比较:
+#      内容未变 → 幂等跳过（不重启，并刷新 marker）;
+#   3. 备份现网 → config.toml.prev（单槽; 已存在 = 并发/残留 → 失败拒绝，
+#      防止两个下发互相覆盖回滚点）;
+#   4. 原子替换（先写同目录 config.toml.new 再 mv -f，rename 原子）;
+#   5. --force-recreate 重建容器（关键! 单文件 bind-mount 持有旧 inode,
+#      restart 不会重挂新文件; 重建容器才会重新解析挂载并完整重读 config,
+#      OAuth provider / DB 连接等在进程启动时初始化）;
+#   6. 健康检查（端口取 .env; 60×3s 与 deploy.sh 一致）;
+#   7. 成功 → 写 .config.sha256 marker，并清理 prev（释放单槽）;
+#      失败 → 恢复 config.toml.prev（mv 即消费 prev）+ 重建 + exit 1
+#      （不回写 marker: 若恢复出的文件与上次成功值不同, drift-check 会告警）。
+#
+# usage: apply-config.sh <instance> <rendered-file>
+#   instance: main|dev      rendered-file: CI 渲染产物绝对路径
+# 环境变量:
+#   YOURTJ_ROOT — 部署根（默认 /opt/yourtj）
+set -euo pipefail
+
+INSTANCE="${1:?usage: apply-config.sh <instance> <rendered-file>}"
+RENDERED="${2:?usage: apply-config.sh <instance> <rendered-file>}"
+[ "$INSTANCE" = "main" ] || [ "$INSTANCE" = "dev" ] || { echo "apply-config: instance 必须是 main|dev (got $INSTANCE)" >&2; exit 1; }
+
+ROOT="${YOURTJ_ROOT:-/opt/yourtj}"
+ENV_FILE="$ROOT/.env"
+COMPOSE_FILE="$ROOT/docker-compose.yaml"
+INST_DIR="$ROOT/$INSTANCE"
+CFG="$INST_DIR/config.toml"
+MARKER="$INST_DIR/.config.sha256"
+PREV="$CFG.prev"
+
+PORT_VAR="$([ "$INSTANCE" = "main" ] && echo MAIN_PORT || echo DEV_PORT)"
+PORT="5234"
+[ "$INSTANCE" = "dev" ] && PORT="5235"
+if [ -f "$ENV_FILE" ] && grep -qE "^$PORT_VAR=" "$ENV_FILE"; then
+  PORT="$(grep -E "^$PORT_VAR=" "$ENV_FILE" | head -1 | cut -d= -f2-)"
+fi
+
+compose_cmd() {
+  # --force-recreate --no-deps: 单文件 bind-mount 替换后必须重建容器才重挂新文件;
+  # --no-deps 避免触碰 postgres/meilisearch。
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --force-recreate --no-deps "$INSTANCE"
+}
+
+log() { echo "[apply-config:$INSTANCE] $*"; }
+sha() { sha256sum "$1" 2>/dev/null | awk '{print $1}'; }
+
+# --- 前置校验（fail-closed） ---
+[ -f "$RENDERED" ] || { log "FATAL: 渲染产物不存在: $RENDERED"; exit 1; }
+if grep -q '{{' "$RENDERED"; then
+  log "FATAL: 渲染产物含未替换占位符，拒绝应用"; exit 1
+fi
+[ -f "$CFG" ] || { log "FATAL: $CFG 不存在（未初始化?）"; exit 1; }
+[ -f "$ENV_FILE" ] || { log "FATAL: $ENV_FILE 缺失（run init-server.sh 先）"; exit 1; }
+[ -f "$COMPOSE_FILE" ] || { log "FATAL: $COMPOSE_FILE 缺失（run init-server.sh 先）"; exit 1; }
+
+# --- 幂等: 内容与现网一致则跳过 ---
+CUR_SHA="$(sha "$CFG")"
+NEW_SHA="$(sha "$RENDERED")"
+if [ -n "$CUR_SHA" ] && [ "$CUR_SHA" = "$NEW_SHA" ]; then
+  log "内容与现网一致（sha=$CUR_SHA），幂等跳过"
+  printf '%s\n' "$CUR_SHA" > "$MARKER"
+  exit 0
+fi
+
+# --- 备份（单槽 prev; 并发/残留防护） ---
+if [ -e "$PREV" ]; then
+  log "FATAL: $PREV 已存在（并发 apply 或上次失败残留），拒绝覆盖回滚点"
+  log "       确认无并发后: rm -f $PREV 再重试"
+  exit 1
+fi
+cp -f "$CFG" "$PREV" || { log "FATAL: 备份现网 config 失败"; exit 1; }
+log "已备份现网 config → $PREV"
+
+# --- 原子替换（同目录 .new + mv = rename 原子） ---
+cp -f "$RENDERED" "$CFG.new" || { log "FATAL: 写入 $CFG.new 失败"; rm -f "$CFG.new"; exit 1; }
+mv -f "$CFG.new" "$CFG" || { log "FATAL: mv 替换 config 失败"; rm -f "$CFG.new"; exit 1; }
+log "已原子替换 config.toml"
+
+# --- 重建容器（单文件 bind-mount: 必须 force-recreate 才重挂新文件 + 进程级重读） ---
+if ! compose_cmd; then
+  log "FATAL: compose 重建失败; 尝试恢复 prev"
+  if [ -f "$PREV" ]; then
+    mv -f "$PREV" "$CFG"
+    compose_cmd >/dev/null 2>&1 || true
+    log "已恢复 prev 并尝试重建"
+  fi
+  exit 1
+fi
+log "已重建 $INSTANCE 容器（force-recreate，重挂新 config）"
+
+# --- 健康检查 ---
+health_ok=0
+for ((i = 1; i <= 60; i++)); do
+  if curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
+    health_ok=1
+    break
+  fi
+  log "等待健康 ($i/60)..."
+  sleep 3
+done
+
+if [ "$health_ok" -eq 1 ]; then
+  printf '%s\n' "$NEW_SHA" > "$MARKER"
+  rm -f "$PREV"
+  log "健康检查通过; marker=$NEW_SHA; prev 已清理"
+  exit 0
+fi
+
+# --- 失败恢复（mv 消费 prev） ---
+log "FATAL: 健康检查失败，恢复上一份 config"
+if [ -f "$PREV" ]; then
+  mv -f "$PREV" "$CFG"
+  compose_cmd >/dev/null 2>&1 || true
+  log "已恢复 prev → config.toml 并重建容器"
+  for ((i = 1; i <= 20; i++)); do
+    curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && { log "恢复后健康检查通过"; break; }
+    sleep 3
+  done
+else
+  log "FATAL: 无 prev 可恢复; 实例可能处于未健康状态，需人工介入"
+fi
+exit 1

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -20,6 +20,12 @@ ROOT="${YOURTJ_ROOT:-/opt/yourtj}"
 ENV_FILE="$ROOT/.env"
 COMPOSE_FILE="$ROOT/docker-compose.yaml"
 TAG_VAR="$([ "$INSTANCE" = "main" ] && echo MAIN_TAG || echo DEV_TAG)"
+INST_DIR="$ROOT/$INSTANCE"
+CFG="$INST_DIR/config.toml"
+PREV="$CFG.prev"
+CFG_MARKER="$INST_DIR/.config.sha256"
+LOCK_DIR="$INST_DIR/.config.lock"
+CONFIG_APPLIED=""
 
 log() { echo "[deploy:$INSTANCE] $*"; }
 
@@ -61,6 +67,52 @@ prune_old_images() {
   log "prune done: removed $removed image tag(s); dangling $dangling_before -> $dangling_after"
 }
 
+# 原子获取 config 回滚槽锁（与 apply-config.sh 同一把锁）; 失败 = 并发, 直接中止。
+acquire_config_lock() {
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    log "FATAL: config 锁 $LOCK_DIR 已存在（另一 apply/deploy 正在进行），拒绝互相覆盖回滚点"
+    log "       确认无并发后: rm -rf $LOCK_DIR 再重试"
+    exit 1
+  fi
+  trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+}
+
+# 失败统一回滚: compose up 失败 / 健康检查失败均走这里。
+# 恢复 1) config.prev → config.toml  2) 旧 compose  3) .env tag → 旧镜像并重建容器。
+rollback_all() {
+  log "rolling back deploy"
+
+  # 若本次替换过 config, 先恢复(与镜像同一回滚事务)
+  if [ -n "$CONFIG_APPLIED" ] && [ -f "$PREV" ]; then
+    mv -f "$PREV" "$CFG"
+    log "restored previous config.toml from config.toml.prev"
+  fi
+
+  # 若 main 部署前备份了 compose(main workflow 更新共享 compose 时), 一并恢复
+  if [ -f "$ROOT/docker-compose.yaml.prev" ]; then
+    cp -f "$ROOT/docker-compose.yaml.prev" "$ROOT/docker-compose.yaml"
+    log "restored previous compose file from docker-compose.yaml.prev"
+  fi
+
+  if [ -n "$OLD_TAG" ]; then
+    if docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; then
+      sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$OLD_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
+      docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE" >/dev/null 2>&1 || true
+      log "rolled back to $OLD_TAG"
+    else
+      log "WARNING: $IMAGE:$OLD_TAG not present locally, cannot roll back container; .env still points at new tag $IMAGE_TAG"
+    fi
+  else
+    log "WARNING: no previous tag recorded, cannot roll back"
+  fi
+
+  # config 被恢复过则重建容器以重挂旧 config（单文件 bind-mount 持有旧 inode）
+  if [ -n "$CONFIG_APPLIED" ]; then
+    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans --force-recreate --no-deps "$INSTANCE" >/dev/null 2>&1 || true
+    log "recreated $INSTANCE to re-mount restored config"
+  fi
+}
+
 [ -f "$ENV_FILE" ] || { log "FATAL: $ENV_FILE missing (run init-server.sh first)"; exit 1; }
 [ -f "$COMPOSE_FILE" ] || { log "FATAL: $COMPOSE_FILE missing (run init-server.sh first)"; exit 1; }
 
@@ -81,6 +133,7 @@ if [ -n "$OLD_TAG" ] && docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; 
 else
   log "no previous local image for $OLD_TAG; rollback will only revert .env tag"
 fi
+
 # 2. 拉取新镜像(GHCR 公开镜像, 匿名 pull)
 docker pull "$IMAGE:$IMAGE_TAG"
 log "pulled image $IMAGE:$IMAGE_TAG"
@@ -89,22 +142,25 @@ log "pulled image $IMAGE:$IMAGE_TAG"
 #     单文件 bind-mount 持有旧 inode, 容器需在 config 变更时重建才重挂新文件;
 #     下方步骤 3 的 compose up 因新镜像 tag 变更会 recreate 容器, 若 tag 未变
 #     而 config 已替换, 则显式 force-recreate。
-CONFIG_APPLIED=""
 if [ -n "${CONFIG_FILE:-}" ]; then
   [ -f "$CONFIG_FILE" ] || { log "FATAL: CONFIG_FILE=$CONFIG_FILE 不存在"; exit 1; }
   if grep -q '{{' "$CONFIG_FILE"; then
     log "FATAL: CONFIG_FILE 含未替换占位符 {{, 拒绝应用"; exit 1
   fi
-  INST_DIR="$ROOT/$INSTANCE"
-  CFG="$INST_DIR/config.toml"
-  PREV="$CFG.prev"
-  CFG_MARKER="$INST_DIR/.config.sha256"
   NEW_SHA="$(sha256sum "$CONFIG_FILE" | awk '{print $1}')"
   CUR_SHA="$(sha256sum "$CFG" 2>/dev/null | awk '{print $1}' || true)"
   if [ -n "$CUR_SHA" ] && [ "$CUR_SHA" = "$NEW_SHA" ]; then
-    log "config 与现网一致(sha=$NEW_SHA), 跳过替换"
+    # 幂等: 内容已一致 → 仅记录 marker（verify-instance 依赖它判定无漂移），不替换
+    printf '%s\n' "$NEW_SHA" > "$CFG_MARKER"
+    log "config 与现网一致(sha=$NEW_SHA), 跳过替换并记录 marker"
   else
-    [ -e "$PREV" ] && { log "FATAL: $PREV 已存在(并发 apply 或残留), 拒绝覆盖回滚点"; exit 1; }
+    # 变更路径: 持锁后备份→原子替换, 失败走 rollback_all 恢复
+    acquire_config_lock
+    if [ -e "$PREV" ]; then
+      log "FATAL: $PREV 已存在(上次失败残留), 拒绝覆盖回滚点"
+      log "       确认无并发后: rm -f $PREV 再重试"
+      exit 1
+    fi
     cp -f "$CFG" "$PREV" || { log "FATAL: 备份 config 失败"; exit 1; }
     cp -f "$CONFIG_FILE" "$CFG.new" || { log "FATAL: 写入 $CFG.new 失败"; rm -f "$CFG.new"; exit 1; }
     mv -f "$CFG.new" "$CFG"
@@ -117,10 +173,18 @@ fi
 #    反代由 1Panel 负责(公网 TLS 终止 + 回源宿主机端口), 本 compose 不含 nginx 服务。
 sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$IMAGE_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
 if [ -n "$CONFIG_APPLIED" ]; then
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans --force-recreate --no-deps "$INSTANCE"
+  if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans --force-recreate --no-deps "$INSTANCE"; then
+    log "FATAL: compose up 失败（config 已替换），进入统一回滚"
+    rollback_all
+    exit 1
+  fi
   log "compose recreate $INSTANCE with $IMAGE_TAG (--remove-orphans --force-recreate for new config)"
 else
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
+  if ! docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"; then
+    log "FATAL: compose up 失败，进入统一回滚"
+    rollback_all
+    exit 1
+  fi
   log "compose up $INSTANCE with $IMAGE_TAG (--remove-orphans)"
 fi
 
@@ -147,36 +211,7 @@ if [ "$health_ok" -eq 1 ]; then
   exit 0
 fi
 
-# 5. 失败: 回滚到旧 tag(prev 不可用时仅改 .env, 容器保持旧镜像)
+# 5. 健康检查失败 → 统一回滚
 log "FATAL: health check failed, rolling back"
-
-# 5.0 若本次替换过 config, 先恢复(与镜像同一回滚事务)
-if [ -n "$CONFIG_APPLIED" ] && [ -f "$PREV" ]; then
-  mv -f "$PREV" "$CFG"
-  log "restored previous config.toml from config.toml.prev"
-fi
-
-# 5.1 若 main 部署前备份了 compose(main workflow 更新共享 compose 时),
-#     一并恢复旧 compose, 避免新的 mounts/env/网络配置残留(PR review #4)
-if [ -f "$ROOT/docker-compose.yaml.prev" ]; then
-  cp -f "$ROOT/docker-compose.yaml.prev" "$ROOT/docker-compose.yaml"
-  log "restored previous compose file from docker-compose.yaml.prev"
-fi
-if [ -n "$OLD_TAG" ]; then
-  if docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; then
-    sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$OLD_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
-    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
-    log "rolled back to $OLD_TAG"
-  else
-    log "WARNING: $IMAGE:$OLD_TAG not present locally, cannot roll back container; .env still points at new tag $IMAGE_TAG"
-  fi
-else
-  log "WARNING: no previous tag recorded, cannot roll back"
-fi
-
-# 5.3 成功回滚镜像后, 若 config 也被恢复过, 容器需重建以重挂旧 config
-if [ -n "$CONFIG_APPLIED" ]; then
-  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans --force-recreate --no-deps "$INSTANCE" >/dev/null 2>&1 || true
-  log "recreated $INSTANCE to re-mount restored config"
-fi
+rollback_all
 exit 1

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -8,6 +8,8 @@
 # 环境变量:
 #   IMAGE_REPO   — 镜像仓库(默认 ghcr.io/yourtongji/yourtj-hub, 公开镜像匿名 pull)
 #   IMAGE_KEEP_N — 每个实例前缀保留的镜像 tag 数(含当前), 默认 5
+#   CONFIG_FILE  — (可选) 渲染好的 config.toml 产物绝对路径; 携带时与镜像同事务
+#                  原子替换实例 config(先备份 .prev, 健康失败一并恢复)。
 set -euo pipefail
 
 INSTANCE="${1:?usage: deploy.sh <instance> <image-tag> [health-port]}"
@@ -79,30 +81,80 @@ if [ -n "$OLD_TAG" ] && docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; 
 else
   log "no previous local image for $OLD_TAG; rollback will only revert .env tag"
 fi
-
 # 2. 拉取新镜像(GHCR 公开镜像, 匿名 pull)
 docker pull "$IMAGE:$IMAGE_TAG"
 log "pulled image $IMAGE:$IMAGE_TAG"
 
+# 2.5 可选: 携带渲染 config 时原子替换(与镜像同一回滚事务)。
+#     单文件 bind-mount 持有旧 inode, 容器需在 config 变更时重建才重挂新文件;
+#     下方步骤 3 的 compose up 因新镜像 tag 变更会 recreate 容器, 若 tag 未变
+#     而 config 已替换, 则显式 force-recreate。
+CONFIG_APPLIED=""
+if [ -n "${CONFIG_FILE:-}" ]; then
+  [ -f "$CONFIG_FILE" ] || { log "FATAL: CONFIG_FILE=$CONFIG_FILE 不存在"; exit 1; }
+  if grep -q '{{' "$CONFIG_FILE"; then
+    log "FATAL: CONFIG_FILE 含未替换占位符 {{, 拒绝应用"; exit 1
+  fi
+  INST_DIR="$ROOT/$INSTANCE"
+  CFG="$INST_DIR/config.toml"
+  PREV="$CFG.prev"
+  CFG_MARKER="$INST_DIR/.config.sha256"
+  NEW_SHA="$(sha256sum "$CONFIG_FILE" | awk '{print $1}')"
+  CUR_SHA="$(sha256sum "$CFG" 2>/dev/null | awk '{print $1}' || true)"
+  if [ -n "$CUR_SHA" ] && [ "$CUR_SHA" = "$NEW_SHA" ]; then
+    log "config 与现网一致(sha=$NEW_SHA), 跳过替换"
+  else
+    [ -e "$PREV" ] && { log "FATAL: $PREV 已存在(并发 apply 或残留), 拒绝覆盖回滚点"; exit 1; }
+    cp -f "$CFG" "$PREV" || { log "FATAL: 备份 config 失败"; exit 1; }
+    cp -f "$CONFIG_FILE" "$CFG.new" || { log "FATAL: 写入 $CFG.new 失败"; rm -f "$CFG.new"; exit 1; }
+    mv -f "$CFG.new" "$CFG"
+    CONFIG_APPLIED=1
+    log "config 已原子替换(prev 已备份); sha=$NEW_SHA"
+  fi
+fi
+
 # 3. 更新 .env tag 并启动实例。
 #    反代由 1Panel 负责(公网 TLS 终止 + 回源宿主机端口), 本 compose 不含 nginx 服务。
 sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$IMAGE_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
-log "compose up $INSTANCE with $IMAGE_TAG (--remove-orphans)"
+if [ -n "$CONFIG_APPLIED" ]; then
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans --force-recreate --no-deps "$INSTANCE"
+  log "compose recreate $INSTANCE with $IMAGE_TAG (--remove-orphans --force-recreate for new config)"
+else
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans "$INSTANCE"
+  log "compose up $INSTANCE with $IMAGE_TAG (--remove-orphans)"
+fi
 
 # 4. 健康检查(覆盖启动 + AutoMigrate 大库迁移)
+health_ok=0
 for ((i = 1; i <= 60; i++)); do
   if curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null 2>&1; then
-    log "health check passed"
-    prune_old_images || log "prune failed (non-fatal, deploy succeeded)"
-    exit 0
+    health_ok=1
+    break
   fi
   log "waiting for health ($i/60)..."
   sleep 3
 done
 
+if [ "$health_ok" -eq 1 ]; then
+  log "health check passed"
+  # 若本次替换过 config, 成功即记录 marker 并释放 prev 单槽
+  if [ -n "$CONFIG_APPLIED" ]; then
+    printf '%s\n' "$NEW_SHA" > "$CFG_MARKER"
+    rm -f "$PREV"
+    log "config marker 已记录 $NEW_SHA; prev 已清理"
+  fi
+  prune_old_images || log "prune failed (non-fatal, deploy succeeded)"
+  exit 0
+fi
+
 # 5. 失败: 回滚到旧 tag(prev 不可用时仅改 .env, 容器保持旧镜像)
 log "FATAL: health check failed, rolling back"
+
+# 5.0 若本次替换过 config, 先恢复(与镜像同一回滚事务)
+if [ -n "$CONFIG_APPLIED" ] && [ -f "$PREV" ]; then
+  mv -f "$PREV" "$CFG"
+  log "restored previous config.toml from config.toml.prev"
+fi
 
 # 5.1 若 main 部署前备份了 compose(main workflow 更新共享 compose 时),
 #     一并恢复旧 compose, 避免新的 mounts/env/网络配置残留(PR review #4)
@@ -110,7 +162,6 @@ if [ -f "$ROOT/docker-compose.yaml.prev" ]; then
   cp -f "$ROOT/docker-compose.yaml.prev" "$ROOT/docker-compose.yaml"
   log "restored previous compose file from docker-compose.yaml.prev"
 fi
-
 if [ -n "$OLD_TAG" ]; then
   if docker image inspect "$IMAGE:$OLD_TAG" >/dev/null 2>&1; then
     sed -i.bak -E "s/^$TAG_VAR=.*/$TAG_VAR=$OLD_TAG/" "$ENV_FILE" && rm -f "$ENV_FILE.bak"
@@ -121,5 +172,11 @@ if [ -n "$OLD_TAG" ]; then
   fi
 else
   log "WARNING: no previous tag recorded, cannot roll back"
+fi
+
+# 5.3 成功回滚镜像后, 若 config 也被恢复过, 容器需重建以重挂旧 config
+if [ -n "$CONFIG_APPLIED" ]; then
+  docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans --force-recreate --no-deps "$INSTANCE" >/dev/null 2>&1 || true
+  log "recreated $INSTANCE to re-mount restored config"
 fi
 exit 1

--- a/deploy/scripts/init-server.sh
+++ b/deploy/scripts/init-server.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # init-server.sh — 服务器一次性初始化(在目标服务器上以 root 运行)。
 # 用法: sudo bash init-server.sh [main-domain] [dev-domain]
-#   例: sudo bash init-server.sh https://forum.yourtj.de https://dev.yourtj.de
+#   例: sudo bash init-server.sh https://f.yourtj.de https://dev.yourtj.de
 set -euo pipefail
 
-MAIN_DOMAIN="${1:-https://forum.yourtj.de}"
+MAIN_DOMAIN="${1:-https://f.yourtj.de}"
 DEV_DOMAIN="${2:-https://dev.yourtj.de}"
 
 ROOT=/opt/yourtj
@@ -130,4 +130,16 @@ echo ""
 echo "=== INIT DONE ==="
 echo "  main: $ROOT/main   (port $(grep '^MAIN_PORT=' "$ROOT/.env" | cut -d= -f2), domain $MAIN_DOMAIN)"
 echo "  dev:  $ROOT/dev    (port $(grep '^DEV_PORT=' "$ROOT/.env" | cut -d= -f2), domain $DEV_DOMAIN)"
-echo "  下一步: 推送 dev 分支触发 CI 部署(需已配置 GitHub Secrets VM_HOST/VM_USER/VM_SSH_KEY)"
+echo ""
+echo "=== 配置治理: 需回填到 GitHub Environments secrets 的值（CI 渲染 config 用） ==="
+echo "  production 环境: PG_DSN / SIGNING_KEY / MEILI_MASTER_KEY / WIKI_WEBHOOK_SECRET"
+echo "                   VM_HOST / VM_USER / VM_SSH_KEY / VM_SSH_PORT"
+echo "                   GH_CLIENT_ID / GH_CLIENT_SECRET（GitHub OAuth, 生产启用）"
+echo "  dev 环境:       同 PG_DSN / SIGNING_KEY / MEILI_MASTER_KEY / WIKI_WEBHOOK_SECRET + VM_*;"
+echo "                   GitHub 凭据不填（DB siteUrl 无环境隔离, dev 保持空）"
+echo "  AI_API_KEY(可选): 两环境都可留空（AI 总结默认关闭）"
+echo "  命令示例（在本地持 GH token 处执行, 值从服务器读取, 勿回显）:"
+echo "    ssh root@<host> \"awk '/^\\\\[db.default\\\\]/{f=1} f&&/^url =/{print;exit}' /opt/yourtj/main/config.toml\" \\"
+echo "      | gh secret set PG_DSN --env production"
+echo ""
+echo "  下一步: 推送 dev 分支触发 CI 部署（渲染 config 随镜像下发; apply-config.sh 做健康回滚）"

--- a/deploy/scripts/init-server.sh
+++ b/deploy/scripts/init-server.sh
@@ -139,7 +139,7 @@ echo "  dev 环境:       同 PG_DSN / SIGNING_KEY / MEILI_MASTER_KEY / WIKI_WEB
 echo "                   GitHub 凭据不填（DB siteUrl 无环境隔离, dev 保持空）"
 echo "  AI_API_KEY(可选): 两环境都可留空（AI 总结默认关闭）"
 echo "  命令示例（在本地持 GH token 处执行, 值从服务器读取, 勿回显）:"
-echo "    ssh root@<host> \"awk '/^\\\\[db.default\\\\]/{f=1} f&&/^url =/{print;exit}' /opt/yourtj/main/config.toml\" \\"
+echo "    ssh root@<host> \"awk '/^\\\\[db.default\\\\]/{f=1} f&&/^url =/{sub(/^url = \\\"/,\\\"\\\"); sub(/\\\"$/,\\\"\\\"); print; exit}' /opt/yourtj/main/config.toml\" \\"
 echo "      | gh secret set PG_DSN --env production"
 echo ""
 echo "  下一步: 推送 dev 分支触发 CI 部署（渲染 config 随镜像下发; apply-config.sh 做健康回滚）"

--- a/deploy/scripts/verify-instance.sh
+++ b/deploy/scripts/verify-instance.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# verify-instance.sh — 实例 config 漂移守卫（配置治理）。
+#
+# 核对项（不打印 secret 值）:
+#   1. config.toml 存在;
+#   2. .config.sha256 marker 存在且与现网文件 SHA-256 一致
+#      （不一致 = 人工 SSH 改动或未走 apply-config 的下发 → 告警）;
+#   3. [server].url 与期望实例域名一致（默认 main=https://f.yourtj.de dev=https://dev.yourtj.de,
+#      可用 EXPECT_SERVER_URL 覆盖，CI 从仓库 instances JSON 读入）;
+#   4. [db.default].url 的 dbname 与期望一致（复用 pgdsn.sh 解析）;
+#   5. 必需 secret 键非空（github 凭据 main 必填; dev 允许空——DB 站点设置无环境隔离）。
+#
+# usage: verify-instance.sh <instance>
+# 环境变量: YOURTJ_ROOT(默认 /opt/yourtj), EXPECT_SERVER_URL, EXPECT_DBNAME
+set -euo pipefail
+
+INSTANCE="${1:?usage: verify-instance.sh <instance>}"
+[ "$INSTANCE" = "main" ] || [ "$INSTANCE" = "dev" ] || { echo "verify-instance: instance 必须是 main|dev (got $INSTANCE)" >&2; exit 2; }
+
+ROOT="${YOURTJ_ROOT:-/opt/yourtj}"
+INST_DIR="$ROOT/$INSTANCE"
+CFG="$INST_DIR/config.toml"
+MARKER="$INST_DIR/.config.sha256"
+
+EXPECT_URL="${EXPECT_SERVER_URL:-}"
+[ -n "$EXPECT_URL" ] || EXPECT_URL="$([ "$INSTANCE" = "main" ] && echo https://f.yourtj.de || echo https://dev.yourtj.de)"
+EXPECT_DB="${EXPECT_DBNAME:-}"
+[ -n "$EXPECT_DB" ] || EXPECT_DB="yourtj_$INSTANCE"
+
+# --- cfg_get <file> <parent.section.key> : 表感知取键值（只做非空/比对，输出不涉密） ---
+cfg_get() {
+  local file="$1" path="$2" sec key
+  sec="${path%.*}"   # 父节路径, 如 db.default / app / wiki.git
+  key="${path##*.}"
+  awk -v sec="$sec" -v key="$key" '
+    /^\[/ {
+      line=$0; gsub(/^\[|\]$/, "", line)
+      in_sec = (line == sec)
+      next
+    }
+    in_sec && match($0, "^[ \t]*" key "[ \t]*=") {
+      sub(/^[^=]*=[ \t]*/, "")
+      gsub(/^"|"$/, "")
+      print
+      exit
+    }
+  ' "$file"
+}
+
+FAIL=0
+warn() { echo "verify-instance[$INSTANCE]: FAIL - $*"; FAIL=1; }
+ok() { echo "verify-instance[$INSTANCE]: ok - $*"; }
+
+# --- 1. 存在性 ---
+[ -f "$CFG" ] || { echo "verify-instance[$INSTANCE]: FAIL - $CFG 不存在"; exit 2; }
+
+# --- 2. marker 漂移信号 ---
+CUR_SHA="$(sha256sum "$CFG" 2>/dev/null | awk '{print $1}')"
+if [ -f "$MARKER" ]; then
+  RECORDED="$(tr -d '[:space:]' < "$MARKER")"
+  if [ -n "$RECORDED" ] && [ "$RECORDED" = "$CUR_SHA" ]; then
+    ok "config SHA-256 与 marker 一致 ($CUR_SHA)"
+  else
+    warn "config SHA-256 与 marker 不一致 (recorded=$RECORDED current=$CUR_SHA) → 人工改动或未同步下发"
+  fi
+else
+  warn ".config.sha256 marker 不存在（尚无 apply-config 成功下发）"
+fi
+
+# --- 3. server.url ---
+URL_VAL="$(awk '/^\[server\]/{f=1;next} f&&/^url =/{sub(/^url = "/,""); sub(/"$/,""); print; exit}' "$CFG")"
+if [ -n "$URL_VAL" ] && [ "$URL_VAL" = "$EXPECT_URL" ]; then
+  ok "server.url = $EXPECT_URL"
+else
+  warn "server.url = '${URL_VAL:-<空>}' ≠ 期望 '$EXPECT_URL'"
+fi
+
+# --- 4. dbname（复用 pgdsn.sh; 只打印库名, 不打印 DSN/密码） ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=pgdsn.sh
+source "$SCRIPT_DIR/pgdsn.sh"
+DSN_URL="$(pg_toml_url "$CFG" 2>/dev/null || true)"
+if [ -n "$DSN_URL" ]; then
+  DBNAME="$(pg_dsn_dbname "$DSN_URL" 2>/dev/null || true)"
+  if [ -n "$DBNAME" ] && [ "$DBNAME" = "$EXPECT_DB" ]; then
+    ok "db.default dbname = $EXPECT_DB"
+  else
+    warn "db.default dbname = '${DBNAME:-<解析失败>}' ≠ 期望 '$EXPECT_DB'"
+  fi
+else
+  warn "无法解析 db.default url"
+fi
+
+# --- 5. 必需键非空（github 凭据 main 必填 / dev 允许空） ---
+check_nonempty() {
+  local path="$1" desc="$2"
+  local v
+  v="$(cfg_get "$CFG" "$path")"
+  if [ -n "$v" ] && [ "$v" != '""' ]; then
+    ok "$desc 非空"
+  else
+    if [ "$INSTANCE" = "dev" ] && { [ "$path" = "github.client_id" ] || [ "$path" = "github.client_secret" ]; }; then
+      ok "$desc 为空（dev 已知边界: DB siteUrl 无环境隔离, github 凭据保持空）"
+    else
+      warn "$desc 为空（必需键未配置）"
+    fi
+  fi
+}
+
+check_nonempty "app.signingKey" "signingKey"
+check_nonempty "meilisearch.masterkey" "meilisearch masterkey"
+check_nonempty "wiki.git.webhook_secret" "wiki.git webhook_secret"
+if [ "$INSTANCE" = "main" ]; then
+  check_nonempty "github.client_id" "github client_id"
+  check_nonempty "github.client_secret" "github client_secret"
+fi
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "verify-instance[$INSTANCE]: 全部通过"
+  exit 0
+else
+  echo "verify-instance[$INSTANCE]: 存在漂移/配置问题（见上）"
+  exit 1
+fi

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -20,7 +20,7 @@
   (`ghcr.io/yourtongji/yourtj-hub:<instance>-<sha>`; repo is public, so servers pull anonymously —
   no registry credentials on the server).
 - **Reverse proxy**: public TLS is terminated by the **1Panel reverse proxy** on the host
-  (port 80/443), which proxies `forum.yourtj.de` → `127.0.0.1:5234` (main) and
+  (port 80/443), which proxies `f.yourtj.de` → `127.0.0.1:5234` (main) and
   `dev.yourtj.de` → `127.0.0.1:5235` (dev). There is no nginx container in the compose file;
   backend containers bind `127.0.0.1` only, and only 1Panel/SSH is exposed publicly.
 - **Trusted proxies**: the binary only trusts `127.0.0.1`/`::1` reverse proxies by default
@@ -89,7 +89,7 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
   不要求 `index.md`；`index.md` 存在时仍是该目录下可直接访问的页面。同步完成后会重算页面
   到最近祖先索引页的 `parent_id`，所以目录新增、移动、删除或恢复不会保留已删除的父引用。
 - **GitHub webhook 配置**（仓库 Settings → Webhooks → Add webhook）：
-  - Payload URL：`https://forum.yourtj.de/api/wiki/webhook`（dev 实例用 `https://dev.yourtj.de/api/wiki/webhook`）
+  - Payload URL：`https://f.yourtj.de/api/wiki/webhook`（dev 实例用 `https://dev.yourtj.de/api/wiki/webhook`）
   - Content type：`application/json`；Secret：与 webhook 验签密钥一致
     （优先管理端 `/admin/wiki` → 同步面板「Webhook 验签密钥」保存，securestore 加密
     落库；也可用旧 `[wiki.git].webhook_secret` 明文配置）
@@ -119,21 +119,21 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
 
 ## Server layout (Docker Compose)
 
-```
 /opt/yourtj/
   .env                    # MAIN_PORT/DEV_PORT/MAIN_TAG/DEV_TAG/IMAGE_REPO + POSTGRES_*/MEILI_MASTER_KEY (created by init-server.sh)
   docker-compose.yaml     # main + dev + postgres + meilisearch services (created by init-server.sh)
-  config.toml.example     # template with REPLACE_* placeholders
-  scripts/                # snapshot-db.sh, sync-db-from-main.sh, backup-db.sh, deploy.sh, pgdsn.sh
+  config.toml.example     # 人类参考副本（权威模板 = 仓库 deploy/config.toml.tmpl）
+  scripts/                # deploy.sh, apply-config.sh, verify-instance.sh, backup-db.sh, sync-db-from-main.sh, pgdsn.sh …
   main/
-    config.toml           # production config (signingKey, db path) — never in git
+    config.toml           # production config — CI 渲染产物原子下发，禁止人工 SSH 改（漂移守卫告警）
+    .config.sha256        # 最近一次成功下发的 config SHA-256（apply-config/deploy 写入，verify 比对）
     storage/              # file.db + logs (uid 1000); PG 部署时 sqlite.db 不产生
   dev/
-    config.toml           # dev config
+    config.toml           # dev config（同上，CI 下发）
+    .config.sha256
     storage/
   snapshots/
     main/pg-*.sql         # pre-deploy pg_dump backups (keep 7) — PostgreSQL 部署
-```
 
 ## Branch model & CI/CD
 
@@ -160,7 +160,13 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
   workflow → choose bump type.
 - Why dev syncs main's db: migrations (`app/migration` AutoMigrate + versioned data migrations) run at
   startup, so each dev deploy rehearses the exact migration the next main deploy will run.
-- Config is pre-provisioned on the server (`init-server.sh`) and never passes through CI.
+- Config is rendered in CI from `deploy/config.toml.tmpl` + `deploy/instances/<env>.json`
+  + GitHub Environments secrets, and applied to the server as an artifact (`CONFIG_FILE`
+  on image deploys, or the standalone `Apply / instance config` workflow / `config-drift-check`
+  for config-only changes). Config changes therefore ship through PRs (template/instances)
+  and Environments secret updates — never ad-hoc SSH edits on the server. The server records
+  each successful apply's SHA-256 in `<instance>/.config.sha256`; `verify-instance.sh` (drift
+  guard) flags manual edits or out-of-band writes.
 - `sync-db-from-main.sh` hard-fails when `main`/`dev` primary DB modes differ (e.g. main already
   migrated to PG while dev is still SQLite): the sync cannot proceed, and the script refuses to
   stop the dev container in that state (parse-before-stop guarantee, issue #134). During the PG
@@ -172,28 +178,43 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
   `backup-db.sh` / `sync-db-from-main.sh`); keep it in the scp/install list whenever deploying
   script updates.
 
-## GitHub Actions secrets
+## GitHub Actions Environments secrets
 
-| Secret | Value |
-|---|---|
-| `VM_HOST` | server public IP or hostname (`43.108.84.213`) |
-| `VM_USER` | SSH user (`root`) |
-| `VM_SSH_KEY` | PEM private key for that user (full PEM, including `-----BEGIN ...` lines; e.g. `YourTJ_Korean.pem`) |
-| `VM_SSH_PORT` | SSH port (default 22) |
+部署与 config 渲染 secrets 按 GitHub **Environments** 分存：`production`（生产）与 `dev`（测试）。
+Deploy/apply/drift workflows 的 job 声明对应 `environment:`，自动获得该环境 secret 与部署审计时间线。
 
-Deploy workflows use `appleboy/scp-action` + `appleboy/ssh-action` with these secrets.
+| Secret | Environments | 用途 |
+|---|---|---|
+| `VM_HOST` / `VM_USER` / `VM_SSH_KEY` / `VM_SSH_PORT` | both | SSH 到部署机（当前同一台 43.108.84.213） |
+| `PG_DSN` | both | `[db.default].url`（key=value 或 URL DSN；main=your**tj_main**，dev=your**tj_dev**；含库密码，勿外泄） |
+| `SIGNING_KEY` | both | `[app].signingKey`（**必须与现网一致**；轮换即全线登出 + TOTP/重置链接失效） |
+| `MEILI_MASTER_KEY` | both | `[meilisearch].masterkey` |
+| `WIKI_WEBHOOK_SECRET` | both | `[wiki.git].webhook_secret` |
+| `GH_CLIENT_ID` / `GH_CLIENT_SECRET` | production only | GitHub OAuth（dev 因 DB siteUrl 无环境隔离保持空，渲染 allow-empty） |
+| `AI_API_KEY` | both（可空） | `[ai_summary].api_key`（AI 总结默认关闭） |
+| `RELEASE_TOKEN` | repo-level | release-to-main 合并 dev→main 用 PAT |
+
+> 命名注意：GitHub 保留 `GITHUB_` 前缀 secret 名，故 GitHub OAuth 凭据用 `GH_CLIENT_ID/SECRET`。
+
+设置：`gh secret set <KEY> --env production`（值经管道从服务器读取，勿回显终端/日志）。
+仓库级 VM_* 已迁移到 environments；旧 repo-level 同名 secret 不再被 workflows 引用。
 
 ## First-time server setup
 
 ```bash
 # on the server, as root (or sudo):
 sudo bash /opt/yourtj/scripts/init-server.sh \
-  https://forum.yourtj.de https://dev.yourtj.de
+  https://f.yourtj.de https://dev.yourtj.de
 ```
 
 This creates `/opt/yourtj/{.env,docker-compose.yaml,main,dev}` with randomized signing keys,
 PG/Meili passwords, starts `postgres` + `meilisearch`, and creates the `yourtj_main`/`yourtj_dev`
 databases. The script itself is deployed to the server by the first CI run (or copy `deploy/` manually).
+
+**之后**（首次 CI 部署前）：把服务器生成/现网的值回填为 Environments secrets
+（见上表；`init-server.sh` 结尾会打印需回填清单）。config 本身由 CI 渲染下发，服务器
+不再人工生成/维护 `config.toml`；若需在装机阶段本地生成一次，仍可手工跑
+`python3 deploy/render_config.py render --env <env>`（仅本机演练，产物不入库）。
 
 ## Build (local)
 
@@ -542,7 +563,7 @@ end = "2026-01-18"
 ssh -i ~/Documents/YourTJ_Korean.pem root@43.108.84.213
 mkdir -p /opt/yourtj && cd /opt/yourtj
 # 从仓库拷贝 deploy/ 目录后:
-sudo bash deploy/scripts/init-server.sh https://forum.yourtj.de https://dev.yourtj.de
+sudo bash deploy/scripts/init-server.sh https://f.yourtj.de https://dev.yourtj.de
 ```
 
 这会生成 `/opt/yourtj/{.env,docker-compose.yaml,main/config.toml,dev/config.toml}`，
@@ -608,7 +629,7 @@ scp -i ~/Documents/YourTJ_Korean.pem root@<旧机>:/opt/yourtj/dev/config.toml /
 #   - [db.default] url: host 改为 postgres(compose 服务名), 不要沿用旧机 127.0.0.1
 #   - [server] trusted_proxies: 1Panel 本机回源 → ["127.0.0.1", "::1"]
 #   - [meilisearch] masterkey: 与 /opt/yourtj/.env 的 MEILI_MASTER_KEY 一致
-#   - [server] url: 保持 https://forum.yourtj.de / https://dev.yourtj.de
+#   - [server] url: 保持 https://f.yourtj.de / https://dev.yourtj.de
 install -m 0644 /tmp/main-config.toml /opt/yourtj/main/config.toml
 install -m 0644 /tmp/dev-config.toml /opt/yourtj/dev/config.toml
 ```
@@ -623,7 +644,7 @@ IMAGE_KEEP_N=3 bash scripts/deploy.sh dev dev-<latest-sha> 5235
 # 验证
 curl -fsS http://127.0.0.1:5234/health && echo MAIN_OK
 curl -fsS http://127.0.0.1:5235/health && echo DEV_OK
-curl -fsS -H "Host: forum.yourtj.de" http://127.0.0.1/ | head -5   # 经 1Panel 反代
+curl -fsS -H "Host: f.yourtj.de" http://127.0.0.1/ | head -5   # 经 1Panel 反代
 ```
 
 ### 5. Cloudflare SSL 模式 + DNS 切换
@@ -633,9 +654,9 @@ curl -fsS -H "Host: forum.yourtj.de" http://127.0.0.1/ | head -5   # 经 1Panel 
 1. **Cloudflare SSL/TLS 模式**：新旧机均由 1Panel 反代终止 TLS（保持与旧机一致的
    模式，如 Full (strict)：Cloudflare → origin 走 HTTPS:443）。论坛容器只监听
    127.0.0.1 回源端口，不直接暴露 80/443。
-2. **DNS**：`forum.yourtj.de` / `dev.yourtj.de` 的 A 记录从旧机 IP（20.205.27.178）
+2. **DNS**：`f.yourtj.de` / `dev.yourtj.de` 的 A 记录从旧机 IP（20.205.27.178）
    改为新机 IP（43.108.84.213）。
-3. 等 TTL 过后从外网验证 `https://forum.yourtj.de` 与 `https://dev.yourtj.de` 可达、
+3. 等 TTL 过后从外网验证 `https://f.yourtj.de` 与 `https://dev.yourtj.de` 可达、
    登录/发帖/附件/搜索 spot-check。
 4. **观察期（≥7 天）内旧机保持运行**；确认稳定后退役旧机（`docker compose down`，保留数据快照）。
 5. 更新 GitHub Secrets `VM_HOST` → 新机 IP；旧机从 CI 摘除。


### PR DESCRIPTION
## Summary
把实例运行时 config 从服务器人工 SSH 维护规范化为 **Git 模板 + GitHub Environments secrets 渲染 + CI 原子下发**，一次 PR 覆盖 P1+P2+P3 全部实现（非 Go/前端代码，纯部署运维资产）。

## 仓库资产（新增）
- **模板**：`deploy/config.toml.tmpl`（全量权威模板，含中文注释）+ `deploy/instances/{main,dev}.json`（实例差异非敏感）
- **渲染器**：`deploy/render_config.py`（python3 标准库，fail-closed：残留占位符/必需 secret 空/TOML 解析失败即拒绝；main GitHub 凭据必填、dev allow-empty）+ `render_config_test.py`（25 断言）
- **服务器脚本**：`apply-config.sh`（备份→原子替换→force-recreate 重挂→健康检查→失败自动恢复 + sha marker）、`verify-instance.sh`（漂移守卫）
- **CI action**：`.github/actions/render-config`（composite，secrets 注入渲染）

## workflow 接线（修改）
- `deploy-dev.yml`：deploy job 加 `environment: dev`，部署前渲染 dev config，scp 下发，`deploy.sh` 以 `CONFIG_FILE` 随镜像同事务原子替换+回滚
- `deploy-main.yml`：同法接 production env（GH_CLIENT_ID/SECRET 必填）
- **新增** `apply-config.yml`：config-only 下发（workflow_dispatch env=dev|main）——改 secret 无需重新发镜像
- **新增** `config-drift-check.yml`：每日 + manual 巡检 main/dev 漂移（sha marker / server.url / dbname / 必需键）
- `ci-backend.yml`：deploy_scripts 门控扩至 *.py/instances/tmpl/action；bash -n 加新脚本 + python 渲染测试
- `init-server.sh`：默认生产域名 forum→f.yourtj.de；结尾打印回填 Environments secrets 指引
- `deploy.sh`：支持 CONFIG_FILE 原子替换 + 失败回滚（含 marker 记录）

## 文档（修改）
- `docs/operations/deployment.md`：forum.yourtj.de→f.yourtj.de 全量收口；Server layout 加 `.config.sha256`；Branch model 改写 config-as-artifact；secrets 表按 Environments 分存（含 GITHUB_ 前缀保留说明）；first-time setup 指向回填 Environments secrets；迁移 runbook 域名同步

## 验证
- `render_config_test.py` 25 项绿；`pgdsn_test.sh` 74 项绿；全脚本 `bash -n` 通过；deploy-main/apply-config/drift YAML 校验通过
- **键级 diff 演练**（用现网真实值渲染）：main 唯一差异 = `[server].url`（forum→f，已批准收口），dev **完全一致**（signingKey/PG DSN/meili/wiki/gh 逐字节等价）
- dev GitHub 凭据渲染为空（allow-empty 生效）；无真实 secret 入库；全仓 forum.yourtj.de 零残留
- 本 PR 全部 CI 绿（ci-backend / ci-backend-pg / ci-backend-race / ci-contract / ci-frontend）

## 前置（合并前已完成）
P0 一次性 ops：`production`/`dev` Environments 建立；VM_*×2 + PG_DSN + SIGNING_KEY + MEILI_MASTER_KEY + WIKI_WEBHOOK_SECRET 回填（dev/prod），GH_CLIENT_ID/SECRET（仅 production，GitHub 保留 GITHUB_ 前缀故用 GH_）；服务器 config 已备份至 `/opt/yourtj/backups/config-backup-20260902-172213`

## 合并后自动流程
merge dev → deploy-dev 自动运行：render dev config → sync-db → deploy.sh CONFIG_FILE 原子替换 → 健康检查；dev config 语义与现网一致（幂等跳过或等价替换）