### PR TITLE
fix(console): startupDone 屏障修复 wait() 竞态吞掉致命迁移错误（dev CI flake）

### DIFF
--- a/apps/gooseforum/app/console/serve.go
+++ b/apps/gooseforum/app/console/serve.go
@@ -175,6 +175,10 @@ type serveRuntime struct {
 	listener      net.Listener
 	quit          chan os.Signal
 	shutdownOnce  sync.Once
+	// startupDone 在启动 goroutine（迁移）落定后关闭。wait() 收到 quit 信号后
+	// 必须先等它再读 fatalErr：外部信号/测试可能抢在 setFatal 之前把信号入队，
+	// 若无此屏障会读到 nil，把致命迁移错误吞掉（#370 遗留竞态）。
+	startupDone   chan struct{}
 	fatalMu       sync.Mutex
 	fatalErr      error
 	migrate       func() error
@@ -204,6 +208,7 @@ func newServeRuntime(port string) (*serveRuntime, error) {
 		startupGate:   startupGate,
 		listener:      listener,
 		quit:          make(chan os.Signal, 1),
+		startupDone:   make(chan struct{}),
 		migrate:       migration.M,
 		startBusiness: startBusinessServices,
 	}, nil
@@ -223,6 +228,8 @@ func (r *serveRuntime) start() {
 	// 业务服务并放行流量；worker/cron 全部在成功路径内启动，避免半迁移
 	// 实例处理业务请求。
 	go func() {
+		// 无论成功/失败/deferred，启动结果落定后关闭屏障，wait() 才能安全读 fatal。
+		defer close(r.startupDone)
 		if err := r.runStartup(); err != nil {
 			r.setFatal(err)
 			r.requestShutdown()
@@ -354,6 +361,11 @@ func (r *serveRuntime) requestShutdown() {
 func (r *serveRuntime) wait() error {
 	signal := <-r.quit
 	slog.Info("Shutdown Server ...", "signal", signal)
+	// 先等启动 goroutine 落定再读 fatal：quit 信号可能先于 setFatal 到达
+	// （外部信号或测试直接 requestShutdown），直接读 fatal() 会把致命迁移
+	// 错误吞成 nil 导致进程以 0 退出。启动 goroutine 内先 setFatal 再发信号，
+	// 屏障等待只有微秒级；外部信号撞上超长迁移时关停会等迁移结束（更安全）。
+	<-r.startupDone
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer shutdownCancel()
 	if err := r.server.Shutdown(shutdownCtx); err != nil {

--- a/apps/gooseforum/app/console/serve_runtime_test.go
+++ b/apps/gooseforum/app/console/serve_runtime_test.go
@@ -31,6 +31,7 @@ func newTestServeRuntime(t *testing.T) *serveRuntime {
 		startupGate:   gate,
 		listener:      listener,
 		quit:          make(chan os.Signal, 1),
+		startupDone:   make(chan struct{}),
 		migrate:       func() error { return nil },
 		startBusiness: func() {},
 	}
@@ -84,6 +85,45 @@ func TestServeRuntimeFatalMigrationSurfaces(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("wait() did not return after fatal shutdown")
+	}
+}
+
+// TestServeRuntimeFatalMigrationRaceWithQuit 确定性复现 #370 遗留竞态：quit 信号
+// 先于启动 goroutine 的 setFatal 到达时，wait() 不得吞掉致命迁移错误。
+// migrate 用阻塞桩挂起，确保信号入队时错误尚未记录：
+//   - 修复前：wait() 立即返回 nil 错误（致命失败被吞 → 进程会以 0 退出）；
+//   - 修复后：wait() 等待启动结果落定（startupDone 屏障），放行后返回 boom。
+func TestServeRuntimeFatalMigrationRaceWithQuit(t *testing.T) {
+	rt := newTestServeRuntime(t)
+	boom := errors.New("schema migration failed: simulate")
+	allowMigrate := make(chan struct{})
+	rt.migrate = func() error { <-allowMigrate; return boom }
+	rt.start()
+
+	// 迁移 goroutine 仍被挂起、setFatal 未执行时信号已入队——最窄窗口。
+	rt.requestShutdown()
+	errCh := make(chan error, 1)
+	go func() { errCh <- rt.wait() }()
+
+	// 修复前：wait() 会立刻读到 nil 并返回，此处直接判负；修复后：wait()
+	// 阻塞在 startupDone 上，等待下面放行。
+	select {
+	case err := <-errCh:
+		t.Fatalf("wait() returned before startup settled = %v, want it to wait for the fatal migration outcome", err)
+	case <-time.After(1 * time.Second):
+	}
+
+	close(allowMigrate)
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, boom) {
+			t.Fatalf("wait() after fatal migration = %v, want %v", err, boom)
+		}
+		if rt.startupGate.Ready() {
+			t.Fatal("startup gate reported ready after a fatal migration failure")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("wait() did not return after startup settled")
 	}
 }
 


### PR DESCRIPTION
## 动机

dev CI 偶发失败（见 issue #428）：`TestServeRuntimeFatalMigrationSurfaces` 报 `wait() after fatal migration = <nil>`。根因是 #370 遗留竞态——quit 信号先于启动 goroutine 的 `setFatal` 到达时，`wait()` 读到 nil 错误，致命迁移失败被吞、进程以 0 退出，破坏「migration failure exits non-zero」验收标准。与 #390 无关（该测试 stub migrate，不触碰 #390 代码；#390 自身 PR CI 全绿）。

## 改动

- `serve.go`：`serveRuntime` 增加 `startupDone chan struct{}`——启动 goroutine 落定（成功/失败/deferred）后关闭；`wait()` 收到 quit 信号后、读 `fatal()` 前先 `<-r.startupDone`，保证退出码一定反映启动结果。
- `serve_runtime_test.go`：新增确定性回归测试 `TestServeRuntimeFatalMigrationRaceWithQuit`（阻塞 migrate 桩构造最窄窗口，不赌调度）。

## 验证（实际执行）

- 新测试修复前 `-count=3`：**3/3 红**（`wait() returned before startup settled = <nil>`，与 CI 失败同型）
- 修复后：全部 `TestServeRuntime*` `-count=10` 通过；`go test ./app/console/ -race` 通过；`go vet ./app/console/` 干净；`git diff --check` 无告警

## 行为说明

唯一语义变化：外部信号撞上**超长迁移进行中**时，关停会等迁移结束再退出（比半迁移退出更安全）；致命失败路径本就「先 setFatal 再发信号」，屏障等待仅微秒级。

## 影响面

仅 `app/console` 两个文件；无契约/迁移/前端/文档影响。Fixes #428。