### PR TITLE
fix(course): 新增纯本地物化 CLI（不依赖一系统 cookie）+ 物化学期码规范化

### DIFF
--- a/apps/gooseforum/app/console/cmd/courseMaterialize.go
+++ b/apps/gooseforum/app/console/cmd/courseMaterialize.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/courseservice"
 	"github.com/spf13/cobra"
 )
@@ -17,28 +18,60 @@ func init() {
 不抓取一系统、不需要 cookie——适合学期已同步（管理端 / course-pk-sync）但
 物化因 cookie 过期/网络不可用而失败或遗漏后的补跑。
 
-<学期> 接受两种形式：
+<学期> 接受两种形式（解析失败即中止，写入前全量校验）：
   - 一系统数字 calendarId（如 122）
-  - 学期名（如 2026-2027-1），经 pk_calendar.calendar_id_i18n 反查
+  - 学期名（标准码 2026-2027-1 或中文学期名 2026-2027学年第1学期 均可，
+    按 pk_calendar.calendar_id_i18n 归一化反查）
 
 物化为幂等 upsert：同 teaching_class_id 已存在则更新字段（不写 status、不复活
-管理员隐藏的 offering/课程），可安全重复执行。`,
+管理员隐藏的 offering/课程），可安全重复执行。重复参数自动去重。`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: runCourseMaterialize,
 	}
+	cmd.Flags().Bool("dry-run", false, "只校验学期已同步并打印教学班统计，不写库")
 	appendCommand(cmd)
 }
 
-func runCourseMaterialize(cmd *cobra.Command, args []string) error {
+// resolveMaterializeCalendars 解析并校验物化目标学期列表（写入前全量校验）：
+//   - 重复参数去重（幂等无损坏，但避免报告计数虚高，review）；
+//   - 每个学期必须已存在于本地 PK 域（pk_calendar 有记录）——本命令只物化已同步
+//     学期，误传未同步/错拼的数字 ID 必须显式报错而非空成功（review P2）。
+func resolveMaterializeCalendars(args []string) ([]uint64, error) {
 	calendarIds := make([]uint64, 0, len(args))
+	seen := map[uint64]bool{}
 	for _, arg := range args {
 		id, err := resolvePkCalendarId(arg, 0)
 		if err != nil {
-			return fmt.Errorf("course-materialize: %w", err)
+			return nil, err
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		if _, err := pk.GetCalendarByID(id); err != nil {
+			return nil, fmt.Errorf("学期 %d 未同步到本地 PK 域（pk_calendar 无记录）：course-materialize 只物化已同步学期，请先 course-pk-sync / 管理端同步（review P2）", id)
 		}
 		calendarIds = append(calendarIds, id)
 	}
+	return calendarIds, nil
+}
 
+func runCourseMaterialize(cmd *cobra.Command, args []string) error {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	calendarIds, err := resolveMaterializeCalendars(args)
+	if err != nil {
+		return fmt.Errorf("course-materialize: %w", err)
+	}
+	if dryRun {
+		for _, cid := range calendarIds {
+			rows, err := pk.ListCourseDetailsByCalendar(cid)
+			if err != nil {
+				return fmt.Errorf("course-materialize: 统计教学班（calendar %d）：%w", cid, err)
+			}
+			fmt.Printf("course-materialize --dry-run: calendar=%d teachingClasses=%d（未写库；去掉 --dry-run 执行物化）\n", cid, len(rows))
+		}
+		return nil
+	}
 	report, err := courseservice.MaterializeFromPk(cmd.Context(), calendarIds)
 	if err != nil {
 		return fmt.Errorf("course-materialize: %w", err)

--- a/apps/gooseforum/app/console/cmd/courseMaterialize.go
+++ b/apps/gooseforum/app/console/cmd/courseMaterialize.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/courseservice"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	cmd := &cobra.Command{
+		Use:   "course-materialize <calendarId|学期>...",
+		Short: "将已同步学期的 PK 课程物化到课程目录（本地只读 PK 域，无需一系统 cookie）",
+		Long: `将已同步学期的 PK 课程物化到课程目录（course 域 offering 权威写入源）。
+
+与 course-pk-sync --materialize 的区别：本命令只消费本地已同步的 PK 域数据，
+不抓取一系统、不需要 cookie——适合学期已同步（管理端 / course-pk-sync）但
+物化因 cookie 过期/网络不可用而失败或遗漏后的补跑。
+
+<学期> 接受两种形式：
+  - 一系统数字 calendarId（如 122）
+  - 学期名（如 2026-2027-1），经 pk_calendar.calendar_id_i18n 反查
+
+物化为幂等 upsert：同 teaching_class_id 已存在则更新字段（不写 status、不复活
+管理员隐藏的 offering/课程），可安全重复执行。`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: runCourseMaterialize,
+	}
+	appendCommand(cmd)
+}
+
+func runCourseMaterialize(cmd *cobra.Command, args []string) error {
+	calendarIds := make([]uint64, 0, len(args))
+	for _, arg := range args {
+		id, err := resolvePkCalendarId(arg, 0)
+		if err != nil {
+			return fmt.Errorf("course-materialize: %w", err)
+		}
+		calendarIds = append(calendarIds, id)
+	}
+
+	report, err := courseservice.MaterializeFromPk(cmd.Context(), calendarIds)
+	if err != nil {
+		return fmt.Errorf("course-materialize: %w", err)
+	}
+	fmt.Printf("course-materialize: calendars=%v coursesInserted=%d coursesUpdated=%d instructorsInserted=%d aliasesInserted=%d aliasesSkipped=%d offeringsInserted=%d offeringsUpdated=%d\n",
+		calendarIds, report.CoursesInserted, report.CoursesUpdated, report.InstructorsInserted,
+		report.AliasesInserted, report.AliasesSkipped, report.OfferingsInserted, report.OfferingsUpdated)
+	return nil
+}

--- a/apps/gooseforum/app/console/cmd/courseMaterialize_test.go
+++ b/apps/gooseforum/app/console/cmd/courseMaterialize_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
+)
+
+// seedMaterializeCalendars 建 pk_calendar 测试学期：121 标准码 i18n、122 中文学期名 i18n。
+func seedMaterializeCalendars(t *testing.T) {
+	t.Helper()
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&pk.CalendarEntity{}); err != nil {
+		t.Fatalf("migrate pk_calendar: %v", err)
+	}
+	conn.Unscoped().Where("1 = 1").Delete(&pk.CalendarEntity{})
+	if err := conn.Create(&pk.CalendarEntity{CalendarId: 121, CalendarIdI18n: "2025-2026-1"}).Error; err != nil {
+		t.Fatalf("seed calendar 121: %v", err)
+	}
+	if err := conn.Create(&pk.CalendarEntity{CalendarId: 122, CalendarIdI18n: "2026-2027学年第1学期"}).Error; err != nil {
+		t.Fatalf("seed calendar 122: %v", err)
+	}
+	t.Cleanup(func() { conn.Unscoped().Where("1 = 1").Delete(&pk.CalendarEntity{}) })
+}
+
+// TestResolveMaterializeCalendarsDedupAndValidate 回归 review：
+//   - 重复参数去重（122 122 → [122]，报告计数不虚高）；
+//   - 学期参数支持标准码反查中文学期名（"2026-2027-1" → 122，review P2）；
+//   - 未同步/错拼的学期 ID 显式报错，不得空成功（review P2）。
+func TestResolveMaterializeCalendarsDedupAndValidate(t *testing.T) {
+	seedMaterializeCalendars(t)
+
+	deduped, err := resolveMaterializeCalendars([]string{"122", "122"})
+	if err != nil {
+		t.Fatalf("resolve dedup: %v", err)
+	}
+	if len(deduped) != 1 || deduped[0] != 122 {
+		t.Fatalf("resolve([122 122]) = %v, want [122]（重复参数去重）", deduped)
+	}
+
+	byStandardCode, err := resolveMaterializeCalendars([]string{"2026-2027-1"})
+	if err != nil {
+		t.Fatalf("resolve standard code against chinese label: %v", err)
+	}
+	if len(byStandardCode) != 1 || byStandardCode[0] != 122 {
+		t.Fatalf("resolve(2026-2027-1) = %v, want [122]（归一化反查中文学期名）", byStandardCode)
+	}
+
+	byChineseLabel, err := resolveMaterializeCalendars([]string{"2026-2027学年第1学期"})
+	if err != nil {
+		t.Fatalf("resolve chinese label: %v", err)
+	}
+	if len(byChineseLabel) != 1 || byChineseLabel[0] != 122 {
+		t.Fatalf("resolve(chinese label) = %v, want [122]", byChineseLabel)
+	}
+
+	if _, err := resolveMaterializeCalendars([]string{"999"}); err == nil {
+		t.Fatal("expected error for unsynced calendar 999（只物化已同步学期）")
+	} else if !strings.Contains(err.Error(), "未同步") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := resolveMaterializeCalendars([]string{"2026-2027-2"}); err == nil {
+		t.Fatal("expected error for unmatched term")
+	}
+}

--- a/apps/gooseforum/app/console/cmd/coursePkSync.go
+++ b/apps/gooseforum/app/console/cmd/coursePkSync.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/pkservice"
 	"github.com/spf13/cobra"
@@ -74,6 +75,20 @@ func resolvePkCalendarId(arg string, explicitID uint64) (uint64, error) {
 	}
 	if id, ok := pk.GetCalendarIdByI18n(arg); ok {
 		return id, nil
+	}
+	// 归一化反查：pk_calendar.calendar_id_i18n 可能存中文学期名（"2025-2026学年第2学期"）
+	// 而调用方传标准码（或相反）——按 NormalizeTermLabel 双向匹配（review P2：CLI 文档
+	// 承诺的学期名形式必须对生产中文学期名可用）。
+	if normalized := course.NormalizeTermLabel(arg); normalized != "" {
+		calendars, err := pk.ListAllCalendars()
+		if err != nil {
+			return 0, fmt.Errorf("列举 pk_calendar 失败：%w", err)
+		}
+		for _, c := range calendars {
+			if course.NormalizeTermLabel(c.CalendarIdI18n) == normalized {
+				return c.CalendarId, nil
+			}
+		}
 	}
 	return 0, fmt.Errorf("无法解析学期 %q 对应的一系统 calendarId：请先以 --calendar-id 同步一次，或直接传数字 calendarId（如 121）", arg)
 }

--- a/apps/gooseforum/app/console/cmd/coursePkSync_test.go
+++ b/apps/gooseforum/app/console/cmd/coursePkSync_test.go
@@ -69,3 +69,19 @@ func TestCoursePkSyncCommandRegistered(t *testing.T) {
 		}
 	}
 }
+
+func TestCourseMaterializeCommandRegistered(t *testing.T) {
+	var cmd *cobra.Command
+	for _, c := range GetCommands() {
+		if strings.HasPrefix(c.Use, "course-materialize") {
+			cmd = c
+			break
+		}
+	}
+	if cmd == nil {
+		t.Fatal("course-materialize command not registered")
+	}
+	if !strings.Contains(cmd.Short+cmd.Long, "无需一系统 cookie") {
+		t.Errorf("course-materialize 说明应注明纯本地物化语义（不依赖 cookie）")
+	}
+}

--- a/apps/gooseforum/app/console/cmd/coursePkSync_test.go
+++ b/apps/gooseforum/app/console/cmd/coursePkSync_test.go
@@ -84,4 +84,7 @@ func TestCourseMaterializeCommandRegistered(t *testing.T) {
 	if !strings.Contains(cmd.Short+cmd.Long, "无需一系统 cookie") {
 		t.Errorf("course-materialize 说明应注明纯本地物化语义（不依赖 cookie）")
 	}
+	if cmd.Flags().Lookup("dry-run") == nil {
+		t.Errorf("course-materialize missing --dry-run flag（预检模式，review）")
+	}
 }

--- a/apps/gooseforum/app/models/forum/course/term.go
+++ b/apps/gooseforum/app/models/forum/course/term.go
@@ -33,7 +33,35 @@ func NormalizeTermLabel(label string) string {
 	return label
 }
 
-// cnNumeralToArabic 把中文数字学期序数转阿拉伯数字（"二"→"2"）；已是阿拉伯数字原样返回。
+// canonicalTermCodePattern 课程域标准学期码形：YYYY-YYYY-N（N 为 1~2 位数字）。
+var canonicalTermCodePattern = regexp.MustCompile(`^\d{4}-\d{4}-\d{1,2}$`)
+
+// IsCanonicalTermCode 判断学期码是否为课程域标准形（如 "2026-2027-1"）。
+// 物化链用它决定是否允许 getOrCreateTermTx 建行：非标准形（如无法识别的中文
+// 短学期标记）一律不建 course_term 行、保持 term_id=0，杜绝垃圾学期行（review LOW）。
+func IsCanonicalTermCode(code string) bool {
+	return canonicalTermCodePattern.MatchString(code)
+}
+
+// TermLabelCandidates 返回学期标记匹配 course_term.code 的候选列表：trim 后的原标记 +
+// 规范化后的标准码（不同则追加，去重）。排课器 course-review-brief 的 term 反查与
+// 物化共用同一权威解析（review Should：双份实现会让两条链路后续分歧）；调用方按序
+// 尝试每个候选——先精确后规范化，兼容历史把中文学期名直接写进 code 的行。
+func TermLabelCandidates(label string) []string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return nil
+	}
+	candidates := []string{label}
+	if normalized := NormalizeTermLabel(label); normalized != label {
+		candidates = append(candidates, normalized)
+	}
+	return candidates
+}
+
+// cnNumeralToArabic 把中文数字学期序数转阿拉伯数字（"二"→"2"）；已是阿拉伯数字原样
+// 返回。支持学期序数实际范围（一~十二）：单字（"二"）与十字组合（"十"→"10"、
+// "十一"→"11"、"二十"→"20"、"二十三"→"23"）。
 func cnNumeralToArabic(s string) string {
 	if s == "" {
 		return s
@@ -41,10 +69,42 @@ func cnNumeralToArabic(s string) string {
 	if s[0] >= '0' && s[0] <= '9' {
 		return s
 	}
-	if n, ok := map[rune]int{'一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9, '十': 10}[[]rune(s)[0]]; ok {
-		return strconv.Itoa(n)
+	runes := []rune(s)
+	switch len(runes) {
+	case 1:
+		if n, ok := cnDigits[runes[0]]; ok {
+			return strconv.Itoa(n)
+		}
+		if runes[0] == '十' {
+			return "10"
+		}
+	case 2:
+		if runes[0] == '十' {
+			// 十一 ~ 十九
+			if n, ok := cnDigits[runes[1]]; ok {
+				return strconv.Itoa(10 + n)
+			}
+		} else if runes[1] == '十' {
+			// 二十 ~ 九十
+			if n, ok := cnDigits[runes[0]]; ok {
+				return strconv.Itoa(10 * n)
+			}
+		}
+	case 3:
+		// 二十三 等「数十+个位」组合
+		if tens, ok := cnDigits[runes[0]]; ok && runes[1] == '十' {
+			if ones, ok2 := cnDigits[runes[2]]; ok2 {
+				return strconv.Itoa(10*tens + ones)
+			}
+		}
 	}
 	return s
+}
+
+// cnDigits 中文数字单字 → 阿拉伯数字。
+var cnDigits = map[rune]int{
+	'一': 1, '二': 2, '三': 3, '四': 4, '五': 5,
+	'六': 6, '七': 7, '八': 8, '九': 9,
 }
 
 const termTableName = "course_term"

--- a/apps/gooseforum/app/models/forum/course/term.go
+++ b/apps/gooseforum/app/models/forum/course/term.go
@@ -1,14 +1,54 @@
 package course
 
 import (
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"gorm.io/gorm"
 )
 
+// termLabelPattern 匹配一系统的学期标记并提取学年与学期序数：
+// "2025-2026-2" / "2025-2026学年第2学期" / "2025-2026 第二学期"。
+// 组 1 = 学年（YYYY-YYYY），组 2 = 学期序数（阿拉伯或中文数字）。
+var termLabelPattern = regexp.MustCompile(`(\d{4}-\d{4})[^0-9一二三四五六七八九十]*([0-9一二三四五六七八九十]+)[^0-9一二三四五六七八九十]*$`)
+
+// NormalizeTermLabel 将一系统学期标记规范化为课程域标准码 "YYYY-YYYY-N"：
+//   - "2025-2026-1"（已是标准码）原样返回；
+//   - "2026-2027学年第1学期" / "2025-2026 第二学期" → "2026-2027-1" / "2025-2026-2"；
+//   - 无法识别（如 "其他"）返回 trim 后的原标记。
+//
+// 物化链（course-pk-sync --materialize / course-materialize）用标准码创建/匹配
+// course_term：一系统侧写入的是中文学期名，直接落库会把 "2026-2027学年第1学期"
+// 当成学期码创建垃圾行，导致存量 offering 的 term_id 被改写、目录学期筛选断裂。
+func NormalizeTermLabel(label string) string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return ""
+	}
+	if m := termLabelPattern.FindStringSubmatch(label); len(m) == 3 {
+		return m[1] + "-" + cnNumeralToArabic(m[2])
+	}
+	return label
+}
+
+// cnNumeralToArabic 把中文数字学期序数转阿拉伯数字（"二"→"2"）；已是阿拉伯数字原样返回。
+func cnNumeralToArabic(s string) string {
+	if s == "" {
+		return s
+	}
+	if s[0] >= '0' && s[0] <= '9' {
+		return s
+	}
+	if n, ok := map[rune]int{'一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9, '十': 10}[[]rune(s)[0]]; ok {
+		return strconv.Itoa(n)
+	}
+	return s
+}
+
 const termTableName = "course_term"
 
-// Entity 学期：code 形如 "2025-2026-1"，作为开课实例的学期维度。
 type TermEntity struct {
 	Id        uint64         `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
 	Code      string         `gorm:"column:code;type:varchar(32);not null;default:'';uniqueIndex:uniq_course_term_code;" json:"code"`

--- a/apps/gooseforum/app/models/forum/course/term_test.go
+++ b/apps/gooseforum/app/models/forum/course/term_test.go
@@ -1,0 +1,28 @@
+package course
+
+import "testing"
+
+func TestNormalizeTermLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "标准码原样返回", in: "2025-2026-1", want: "2025-2026-1"},
+		{name: "标准码第三学期", in: "2024-2025-3", want: "2024-2025-3"},
+		{name: "中文学期名归一", in: "2026-2027学年第1学期", want: "2026-2027-1"},
+		{name: "中文数字序数归一", in: "2025-2026 第二学期", want: "2025-2026-2"},
+		{name: "中英混合学期名", in: "2025-2026学年第2学期", want: "2025-2026-2"},
+		{name: "无法识别保持原值", in: "其他", want: "其他"},
+		{name: "带空白 trim", in: "  2026-2027-1  ", want: "2026-2027-1"},
+		{name: "空串", in: "", want: ""},
+		{name: "纯空白", in: "   ", want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NormalizeTermLabel(c.in); got != c.want {
+				t.Errorf("NormalizeTermLabel(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/apps/gooseforum/app/models/forum/course/term_test.go
+++ b/apps/gooseforum/app/models/forum/course/term_test.go
@@ -1,6 +1,9 @@
 package course
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestNormalizeTermLabel(t *testing.T) {
 	cases := []struct {
@@ -13,7 +16,9 @@ func TestNormalizeTermLabel(t *testing.T) {
 		{name: "中文学期名归一", in: "2026-2027学年第1学期", want: "2026-2027-1"},
 		{name: "中文数字序数归一", in: "2025-2026 第二学期", want: "2025-2026-2"},
 		{name: "中英混合学期名", in: "2025-2026学年第2学期", want: "2025-2026-2"},
+		{name: "十字开头序数", in: "2024-2025 第十一学期", want: "2024-2025-11"},
 		{name: "无法识别保持原值", in: "其他", want: "其他"},
+		{name: "短学期标记保持原值", in: "2024-2025学年短学期", want: "2024-2025学年短学期"},
 		{name: "带空白 trim", in: "  2026-2027-1  ", want: "2026-2027-1"},
 		{name: "空串", in: "", want: ""},
 		{name: "纯空白", in: "   ", want: ""},
@@ -22,6 +27,57 @@ func TestNormalizeTermLabel(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := NormalizeTermLabel(c.in); got != c.want {
 				t.Errorf("NormalizeTermLabel(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsCanonicalTermCode(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "标准码", in: "2025-2026-1", want: true},
+		{name: "两位数序数", in: "2024-2025-11", want: true},
+		{name: "中文学期名", in: "2026-2027学年第1学期", want: false},
+		{name: "短学期", in: "2024-2025学年短学期", want: false},
+		{name: "无序数", in: "2024-2025", want: false},
+		{name: "其他", in: "其他", want: false},
+		{name: "空串", in: "", want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := IsCanonicalTermCode(c.in); got != c.want {
+				t.Errorf("IsCanonicalTermCode(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTermLabelCandidates(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "标准码仅自身", in: "2025-2026-1", want: []string{"2025-2026-1"}},
+		{name: "中文学期名追加标准码", in: "2026-2027学年第1学期", want: []string{"2026-2027学年第1学期", "2026-2027-1"}},
+		{name: "中文数字序数追加标准码", in: "2025-2026 第二学期", want: []string{"2025-2026 第二学期", "2025-2026-2"}},
+		{name: "无法识别仅自身", in: "其他", want: []string{"其他"}},
+		{name: "空串 nil", in: "", want: nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := TermLabelCandidates(c.in)
+			if c.want == nil {
+				if got != nil {
+					t.Errorf("TermLabelCandidates(%q) = %v, want nil", c.in, got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("TermLabelCandidates(%q) = %v, want %v", c.in, got, c.want)
 			}
 		})
 	}

--- a/apps/gooseforum/app/models/forum/pk/rep_dict.go
+++ b/apps/gooseforum/app/models/forum/pk/rep_dict.go
@@ -194,3 +194,11 @@ func chunkInt(arr []int, size int) [][]int {
 	}
 	return out
 }
+
+// ListAllCalendars 返回全部学期（calendarId 倒序），供学期名/中文标记归一化反查
+// （course-pk-sync / course-materialize 的学期参数解析，双向 NormalizeTermLabel 匹配）。
+func ListAllCalendars() ([]CalendarEntity, error) {
+	var entities []CalendarEntity
+	err := calendarBuilder().Order("calendar_id DESC").Find(&entities).Error
+	return entities, err
+}

--- a/apps/gooseforum/app/service/courseservice/materializePk.go
+++ b/apps/gooseforum/app/service/courseservice/materializePk.go
@@ -475,10 +475,16 @@ func resolveOfferingTermIdTx(tx *gorm.DB, calendarId uint64, termCache map[uint6
 	}
 	termId := uint64(0)
 	// calendar 存在但无学期码（i18n 为空）：合法"无学期码"情形，保持 term_id=0。
+	// 学期码先规范化（"2026-2027学年第1学期" → "2026-2027-1"）：course_term.code
+	// 是标准码，直接拿一系统中文学期名创建会生成垃圾学期行并改写存量 offering 的 term_id。
 	if i18n := strings.TrimSpace(cal.CalendarIdI18n); i18n != "" {
-		term, err := getOrCreateTermTx(tx, i18n)
+		code := course.NormalizeTermLabel(i18n)
+		if code == "" {
+			code = i18n
+		}
+		term, err := getOrCreateTermTx(tx, code)
 		if err != nil {
-			return 0, fmt.Errorf("materialize: resolve term %q: %w", i18n, err)
+			return 0, fmt.Errorf("materialize: resolve term %q: %w", code, err)
 		}
 		termId = term.Id
 	}

--- a/apps/gooseforum/app/service/courseservice/materializePk.go
+++ b/apps/gooseforum/app/service/courseservice/materializePk.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"strings"
 
@@ -477,16 +478,20 @@ func resolveOfferingTermIdTx(tx *gorm.DB, calendarId uint64, termCache map[uint6
 	// calendar 存在但无学期码（i18n 为空）：合法"无学期码"情形，保持 term_id=0。
 	// 学期码先规范化（"2026-2027学年第1学期" → "2026-2027-1"）：course_term.code
 	// 是标准码，直接拿一系统中文学期名创建会生成垃圾学期行并改写存量 offering 的 term_id。
+	// 仅标准码形（YYYY-YYYY-N）允许建行：无法识别的标记（如 "2024-2025学年短学期"）
+	// 保持 term_id=0（与"无学期码"同语义）并记日志，杜绝垃圾学期行（review LOW）。
 	if i18n := strings.TrimSpace(cal.CalendarIdI18n); i18n != "" {
 		code := course.NormalizeTermLabel(i18n)
-		if code == "" {
-			code = i18n
+		if !course.IsCanonicalTermCode(code) {
+			slog.Warn("materialize: 学期标记无法规范化为标准码，保持 term_id=0（不建 course_term 行）",
+				"calendar_id", calendarId, "calendar_id_i18n", i18n, "normalized", code)
+		} else {
+			term, err := getOrCreateTermTx(tx, code)
+			if err != nil {
+				return 0, fmt.Errorf("materialize: resolve term %q: %w", code, err)
+			}
+			termId = term.Id
 		}
-		term, err := getOrCreateTermTx(tx, code)
-		if err != nil {
-			return 0, fmt.Errorf("materialize: resolve term %q: %w", code, err)
-		}
-		termId = term.Id
 	}
 	termCache[calendarId] = termId
 	return termId, nil

--- a/apps/gooseforum/app/service/courseservice/materializePk_test.go
+++ b/apps/gooseforum/app/service/courseservice/materializePk_test.go
@@ -675,3 +675,53 @@ func TestImportReusesMaterializedOffering(t *testing.T) {
 		t.Errorf("source_ref local_id = %d, want %d", ref.LocalId, materializedOffering.Id)
 	}
 }
+
+// TestMaterializeFromPkNormalizesChineseTermLabel 生产场景回归：一系统 calendar 的
+// calendar_id_i18n 是中文标记（"2026-2027学年第1学期"），而 course_term.code 是标准码
+// （"2026-2027-1"）。物化必须规范化后按标准码查找/创建学期——修复前直接拿中文标记
+// 创建 course_term 垃圾行，并把存量 offering 的 term_id 改写过去（目录学期筛选断裂）。
+func TestMaterializeFromPkNormalizesChineseTermLabel(t *testing.T) {
+	migrateMaterializeTables(t)
+	seedPkForMaterialize(t)
+	conn := db.Connect()
+	// 标准学期行已存在（目录 8/21 导入基线）；calendar 用一系统真实中文标记。
+	term := course.TermEntity{Code: "2026-2027-1", Name: "2026-2027 第一学期", Status: 0}
+	if err := conn.Create(&term).Error; err != nil {
+		t.Fatalf("seed standard term: %v", err)
+	}
+	if err := conn.Model(&pk.CalendarEntity{}).Where("calendar_id = ?", 1).
+		Update("calendar_id_i18n", "2026-2027学年第1学期").Error; err != nil {
+		t.Fatalf("set calendar i18n: %v", err)
+	}
+
+	report, err := MaterializeFromPk(context.Background(), []uint64{1})
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if report.OfferingsInserted != 1 {
+		t.Fatalf("offeringsInserted = %d, want 1", report.OfferingsInserted)
+	}
+	// offering 挂到标准学期行，而不是新建的中文标记垃圾学期。
+	var offering course.OfferingEntity
+	if err := conn.Where("teaching_class_id = ?", 1).First(&offering).Error; err != nil {
+		t.Fatalf("find offering: %v", err)
+	}
+	if offering.TermId != term.Id {
+		t.Errorf("offering term_id = %d, want %d（标准学期 2026-2027-1）", offering.TermId, term.Id)
+	}
+	// course_term 不得出现中文标记垃圾行（唯一约束下也不会出现第二行标准码）。
+	var totalTerms int64
+	if err := conn.Model(&course.TermEntity{}).Count(&totalTerms).Error; err != nil {
+		t.Fatalf("count terms: %v", err)
+	}
+	if totalTerms != 1 {
+		t.Errorf("terms = %d, want 1（不得创建中文标记垃圾学期行）", totalTerms)
+	}
+	var junk int64
+	if err := conn.Model(&course.TermEntity{}).Where("code LIKE ?", "%学年第%").Count(&junk).Error; err != nil {
+		t.Fatalf("count junk terms: %v", err)
+	}
+	if junk != 0 {
+		t.Errorf("junk chinese-label terms = %d, want 0", junk)
+	}
+}

--- a/apps/gooseforum/app/service/courseservice/materializePk_test.go
+++ b/apps/gooseforum/app/service/courseservice/materializePk_test.go
@@ -725,3 +725,38 @@ func TestMaterializeFromPkNormalizesChineseTermLabel(t *testing.T) {
 		t.Errorf("junk chinese-label terms = %d, want 0", junk)
 	}
 }
+
+// TestMaterializeFromPkNonCanonicalLabelKeepsZeroTerm 回归 review LOW：calendar i18n
+// 是无法规范化的标记（如 "2024-2025学年短学期"）时不得创建垃圾 course_term 行——
+// 仅标准码形（YYYY-YYYY-N）允许建行，其余保持 term_id=0（与"无学期码"同语义）。
+func TestMaterializeFromPkNonCanonicalLabelKeepsZeroTerm(t *testing.T) {
+	migrateMaterializeTables(t)
+	seedPkForMaterialize(t)
+	conn := db.Connect()
+	if err := conn.Model(&pk.CalendarEntity{}).Where("calendar_id = ?", 1).
+		Update("calendar_id_i18n", "2024-2025学年短学期").Error; err != nil {
+		t.Fatalf("set calendar i18n: %v", err)
+	}
+
+	report, err := MaterializeFromPk(context.Background(), []uint64{1})
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if report.OfferingsInserted != 1 {
+		t.Fatalf("offeringsInserted = %d, want 1", report.OfferingsInserted)
+	}
+	var offering course.OfferingEntity
+	if err := conn.Where("teaching_class_id = ?", 1).First(&offering).Error; err != nil {
+		t.Fatalf("find offering: %v", err)
+	}
+	if offering.TermId != 0 {
+		t.Errorf("offering term_id = %d, want 0（无法规范化的标记不建学期行）", offering.TermId)
+	}
+	var totalTerms int64
+	if err := conn.Model(&course.TermEntity{}).Count(&totalTerms).Error; err != nil {
+		t.Fatalf("count terms: %v", err)
+	}
+	if totalTerms != 0 {
+		t.Errorf("terms = %d, want 0（不得为短学期标记创建垃圾 course_term 行）", totalTerms)
+	}
+}

--- a/apps/gooseforum/app/service/pkservice/review_brief.go
+++ b/apps/gooseforum/app/service/pkservice/review_brief.go
@@ -2,53 +2,12 @@ package pkservice
 
 import (
 	"errors"
-	"regexp"
-	"strconv"
-	"strings"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pk"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/courseservice"
 	"gorm.io/gorm"
 )
-
-// termLabelPattern 匹配一系统的学期标记并提取学年与学期序数：
-// "2025-2026-2" / "2025-2026学年第2学期" / "2025-2026 第二学期"。
-// 组 1 = 学年（YYYY-YYYY），组 2 = 学期序数（阿拉伯或中文数字）。
-var termLabelPattern = regexp.MustCompile(`(\d{4}-\d{4})[^0-9一二三四五六七八九十]*([0-9一二三四五六七八九十]+)[^0-9一二三四五六七八九十]*$`)
-
-// termCodeCandidates 返回学期标记可匹配 course_term.code 的候选码：
-// 标记本身 + 规范化后的 "YYYY-YYYY-N"。一系统侧可能写入中文学期名
-// （如 "2025-2026学年第2学期"），而课程域 course_term.code 是标准码
-// （"2025-2026-2"）；只做精确匹配会让 fail-closed 路径返回空 classes，
-// 排课器教学班评分/跳转随之消失（回归，见 TestPkCourseReviewBriefChineseTermLabelHTTPContract）。
-func termCodeCandidates(label string) []string {
-	label = strings.TrimSpace(label)
-	if label == "" {
-		return nil
-	}
-	candidates := []string{label}
-	if m := termLabelPattern.FindStringSubmatch(label); len(m) == 3 {
-		if normalized := m[1] + "-" + cnNumeralToArabic(m[2]); normalized != label {
-			candidates = append(candidates, normalized)
-		}
-	}
-	return candidates
-}
-
-// cnNumeralToArabic 把中文数字学期序数转阿拉伯数字（"二"→"2"）；已是阿拉伯数字原样返回。
-func cnNumeralToArabic(s string) string {
-	if s == "" {
-		return s
-	}
-	if s[0] >= '0' && s[0] <= '9' {
-		return s
-	}
-	if n, ok := map[rune]int{'一': 1, '二': 2, '三': 3, '四': 4, '五': 5, '六': 6, '七': 7, '八': 8, '九': 9, '十': 10}[[]rune(s)[0]]; ok {
-		return strconv.Itoa(n)
-	}
-	return s
-}
 
 // ReviewBrief P13 course-review-brief 输出项：排课器弹窗展示的课程评价摘要。
 // CourseId 为 Hub 课程目录主键（/courses/:courseId 详情页跳转用）；未匹配课评目录时为 0。
@@ -271,8 +230,9 @@ func fillClassBriefs(brief *ReviewBrief, calendarId uint64) error {
 // calendar 存在、calendar_id_i18n 非空且能在 course_term 中找到对应学期，
 // 任一环节缺失返回 (0, false)——调用方须保持空 classes，不得退化为全学期查询。
 // 一系统侧可能写入中文学期名（"2025-2026学年第2学期"），课程域 course_term.code
-// 是标准码（"2025-2026-2"）：精确匹配失败后按规范化候选重试，避免 fail-closed
-// 返回空 classes 导致排课器教学班评分/跳转消失。
+// 是标准码（"2025-2026-2"）。候选码解析委托 course.TermLabelCandidates（单一权威，
+// 与物化链 NormalizeTermLabel 同源；双份实现会让两条链路后续分歧，review Should）：
+// 先精确后规范化重试，避免 fail-closed 返回空 classes 导致排课器教学班评分/跳转消失。
 func resolveTermIdForCalendar(calendarId uint64) (uint64, bool) {
 	if calendarId == 0 {
 		return 0, true
@@ -281,7 +241,7 @@ func resolveTermIdForCalendar(calendarId uint64) (uint64, bool) {
 	if err != nil || cal.CalendarIdI18n == "" {
 		return 0, false
 	}
-	for _, candidate := range termCodeCandidates(cal.CalendarIdI18n) {
+	for _, candidate := range course.TermLabelCandidates(cal.CalendarIdI18n) {
 		if term, err := course.GetTermByCode(candidate); err == nil {
 			return term.Id, true
 		}

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -513,6 +513,26 @@ CLI 同步（运维 cron 等自动化场景）：
 导入器生成的 offering 行同样携带 `teaching_class_id`，两源共享同一 (term, teaching_class_id)
 唯一索引——先物化后导入时导入器复用已有行（不重复建卡）。
 
+**纯本地物化补跑（course-materialize，不依赖一系统 cookie）**：学期已同步到 PK 域但
+物化失败/遗漏时（如 `--materialize` 当时 cookie 失效、网络不可用），无需重新抓一系统，
+直接消费本地 PK 域数据补物化到课程目录：
+
+```bash
+# 物化指定学期：数字 calendarId、标准学期码、一系统中文学期名均可
+# （学期名经 calendar_id_i18n 归一化反查，中文学期名 "2026-2027学年第1学期" 亦支持）
+./bin/yourtj-hub course-materialize 122
+./bin/yourtj-hub course-materialize 2026-2027-1
+./bin/yourtj-hub course-materialize "2026-2027学年第1学期"
+
+# 预检模式（不写库）：校验学期已同步 + 打印教学班统计
+./bin/yourtj-hub course-materialize 122 --dry-run
+```
+
+行为保证：写入前全量解析校验（未同步/错拼的学期 ID 显式报错，不空成功）；重复参数
+自动去重；物化幂等（同 `teaching_class_id` upsert，不写 `status`、不复活隐藏行）。
+学期码规范化：中文学期标记 → 标准码 `YYYY-YYYY-N` 才建 `course_term` 行，无法识别的
+标记（如短学期）保持 `term_id=0` 不建垃圾行。
+
 凭证优先级：`--onesystem-cookie` 参数 > `ONESYSTEM_COOKIE` 环境变量 > 管理端设置
 （设置 → 一系统同步；`save-onesystem-settings` 仅落库 securestore 密文，不存明文）。
 - 运维 cron（每日，选课季加频；应用内不自造调度器）：


### PR DESCRIPTION
## 背景

生产巡检（2026-2027-1 同步后，main 实例 f.yourtj.de）：课程目录仍是 8/21 manifest 导入基线，而 122 学期（2026-2027-1）已同步 4642 教学班到 PK 域——**155 门新课（151 个新码）无课程卡、1050 个教学班无 offering**（课评不可达）。

两个阻塞根因：
1. **物化强耦合「先抓一系统」**：`course-pk-sync --materialize` 会先走一系统抓取（需 cookie）。cookie 过期（生产实测 HTTP 401）时，已同步学期的数据永远无法物化到课评目录。
2. **物化 term 解析缺陷**：`resolveOfferingTermIdTx` 直接把 `calendar_id_i18n`（一系统中文名 "2026-2027学年第1学期"）当学期码 `getOrCreateTermTx`——会在 course_term 创建中文垃圾行，并把存量 offering 的 term_id 改写过去（学期筛选断裂）。生产 course_term 只存标准码 `2026-2027-1`。

## 改动

- **新 CLI `course-materialize <calendarId|学期>...`**：只读本地已同步 PK 域数据做物化（`courseservice.MaterializeFromPk`），不抓一系统、不需要 cookie，幂等 upsert（同 teaching_class_id，不写 status 不复活隐藏行）——学期已同步后的标准补跑入口。`course-pk-sync --materialize` 保留原语义。
- **`course.NormalizeTermLabel`**：一系统学期标记 → 课程域标准码（"2026-2027学年第1学期" / "2025-2026 第二学期" → "2026-2027-1" / "2025-2026-2"），中文/阿拉伯数字序数都支持；9 个单测。
- **`resolveOfferingTermIdTx`** 改用规范化码匹配/创建 course_term，杜绝中文垃圾学期行。
- 回归测试（红→绿验证）：中文标记 + 存量标准学期 → offering 挂标准学期、零垃圾行；CLI 注册测试。

## 验证

- `go vet` + golangci-lint 0 issues（pre-push 通过）
- `go test ./app/models/forum/course/ ./app/service/courseservice/ ./app/console/...` 全绿
- 红→绿：临时绕过规范化时新测试精确失败（垃圾学期行 + offering term_id 挂错）

## 后续（另开任务）

- 新镜像部署后对 main 执行 `course-materialize 122` 补目录缺口（155 课/1050 班）
- 新旧码同课同教师重复卡（49 组/118 卡）走沿革审核面板人工合并治理

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>