### PR TITLE
fix(frontend): 搜索提交拦截为客户端路由跳转，消除整页导航白屏

### DIFF
--- a/apps/gooseforum/resource/src/site/pages/SearchPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/SearchPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { BookOpen, FolderOpen, Search, UsersRound } from '@lucide/vue'
@@ -14,6 +15,7 @@ const page = defineProps<{
   pageUrl: string
 }>()
 const { t } = useI18n()
+const router = useRouter()
 
 const query = ref(page.props.query)
 const scope = computed(() => page.props.scope || 'all')
@@ -75,6 +77,26 @@ function courseUrl(course: { id: number }) {
   return `/courses/${course.id}`
 }
 
+// 搜索提交走客户端路由跳转：页面 body 为空壳、内容由 Vue 客户端渲染，
+// 原生 GET 提交会先卸载整页再渲染（期间白屏），故拦截 submit 复用
+// router.push 的 X-Goose-Page JSON 拉取路径（顶部 loading bar，旧页保持）。
+// action/method 保留作无 JS 环境的原生回退。
+async function submitSearch(event: SubmitEvent) {
+  event.preventDefault()
+  const form = event.currentTarget as HTMLFormElement
+  const rawQuery = new FormData(form).get('q')
+  const q = typeof rawQuery === 'string' ? rawQuery.trim() : ''
+  const params = new URLSearchParams()
+  if (q) params.set('q', q)
+  if (scope.value !== 'all') params.set('scope', scope.value)
+  const qs = params.toString()
+  try {
+    await router.push(qs ? `/search?${qs}` : '/search')
+  } catch {
+    form.submit()
+  }
+}
+
 watch(
   () => page.props.query,
   () => {
@@ -90,7 +112,7 @@ watch(
         <span class="gf-badge gf-badge-muted h-5 text-[11px] uppercase">{{ t('searchPage.label') }}</span>
       </template>
       <template #actions>
-        <form action="/search" method="GET" class="w-full sm:w-80 lg:w-96">
+        <form action="/search" method="GET" class="w-full sm:w-80 lg:w-96" @submit="submitSearch">
           <input v-if="scope !== 'all'" type="hidden" name="scope" :value="scope" />
           <label class="flex h-10 items-center gap-2 rounded-field border border-line bg-base-100 px-3 text-sm text-base-content/55 transition focus-within:border-primary focus-within:ring-4 focus-within:ring-primary/20">
             <Search class="h-4 w-4 shrink-0" />

--- a/apps/gooseforum/resource/test/search-page-submit.test.ts
+++ b/apps/gooseforum/resource/test/search-page-submit.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { vi } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+import { i18n } from '../src/runtime/i18n'
+import SearchPage from '../src/site/pages/SearchPage.vue'
+import type { SearchPageProps } from '@gooseforum/client'
+
+function emptyProps(overrides: Partial<SearchPageProps> = {}): SearchPageProps {
+  return {
+    query: '',
+    scope: 'all',
+    topics: [],
+    users: [],
+    categories: [],
+    courses: [],
+    total: 0,
+    usersTotal: 0,
+    categoriesTotal: 0,
+    coursesTotal: 0,
+    totalPages: 0,
+    pagination: { page: 1, nextPage: 0, hasNext: false, nextUrl: '' },
+    ...overrides,
+  }
+}
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+  })
+}
+
+async function mountPage(router: Router, props: SearchPageProps): Promise<VueWrapper> {
+  const wrapper = mount(SearchPage, {
+    props: { layout: {}, props, pageUrl: '/search' },
+    global: { plugins: [i18n, router] },
+    attachTo: document.body,
+  })
+  return wrapper
+}
+
+// 回归测试（issue：搜索提交整页导航导致短暂白屏）：
+// 页面 body 为空壳、内容由 Vue 客户端渲染，原生 GET 提交会先卸载整页再渲染，
+// 期间画面空白。表单必须拦截 submit 走客户端路由（router.push），
+// 保留 action/method 作为无 JS 环境的原生回退。
+describe('SearchPage 搜索表单提交', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('提交查询走客户端路由跳转（不再整页导航）', async () => {
+    const router = makeRouter()
+    const wrapper = await mountPage(router, emptyProps())
+    await wrapper.get('input[name="q"]').setValue('Vue 白屏')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/search')
+    expect(router.currentRoute.value.query.q).toBe('Vue 白屏')
+    wrapper.unmount()
+  })
+
+  test('当前 scope 非 all 时提交保留 scope 参数', async () => {
+    const router = makeRouter()
+    const wrapper = await mountPage(router, emptyProps({ scope: 'topics' }))
+    expect(wrapper.get('input[name="scope"]').attributes('value')).toBe('topics')
+    await wrapper.get('input[name="q"]').setValue('食堂')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/search')
+    expect(router.currentRoute.value.query).toEqual({ q: '食堂', scope: 'topics' })
+    wrapper.unmount()
+  })
+
+  test('查询词首尾空白被裁剪（与后端 buildSearchURL 语义一致）', async () => {
+    const router = makeRouter()
+    const wrapper = await mountPage(router, emptyProps())
+    await wrapper.get('input[name="q"]').setValue('  选课  ')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.query.q).toBe('选课')
+    wrapper.unmount()
+  })
+
+  test('空查询提交回到 /search 空状态页（不带多余参数）', async () => {
+    const router = makeRouter()
+    const wrapper = await mountPage(router, emptyProps())
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.fullPath).toBe('/search')
+    wrapper.unmount()
+  })
+
+  test('已在 /search 空状态页再次提交不触发原生整页回退', async () => {
+    const router = makeRouter()
+    await router.push('/search')
+    const wrapper = await mountPage(router, emptyProps())
+    const form = wrapper.get('form').element as HTMLFormElement
+    const submitSpy = vi.spyOn(form, 'submit').mockImplementation(() => {})
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    // duplicated navigation 属正常取消（非异常），绝不落入 form.submit() 原生回退
+    expect(router.currentRoute.value.fullPath).toBe('/search')
+    expect(submitSpy).not.toHaveBeenCalled()
+    submitSpy.mockRestore()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Motivation

页面 body 是空壳、所有内容由 Vue 客户端挂载渲染。搜索页表单此前是原生 `GET /search` 提交——浏览器先卸载整页再加载新文档，期间 `#goose-app` 为空，出现短暂白屏后才呈现结果（而全站链接导航走 `router.push` 的 `X-Goose-Page` JSON 拉取路径，旧页保持 + 顶部 loading bar，不白屏）。搜索页后端还同步等待 Meilisearch 聚合搜索，TTFB 较长时白屏窗口更明显。

## Behavior change

- `SearchPage.vue` 搜索表单拦截 `submit`,走 `router.push('/search?q=…')` 客户端路由跳转:旧页面保持显示、顶部出现 loading bar,不再整页卸载白屏。
- 提交时裁剪查询词首尾空白、非 all scope 时保留 `scope` 参数,与后端 `buildSearchURL` 语义一致。
- 表单保留 `action="/search" method="GET"` 作为无 JS 环境的原生回退;`router.push` 真异常(非 duplicated navigation)时才回退 `form.submit()`。
- 空查询/已在 /search 页重复提交均为 no-op,不会落入原生回退。

## Verification

- 红→绿:先写 `resource/test/search-page-submit.test.ts`(4 用例)确认原生提交无路由跳转(红),实现后转绿。
- 补第 5 个回归用例:已在 `/search` 空状态页再次提交不触发原生整页回退。
- `pnpm vitest run --dir test search-page-submit.test.ts` — 5/5 passed
- `pnpm test` — 50 files / 354 tests passed
- `pnpm typecheck` — exit 0
- pre-push 钩子(go vet + golangci-lint + frontend typecheck)全部通过后推送。

## Documentation / contract impact

无。纯前端交互改动,不涉及 OpenAPI 契约、数据库、公开行为。

## Known gaps

无 JS 环境(禁用脚本)仍走原生整页提交——这与站点其余部分(无 JS 只见 noscript 提示)一致,属预期回退。