### PR TITLE
fix(auth): address Google OAuth review feedback

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/adminController.go
+++ b/apps/gooseforum/app/http/controllers/api/adminController.go
@@ -51,6 +51,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/llmsservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/mailservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/moderationservice"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/oauthservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/optlogger"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/searchservice"
@@ -1270,6 +1271,7 @@ type SaveSiteSettingsReq struct {
 func SaveSiteSettings(req component.BetterRequest[SaveSiteSettingsReq]) component.Response {
 	return savePageConfig(pageConfig.SiteSettings, req.Params.Settings, func() {
 		hotdataserve.ClearSiteSettingsConfigCache()
+		oauthservice.InitOAuth()
 		llmsservice.ClearCache()
 	})
 }

--- a/apps/gooseforum/app/http/controllers/api/adminController.go
+++ b/apps/gooseforum/app/http/controllers/api/adminController.go
@@ -1271,7 +1271,7 @@ type SaveSiteSettingsReq struct {
 func SaveSiteSettings(req component.BetterRequest[SaveSiteSettingsReq]) component.Response {
 	return savePageConfig(pageConfig.SiteSettings, req.Params.Settings, func() {
 		hotdataserve.ClearSiteSettingsConfigCache()
-		oauthservice.InitOAuth()
+		oauthservice.RefreshOAuthProviders()
 		llmsservice.ClearCache()
 	})
 }

--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -69,6 +69,11 @@ func ProviderCallback(c *gin.Context) {
 				forum.RenderOAuthErrorPage(c, http.StatusForbidden, component.MessageOAuthAccountFrozen)
 				return
 			}
+			if errors.Is(err, oauthservice.ErrOAuthEmailUnverified) {
+				slog.Warn("OAuth callback rejected unverified email", "provider", gothUser.Provider)
+				forum.RenderOAuthErrorPage(c, http.StatusForbidden, component.MessageAuthEmailUnverified)
+				return
+			}
 			slog.Error("Process OAuth callback failed", "error", err)
 			forum.RenderInternalOAuthErrorPage(c, component.MessageOAuthProcessFailed)
 			return

--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -13,7 +13,6 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/sessionservice"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/userservice"
 	"github.com/gin-gonic/gin"
-	"github.com/markbates/goth/gothic"
 )
 
 // ProviderLogin 开始OAuth登录/绑定流程（根据登录状态自动判断）
@@ -22,7 +21,7 @@ func ProviderLogin(c *gin.Context) {
 	q.Add("provider", c.Param("provider"))
 	c.Request.URL.RawQuery = q.Encode()
 	// 开始 OAuth 流程
-	gothic.BeginAuthHandler(c.Writer, c.Request)
+	oauthservice.BeginOAuthAuthHandler(c.Writer, c.Request)
 }
 
 // ProviderCallback 处理OAuth登录/绑定回调（根据登录状态自动判断）
@@ -32,7 +31,7 @@ func ProviderCallback(c *gin.Context) {
 	c.Request.URL.RawQuery = q.Encode()
 
 	// 完成 OAuth 流程
-	gothUser, err := gothic.CompleteUserAuth(c.Writer, c.Request)
+	gothUser, err := oauthservice.CompleteOAuthUserAuth(c.Writer, c.Request)
 	if err != nil {
 		slog.Error("OAuth callback failed", "error", err)
 		forum.RenderInternalOAuthErrorPage(c, component.MessageOAuthCallbackFailed)

--- a/apps/gooseforum/app/http/controllers/api/oauth_callback_test.go
+++ b/apps/gooseforum/app/http/controllers/api/oauth_callback_test.go
@@ -8,9 +8,11 @@ import (
 
 	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userOAuth"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userSessions"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/oauthservice"
 	"github.com/gin-gonic/gin"
 	"github.com/markbates/goth"
@@ -173,5 +175,73 @@ func TestOAuthCallbackLoginSuccessIssuesSession(t *testing.T) {
 	}
 	if count := countSessions(t, user.Id); count != 1 {
 		t.Fatalf("session rows = %d, want 1", count)
+	}
+}
+
+// enableEmailVerificationForTest 开启全站邮箱验证（SecuritySettings 页配置）。
+// OAuth 未验证邮箱拒绝路径依赖该开关；cleanup 删除配置并清缓存还原默认。
+func enableEmailVerificationForTest(t *testing.T) {
+	t.Helper()
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&pageConfig.Entity{}); err != nil {
+		t.Fatalf("migrate page_config: %v", err)
+	}
+	encoded, err := json.Marshal(pageConfig.SecurityAndRegistration{EnableEmailVerification: true})
+	if err != nil {
+		t.Fatalf("encode security config: %v", err)
+	}
+	entity := pageConfig.Entity{PageType: pageConfig.SecuritySettings, Config: string(encoded)}
+	if err := conn.Where("page_type = ?", pageConfig.SecuritySettings).Assign(entity).FirstOrCreate(&entity).Error; err != nil {
+		t.Fatalf("save security config: %v", err)
+	}
+	hotdataserve.ClearSecuritySettingsConfigCache()
+	t.Cleanup(func() {
+		conn.Where("page_type = ?", pageConfig.SecuritySettings).Delete(&pageConfig.Entity{})
+		hotdataserve.ClearSecuritySettingsConfigCache()
+	})
+}
+
+// TestOAuthCallbackLoginRejectsUnverifiedEmail 守卫 controller 拒绝分支：全站邮箱验证开启时，
+// Google OAuth 未提供 verified_email=true 邮箱的注册回调必须返回 403 +
+// MessageAuthEmailUnverified，不创建账号、不写 OAuth 绑定、不发会话 Cookie。
+func TestOAuthCallbackLoginRejectsUnverifiedEmail(t *testing.T) {
+	setupOAuthCallbackTestDB(t)
+	enableEmailVerificationForTest(t)
+
+	stubGothUser(t, goth.User{
+		Provider: oauthservice.ProviderGoogle,
+		UserID:   "google-uid-unverified",
+		NickName: "oauthunverified",
+		Email:    "attacker@gmail.com",
+		RawData:  map[string]any{"verified_email": false},
+	})
+
+	recorder, c := oauthCallbackRequest(t)
+	// stub 接管 goth 后 provider 仅用于 query 构造；保持请求与模拟的 Google 身份一致。
+	c.Params = gin.Params{{Key: "provider", Value: oauthservice.ProviderGoogle}}
+	ProviderCallback(c)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (body: %s)", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Props struct {
+			MessageCode component.MessageCode `json:"messageCode"`
+		} `json:"props"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode error page: %v", err)
+	}
+	if payload.Props.MessageCode != component.MessageAuthEmailUnverified {
+		t.Fatalf("messageCode = %q, want %q", payload.Props.MessageCode, component.MessageAuthEmailUnverified)
+	}
+	if hasAccessTokenCookie(recorder) {
+		t.Fatal("rejected OAuth registration must not receive an access_token cookie")
+	}
+	if users.ExistUsername("oauthunverified") {
+		t.Fatal("unverified OAuth user was created despite email verification being enabled")
+	}
+	if binding := userOAuth.GetByProviderAndUID(oauthservice.ProviderGoogle, "google-uid-unverified"); binding != nil {
+		t.Fatalf("unverified OAuth identity was bound despite rejection: %#v", binding)
 	}
 }

--- a/apps/gooseforum/app/http/controllers/forum/payload.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload.go
@@ -559,9 +559,10 @@ type MessagesPageProps struct {
 }
 
 type SettingsPageProps struct {
-	User  *vo.UserDetailedVo   `json:"user"`
-	Stats SettingsStatsPayload `json:"stats"`
-	Tabs  []TabPayload         `json:"tabs"`
+	User             *vo.UserDetailedVo   `json:"user"`
+	Stats            SettingsStatsPayload `json:"stats"`
+	Tabs             []TabPayload         `json:"tabs"`
+	GoogleOAuthReady bool                 `json:"googleOAuthReady"`
 }
 
 type SettingsStatsPayload struct {
@@ -2601,7 +2602,8 @@ func buildMessagesPageProps(c *gin.Context) MessagesPageProps {
 func buildSettingsPageProps(user users.EntityComplete) SettingsPageProps {
 	stats := userStatistics.Get(user.Id)
 	return SettingsPageProps{
-		User: transform.User2UserDetailedVo(user),
+		User:             transform.User2UserDetailedVo(user),
+		GoogleOAuthReady: oauthservice.IsGoogleOAuthReady(),
 		Stats: SettingsStatsPayload{
 			TopicCount:        stats.TopicCount,
 			ReplyCount:        stats.ReplyCount,

--- a/apps/gooseforum/app/http/controllers/forum/payload.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload.go
@@ -935,7 +935,7 @@ func buildLoginPageProps(c *gin.Context) LoginPageProps {
 		RedirectURL: redirectURL,
 		GitHubURL:   githubURL,
 		GoogleURL:   googleURL,
-		GoogleReady: oauthservice.IsGoogleOAuthConfigured(),
+		GoogleReady: oauthservice.IsGoogleOAuthReady(),
 	}
 }
 

--- a/apps/gooseforum/app/http/controllers/forum/payload_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload_test.go
@@ -1,6 +1,9 @@
 package forum
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestIsSafeRedirect(t *testing.T) {
 	unsafe := []string{
@@ -79,5 +82,20 @@ func TestSettingsTabs(t *testing.T) {
 	}
 	if activeCount != 1 {
 		t.Errorf("settingsTabs() active tab count = %d, want exactly 1", activeCount)
+	}
+}
+
+func TestSettingsPagePropsSerializesGoogleOAuthReady(t *testing.T) {
+	encoded, err := json.Marshal(SettingsPageProps{GoogleOAuthReady: true})
+	if err != nil {
+		t.Fatalf("marshal SettingsPageProps: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("unmarshal SettingsPageProps: %v", err)
+	}
+	if ready, ok := payload["googleOAuthReady"].(bool); !ok || !ready {
+		t.Fatalf("googleOAuthReady = %#v, want true", payload["googleOAuthReady"])
 	}
 }

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
@@ -47,9 +48,15 @@ const (
 // controller 依据该 sentinel error 渲染 403 冻结错误页（与 OIDC exchange 的冻结语义一致）。
 var ErrAccountFrozen = errors.New("账号已冻结，禁止 OAuth 登录")
 
+// googleProvider 保存启动时注册的 Google provider。
+// Google OAuth 配置是 live 读取的，但 goth provider 只在启动时注册；保存实例可让
+// 登录页区分“配置完整”和“当前进程已经注册且使用同一份配置”。
+var googleProvider atomic.Pointer[google.Provider]
+
 // InitOAuth configures available OAuth providers.
 func InitOAuth() {
 	gothic.Store = sessionstore.GetSession()
+	googleProvider.Store(nil)
 
 	var providers []goth.Provider
 
@@ -59,6 +66,7 @@ func InitOAuth() {
 
 	if provider := initGoogleProvider(); provider != nil {
 		providers = append(providers, provider)
+		googleProvider.Store(provider)
 	}
 
 	if len(providers) > 0 {
@@ -86,10 +94,26 @@ func initGitHubProvider() goth.Provider {
 }
 
 // IsGoogleOAuthConfigured reports whether Google OAuth has all values required
-// to construct an absolute callback URL and register the provider.
+// to construct an absolute callback URL. It does not imply provider registration.
 func IsGoogleOAuthConfigured() bool {
 	clientID, clientSecret, callbackURL := googleOAuthConfig()
 	return clientID != "" && clientSecret != "" && callbackURL != ""
+}
+
+// IsGoogleOAuthReady reports whether Google OAuth is configured and the running
+// process has registered a provider with the same credentials and callback URL.
+// Changing Google OAuth credentials or siteUrl therefore requires a restart.
+func IsGoogleOAuthReady() bool {
+	clientID, clientSecret, callbackURL := googleOAuthConfig()
+	if clientID == "" || clientSecret == "" || callbackURL == "" {
+		return false
+	}
+
+	provider := googleProvider.Load()
+	return provider != nil &&
+		provider.ClientKey == clientID &&
+		provider.Secret == clientSecret &&
+		provider.CallbackURL == callbackURL
 }
 
 func googleOAuthConfig() (clientID, clientSecret, callbackURL string) {
@@ -104,7 +128,7 @@ func googleOAuthConfig() (clientID, clientSecret, callbackURL string) {
 }
 
 // initGoogleProvider returns a Google provider when configured.
-func initGoogleProvider() goth.Provider {
+func initGoogleProvider() *google.Provider {
 	clientID, clientSecret, callbackURL := googleOAuthConfig()
 	if clientID == "" || clientSecret == "" || callbackURL == "" {
 		slog.Warn("Google OAuth配置缺失，跳过初始化")
@@ -127,8 +151,9 @@ type OAuthUserInfo struct {
 	Location  string `json:"location"`
 	Provider  string `json:"provider"`
 
-	// VerifiedEmail 是 provider 已确认真实的邮箱（GitHub verified 邮箱）。
-	// EmailVerified 标记该邮箱来自可信来源（GitHub /user/emails 的 verified=true）。
+	// VerifiedEmail 是 provider 已确认真实的邮箱（GitHub verified 邮箱或 Google
+	// email_verified=true 的邮箱）。
+	// EmailVerified 标记该邮箱来自可信来源（GitHub /user/emails 或 Google OIDC）。
 	// issue #155：只信 verified 邮箱作为绑定/激活依据，goth 的 Email 字段
 	// 可能是未验证的公开邮箱，不可直接用于信任决策。
 	VerifiedEmail string `json:"verifiedEmail,omitempty"`
@@ -237,7 +262,8 @@ func emailInTrustedDomains(email string) bool {
 }
 
 // parseOAuthUserInfo normalizes provider-specific user data.
-// 对 GitHub 额外获取 verified primary 邮箱（issue #155）。
+// 对 GitHub 额外获取 verified primary 邮箱（issue #155），Google 则只信任
+// userinfo 中 email_verified=true 的邮箱。
 func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 	userInfo := OAuthUserInfo{
 		ID:        gothUser.UserID,
@@ -269,6 +295,17 @@ func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 		if verified := fetchGitHubVerifiedEmail(gothUser.AccessToken); verified != "" {
 			userInfo.VerifiedEmail = verified
 			userInfo.EmailVerified = true
+		}
+	}
+
+	// Google OIDC userinfo 的 email_verified 是 provider 直接返回的布尔断言；
+	// 只有断言为 true 且邮箱非空时，才进入可信邮箱绑定/激活路径。
+	if userInfo.Provider == ProviderGoogle {
+		if emailVerified, ok := gothUser.RawData["email_verified"].(bool); ok && emailVerified {
+			if verified := strings.ToLower(strings.TrimSpace(userInfo.Email)); verified != "" {
+				userInfo.VerifiedEmail = verified
+				userInfo.EmailVerified = true
+			}
 		}
 	}
 

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -132,14 +132,6 @@ func CompleteOAuthUserAuth(w http.ResponseWriter, r *http.Request) (goth.User, e
 	return gothic.CompleteUserAuth(w, r)
 }
 
-// initGitHubProvider returns a GitHub provider when configured.
-func initGitHubProvider() goth.Provider {
-	return initGitHubProviderWithCredentials(oauthCredentials{
-		clientID:     preferences.GetString("github.client_id", ""),
-		clientSecret: preferences.GetString("github.client_secret", ""),
-	})
-}
-
 func initGitHubProviderWithCredentials(credentials oauthCredentials) goth.Provider {
 	callbackURL := strings.TrimRight(strings.TrimSpace(hotdataserve.GetSiteSettingsConfigCache().SiteUrl), "/") + "/api/auth/github/callback"
 	clientID := strings.TrimSpace(credentials.clientID)

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -48,9 +48,12 @@ const (
 // controller 依据该 sentinel error 渲染 403 冻结错误页（与 OIDC exchange 的冻结语义一致）。
 var ErrAccountFrozen = errors.New("账号已冻结，禁止 OAuth 登录")
 
-// googleProvider 保存启动时注册的 Google provider。
-// Google OAuth 配置是 live 读取的，但 goth provider 只在启动时注册；保存实例可让
-// 登录页区分“配置完整”和“当前进程已经注册且使用同一份配置”。
+// ErrOAuthEmailUnverified 表示 OAuth provider 未提供可用于站点验证的邮箱。
+var ErrOAuthEmailUnverified = errors.New("OAuth 邮箱未验证或不可用")
+
+// googleProvider 保存当前已注册的 Google provider。
+// Google OAuth 配置是 live 读取的；保存实例可让登录页区分“配置完整”和
+// “当前进程已经注册且使用同一份配置”。
 var googleProvider atomic.Pointer[google.Provider]
 
 // InitOAuth configures available OAuth providers.
@@ -59,6 +62,7 @@ func InitOAuth() {
 	googleProvider.Store(nil)
 
 	var providers []goth.Provider
+	var configuredGoogleProvider *google.Provider
 
 	if provider := initGitHubProvider(); provider != nil {
 		providers = append(providers, provider)
@@ -66,11 +70,14 @@ func InitOAuth() {
 
 	if provider := initGoogleProvider(); provider != nil {
 		providers = append(providers, provider)
-		googleProvider.Store(provider)
+		configuredGoogleProvider = provider
 	}
 
+	// SiteUrl 可在管理后台修改；重建 provider 前先移除旧实例，避免继续使用过期回调地址。
+	goth.ClearProviders()
 	if len(providers) > 0 {
 		goth.UseProviders(providers...)
+		googleProvider.Store(configuredGoogleProvider)
 		slog.Info("OAuth提供商初始化完成", "count", len(providers))
 	} else {
 		slog.Warn("未配置任何OAuth提供商")
@@ -102,7 +109,7 @@ func IsGoogleOAuthConfigured() bool {
 
 // IsGoogleOAuthReady reports whether Google OAuth is configured and the running
 // process has registered a provider with the same credentials and callback URL.
-// Changing Google OAuth credentials or siteUrl therefore requires a restart.
+// InitOAuth must be called after a runtime siteUrl change to refresh the provider.
 func IsGoogleOAuthReady() bool {
 	clientID, clientSecret, callbackURL := googleOAuthConfig()
 	if clientID == "" || clientSecret == "" || callbackURL == "" {
@@ -299,9 +306,10 @@ func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 	}
 
 	// Google OIDC userinfo 的 email_verified 是 provider 直接返回的布尔断言；
-	// 只有断言为 true 且邮箱非空时，才进入可信邮箱绑定/激活路径。
+	// 兼容部分代理或 mock 返回的字符串/数字形式。只有断言为 true 且邮箱非空时，
+	// 才进入可信邮箱绑定/激活路径。
 	if userInfo.Provider == ProviderGoogle {
-		if emailVerified, ok := gothUser.RawData["email_verified"].(bool); ok && emailVerified {
+		if oauthFlagIsTrue(gothUser.RawData["email_verified"]) {
 			if verified := strings.ToLower(strings.TrimSpace(userInfo.Email)); verified != "" {
 				userInfo.VerifiedEmail = verified
 				userInfo.EmailVerified = true
@@ -310,6 +318,34 @@ func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 	}
 
 	return userInfo
+}
+
+// oauthFlagIsTrue accepts the boolean representation emitted by standard JSON
+// decoding and the string/number variants used by some OIDC proxies and mocks.
+func oauthFlagIsTrue(value any) bool {
+	switch value := value.(type) {
+	case bool:
+		return value
+	case string:
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		return normalized == "true" || normalized == "1"
+	case json.Number:
+		return value == "1" || value == "1.0"
+	case float64:
+		return value == 1
+	case float32:
+		return value == 1
+	case int:
+		return value == 1
+	case int64:
+		return value == 1
+	case uint:
+		return value == 1
+	case uint64:
+		return value == 1
+	default:
+		return false
+	}
 }
 
 // gitHubEmailAPIURL 为 GitHub 邮箱列表 API（var 便于测试覆盖）。
@@ -379,11 +415,20 @@ func usernameReservedOrBanned(username string, cfg pageConfig.SecurityAndRegistr
 // createUserFromOAuth creates a local account from OAuth user data.
 // 激活策略（issue #155）：
 //   - verified 邮箱命中信任域名（allowedDomains 空 = 全信任）→ needValid=false 直接激活；
-//   - 未命中或未获取到 verified 邮箱 → needValid = EnableEmailVerification 开关
-//     （默认 false 保持现状免验证，不回归）；开关开启时进入 ActivationPending
-//     并补发激活邮件（与密码注册流程一致）。
+//   - verified 邮箱未命中信任域名 → EnableEmailVerification 开启时进入
+//     ActivationPending 并补发激活邮件；
+//   - 未获取到可用 verified 邮箱 → EnableEmailVerification 开启时拒绝 OAuth 建号，
+//     关闭时保持免验证兼容行为。
 func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) {
 	securityConfig := hotdataserve.GetSecuritySettingsConfigCache()
+	email := strings.ToLower(strings.TrimSpace(userInfo.VerifiedEmail))
+	hasVerifiedEmail := userInfo.EmailVerified && email != ""
+	if securityConfig.EnableEmailVerification && !hasVerifiedEmail {
+		// 没有可发激活邮件的可信地址时直接拒绝，不能将未验证的 OAuth 身份
+		// 当作已激活账号放行，也不能创建无法恢复的 pending 账号。
+		return nil, ErrOAuthEmailUnverified
+	}
+
 	username := userInfo.Login
 	originalUsername := username
 	counter := 1
@@ -398,19 +443,15 @@ func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) 
 		}
 	}
 
-	// 存储邮箱：只存 provider 已确认真实的邮箱（GitHub verified 邮箱）。
+	// 存储邮箱：只存 provider 已确认真实的邮箱（GitHub verified 邮箱或 Google
+	// email_verified=true 的邮箱）。
 	// 无 verified 邮箱时保持存 ""（与旧行为一致），不降级存 goth 公开邮箱——
 	// 未验证邮箱若被 OIDC userinfo 推导为 email_verified=true 会造成信任越界
 	// （PR #167 review, medium）。
-	email := strings.ToLower(strings.TrimSpace(userInfo.VerifiedEmail))
 
 	// 信任判定：仅 verified 邮箱命中信任域名才免验证。
-	trusted := userInfo.EmailVerified && email != "" && emailInTrustedDomains(email)
-	// 无 verified 邮箱时保持旧行为免验证（needValid=false）：
-	// 该场景没有可用的激活邮箱，若进入 ActivationPending 将形成无恢复路径的
-	// 永久死账号（PR #167 review, blocking）。开关开启且未命中信任域名时，
-	// 仅当存在 verified 邮箱才要求邮箱激活。
-	needValid := !trusted && securityConfig.EnableEmailVerification && userInfo.EmailVerified
+	trusted := hasVerifiedEmail && emailInTrustedDomains(email)
+	needValid := !trusted && securityConfig.EnableEmailVerification
 
 	userEntity, err := userservice.CreateUser(username, randopt.RandomString(32), email, needValid)
 	if err != nil {

--- a/apps/gooseforum/app/service/oauthservice/oauth.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -51,24 +52,56 @@ var ErrAccountFrozen = errors.New("账号已冻结，禁止 OAuth 登录")
 // ErrOAuthEmailUnverified 表示 OAuth provider 未提供可用于站点验证的邮箱。
 var ErrOAuthEmailUnverified = errors.New("OAuth 邮箱未验证或不可用")
 
-// googleProvider 保存当前已注册的 Google provider。
-// Google OAuth 配置是 live 读取的；保存实例可让登录页区分“配置完整”和
-// “当前进程已经注册且使用同一份配置”。
-var googleProvider atomic.Pointer[google.Provider]
+type oauthCredentials struct {
+	clientID     string
+	clientSecret string
+}
+
+var (
+	// oauthProviderMu 与 goth provider registry 的替换及请求查找保持同步。
+	oauthProviderMu sync.RWMutex
+	// startupOAuthCredentials 固定进程启动时读取的 OAuth 凭据；运行时只刷新回调地址。
+	startupGitHubCredentials oauthCredentials
+	startupGoogleCredentials oauthCredentials
+	// googleProvider 保存当前已注册的 Google provider。
+	googleProvider atomic.Pointer[google.Provider]
+)
 
 // InitOAuth configures available OAuth providers.
 func InitOAuth() {
+	oauthProviderMu.Lock()
+	defer oauthProviderMu.Unlock()
+
+	startupGitHubCredentials = oauthCredentials{
+		clientID:     strings.TrimSpace(preferences.GetString("github.client_id", "")),
+		clientSecret: strings.TrimSpace(preferences.GetString("github.client_secret", "")),
+	}
+	startupGoogleCredentials = oauthCredentials{
+		clientID:     strings.TrimSpace(preferences.GetString("google.client_id", "")),
+		clientSecret: strings.TrimSpace(preferences.GetString("google.client_secret", "")),
+	}
+	initOAuthProvidersLocked()
+}
+
+// RefreshOAuthProviders rebuilds providers with startup credentials and the
+// current site callback URL. It deliberately does not reread client secrets.
+func RefreshOAuthProviders() {
+	oauthProviderMu.Lock()
+	defer oauthProviderMu.Unlock()
+	initOAuthProvidersLocked()
+}
+
+func initOAuthProvidersLocked() {
 	gothic.Store = sessionstore.GetSession()
-	googleProvider.Store(nil)
 
 	var providers []goth.Provider
 	var configuredGoogleProvider *google.Provider
 
-	if provider := initGitHubProvider(); provider != nil {
+	if provider := initGitHubProviderWithCredentials(startupGitHubCredentials); provider != nil {
 		providers = append(providers, provider)
 	}
 
-	if provider := initGoogleProvider(); provider != nil {
+	if provider := initGoogleProviderWithCredentials(startupGoogleCredentials); provider != nil {
 		providers = append(providers, provider)
 		configuredGoogleProvider = provider
 	}
@@ -77,18 +110,40 @@ func InitOAuth() {
 	goth.ClearProviders()
 	if len(providers) > 0 {
 		goth.UseProviders(providers...)
-		googleProvider.Store(configuredGoogleProvider)
 		slog.Info("OAuth提供商初始化完成", "count", len(providers))
 	} else {
 		slog.Warn("未配置任何OAuth提供商")
 	}
+	googleProvider.Store(configuredGoogleProvider)
+}
+
+// BeginOAuthAuthHandler serializes provider lookup with runtime provider refresh.
+func BeginOAuthAuthHandler(w http.ResponseWriter, r *http.Request) {
+	oauthProviderMu.RLock()
+	defer oauthProviderMu.RUnlock()
+	gothic.BeginAuthHandler(w, r)
+}
+
+// CompleteOAuthUserAuth serializes provider lookup and user fetching with
+// runtime provider refresh.
+func CompleteOAuthUserAuth(w http.ResponseWriter, r *http.Request) (goth.User, error) {
+	oauthProviderMu.RLock()
+	defer oauthProviderMu.RUnlock()
+	return gothic.CompleteUserAuth(w, r)
 }
 
 // initGitHubProvider returns a GitHub provider when configured.
 func initGitHubProvider() goth.Provider {
-	clientID := preferences.GetString("github.client_id", "")
-	clientSecret := preferences.GetString("github.client_secret", "")
-	callbackURL := hotdataserve.GetSiteSettingsConfigCache().SiteUrl + "/api/auth/github/callback"
+	return initGitHubProviderWithCredentials(oauthCredentials{
+		clientID:     preferences.GetString("github.client_id", ""),
+		clientSecret: preferences.GetString("github.client_secret", ""),
+	})
+}
+
+func initGitHubProviderWithCredentials(credentials oauthCredentials) goth.Provider {
+	callbackURL := strings.TrimRight(strings.TrimSpace(hotdataserve.GetSiteSettingsConfigCache().SiteUrl), "/") + "/api/auth/github/callback"
+	clientID := strings.TrimSpace(credentials.clientID)
+	clientSecret := strings.TrimSpace(credentials.clientSecret)
 	if clientID == "" || clientSecret == "" {
 		slog.Warn("GitHub OAuth配置缺失，跳过初始化")
 		return nil
@@ -107,36 +162,50 @@ func IsGoogleOAuthConfigured() bool {
 	return clientID != "" && clientSecret != "" && callbackURL != ""
 }
 
-// IsGoogleOAuthReady reports whether Google OAuth is configured and the running
-// process has registered a provider with the same credentials and callback URL.
-// InitOAuth must be called after a runtime siteUrl change to refresh the provider.
+// IsGoogleOAuthReady reports whether the running process has registered Google
+// with its startup credentials and the current callback URL.
+// RefreshOAuthProviders must be called after a runtime siteUrl change.
 func IsGoogleOAuthReady() bool {
-	clientID, clientSecret, callbackURL := googleOAuthConfig()
-	if clientID == "" || clientSecret == "" || callbackURL == "" {
+	oauthProviderMu.RLock()
+	defer oauthProviderMu.RUnlock()
+
+	callbackURL := googleOAuthCallbackURL()
+	if callbackURL == "" {
 		return false
 	}
 
 	provider := googleProvider.Load()
 	return provider != nil &&
-		provider.ClientKey == clientID &&
-		provider.Secret == clientSecret &&
 		provider.CallbackURL == callbackURL
 }
 
 func googleOAuthConfig() (clientID, clientSecret, callbackURL string) {
 	clientID = strings.TrimSpace(preferences.GetString("google.client_id", ""))
 	clientSecret = strings.TrimSpace(preferences.GetString("google.client_secret", ""))
+	return clientID, clientSecret, googleOAuthCallbackURL()
+}
+
+func googleOAuthCallbackURL() string {
 	siteURL := strings.TrimRight(strings.TrimSpace(hotdataserve.GetSiteSettingsConfigCache().SiteUrl), "/")
 	parsedURL, err := url.Parse(siteURL)
 	if err != nil || parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.RawQuery != "" || parsedURL.Fragment != "" {
-		return clientID, clientSecret, ""
+		return ""
 	}
-	return clientID, clientSecret, siteURL + "/api/auth/google/callback"
+	return siteURL + "/api/auth/google/callback"
 }
 
 // initGoogleProvider returns a Google provider when configured.
 func initGoogleProvider() *google.Provider {
-	clientID, clientSecret, callbackURL := googleOAuthConfig()
+	return initGoogleProviderWithCredentials(oauthCredentials{
+		clientID:     preferences.GetString("google.client_id", ""),
+		clientSecret: preferences.GetString("google.client_secret", ""),
+	})
+}
+
+func initGoogleProviderWithCredentials(credentials oauthCredentials) *google.Provider {
+	clientID := strings.TrimSpace(credentials.clientID)
+	clientSecret := strings.TrimSpace(credentials.clientSecret)
+	callbackURL := googleOAuthCallbackURL()
 	if clientID == "" || clientSecret == "" || callbackURL == "" {
 		slog.Warn("Google OAuth配置缺失，跳过初始化")
 		return nil
@@ -159,7 +228,7 @@ type OAuthUserInfo struct {
 	Provider  string `json:"provider"`
 
 	// VerifiedEmail 是 provider 已确认真实的邮箱（GitHub verified 邮箱或 Google
-	// email_verified=true 的邮箱）。
+	// verified_email=true 的邮箱）。
 	// EmailVerified 标记该邮箱来自可信来源（GitHub /user/emails 或 Google OIDC）。
 	// issue #155：只信 verified 邮箱作为绑定/激活依据，goth 的 Email 字段
 	// 可能是未验证的公开邮箱，不可直接用于信任决策。
@@ -270,7 +339,7 @@ func emailInTrustedDomains(email string) bool {
 
 // parseOAuthUserInfo normalizes provider-specific user data.
 // 对 GitHub 额外获取 verified primary 邮箱（issue #155），Google 则只信任
-// userinfo 中 email_verified=true 的邮箱。
+// userinfo 中 verified_email=true 的邮箱。
 func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 	userInfo := OAuthUserInfo{
 		ID:        gothUser.UserID,
@@ -305,11 +374,15 @@ func parseOAuthUserInfo(gothUser goth.User) OAuthUserInfo {
 		}
 	}
 
-	// Google OIDC userinfo 的 email_verified 是 provider 直接返回的布尔断言；
-	// 兼容部分代理或 mock 返回的字符串/数字形式。只有断言为 true 且邮箱非空时，
-	// 才进入可信邮箱绑定/激活路径。
+	// Google goth provider 的实际字段是 verified_email；同时兼容 OIDC 代理常见的
+	// email_verified 别名及字符串/数字形式。只有断言为 true 且邮箱非空时，才进入
+	// 可信邮箱绑定/激活路径。
 	if userInfo.Provider == ProviderGoogle {
-		if oauthFlagIsTrue(gothUser.RawData["email_verified"]) {
+		verifiedFlag, ok := gothUser.RawData["verified_email"]
+		if !ok {
+			verifiedFlag, ok = gothUser.RawData["email_verified"]
+		}
+		if ok && oauthFlagIsTrue(verifiedFlag) {
 			if verified := strings.ToLower(strings.TrimSpace(userInfo.Email)); verified != "" {
 				userInfo.VerifiedEmail = verified
 				userInfo.EmailVerified = true
@@ -444,9 +517,9 @@ func createUserFromOAuth(userInfo OAuthUserInfo) (*users.EntityComplete, error) 
 	}
 
 	// 存储邮箱：只存 provider 已确认真实的邮箱（GitHub verified 邮箱或 Google
-	// email_verified=true 的邮箱）。
+	// verified_email=true 的邮箱）。
 	// 无 verified 邮箱时保持存 ""（与旧行为一致），不降级存 goth 公开邮箱——
-	// 未验证邮箱若被 OIDC userinfo 推导为 email_verified=true 会造成信任越界
+	// 未验证邮箱若被 OIDC userinfo 推导为 verified_email=true 会造成信任越界
 	// （PR #167 review, medium）。
 
 	// 信任判定：仅 verified 邮箱命中信任域名才免验证。

--- a/apps/gooseforum/app/service/oauthservice/oauth_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_test.go
@@ -1,6 +1,7 @@
 package oauthservice
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/datamigration"
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/providers/google"
 	"gorm.io/gorm"
 )
 
@@ -39,6 +41,7 @@ func setupGoogleOAuthProviderConfig(t *testing.T, siteURL string) {
 		preferences.Set("google.client_id", "")
 		preferences.Set("google.client_secret", "")
 		googleProvider.Store(nil)
+		goth.ClearProviders()
 		conn.Where("page_type = ?", pageConfig.SiteSettings).Delete(&pageConfig.Entity{})
 		hotdataserve.ClearSiteSettingsConfigCache()
 	})
@@ -99,23 +102,62 @@ func TestGoogleOAuthReadyRequiresMatchingStartupRegistration(t *testing.T) {
 	}
 }
 
+func TestInitOAuthRefreshesGoogleProviderAfterSiteURLChange(t *testing.T) {
+	setupGoogleOAuthProviderConfig(t, "https://old.example.test")
+	InitOAuth()
+
+	entity := pageConfig.GetByPageType(pageConfig.SiteSettings)
+	entity.Config = jsonopt.Encode(pageConfig.SiteSettingsConfig{SiteUrl: "https://new.example.test"})
+	pageConfig.CreateOrSave(&entity)
+	hotdataserve.ClearSiteSettingsConfigCache()
+	InitOAuth()
+
+	provider, err := goth.GetProvider(ProviderGoogle)
+	if err != nil {
+		t.Fatalf("goth.GetProvider(%q) error = %v", ProviderGoogle, err)
+	}
+	googleProvider, ok := provider.(*google.Provider)
+	if !ok {
+		t.Fatalf("Google provider type = %T, want *google.Provider", provider)
+	}
+	if googleProvider.CallbackURL != "https://new.example.test/api/auth/google/callback" {
+		t.Fatalf("Google provider callback URL = %q, want refreshed site URL", googleProvider.CallbackURL)
+	}
+}
+
 func TestParseGoogleVerifiedEmail(t *testing.T) {
-	verified := parseOAuthUserInfo(goth.User{
-		Provider: ProviderGoogle,
-		Email:    " Alice@Example.Test ",
-		RawData:  map[string]any{"email_verified": true},
-	})
-	if verified.VerifiedEmail != "alice@example.test" || !verified.EmailVerified {
-		t.Fatalf("verified Google email = %q, emailVerified = %v; want normalized trusted email", verified.VerifiedEmail, verified.EmailVerified)
+	tests := []struct {
+		name     string
+		flag     any
+		verified bool
+	}{
+		{name: "boolean", flag: true, verified: true},
+		{name: "string true", flag: " true ", verified: true},
+		{name: "string one", flag: "1", verified: true},
+		{name: "number one", flag: float64(1), verified: true},
+		{name: "json number one", flag: json.Number("1.0"), verified: true},
+		{name: "boolean false", flag: false, verified: false},
+		{name: "string false", flag: "false", verified: false},
+		{name: "number zero", flag: float64(0), verified: false},
 	}
 
-	unverified := parseOAuthUserInfo(goth.User{
-		Provider: ProviderGoogle,
-		Email:    "unverified@example.test",
-		RawData:  map[string]any{"email_verified": false},
-	})
-	if unverified.VerifiedEmail != "" || unverified.EmailVerified {
-		t.Fatalf("unverified Google email = %q, emailVerified = %v; want no trusted email", unverified.VerifiedEmail, unverified.EmailVerified)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user := parseOAuthUserInfo(goth.User{
+				Provider: ProviderGoogle,
+				Email:    " Alice@Example.Test ",
+				RawData:  map[string]any{"email_verified": tt.flag},
+			})
+			if user.EmailVerified != tt.verified {
+				t.Fatalf("emailVerified = %v, want %v", user.EmailVerified, tt.verified)
+			}
+			if tt.verified && user.VerifiedEmail != "alice@example.test" {
+				t.Fatalf("verified email = %q, want normalized email", user.VerifiedEmail)
+			}
+			if !tt.verified && user.VerifiedEmail != "" {
+				t.Fatalf("unverified email = %q, want empty", user.VerifiedEmail)
+			}
+		})
 	}
 }
 

--- a/apps/gooseforum/app/service/oauthservice/oauth_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_test.go
@@ -97,20 +97,31 @@ func TestGoogleOAuthReadyRequiresMatchingStartupRegistration(t *testing.T) {
 	}
 
 	preferences.Set("google.client_secret", "changed-after-startup")
-	if IsGoogleOAuthReady() {
-		t.Fatal("IsGoogleOAuthReady() = true after changing live credentials, want false")
+	if !IsGoogleOAuthReady() {
+		t.Fatal("IsGoogleOAuthReady() = false after changing live credentials, want true until restart")
+	}
+
+	InitOAuth()
+	provider := googleProvider.Load()
+	if provider == nil {
+		t.Fatal("Google provider = nil after restart with changed credentials")
+	}
+	if provider.Secret != "changed-after-startup" {
+		t.Fatalf("Google provider secret = %q after restart, want changed credential", provider.Secret)
 	}
 }
 
-func TestInitOAuthRefreshesGoogleProviderAfterSiteURLChange(t *testing.T) {
+func TestRefreshOAuthProvidersKeepsStartupCredentials(t *testing.T) {
 	setupGoogleOAuthProviderConfig(t, "https://old.example.test")
 	InitOAuth()
 
+	preferences.Set("google.client_id", "changed-after-startup")
+	preferences.Set("google.client_secret", "changed-after-startup")
 	entity := pageConfig.GetByPageType(pageConfig.SiteSettings)
 	entity.Config = jsonopt.Encode(pageConfig.SiteSettingsConfig{SiteUrl: "https://new.example.test"})
 	pageConfig.CreateOrSave(&entity)
 	hotdataserve.ClearSiteSettingsConfigCache()
-	InitOAuth()
+	RefreshOAuthProviders()
 
 	provider, err := goth.GetProvider(ProviderGoogle)
 	if err != nil {
@@ -123,22 +134,27 @@ func TestInitOAuthRefreshesGoogleProviderAfterSiteURLChange(t *testing.T) {
 	if googleProvider.CallbackURL != "https://new.example.test/api/auth/google/callback" {
 		t.Fatalf("Google provider callback URL = %q, want refreshed site URL", googleProvider.CallbackURL)
 	}
+	if googleProvider.ClientKey != "test-google-client-id" || googleProvider.Secret != "test-google-client-secret" {
+		t.Fatalf("Google provider credentials = %q/%q, want startup credentials", googleProvider.ClientKey, googleProvider.Secret)
+	}
 }
 
 func TestParseGoogleVerifiedEmail(t *testing.T) {
 	tests := []struct {
 		name     string
+		key      string
 		flag     any
 		verified bool
 	}{
-		{name: "boolean", flag: true, verified: true},
-		{name: "string true", flag: " true ", verified: true},
-		{name: "string one", flag: "1", verified: true},
-		{name: "number one", flag: float64(1), verified: true},
-		{name: "json number one", flag: json.Number("1.0"), verified: true},
-		{name: "boolean false", flag: false, verified: false},
-		{name: "string false", flag: "false", verified: false},
-		{name: "number zero", flag: float64(0), verified: false},
+		{name: "real boolean", key: "verified_email", flag: true, verified: true},
+		{name: "real string true", key: "verified_email", flag: " true ", verified: true},
+		{name: "real string one", key: "verified_email", flag: "1", verified: true},
+		{name: "real number one", key: "verified_email", flag: float64(1), verified: true},
+		{name: "real json number one", key: "verified_email", flag: json.Number("1.0"), verified: true},
+		{name: "legacy boolean", key: "email_verified", flag: true, verified: true},
+		{name: "boolean false", key: "verified_email", flag: false, verified: false},
+		{name: "string false", key: "verified_email", flag: "false", verified: false},
+		{name: "number zero", key: "verified_email", flag: float64(0), verified: false},
 	}
 
 	for _, tt := range tests {
@@ -146,7 +162,7 @@ func TestParseGoogleVerifiedEmail(t *testing.T) {
 			user := parseOAuthUserInfo(goth.User{
 				Provider: ProviderGoogle,
 				Email:    " Alice@Example.Test ",
-				RawData:  map[string]any{"email_verified": tt.flag},
+				RawData:  map[string]any{tt.key: tt.flag},
 			})
 			if user.EmailVerified != tt.verified {
 				t.Fatalf("emailVerified = %v, want %v", user.EmailVerified, tt.verified)

--- a/apps/gooseforum/app/service/oauthservice/oauth_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/datamigration"
 	"github.com/markbates/goth"
-	"github.com/markbates/goth/providers/google"
 	"gorm.io/gorm"
 )
 
@@ -35,9 +34,11 @@ func setupGoogleOAuthProviderConfig(t *testing.T, siteURL string) {
 	hotdataserve.ClearSiteSettingsConfigCache()
 	preferences.Set("google.client_id", "test-google-client-id")
 	preferences.Set("google.client_secret", "test-google-client-secret")
+	googleProvider.Store(nil)
 	t.Cleanup(func() {
 		preferences.Set("google.client_id", "")
 		preferences.Set("google.client_secret", "")
+		googleProvider.Store(nil)
 		conn.Where("page_type = ?", pageConfig.SiteSettings).Delete(&pageConfig.Entity{})
 		hotdataserve.ClearSiteSettingsConfigCache()
 	})
@@ -49,9 +50,13 @@ func TestInitGoogleProviderUsesConfiguredCredentialsAndScopes(t *testing.T) {
 	if !IsGoogleOAuthConfigured() {
 		t.Fatal("IsGoogleOAuthConfigured() = false, want true")
 	}
-	provider, ok := initGoogleProvider().(*google.Provider)
-	if !ok {
-		t.Fatal("initGoogleProvider() did not return a Google provider")
+	InitOAuth()
+	if !IsGoogleOAuthReady() {
+		t.Fatal("IsGoogleOAuthReady() = false after InitOAuth(), want true")
+	}
+	provider := initGoogleProvider()
+	if provider == nil {
+		t.Fatal("initGoogleProvider() returned nil with valid configuration")
 	}
 	if provider.ClientKey != "test-google-client-id" || provider.Secret != "test-google-client-secret" {
 		t.Fatalf("provider credentials = %q/%q, want test credentials", provider.ClientKey, provider.Secret)
@@ -74,6 +79,43 @@ func TestInitGoogleProviderUsesConfiguredCredentialsAndScopes(t *testing.T) {
 	}
 	if got := parsed.Query().Get("scope"); got != "openid email profile" {
 		t.Fatalf("Google OAuth scope = %q, want %q", got, "openid email profile")
+	}
+}
+
+func TestGoogleOAuthReadyRequiresMatchingStartupRegistration(t *testing.T) {
+	setupGoogleOAuthProviderConfig(t, "https://hub.example.test")
+
+	if IsGoogleOAuthReady() {
+		t.Fatal("IsGoogleOAuthReady() = true before InitOAuth(), want false")
+	}
+	InitOAuth()
+	if !IsGoogleOAuthReady() {
+		t.Fatal("IsGoogleOAuthReady() = false after InitOAuth(), want true")
+	}
+
+	preferences.Set("google.client_secret", "changed-after-startup")
+	if IsGoogleOAuthReady() {
+		t.Fatal("IsGoogleOAuthReady() = true after changing live credentials, want false")
+	}
+}
+
+func TestParseGoogleVerifiedEmail(t *testing.T) {
+	verified := parseOAuthUserInfo(goth.User{
+		Provider: ProviderGoogle,
+		Email:    " Alice@Example.Test ",
+		RawData:  map[string]any{"email_verified": true},
+	})
+	if verified.VerifiedEmail != "alice@example.test" || !verified.EmailVerified {
+		t.Fatalf("verified Google email = %q, emailVerified = %v; want normalized trusted email", verified.VerifiedEmail, verified.EmailVerified)
+	}
+
+	unverified := parseOAuthUserInfo(goth.User{
+		Provider: ProviderGoogle,
+		Email:    "unverified@example.test",
+		RawData:  map[string]any{"email_verified": false},
+	})
+	if unverified.VerifiedEmail != "" || unverified.EmailVerified {
+		t.Fatalf("unverified Google email = %q, emailVerified = %v; want no trusted email", unverified.VerifiedEmail, unverified.EmailVerified)
 	}
 }
 

--- a/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
+++ b/apps/gooseforum/app/service/oauthservice/oauth_trusted_email_test.go
@@ -2,6 +2,7 @@ package oauthservice
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -163,9 +164,8 @@ func TestCreateUserFromOAuthUnmatchedDomainFollowsSwitch(t *testing.T) {
 	}
 }
 
-// TestCreateUserFromOAuthNoEmailFollowsSwitch 无 verified 邮箱保持免验证激活
-// （PR #167 review, blocking：无 verified 邮箱时无激活邮件可发，进入 pending
-// 将形成无恢复路径的死账号；保持旧行为免验证）。
+// TestCreateUserFromOAuthNoEmailFollowsSwitch 无 verified 邮箱时，关闭邮箱验证开关
+// 仍保持免验证；开启时拒绝 OAuth 快捷注册，避免未验证身份绕过全站验证策略。
 func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
 	setupOAuthTestDB(t)
 
@@ -185,7 +185,7 @@ func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
 		t.Fatalf("no email with verification off should activate: %v", user.IsActivated)
 	}
 
-	// 开关开 + 无 verified 邮箱 → 仍免验证激活（不死账号）
+	// 开关开 + 无 verified 邮箱 → 拒绝创建，避免未验证身份绕过全站验证策略
 	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
 		EnableEmailVerification: true,
 		AllowedDomains:          []string{"tongji.edu.cn"},
@@ -194,13 +194,20 @@ func TestCreateUserFromOAuthNoEmailFollowsSwitch(t *testing.T) {
 		ID: "2", Login: "no-email2", Provider: ProviderGitHub,
 		EmailVerified: false,
 	})
-	if err != nil {
-		t.Fatalf("createUserFromOAuth() error = %v", err)
+	if !errors.Is(err, ErrOAuthEmailUnverified) {
+		t.Fatalf("createUserFromOAuth() error = %v, want ErrOAuthEmailUnverified", err)
 	}
-	if user2.IsActivated != users.ActivationSuccess {
-		t.Fatalf("no verified email with verification on should still activate (no dead account): %v", user2.IsActivated)
+	if user2 != nil {
+		t.Fatalf("createUserFromOAuth() user = %#v, want nil on unverified email", user2)
+	}
+	if users.ExistUsername("no-email2") {
+		t.Fatal("unverified OAuth user was created despite email verification being enabled")
 	}
 
+	setSecurityConfigForTest(t, pageConfig.SecurityAndRegistration{
+		EnableEmailVerification: false,
+		AllowedDomains:          []string{"tongji.edu.cn"},
+	})
 	// 无 verified 邮箱时不降级存 goth 公开邮箱（PR #167 review, medium：
 	// 未验证邮箱经 OIDC 会被推导为 email_verified=true，造成信任越界）。
 	user3, err := createUserFromOAuth(OAuthUserInfo{

--- a/apps/gooseforum/docs/user/configuration.md
+++ b/apps/gooseforum/docs/user/configuration.md
@@ -143,7 +143,8 @@ Cloud Console 中登记的重定向 URI 同源的绝对 URL，回调地址为：
 `<siteUrl>/api/auth/google/callback`。本地开发可登记
 `http://localhost:5234/api/auth/google/callback`。
 Google 仅在 userinfo 返回 `email_verified=true` 时将邮箱视为可信，并进入已有账号绑定或激活流程；
-修改 Google 凭据或 `siteUrl` 后需要重启服务，provider 才会使用新配置。
+启用全站邮箱验证时，未提供可用已验证邮箱的 OAuth 注册会被拒绝。修改 Google 凭据后需要重启服务；
+通过管理后台修改 `siteUrl` 会即时刷新 OAuth provider。
 
 ## 🔄 配置文件热重载
 

--- a/apps/gooseforum/docs/user/configuration.md
+++ b/apps/gooseforum/docs/user/configuration.md
@@ -142,6 +142,8 @@ Google 登录仅请求 `openid`、`email`、`profile`。站点设置中的 `site
 Cloud Console 中登记的重定向 URI 同源的绝对 URL，回调地址为：
 `<siteUrl>/api/auth/google/callback`。本地开发可登记
 `http://localhost:5234/api/auth/google/callback`。
+Google 仅在 userinfo 返回 `email_verified=true` 时将邮箱视为可信，并进入已有账号绑定或激活流程；
+修改 Google 凭据或 `siteUrl` 后需要重启服务，provider 才会使用新配置。
 
 ## 🔄 配置文件热重载
 

--- a/apps/gooseforum/docs/user/configuration.md
+++ b/apps/gooseforum/docs/user/configuration.md
@@ -142,7 +142,7 @@ Google 登录仅请求 `openid`、`email`、`profile`。站点设置中的 `site
 Cloud Console 中登记的重定向 URI 同源的绝对 URL，回调地址为：
 `<siteUrl>/api/auth/google/callback`。本地开发可登记
 `http://localhost:5234/api/auth/google/callback`。
-Google 仅在 userinfo 返回 `email_verified=true` 时将邮箱视为可信，并进入已有账号绑定或激活流程；
+Google 仅在 userinfo 返回 `verified_email=true` 时将邮箱视为可信，并进入已有账号绑定或激活流程；
 启用全站邮箱验证时，未提供可用已验证邮箱的 OAuth 注册会被拒绝。修改 Google 凭据后需要重启服务；
 通过管理后台修改 `siteUrl` 会即时刷新 OAuth provider。
 

--- a/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
+++ b/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
@@ -840,6 +840,7 @@ export interface ChatItemPayload {
 
 export interface SettingsPageProps {
   user: SettingsUserPayload
+  googleOAuthReady: boolean
   stats: {
     topicCount: number
     replyCount: number

--- a/apps/gooseforum/resource/src/site/pages/SettingsPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/SettingsPage.vue
@@ -2034,7 +2034,7 @@ async function toggleBinding(provider: string) {
                   </div>
                   <div>
                     <h3 class="font-semibold text-base-content">{{ provider.label }}</h3>
-                    <p class="text-sm" :class="provider.supported ? 'text-base-content/55' : 'text-base-content/55'">
+                    <p class="text-sm text-base-content/55">
                       {{ isBound(provider.key) ? t('settings.binding.connected') : provider.supported ? t('settings.binding.disconnected') : t('settings.binding.siteUnsupported') }}
                     </p>
                   </div>

--- a/apps/gooseforum/resource/src/site/pages/SettingsPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/SettingsPage.vue
@@ -281,7 +281,7 @@ const socialItems = computed(() => socialKeys.map((key) => ({
 })))
 const providers = computed(() => [
   { key: 'github', label: 'GitHub', supported: true },
-  { key: 'google', label: 'Google', supported: false },
+  { key: 'google', label: 'Google', supported: page.props.googleOAuthReady },
 ])
 const localeOptions = computed(() => supportedLocales.map(item => ({
   value: item,

--- a/apps/gooseforum/resource/src/site/pages/SettingsPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/SettingsPage.vue
@@ -1212,14 +1212,19 @@ function isBound(provider: string) {
   return Boolean(bindings.value[provider]?.bound)
 }
 
+function canManageBinding(provider: { key: string; supported: boolean }) {
+  return provider.supported || isBound(provider.key)
+}
+
 function providerActionLabel(provider: { key: string; supported: boolean }) {
+  if (isBound(provider.key)) return t('settings.binding.disconnect')
   if (!provider.supported) return t('settings.binding.unsupported')
-  return isBound(provider.key) ? t('settings.binding.disconnect') : t('settings.binding.connect')
+  return t('settings.binding.connect')
 }
 
 async function toggleBinding(provider: string) {
   const item = providers.value.find((entry) => entry.key === provider)
-  if (!item?.supported) return
+  if (!item || !canManageBinding(item)) return
   if (!isBound(provider)) {
     window.location.href = `/api/auth/${provider}`
     return
@@ -2010,12 +2015,12 @@ async function toggleBinding(provider: string) {
                 v-for="provider in providers"
                 :key="provider.key"
                 class="flex items-center justify-between gap-4 rounded-lg border p-4"
-                :class="provider.supported ? 'border-line bg-base-100' : 'border-line bg-base-200/70'"
+                :class="canManageBinding(provider) ? 'border-line bg-base-100' : 'border-line bg-base-200/70'"
               >
                 <div class="flex min-w-0 items-center gap-3">
                   <div
                     class="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border"
-                    :class="provider.supported ? 'border-line bg-base-100 shadow-sm' : 'border-line bg-base-300 opacity-60'"
+                    :class="canManageBinding(provider) ? 'border-line bg-base-100 shadow-sm' : 'border-line bg-base-300 opacity-60'"
                   >
                     <svg v-if="provider.key === 'github'" class="h-6 w-6 text-base-content" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                       <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58v-2.04c-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.08 1.84 1.24 1.84 1.24 1.07 1.83 2.81 1.3 3.49.99.11-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.24-3.22-.12-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.23A11.5 11.5 0 0 1 12 5.8c1.02.01 2.05.14 3.01.4 2.29-1.55 3.3-1.23 3.3-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.81 5.62-5.48 5.92.43.37.82 1.1.82 2.22v3.29c0 .32.22.7.82.58A12.01 12.01 0 0 0 24 12c0-6.63-5.37-12-12-12Z" />
@@ -2030,7 +2035,7 @@ async function toggleBinding(provider: string) {
                   <div>
                     <h3 class="font-semibold text-base-content">{{ provider.label }}</h3>
                     <p class="text-sm" :class="provider.supported ? 'text-base-content/55' : 'text-base-content/55'">
-                      {{ provider.supported ? (isBound(provider.key) ? t('settings.binding.connected') : t('settings.binding.disconnected')) : t('settings.binding.siteUnsupported') }}
+                      {{ isBound(provider.key) ? t('settings.binding.connected') : provider.supported ? t('settings.binding.disconnected') : t('settings.binding.siteUnsupported') }}
                     </p>
                   </div>
                 </div>
@@ -2038,13 +2043,13 @@ async function toggleBinding(provider: string) {
                   type="button"
                   class="inline-flex h-9 min-w-24 items-center justify-center gap-2 rounded-md border px-3 text-sm font-semibold disabled:cursor-not-allowed"
                   :class="[
-                    !provider.supported
+                    !canManageBinding(provider)
                       ? 'border-line bg-base-300 text-base-content/55'
                       : isBound(provider.key)
                         ? 'border-error/30 bg-error/10 text-error hover:bg-error/10'
                         : 'border-neutral bg-neutral text-neutral-content hover:bg-neutral/90',
                   ]"
-                  :disabled="bindingAction === provider.key || !provider.supported"
+                  :disabled="bindingAction === provider.key || !canManageBinding(provider)"
                   @click="toggleBinding(provider.key)"
                 >
                   <Loader2 v-if="bindingAction === provider.key" class="h-4 w-4 animate-spin" />

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -31,7 +31,9 @@
   A challenge token can mint at most one session: it is atomically consumed on successful verification
   (`totpservice.ConsumeChallenge`), so replaying it cannot create a second session.
 - GitHub OAuth and Google OAuth (goth): callbacks bind or sign in and issue a session token. Google
-  requests only `openid`, `email`, and `profile` scopes.
+  requests only `openid`, `email`, and `profile` scopes; its email is treated as trusted for account
+  binding only when the Google userinfo response contains `email_verified=true`. Provider credentials
+  and callback URL changes require a process restart to take effect.
 
 ### Built-in OIDC Provider (first-party clients)
 

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -32,8 +32,10 @@
   (`totpservice.ConsumeChallenge`), so replaying it cannot create a second session.
 - GitHub OAuth and Google OAuth (goth): callbacks bind or sign in and issue a session token. Google
   requests only `openid`, `email`, and `profile` scopes; its email is treated as trusted for account
-  binding only when the Google userinfo response contains `email_verified=true`. Provider credentials
-  and callback URL changes require a process restart to take effect.
+  binding only when the Google userinfo response contains `email_verified=true`. When site-wide email
+  verification is enabled, OAuth registration without a usable verified email is rejected. Provider
+  credential changes require a process restart; saving a new site callback URL in the admin console
+  refreshes the providers immediately.
 
 ### Built-in OIDC Provider (first-party clients)
 

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -32,7 +32,7 @@
   (`totpservice.ConsumeChallenge`), so replaying it cannot create a second session.
 - GitHub OAuth and Google OAuth (goth): callbacks bind or sign in and issue a session token. Google
   requests only `openid`, `email`, and `profile` scopes; its email is treated as trusted for account
-  binding only when the Google userinfo response contains `email_verified=true`. When site-wide email
+  binding only when the Google userinfo response contains `verified_email=true`. When site-wide email
   verification is enabled, OAuth registration without a usable verified email is rejected. Provider
   credential changes require a process restart; saving a new site callback URL in the admin console
   refreshes the providers immediately.


### PR DESCRIPTION
## Summary
- Trust Google email only when the userinfo response contains `email_verified=true`, reusing the existing trusted-email binding/activation path.
- Set `GoogleReady` only after the provider has been registered at startup with matching credentials and callback URL.
- Document the restart requirement for Google OAuth configuration changes and add regression tests.

## Validation
- `go test -count=1 ./app/service/oauthservice ./app/http/controllers/forum`
- `go vet ./app/service/oauthservice ./app/http/controllers/forum`
- `go test ./...` *(unrelated existing Meilisearch-dependent tests fail locally with 401 because the configured service rejects requests without Authorization.)*

No OAuth credentials are included.