### PR TITLE
fix(deploy): config workflows 按实例映射 production/dev 环境，移除 repo-level VM_* 兜底

### DIFF
--- a/.github/workflows/apply-config.yml
+++ b/.github/workflows/apply-config.yml
@@ -19,7 +19,9 @@ concurrency:
 jobs:
   apply:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.env }}
+    # GitHub Environment 与实例名解耦: main 实例的 secrets 存在 production 环境。
+    # 直接写 environment: main 会命中空环境, 渲染必失败(fail-closed)。
+    environment: ${{ github.event.inputs.env == 'main' && 'production' || 'dev' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/config-drift-check.yml
+++ b/.github/workflows/config-drift-check.yml
@@ -17,7 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         env: [dev, main]
-    environment: ${{ matrix.env }}
+    # GitHub Environment 与实例名解耦: main 实例的 VM_* secrets 存在 production 环境
+    # （matrix.env 是实例名 main/dev; production 环境承载生产部署与巡检 secrets）。
+    environment: ${{ matrix.env == 'main' && 'production' || 'dev' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/config-drift-check.yml
+++ b/.github/workflows/config-drift-check.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ secrets.VM_SSH_KEY }}
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           source: "deploy/scripts/verify-instance.sh,deploy/scripts/pgdsn.sh"
-          target: "/tmp/yourtj-drift-${{ github.run_id }}"
+          target: "/tmp/yourtj-drift-${{ github.run_id }}-${{ matrix.env }}"
           strip_components: 2
 
       - name: Verify ${{ matrix.env }} instance config drift
@@ -51,7 +51,7 @@ jobs:
           port: ${{ secrets.VM_SSH_PORT || '22' }}
           script: |
             set -e
-            RUN_DIR=/tmp/yourtj-drift-${{ github.run_id }}
+            RUN_DIR=/tmp/yourtj-drift-${{ github.run_id }}-${{ matrix.env }}
             install -m 0755 "$RUN_DIR/verify-instance.sh" /opt/yourtj/scripts/verify-instance.sh
             install -m 0755 "$RUN_DIR/pgdsn.sh" /opt/yourtj/scripts/pgdsn.sh
             EXPECT_SERVER_URL="${{ steps.expected.outputs.exp_server_url }}" \

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -197,7 +197,16 @@ Deploy/apply/drift workflows 的 job 声明对应 `environment:`，自动获得�
 > 命名注意：GitHub 保留 `GITHUB_` 前缀 secret 名，故 GitHub OAuth 凭据用 `GH_CLIENT_ID/SECRET`。
 
 设置：`gh secret set <KEY> --env production`（值经管道从服务器读取，勿回显终端/日志）。
-仓库级 VM_* 已迁移到 environments；旧 repo-level 同名 secret 不再被 workflows 引用。
+
+**实例 ↔ GitHub Environment 映射**：部署/巡检 workflow 的 job 一律按此声明 `environment:`，
+从对应环境读取 `VM_*` 与渲染 secrets（不存在仓库级 fallback）：
+- `deploy-dev.yml` / `apply-config.yml(env=dev)` / `config-drift-check.yml(matrix=dev)` → `dev`
+- `deploy-main.yml` / `apply-config.yml(env=main)` / `config-drift-check.yml(matrix=main)` → `production`
+
+> 注意实例名 ≠ GitHub Environment：`main`/`dev` 是 workflow 输入里的实例名，对应 secrets 分别
+> 存在 `production`/`dev` 环境（早期错误映射 `environment: main` 曾命中一个空的 `main` 环境，
+> 本次修复已删除该空环境）。仓库级同名 `VM_*` 已一并移除（此前作为迁移兜底存在）——当前无任何
+> workflow 引用 repo-level `VM_*`；缺环境 secret 时渲染/apply/drift 会 fail-closed，不再静默 fallback。
 
 ## First-time server setup
 
@@ -550,9 +559,10 @@ end = "2026-01-18"
 
 - 新机已装 Docker Engine + Compose + 2G swap（`deploy/scripts/init-server.sh` 会在 CI 首次部署时下发，
   也可手动拷贝 `deploy/` 后在服务器执行）。
-- 仓库侧 GHCR 镜像流 PR 已合并；**合并后先更新 GitHub Secrets（`VM_HOST` → 新机 IP、
-  `VM_USER` → `root`、`VM_SSH_KEY` → PEM 内容）再触发 dev 部署**。反代统一由 1Panel 承担
-  （自管 nginx 容器已移除, 不再有 :80 与 openresty 冲突的问题）。
+- 仓库侧 GHCR 镜像流 PR 已合并；**合并后先在 GitHub Environments secrets 更新
+  `VM_HOST`（production 与 dev 均改新机 IP）、`VM_USER` → `root`、`VM_SSH_KEY` → 新机 PEM
+  内容，再触发 dev 部署**（workflows 只读 Environments，无 repo 级 fallback）。反代统一由
+  1Panel 承担（自管 nginx 容器已移除, 不再有 :80 与 openresty 冲突的问题）。
 - **GHCR 包可见性**：首次 build-image 推送后，GitHub Packages → `yourtj-hub` → Settings →
   Change visibility → **Public**（默认 private，服务器匿名 pull 会 401）。
 - 备份密钥：`~/Documents/YourTJ_Korean.pem`（新机 SSH PEM）。
@@ -659,7 +669,7 @@ curl -fsS -H "Host: f.yourtj.de" http://127.0.0.1/ | head -5   # 经 1Panel 反�
 3. 等 TTL 过后从外网验证 `https://f.yourtj.de` 与 `https://dev.yourtj.de` 可达、
    登录/发帖/附件/搜索 spot-check。
 4. **观察期（≥7 天）内旧机保持运行**；确认稳定后退役旧机（`docker compose down`，保留数据快照）。
-5. 更新 GitHub Secrets `VM_HOST` → 新机 IP；旧机从 CI 摘除。
+5. 更新 GitHub Environments secrets `VM_HOST`（production 与 dev）→ 新机 IP；旧机从 CI 摘除。
 
 ### 风险与回滚
 


### PR DESCRIPTION
## Summary

Audit round-2 修复（Blueprint「Deployment 配置治理」PR #385 的 review 反馈）：

1. **环境映射解耦**：`apply-config.yml` / `config-drift-check.yml` 的 job `environment:` 原先直接取实例名 `main`/`dev` —— `main` 命中一个空的 GitHub Environment，渲染/巡检全靠 repo-level `VM_*` fallback 才跑通。现改为 `main → production`、`dev → dev`（与 `deploy-main.yml`/`deploy-dev.yml` 一致）。
2. **drift-check 矩阵 leg 远端目录竞态修复**：matrix dev/main 两 leg 并发跑同一台服务器，原共享 `/tmp/yourtj-drift-<run_id>`，dev leg 清理时删掉 main leg 刚上传的脚本（实测 run 33624597884: `install: cannot stat ... verify-instance.sh`）。改为 `run_id + matrix.env` 两级目录。
3. **删除空的 `main` environment 与 repo-level `VM_*` secrets**（VM_HOST/USER/SSH_KEY/PORT）——当前无任何 workflow 引用 repo-level `VM_*`；缺环境 secret 时 fail-closed，不再静默 fallback。
4. **deployment.md**：secrets 表补「实例 ↔ GitHub Environment」映射说明，迁移 runbook 措辞改为 Environments secrets（无 repo 级 fallback），与现状对齐。

## Verification（均在 fix 分支、repo-level fallback 已删除后实测）

- `config-drift-check` dev+main 双 leg 绿 × 2（run 33624805426 修复竞态后、run 33625633984 演练清理后）
- `apply-config` env=dev 首个真实 run 成功（run 33624986401）：dev 环境 secrets 渲染 → scp → apply-config.sh 幂等跳过（sha 与现网一致），健康 200
- **dev 故障注入回滚演练**（按 Blueprint cutover 验收）：
  - Drill A：残留 `{{` 占位 → 拒绝应用（exit 1），config 未动，健康 200
  - Drill B：空 signingKey 坏渲染 → 应用后健康检查 60×3s 失败 → **自动恢复 config.toml.prev** → 重建容器 → 恢复后健康通过（exit 1，marker 与 config 一致 deb90e1d，prev/lock 无残留）
  - 演练产物已全部清理，dev/main 健康 200

## Files

- `.github/workflows/apply-config.yml`
- `.github/workflows/config-drift-check.yml`
- `docs/operations/deployment.md`