### PR TITLE
fix(auth): enforce origin check for cookie-authenticated state-changing requests (issue #406)

### DIFF
--- a/apps/gooseforum/app/bundles/preferences/config.templ.toml
+++ b/apps/gooseforum/app/bundles/preferences/config.templ.toml
@@ -20,6 +20,12 @@ port = 5234
 accessLog = false
 gzip = true # 应用层 gzip 开关
 
+[csrf]
+# Cookie 认证写接口的跨站请求防护（issue #406）额外允许的来源（逗号分隔，
+# 完整 origin，如 https://forum.example.com）。默认只需请求自身的 Host 同源即可，
+# 仅当存在必须共享会话 Cookie 的独立前端域时才需要配置。
+allowedOrigins = ""
+
 [jwtopt]
 validTime = 604800
 

--- a/apps/gooseforum/app/http/controllers/component/message_code.go
+++ b/apps/gooseforum/app/http/controllers/component/message_code.go
@@ -80,6 +80,7 @@ const (
 	MessageAuthActivationResendCooldown  MessageCode = "auth.activation.resendCooldown"  // 验证邮件发送过于频繁，params.retryAfterSeconds。
 	MessageAuthActivationResendDaily     MessageCode = "auth.activation.resendDaily"     // 验证邮件达到当天重发上限，params.limit。
 	MessageAuthActivationResendFailed    MessageCode = "auth.activation.resendFailed"    // 验证邮件重新发送失败。
+	MessageAuthCsrfRejected              MessageCode = "auth.csrf.rejected"              // 跨站请求被拒绝（Origin/Referer 校验失败，issue #406）。
 )
 
 const (

--- a/apps/gooseforum/app/http/middleware/csrfProtection.go
+++ b/apps/gooseforum/app/http/middleware/csrfProtection.go
@@ -45,9 +45,12 @@ const accessTokenCookieName = "access_token"
 // origin check additionally covers the cases SameSite=Lax does not: same-site
 // cross-origin (subdomain) attacks and browsers without SameSite support.
 //
-// Mounted per write-route group (route4api.go) after the authentication
-// middleware, never globally, so anonymous 401 semantics and public POSTs are
-// untouched. Do not move this into bridge.go's global chain.
+// Mounted per write-route group (route4api.go), never globally, so anonymous
+// 401 semantics and public POSTs are untouched. Auth-first groups mount it
+// after the authentication middleware; the /file group mounts it at group
+// level before the per-route auth, so a cookie-bearing foreign-origin upload
+// is rejected by this gate (403) instead of the auth middleware (401). Do not
+// move this into bridge.go's global chain.
 func CSRFProtection(c *gin.Context) {
 	method := c.Request.Method
 	if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {

--- a/apps/gooseforum/app/http/middleware/csrfProtection.go
+++ b/apps/gooseforum/app/http/middleware/csrfProtection.go
@@ -1,0 +1,166 @@
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
+	"github.com/gin-gonic/gin"
+)
+
+// accessTokenCookieName mirrors the session cookie written by bundles/jwtopt
+// (TokenSetting/TokenClean). Browsers authenticate the forum API with this
+// HttpOnly cookie; non-browser clients authenticate with the Authorization
+// header and never depend on the cookie (see docs/product/identity-and-access.md
+// "认证与 CSRF 边界", issue #406).
+const accessTokenCookieName = "access_token"
+
+// CSRFProtection rejects cross-site state-changing requests that would
+// otherwise be authenticated by the access_token cookie.
+//
+// Auth contract (issue #406):
+//   - Bearer clients (mobile app, Agent agt_, MCP, curl/API clients) send an
+//     Authorization header and are exempt even when a cookie is also present.
+//   - Browser pages (site + admin SPA, GoHTML SSR) are same-origin with the
+//     API in the single-binary deployment, so every fetch/POST carries the
+//     page Origin (and usually a Referer). Dev mode proxies only /assets/* to
+//     Vite; the page itself is still served by the Go backend, so the Origin
+//     always equals the request Host (localhost, LAN IP, or public domain).
+//   - GET/HEAD/OPTIONS are exempt (no state change; preflight support).
+//   - Requests without an access_token cookie are exempt: there is no
+//     cookie-authenticated state change to protect (anonymous writes, the
+//     GitHub wiki webhook's HMAC auth, OIDC token endpoints).
+//
+// Enforcement for the remaining cookie-authenticated state changes: the
+// Origin must match the site origin (derived from the request Host plus the
+// X-Forwarded-Proto/TLS scheme so TLS-terminating proxies pass) or one of the
+// explicitly configured origins in `csrf.allowedOrigins`. When the Origin
+// header is missing (legacy browsers that omit Origin on same-origin POSTs),
+// the Referer origin is checked instead. Any mismatch is rejected with 403
+// (envelope messageCode `auth.csrf.rejected`).
+//
+// SameSite=Lax + HttpOnly + Secure cookies remain as defense in depth; the
+// origin check additionally covers the cases SameSite=Lax does not: same-site
+// cross-origin (subdomain) attacks and browsers without SameSite support.
+//
+// Mounted per write-route group (route4api.go) after the authentication
+// middleware, never globally, so anonymous 401 semantics and public POSTs are
+// untouched. Do not move this into bridge.go's global chain.
+func CSRFProtection(c *gin.Context) {
+	method := c.Request.Method
+	if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
+		c.Next()
+		return
+	}
+	// Bearer-authenticated API clients are exempt: their credential cannot be
+	// attached cross-site by a browser, so Origin checking would only add
+	// friction (mobile, Agent, MCP, curl with an explicit token).
+	if strings.TrimSpace(c.GetHeader("Authorization")) != "" {
+		c.Next()
+		return
+	}
+	// No session cookie -> nothing cookie-authenticated rides along. Public or
+	// server-to-server writes (e.g. wiki webhook HMAC, OIDC token endpoint)
+	// legitimately arrive without Origin and must keep working.
+	cookie, err := c.Cookie(accessTokenCookieName)
+	if err != nil || strings.TrimSpace(cookie) == "" {
+		c.Next()
+		return
+	}
+	if sameSiteRequest(c) {
+		c.Next()
+		return
+	}
+	c.JSON(http.StatusForbidden, component.FailDataCode(component.MessageAuthCsrfRejected, nil))
+	c.Abort()
+}
+
+// sameSiteRequest reports whether the request comes from a site-controlled
+// origin: the Origin header when present, otherwise the Referer origin.
+func sameSiteRequest(c *gin.Context) bool {
+	if origin := strings.TrimSpace(c.GetHeader("Origin")); origin != "" {
+		return originMatches(c, origin)
+	}
+	// Referer fallback: only meaningful for browser requests. The header is
+	// absent on curl/scripting clients, which then get rejected fail-closed.
+	if referer := strings.TrimSpace(c.GetHeader("Referer")); referer != "" {
+		if ref, err := url.Parse(referer); err == nil && ref.Host != "" {
+			return originMatches(c, ref.Scheme+"://"+ref.Host)
+		}
+	}
+	return false
+}
+
+// originMatches compares origin against the site-controlled origin set: the
+// request's own Host-derived origin and the configured csrf.allowedOrigins.
+func originMatches(c *gin.Context, origin string) bool {
+	candidate, err := url.Parse(origin)
+	if err != nil || candidate.Host == "" {
+		return false
+	}
+	for _, allowed := range siteAllowedOrigins(c) {
+		parsed, err := url.Parse(allowed)
+		if err != nil || parsed.Host == "" {
+			continue
+		}
+		if sameOrigin(candidate, parsed) {
+			return true
+		}
+	}
+	return false
+}
+
+// siteAllowedOrigins returns the origins this deployment accepts for
+// cookie-authenticated writes. The request's own Host always wins: the browser
+// Origin equals the URL the user visited, which is also the domain the
+// host-only access_token cookie is scoped to. X-Forwarded-Proto is honored
+// (first hop) so TLS-terminating reverse proxies (the supported deployment)
+// produce https origins; widening the allowed set by scheme is safe because an
+// attacker still cannot make its own Origin equal the victim host. Extra
+// origins (e.g. an alternate front-end domain that must share the cookie
+// session) are configured via `csrf.allowedOrigins` (comma separated).
+func siteAllowedOrigins(c *gin.Context) []string {
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	if forwardedProto := strings.TrimSpace(c.GetHeader("X-Forwarded-Proto")); forwardedProto != "" {
+		if first, _, ok := strings.Cut(forwardedProto, ","); ok {
+			forwardedProto = first
+		}
+		if proto := strings.ToLower(strings.TrimSpace(forwardedProto)); proto == "http" || proto == "https" {
+			scheme = proto
+		}
+	}
+	allowed := []string{scheme + "://" + c.Request.Host}
+	for _, raw := range strings.Split(preferences.GetString("csrf.allowedOrigins", ""), ",") {
+		if origin := strings.TrimSpace(raw); origin != "" {
+			allowed = append(allowed, origin)
+		}
+	}
+	return allowed
+}
+
+// sameOrigin compares scheme, hostname, and effective port (default ports are
+// normalized: browsers omit :80/:443 from Origin while Host may carry them).
+func sameOrigin(a, b *url.URL) bool {
+	if !strings.EqualFold(a.Scheme, b.Scheme) {
+		return false
+	}
+	if !strings.EqualFold(a.Hostname(), b.Hostname()) {
+		return false
+	}
+	return effectivePort(a) == effectivePort(b)
+}
+
+func effectivePort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	if u.Scheme == "https" {
+		return "443"
+	}
+	return "80"
+}

--- a/apps/gooseforum/app/http/middleware/csrfProtection_test.go
+++ b/apps/gooseforum/app/http/middleware/csrfProtection_test.go
@@ -214,3 +214,42 @@ func TestCSRFProtectionOptionsExemptFromOriginCheck(t *testing.T) {
 		t.Fatalf("OPTIONS status = %d, want 204", recorder.Code)
 	}
 }
+
+func TestCSRFProtectionHeadExemptFromOriginCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.HEAD("/read", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	request := httptest.NewRequest(http.MethodHead, "http://forum.example.test/read", nil)
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
+	request.Header.Set("Origin", "http://evil.example.test")
+	recorder := performCsrf(router, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d, want 200", recorder.Code)
+	}
+}
+
+func TestCSRFProtectionNullOriginRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// Sandboxed iframes and some redirect chains send the string "null"; it
+	// parses as a path without a host and must fail closed.
+	request := csrfRequest(t, "session-token", "", "null", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionMalformedRefererRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// A Referer that does not parse to an absolute URL with a host fails
+	// closed instead of falling through to allow.
+	request := csrfRequest(t, "session-token", "", "", "not-a-url")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionInvalidForwardedProtoIgnored(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// X-Forwarded-Proto values other than http/https are ignored: the
+	// host-derived scheme stays http, so an https Origin must still fail.
+	request := csrfRequest(t, "session-token", "", "https://forum.example.test", "")
+	request.Header.Set("X-Forwarded-Proto", "gopher")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}

--- a/apps/gooseforum/app/http/middleware/csrfProtection_test.go
+++ b/apps/gooseforum/app/http/middleware/csrfProtection_test.go
@@ -1,0 +1,216 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
+	"github.com/gin-gonic/gin"
+)
+
+// csrfTestRouter builds a gin engine with CSRFProtection mounted in front of a
+// POST handler, mirroring the production write-group order (auth first, CSRF
+// after). The handler records that it ran.
+func csrfTestRouter() (*gin.Engine, *bool) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	reached := false
+	router.POST("/write", CSRFProtection, func(c *gin.Context) {
+		reached = true
+		c.Status(http.StatusOK)
+	})
+	router.GET("/read", CSRFProtection, func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	router.OPTIONS("/write", CSRFProtection, func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	return router, &reached
+}
+
+// csrfRequest builds a POST request with an optional access_token cookie,
+// optional Authorization header, and optional Origin/Referer.
+func csrfRequest(t *testing.T, cookie, authorization, origin, referer string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test/write", strings.NewReader(`{}`))
+	request.Header.Set("Content-Type", "application/json")
+	if cookie != "" {
+		request.AddCookie(&http.Cookie{Name: "access_token", Value: cookie})
+	}
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+	if origin != "" {
+		request.Header.Set("Origin", origin)
+	}
+	if referer != "" {
+		request.Header.Set("Referer", referer)
+	}
+	return request
+}
+
+func performCsrf(router http.Handler, request *http.Request) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func assertCsrfAllowed(t *testing.T, recorder *httptest.ResponseRecorder, reached *bool) {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+	}
+	if !*reached {
+		t.Fatal("handler did not run")
+	}
+}
+
+func assertCsrfRejected(t *testing.T, recorder *httptest.ResponseRecorder, reached *bool) {
+	t.Helper()
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (body %s)", recorder.Code, recorder.Body.String())
+	}
+	if *reached {
+		t.Fatal("handler ran despite CSRF rejection")
+	}
+	var envelope struct {
+		Code        int    `json:"code"`
+		MessageCode string `json:"messageCode"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode CSRF rejection body %q: %v", recorder.Body.String(), err)
+	}
+	if envelope.MessageCode != "auth.csrf.rejected" {
+		t.Fatalf("messageCode = %q, want auth.csrf.rejected", envelope.MessageCode)
+	}
+}
+
+func TestCSRFProtectionSameOriginCookiePostAllowed(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "http://forum.example.test", "")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionDefaultPortNormalized(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// Browsers omit the default port from Origin while Host keeps it implicit.
+	request := csrfRequest(t, "session-token", "", "http://forum.example.test:80", "")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionHttpsViaForwardedProto(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "https://forum.example.test", "")
+	request.Header.Set("X-Forwarded-Proto", "https")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionCrossSiteOriginRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "http://evil.example.test", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionSchemeMismatchRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// https origin against a plain-http request must not pass.
+	request := csrfRequest(t, "session-token", "", "https://forum.example.test", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionSubdomainOriginRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "http://sub.forum.example.test", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionMissingOriginAndRefererRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionRefererFallbackAllowed(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// Origin-less legacy browser POST carrying a same-site Referer.
+	request := csrfRequest(t, "session-token", "", "", "http://forum.example.test/publish")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionCrossSiteRefererRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "", "http://evil.example.test/x")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionMalformedOriginRejected(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "not a url", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionConfiguredExtraOriginAllowed(t *testing.T) {
+	previous := preferences.GetString("csrf.allowedOrigins", "")
+	preferences.Set("csrf.allowedOrigins", "https://front.example.test")
+	t.Cleanup(func() { preferences.Set("csrf.allowedOrigins", previous) })
+
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "https://front.example.test", "")
+	request.Header.Set("X-Forwarded-Proto", "https")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionConfiguredExtraOriginDoesNotWidenHostCheck(t *testing.T) {
+	previous := preferences.GetString("csrf.allowedOrigins", "")
+	preferences.Set("csrf.allowedOrigins", "https://front.example.test")
+	t.Cleanup(func() { preferences.Set("csrf.allowedOrigins", previous) })
+
+	router, reached := csrfTestRouter()
+	// The extra origin must not make the attacker's own origin acceptable.
+	request := csrfRequest(t, "session-token", "", "http://evil.example.test", "")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionBearerExemptEvenWithCookieAndForeignOrigin(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "Bearer api-client-token", "http://evil.example.test", "")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionNoCookieAnonymousPostAllowed(t *testing.T) {
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "", "", "", "")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionGetExemptFromOriginCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/read", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	request := httptest.NewRequest(http.MethodGet, "http://forum.example.test/read", nil)
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
+	request.Header.Set("Origin", "http://evil.example.test")
+	recorder := performCsrf(router, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", recorder.Code)
+	}
+}
+
+func TestCSRFProtectionOptionsExemptFromOriginCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.OPTIONS("/write", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+	request := httptest.NewRequest(http.MethodOptions, "http://forum.example.test/write", nil)
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
+	request.Header.Set("Origin", "http://evil.example.test")
+	request.Header.Set("Access-Control-Request-Method", "POST")
+	recorder := performCsrf(router, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS status = %d, want 204", recorder.Code)
+	}
+}

--- a/apps/gooseforum/app/http/routes/csrf_route_protection_test.go
+++ b/apps/gooseforum/app/http/routes/csrf_route_protection_test.go
@@ -1,0 +1,170 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Route-level CSRF matrix (issue #406). Unlike the middleware unit tests in
+// app/http/middleware, these exercise the production route assembly
+// (apiRoute): CSRFProtection is mounted exactly where production mounts it
+// (logout before the handler; login/forum/admin groups after JWTAuthCheck).
+// /api/logout is used because its handler never touches the database when the
+// token is not a valid session JWT, so no test DB is needed.
+
+func csrfRouteRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	apiRoute(router)
+	return router
+}
+
+func csrfRoutePost(t *testing.T, router http.Handler, cookie, authorization, origin, referer string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test/api/logout", strings.NewReader(`{}`))
+	request.Header.Set("Content-Type", "application/json")
+	if cookie != "" {
+		request.AddCookie(&http.Cookie{Name: "access_token", Value: cookie})
+	}
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+	if origin != "" {
+		request.Header.Set("Origin", origin)
+	}
+	if referer != "" {
+		request.Header.Set("Referer", referer)
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func assertCsrfRouteRejected(t *testing.T, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (body %s)", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Code        int    `json:"code"`
+		MessageCode string `json:"messageCode"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode rejection body %q: %v", recorder.Body.String(), err)
+	}
+	if envelope.MessageCode != "auth.csrf.rejected" {
+		t.Fatalf("messageCode = %q, want auth.csrf.rejected", envelope.MessageCode)
+	}
+	if strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token") {
+		t.Fatal("rejected request must not clear or set the session cookie")
+	}
+}
+
+func assertCsrfRouteAllowed(t *testing.T, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCSRFLogoutRejectsCookiePostWithoutOrigin(t *testing.T) {
+	router := csrfRouteRouter()
+	assertCsrfRouteRejected(t, csrfRoutePost(t, router, "session-jwt", "", "", ""))
+}
+
+func TestCSRFLogoutRejectsCrossSiteOrigin(t *testing.T) {
+	router := csrfRouteRouter()
+	assertCsrfRouteRejected(t, csrfRoutePost(t, router, "session-jwt", "", "http://evil.example.test", ""))
+}
+
+func TestCSRFLogoutAllowsSameOriginCookiePost(t *testing.T) {
+	router := csrfRouteRouter()
+	// Invalid JWT in the cookie: the CSRF gate passes (same origin), then
+	// logout clears the cookie and stays idempotent.
+	recorder := csrfRoutePost(t, router, "not-a-jwt", "", "http://forum.example.test", "")
+	assertCsrfRouteAllowed(t, recorder)
+	if !strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token") {
+		t.Fatal("same-origin logout should still clear the access_token cookie")
+	}
+}
+
+func TestCSRFLogoutAllowsRefererFallbackForCookiePost(t *testing.T) {
+	router := csrfRouteRouter()
+	recorder := csrfRoutePost(t, router, "not-a-jwt", "", "", "http://forum.example.test/p/1")
+	assertCsrfRouteAllowed(t, recorder)
+}
+
+func TestCSRFLogoutAllowsApiClientWithAuthorizationEvenWithForeignOrigin(t *testing.T) {
+	router := csrfRouteRouter()
+	// Bearer API clients are exempt from the origin check even when a cookie
+	// is also present and the Origin is foreign.
+	recorder := csrfRoutePost(t, router, "session-jwt", "Bearer api-token", "http://evil.example.test", "")
+	assertCsrfRouteAllowed(t, recorder)
+}
+
+func TestCSRFLogoutAllowsAnonymousPostWithoutOrigin(t *testing.T) {
+	router := csrfRouteRouter()
+	// No access_token cookie -> nothing cookie-authenticated to protect;
+	// anonymous logout stays an idempotent success.
+	recorder := csrfRoutePost(t, router, "", "", "", "")
+	assertCsrfRouteAllowed(t, recorder)
+}
+
+// TestCSRFProtectedForumWriteRoute rejects cookie POSTs without Origin on the
+// real /api/forum write chain (JWTAuthCheck + CSRFProtection + handler).
+func TestCSRFProtectedForumWriteRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	// Reuse the full apiRoute assembly; only the middleware ordering matters
+	// here and the request is rejected before any DB access.
+	apiRoute(router)
+
+	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test/api/forum/topics/write", strings.NewReader(`{}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-jwt"})
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	// JWTAuthCheck runs first and fails on the bogus JWT before CSRF runs, so
+	// an unauthenticated write stays a 401 (anonymous semantics preserved).
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (body %s)", recorder.Code, recorder.Body.String())
+	}
+}
+
+// TestCSRFProtectedWriteRoutesRegistered verifies every cookie-authenticated
+// write group carries the CSRF middleware in the production assembly.
+func TestCSRFProtectedWriteRoutesRegistered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	apiRoute(router)
+	fileServer(router)
+
+	for _, route := range []string{
+		"POST /api/logout",
+		"POST /api/set-user-info",
+		"POST /api/forum/topics/write",
+		"POST /api/forum/posts/create",
+		"POST /api/forum/moderation/topic-status",
+		"POST /api/forum/chat/send",
+		"POST /api/admin/traffic-overview",
+		"POST /api/admin/save-site-settings",
+		"POST /file/img-upload",
+	} {
+		found := false
+		for _, r := range router.Routes() {
+			if r.Method+" "+r.Path == route {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("%s was not registered", route)
+		}
+	}
+}

--- a/apps/gooseforum/app/http/routes/csrf_route_protection_test.go
+++ b/apps/gooseforum/app/http/routes/csrf_route_protection_test.go
@@ -7,15 +7,38 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userSessions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userStatistics"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // Route-level CSRF matrix (issue #406). Unlike the middleware unit tests in
 // app/http/middleware, these exercise the production route assembly
 // (apiRoute): CSRFProtection is mounted exactly where production mounts it
 // (logout before the handler; login/forum/admin groups after JWTAuthCheck).
-// /api/logout is used because its handler never touches the database when the
-// token is not a valid session JWT, so no test DB is needed.
+// The logout matrix below needs no database (an invalid session JWT never
+// reaches one); the chain-attachment and real-session tests bootstrap the
+// minimal table set (users, user statistics, user sessions) so JWTAuthCheck
+// can validate a minted session.
+
+// csrfChainTestDB migrates the tables the auth chain needs and nothing else:
+// the requests under test are rejected at the CSRF gate before any handler
+// runs.
+func csrfChainTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(
+		&users.EntityComplete{},
+		&userStatistics.Entity{},
+		&userSessions.Entity{},
+	); err != nil {
+		t.Fatalf("migrate CSRF chain test tables: %v", err)
+	}
+	return conn
+}
 
 func csrfRouteRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
@@ -137,8 +160,11 @@ func TestCSRFProtectedForumWriteRoute(t *testing.T) {
 	}
 }
 
-// TestCSRFProtectedWriteRoutesRegistered verifies every cookie-authenticated
-// write group carries the CSRF middleware in the production assembly.
+// TestCSRFProtectedWriteRoutesRegistered pins the registered paths of the
+// cookie-authenticated write surface (a registration smoke test only:
+// router.Routes() exposes method+path+final handler, not the middleware
+// chain). TestCSRFGroupChainsRejectCrossSiteSessionWrites below is what
+// proves the middleware is attached.
 func TestCSRFProtectedWriteRoutesRegistered(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -166,5 +192,79 @@ func TestCSRFProtectedWriteRoutesRegistered(t *testing.T) {
 		if !found {
 			t.Fatalf("%s was not registered", route)
 		}
+	}
+}
+
+// TestCSRFGroupChainsRejectCrossSiteSessionWrites proves CSRFProtection is
+// actually in every production cookie-authenticated write chain. The group
+// middleware added via .Use() is invisible to router.Routes(), so this fires
+// a valid-session, foreign-Origin write at one representative route per
+// protected group and requires the 403 auth.csrf.rejected envelope; if the
+// middleware is dropped from a group the request proceeds past auth and the
+// assertion fails.
+func TestCSRFGroupChainsRejectCrossSiteSessionWrites(t *testing.T) {
+	conn := csrfChainTestDB(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	apiRoute(router)
+	fileServer(router)
+
+	user := createHTTPContractUser(t, conn, contractTestID())
+	sessionToken := contractSessionToken(t, user)
+
+	for _, tc := range []struct{ group, path string }{
+		{"loginApi", "/api/user/sessions/revoke"},
+		{"forumLoginApi", "/api/forum/topics/write"},
+		{"chatApi", "/api/forum/chat/send"},
+		{"adminApi", "/api/admin/traffic-overview"},
+		// The /file group mounts CSRFProtection at group level, before the
+		// per-route auth — the mount-order exception documented in
+		// middleware/csrfProtection.go. A rejection here (not a 401) pins it.
+		{"fileGroup", "/file/img-upload"},
+	} {
+		request := httptest.NewRequest(http.MethodPost, "http://forum.example.test"+tc.path, strings.NewReader(`{}`))
+		request.Header.Set("Content-Type", "application/json")
+		request.AddCookie(&http.Cookie{Name: "access_token", Value: sessionToken})
+		request.Header.Set("Origin", "http://evil.example.test")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("%s: status = %d, want 403 (body %s)", tc.group, recorder.Code, recorder.Body.String())
+		}
+		if !strings.Contains(recorder.Body.String(), "auth.csrf.rejected") {
+			t.Fatalf("%s: body %q lacks auth.csrf.rejected", tc.group, recorder.Body.String())
+		}
+	}
+}
+
+// TestCSRFRealSessionSameOriginLogoutPasses guards against over-blocking: a
+// legitimate same-origin write carrying a real session passes the gate and
+// reaches the handler, which revokes the session row.
+func TestCSRFRealSessionSameOriginLogoutPasses(t *testing.T) {
+	conn := csrfChainTestDB(t)
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	apiRoute(router)
+
+	user := createHTTPContractUser(t, conn, contractTestID())
+	sessionToken := contractSessionToken(t, user)
+
+	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test/api/logout", strings.NewReader(`{}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: sessionToken})
+	request.Header.Set("Origin", "http://forum.example.test")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+	}
+	// Revocation deletes the session row (sessionservice.RevokeByJti).
+	var remaining int64
+	if err := conn.Model(&userSessions.Entity{}).Where("user_id = ?", user.Id).Count(&remaining).Error; err != nil {
+		t.Fatalf("count session rows: %v", err)
+	}
+	if remaining != 0 {
+		t.Fatalf("same-origin logout must revoke the session row, %d remain", remaining)
 	}
 }

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -136,7 +136,7 @@ func apiRoute(ginApp *gin.Engine) {
 	baseApi.POST("login", middleware.RateLimit(middleware.RateLimitLogin), api.Login)
 	baseApi.GET("login-public-key", api.LoginPublicKey)
 	baseApi.POST("register", middleware.RateLimit(middleware.RateLimitRegister), api.Register)
-	baseApi.POST("logout", api.Logout)
+	baseApi.POST("logout", middleware.CSRFProtection, api.Logout)
 
 	baseApi.GET("get-captcha", UpQueryReq(api.GetCaptcha))
 	baseApi.GET("user-card", UpQueryReq(api.GetUserCard))
@@ -168,7 +168,11 @@ func apiRoute(ginApp *gin.Engine) {
 	baseApi.POST("auth/totp/verify", middleware.TOTPChallengeAuth, api.TotpVerify)
 	baseApi.POST("auth/oidc/exchange", middleware.RateLimit(middleware.RateLimitLogin), api.OidcExchange)
 
-	loginApi := ginApp.Group("api").Use(middleware.JWTAuthCheck)
+	// CSRF 防护（issue #406）：挂在认证之后的写组中间件，仅校验「Cookie 可认证 +
+	// 状态变更方法」请求（Bearer 客户端豁免），详见 middleware/csrfProtection.go
+	// 与 docs/product/identity-and-access.md「认证与 CSRF 边界」。不挂全局，避免与
+	// #407 全局安全头中间件冲突；GET/HEAD/OPTIONS 与匿名请求原样放行。
+	loginApi := ginApp.Group("api").Use(middleware.JWTAuthCheck, middleware.CSRFProtection)
 	loginApi.POST("set-user-info", middleware.CheckWritableAccount, UpButterReq(api.EditUserInfo))
 	loginApi.POST("set-user-profile-cover", middleware.CheckWritableAccount, UpButterReq(api.EditUserProfileCover))
 	loginApi.POST("set-user-email", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitEmailChange), UpButterReq(api.EditUserEmail))
@@ -241,7 +245,7 @@ func apiRoute(ginApp *gin.Engine) {
 	// 不要求登录；待审版本正文在控制器内对非版主屏蔽。
 	forumApi.GET("posts/revisions", middleware.JWTAuth, middleware.NoUpdateUserActivity, UpQueryReq(forum.PostRevisions))
 
-	forumLoginApi := forumApi.Use(middleware.JWTAuthCheck)
+	forumLoginApi := forumApi.Use(middleware.JWTAuthCheck, middleware.CSRFProtection)
 	forumLoginApi.GET("unread-status", middleware.NoUpdateUserActivity, UpButterReq(api.GetUnreadStatus))
 	forumLoginApi.GET("notifications", middleware.NoUpdateUserActivity, UpQueryReq(api.NotificationList))
 	forumLoginApi.POST("notification/mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkAsRead))
@@ -308,7 +312,7 @@ func apiRoute(ginApp *gin.Engine) {
 	forumLoginApi.POST("moderation/logs", middleware.NoUpdateUserActivity, UpButterReq(forum.ModerationLogList))
 	forumLoginApi.POST("moderation/view-deleted-content", middleware.CheckWritableAccount, UpButterReq(forum.ViewDeletedContent))
 
-	chatApi := forumApi.Group("chat", middleware.JWTAuthCheck)
+	chatApi := forumApi.Group("chat", middleware.JWTAuthCheck, middleware.CSRFProtection)
 
 	// Agent public API: opaque bearer-token authentication only. Writes reuse
 	// the human topic/post rate limits keyed by IP and bot userId.
@@ -323,7 +327,7 @@ func apiRoute(ginApp *gin.Engine) {
 	chatApi.POST("messages", UpButterReq(api.GetMessages))
 	chatApi.POST("mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkChatRead))
 
-	adminApi := baseApi.Group("admin", middleware.JWTAuthCheck, middleware.CheckWritableAccount)
+	adminApi := baseApi.Group("admin", middleware.JWTAuthCheck, middleware.CheckWritableAccount, middleware.CSRFProtection)
 
 	adminApi.POST("traffic-overview", middleware.CheckPermission(permission.Admin), UpButterReq(api.GetTrafficOverview))
 
@@ -441,7 +445,7 @@ func apiRoute(ginApp *gin.Engine) {
 }
 
 func fileServer(ginApp *gin.Engine) {
-	r := ginApp.Group("file")
+	r := ginApp.Group("file", middleware.CSRFProtection)
 	r.POST("/img-upload", middleware.JWTAuthCheck, middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitUpload), api.SaveImgByGinContext)
 	r.POST("/img-upload/init", middleware.JWTAuthCheck, middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitUpload), api.InitDirectImageUpload)
 	r.POST("/img-upload/complete", middleware.JWTAuthCheck, middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitUpload), api.CompleteDirectImageUpload)

--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -2082,6 +2082,7 @@ export default {
     'common.rateLimited': 'Too many attempts. Please try again in {retryAfterSeconds} seconds.',
     'page.notFound': 'The page does not exist or has been deleted.',
     'route.notFound': 'Route not found. Please check the URL and request method.',
+    'auth.csrf.rejected': 'The request origin could not be verified. Refresh the page and try again.',
     'admin.moderator.userRequired': 'Please enter a moderator user.',
     'admin.moderator.userNotFound': 'Moderator user not found.',
     'admin.moderator.notFound': 'Moderator record not found.',

--- a/apps/gooseforum/resource/src/locales/it.ts
+++ b/apps/gooseforum/resource/src/locales/it.ts
@@ -2082,6 +2082,7 @@ export default {
     'common.rateLimited': 'Troppi tentativi. Riprova tra {retryAfterSeconds} secondi.',
     'page.notFound': 'La pagina non esiste o è stata eliminata.',
     'route.notFound': 'Route non trovata. Controlla l’URL e il metodo della richiesta.',
+    'auth.csrf.rejected': 'Impossibile verificare l\'origine della richiesta. Aggiorna la pagina e riprova.',
     'admin.moderator.userRequired': 'Inserisci un utente moderatore.',
     'admin.moderator.userNotFound': 'Utente moderatore non trovato.',
     'admin.moderator.notFound': 'Record del moderatore non trovato.',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -2082,6 +2082,7 @@ export default {
     'common.rateLimited': '操作が多すぎます。{retryAfterSeconds} 秒後に再度お試しください。',
     'page.notFound': 'ページが存在しないか、削除されています。',
     'route.notFound': 'ルートが見つかりません。URL とリクエストメソッドを確認してください。',
+    'auth.csrf.rejected': 'リクエスト元を検証できませんでした。ページを再読み込みして、もう一度お試しください。',
     'admin.moderator.userRequired': 'Please enter a moderator user.',
     'admin.moderator.userNotFound': 'Moderator user not found.',
     'admin.moderator.notFound': 'Moderator record not found.',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -2084,6 +2084,7 @@ export default {
     'common.rateLimited': '操作过于频繁，请 {retryAfterSeconds} 秒后再试。',
     'page.notFound': '页面不存在，或已经被删除。',
     'route.notFound': '路由未定义，请确认 URL 和请求方法是否正确。',
+    'auth.csrf.rejected': '请求来源校验未通过（已拒绝跨站请求），请刷新页面后重试。',
     'admin.moderator.userRequired': '请输入版主用户。',
     'admin.moderator.userNotFound': '版主用户不存在。',
     'admin.moderator.notFound': '版主记录不存在。',

--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -19,6 +19,12 @@ gzip = true
 # 仅信任本机回源即可正确解析 X-Forwarded-For(限流按真实客户端 IP 归并)
 trusted_proxies = ["127.0.0.1", "::1"]
 
+[csrf]
+# Cookie 认证写接口的跨站请求防护（issue #406）额外允许的来源（逗号分隔，
+# 完整 origin，如 https://forum.example.com）。默认只需请求自身的 Host 同源即可，
+# 仅当存在必须共享会话 Cookie 的独立前端域时才需要配置。
+allowedOrigins = ""
+
 [jwtopt]
 validTime = 604800
 

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -149,6 +149,54 @@
   creation always publishes (`topicStatus=1`).
 - Mention parsing, webhook sending, OAuth/session/scopes for Agents remain `Planned`.
 
+## Credential transport & CSRF boundary
+
+Auth contract for state-changing API requests (issue #406):
+
+- **Browser pages (site + admin SPA, GoHTML SSR views)** authenticate solely with the HttpOnly
+  `access_token` cookie that login flows set (password/TOTP, GitHub/Google OAuth callbacks, OIDC
+  exchange). They issue same-origin relative `fetch()` calls and never send an `Authorization`
+  header. The cookie is `SameSite=Lax` + `Secure` (whenever `app.env != "local"`) and is
+  host-only, so it is only sent to the exact domain that set it.
+- **Non-browser clients** authenticate with an `Authorization: Bearer` header: the mobile app
+  (forum JWT from `POST /api/auth/oidc/exchange`, stored in Keychain/Keystore), Agent `agt_`
+  tokens (`/api/v1/agent/*`, MCP), and curl/scripting API clients. A browser cannot attach these
+  headers cross-site, so bearer-authenticated requests carry no CSRF risk.
+- **Exempt flows**: top-level navigation and `Set-Cookie` flows (login/register/reset, OAuth and
+  OIDC callbacks, `/api/auth/oidc/exchange`) are GET/state-creating entry points that cannot be
+  CSRF'd against an existing session (they create rather than mutate a session). The wiki GitHub
+  webhook authenticates by HMAC signature, not by cookie. `/api/auth/totp/verify` consumes a
+  short-lived challenge cookie that is only issued as the response to a successful password
+  verification, so a cross-site attacker cannot obtain it.
+
+CSRF enforcement (`middleware.CSRFProtection`, mounted per write-route group in `route4api.go`
+after the authentication middleware — never in the global chain):
+
+- Only **state-changing methods (POST/PUT/PATCH/DELETE) that carry the `access_token` cookie**
+  are checked; GET/HEAD/OPTIONS and cookie-less requests (anonymous writes, server-to-server)
+  pass.
+- A request with an `Authorization` header is always exempt (Bearer clients, even when a cookie
+  happens to ride along).
+- The remaining cookie-authenticated writes must present an `Origin` that matches the
+  site-controlled origin set: the request's own `Host`-derived origin (scheme from TLS or the
+  first `X-Forwarded-Proto` hop so TLS-terminating proxies work; default ports normalized), plus
+  any origins listed in the `csrf.allowedOrigins` config (comma separated) for deployments that
+  must accept an alternate front-end origin. The host-derived rule keeps multi-domain, LAN-IP,
+  and `localhost` dev deployments working without enumerating origins, because a browser Origin
+  is always the domain the host-only session cookie is scoped to.
+- When `Origin` is missing (legacy browsers that omit it on same-origin POSTs), the `Referer`
+  origin is checked instead; otherwise the request is rejected with HTTP 403 and message code
+  `auth.csrf.rejected`. curl/scripting clients that carry a cookie but no Origin/Referer are
+  rejected fail-closed — they should send `Authorization` instead.
+
+Rationale for Origin checking instead of a double-submit CSRF token: both web frontends run on
+modern browsers that send `Origin` on every state-changing request, and the host-only +
+`SameSite=Lax` cookie already stops the classic cross-site POST. A double-submit token would add
+a JS-readable cookie surface and frontend plumbing to every write call while contributing almost
+no additional protection for this deployment shape. SameSite alone is not relied on: the Origin
+check additionally covers same-site cross-origin (subdomain) hosts and browsers without SameSite
+support.
+
 ## Security notes
 
 - PKCE S256 required on authorize; nonce prevents replay; state prevents CSRF on the callback; the


### PR DESCRIPTION
## Summary
- Adds CSRF protection for cookie-authenticated state-changing requests (issue #406, P2).
- New origin-check middleware mounted after auth on write route groups (logout, account/session, forum writes, chat, admin, file upload). Non-GET requests carrying the `access_token` cookie must pass same-origin Origin/Referer validation (derived from request Host + configurable `csrf.allowedOrigins`); `Authorization` (Bearer) clients are exempt; anonymous/service POSTs (webhooks, OIDC token) are exempt.
- New stable error code `auth.csrf.rejected` with zh/en/ja/it messages (frontend TS + backend JSON + config template + deploy example).
- Double-submit token intentionally not added (modern browsers always send Origin; host-only + SameSite=Lax cookie already stops classic CSRF) - rationale recorded in docs.

## Testing
- 16 middleware cases + 8 real route-level cases, all PASS; zero changes needed to existing tests (existing suites use Bearer or self-registered routes - no test escape hatch).
- `go build ./...`; affected packages pass; `pnpm typecheck` exit 0.
- No model/migration changes; bridge.go untouched (no overlap with #407).

## Notes
- Referer fallback only for legacy browsers missing Origin; Host-derived rule requires correct `trusted_proxies` when behind a reverse proxy.
- Exempt by design: /api/oauth/* (protocol semantics), /api/v1/agent/* (Bearer-only), wiki webhook (HMAC) - documented.
- Reviewed independently by security review: no blockers.
