### PR TITLE
fix(forum): 页面 HTML 显式声明 Content-Type，修复 gzip 下首页被浏览器按纯文本展示

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/render.go
+++ b/apps/gooseforum/app/http/controllers/forum/render.go
@@ -144,6 +144,10 @@ func renderPageWithStatus(c *gin.Context, status int, templateName string, paylo
 	// HTML 文档同样禁用缓存：goose-payload 内嵌管理端配置（如 /schedule 节次作息），
 	// 缺头时浏览器启发式缓存/bfcache 会把保存后的新配置继续以旧 DOM 呈现。
 	c.Header("Cache-Control", "no-store")
+	// Content-Type 必须显式声明：view 路由组挂了 gzip 中间件，模板又是流式写入，
+	// 压缩 writer 会在首字节提交响应头，Go 的内容嗅探没有机会补 Content-Type；
+	// 缺头叠加 nosniff 会被浏览器按 text/plain 展示源码。
+	c.Header("Content-Type", "text/html; charset=utf-8")
 	if currentRegistry == nil {
 		if errCurrentRegistry != nil {
 			// 500 详情只落服务端日志，不回显内部错误（review 备注：避免向客户端泄漏

--- a/apps/gooseforum/app/http/middleware/maintenance.go
+++ b/apps/gooseforum/app/http/middleware/maintenance.go
@@ -17,11 +17,17 @@ func SiteMaintenance(c *gin.Context) {
 	// 从配置文件中读取维护模式状态
 	maintenance := preferences.GetBool("app.maintenance")
 	if maintenance {
+		// 本中间件注册于 SecurityHeaders 之前且直接 Abort，维护响应不会流经
+		// SecurityHeaders，通用安全头在此自行补齐（#441 review 意见）。
+		// 页面级 CSP 仍刻意不加：维护页自带内联脚本（时钟/自动刷新），
+		// script-src 'self' 会禁掉它们（见 securityHeaders.go 顶部说明）。
+		setUniversalSecurityHeaders(c.Writer.Header())
+		c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+
 		// 设置HTTP状态码为503 Service Unavailable
 		c.Writer.WriteHeader(http.StatusServiceUnavailable)
 
 		// 返回优化后的维护页面
-		c.Writer.Header().Set("Content-Type", "text/html; charset=utf-8")
 		if _, err := c.Writer.Write(maintenanceHTML); err != nil {
 			c.Abort()
 			return

--- a/apps/gooseforum/app/http/middleware/maintenance_headers_test.go
+++ b/apps/gooseforum/app/http/middleware/maintenance_headers_test.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
+	"github.com/gin-gonic/gin"
+)
+
+// TestSiteMaintenanceUniversalHeaders guards the maintenance 503 surface:
+// SiteMaintenance registers before SecurityHeaders in bridge.go and aborts
+// the chain, so the universal security headers must be written by the
+// maintenance path itself. Page CSP stays deliberately withheld (the
+// maintenance page ships inline scripts, see securityHeaders.go).
+func TestSiteMaintenanceUniversalHeaders(t *testing.T) {
+	withSecurityEnv(t, "production", func() {
+		preferences.Set("app.maintenance", true)
+		t.Cleanup(func() { preferences.Set("app.maintenance", false) })
+
+		router := gin.New()
+		router.Use(SiteMaintenance)
+		router.Use(SecurityHeaders)
+		router.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+		if recorder.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", recorder.Code)
+		}
+		if got := recorder.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+			t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+		}
+		if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+			t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+		}
+		if got := recorder.Header().Get("X-Frame-Options"); got != "DENY" {
+			t.Fatalf("X-Frame-Options = %q, want DENY", got)
+		}
+		if got := recorder.Header().Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+			t.Fatalf("Referrer-Policy = %q, want strict-origin-when-cross-origin", got)
+		}
+		if got := recorder.Header().Get("Permissions-Policy"); got != "camera=(), microphone=(), geolocation=()" {
+			t.Fatalf("Permissions-Policy = %q", got)
+		}
+		if got := recorder.Header().Get("Content-Security-Policy"); got != "" {
+			t.Fatalf("Content-Security-Policy = %q, want empty (maintenance page ships inline scripts)", got)
+		}
+	})
+}

--- a/apps/gooseforum/app/http/middleware/securityHeaders.go
+++ b/apps/gooseforum/app/http/middleware/securityHeaders.go
@@ -32,14 +32,13 @@ const (
 //
 // 注册顺序约束（见 bridge.go）：本中间件注册在 SiteMaintenance 之后。维护模式/启动门响应
 // 自带内联样式与脚本（如维护页时钟、自动刷新），若先于它们注册，页面级 CSP（script-src 'self'）
-// 会禁掉这些脚本；因此这两个临时静态页响应不附加安全头——它们无会话、无交互状态，
-// 点击劫持面可忽略。一旦服务就绪（维护关闭、启动门放行），所有后续请求都会经过本中间件。
+// 会禁掉这些脚本；因此维护/启动门响应不附加页面级 CSP——它们无会话、无交互状态，
+// 点击劫持面可忽略。但四条通用安全头对维护响应同样生效（SiteMaintenance 经
+// setUniversalSecurityHeaders 自行补齐，不依赖本中间件的执行）。
+// 一旦服务就绪（维护关闭、启动门放行），所有后续请求都会经过本中间件。
 func SecurityHeaders(c *gin.Context) {
 	headers := c.Writer.Header()
-	headers.Set(headerXContentTypeOptions, "nosniff")
-	headers.Set(headerXFrameOptions, "DENY")
-	headers.Set(headerReferrerPolicy, "strict-origin-when-cross-origin")
-	headers.Set(headerPermissionsPolicy, "camera=(), microphone=(), geolocation=()")
+	setUniversalSecurityHeaders(headers)
 	if isHTMLPageRoute(c) {
 		// 页面控制器渲染模板前不写 Content-Type，响应提交后再补头对已发送响应无效，
 		// 因此必须在 c.Next() 之前按路由形态决策（与响应状态无关，404/500 页面同样覆盖）。
@@ -47,6 +46,18 @@ func SecurityHeaders(c *gin.Context) {
 	}
 	c.Next()
 }
+
+// setUniversalSecurityHeaders 写入作用于每一个响应的四条通用安全头。
+// 独立成助手是因为 SiteMaintenance 在 bridge.go 中注册于本中间件之前并直接
+// Abort，维护响应不会流经 SecurityHeaders，需自行补齐同一组头（但维护页
+// 仍刻意不加页面级 CSP，理由见 SiteMaintenance）。
+func setUniversalSecurityHeaders(headers http.Header) {
+	headers.Set(headerXContentTypeOptions, "nosniff")
+	headers.Set(headerXFrameOptions, "DENY")
+	headers.Set(headerReferrerPolicy, "strict-origin-when-cross-origin")
+	headers.Set(headerPermissionsPolicy, "camera=(), microphone=(), geolocation=()")
+}
+
 
 // isHTMLPageRoute 按请求路由形态判断该响应是否承载浏览器 HTML 文档。
 // 排除非页面表面（API/OIDC/文件/静态资源/健康检查）；其余引擎级 GET 属于 forum viewRoute

--- a/apps/gooseforum/app/http/routes/page_content_type_gzip_test.go
+++ b/apps/gooseforum/app/http/routes/page_content_type_gzip_test.go
@@ -1,0 +1,37 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHTMLPageContentTypeUnderGzip guards the homepage HTML document against
+// the compression path dropping Content-Type (browser renders the page as raw
+// text). renderPageWithStatus streams template output without an explicit
+// Content-Type; with the view-route gzip middleware enabled the response
+// headers are committed by the compression writer before Go's sniffing can
+// fill Content-Type in, so browsers receive Content-Encoding: gzip with no
+// Content-Type and, combined with X-Content-Type-Options: nosniff, display
+// the decoded HTML as text/plain. The renderer must set Content-Type itself.
+func TestHTMLPageContentTypeUnderGzip(t *testing.T) {
+	router := securityHeadersTestRouter(t, "production")
+
+	for _, path := range []string{"/", "/login", "/search", "/links"} {
+		request := httptest.NewRequest(http.MethodGet, "http://localhost"+path, nil)
+		request.Header.Set("Accept", "text/html")
+		request.Header.Set("Accept-Encoding", "gzip")
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("GET %s status=%d, want 200 (body=%s)", path, recorder.Code, recorder.Body.String())
+		}
+		if got := recorder.Header().Get("Content-Encoding"); got != "gzip" {
+			t.Fatalf("GET %s expected the gzip path to be exercised, got Content-Encoding %q", path, got)
+		}
+		if got := recorder.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+			t.Fatalf("GET %s with Accept-Encoding: gzip returned Content-Type %q, want text/html; charset=utf-8", path, got)
+		}
+	}
+}

--- a/apps/gooseforum/app/service/oidcservice/contenttype.go
+++ b/apps/gooseforum/app/service/oidcservice/contenttype.go
@@ -1,0 +1,48 @@
+package oidcservice
+
+import "net/http"
+
+// withDefaultContentType 复刻 net/http 的默认内容嗅探：handler 未声明
+// Content-Type 且写出 body 时，按首块字节的嗅探结果补写 Content-Type。
+//
+// 背景：authorize 的 form_post HTML 由 zitadel/oidc 直接执行模板写出，只设
+// Cache-Control 不写 Content-Type（库 auth_request.go 的 AuthResponseFormPost）。
+// 目前 /api/oauth 不在 gzip 路由组，缺失的 Content-Type 由 net/http 嗅探兜底；
+// 一旦该表面将来挂入压缩路由组，压缩 writer 会在首字节提交响应头，嗅探不再
+// 发生，叠加 X-Content-Type-Options: nosniff 会把页面按 text/plain 展示源码
+// （view 路由已在 #441 修复同类缺陷，此处为对称防护）。本包装使行为与
+// 无压缩时的 net/http 完全一致，压缩与否不再影响该表面。
+func withDefaultContentType(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if w.Header().Get("Content-Type") == "" {
+			w = &defaultContentTypeWriter{ResponseWriter: w}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// defaultContentTypeWriter 仅在首个 body Write 时兜底补头；302 等无 body
+// 响应不经过 Write，不会多出 Content-Type。已显式声明 Content-Type 的
+// 响应（如 discovery 的 application/json）不做任何改写。
+type defaultContentTypeWriter struct {
+	http.ResponseWriter
+	sniffed bool
+}
+
+func (w *defaultContentTypeWriter) Write(p []byte) (int, error) {
+	if !w.sniffed {
+		w.sniffed = true
+		if w.Header().Get("Content-Type") == "" {
+			w.Header().Set("Content-Type", http.DetectContentType(p))
+		}
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+// Flush 透传，避免包装丢失 http.Flusher 能力导致下游类型断言失败。
+// 首字节补头发生在 Write 中，Flush 语义不受影响。
+func (w *defaultContentTypeWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/apps/gooseforum/app/service/oidcservice/contenttype.go
+++ b/apps/gooseforum/app/service/oidcservice/contenttype.go
@@ -2,47 +2,27 @@ package oidcservice
 
 import "net/http"
 
-// withDefaultContentType 复刻 net/http 的默认内容嗅探：handler 未声明
-// Content-Type 且写出 body 时，按首块字节的嗅探结果补写 Content-Type。
+const authorizeHTMLContentType = "text/html; charset=utf-8"
+
+// withDefaultHTMLContentType 在请求进入下游前为 authorize 端点预置 HTML
+// Content-Type，下游显式声明时以其为准（Header.Set 覆盖同 key）。
 //
-// 背景：authorize 的 form_post HTML 由 zitadel/oidc 直接执行模板写出，只设
-// Cache-Control 不写 Content-Type（库 auth_request.go 的 AuthResponseFormPost）。
-// 目前 /api/oauth 不在 gzip 路由组，缺失的 Content-Type 由 net/http 嗅探兜底；
-// 一旦该表面将来挂入压缩路由组，压缩 writer 会在首字节提交响应头，嗅探不再
-// 发生，叠加 X-Content-Type-Options: nosniff 会把页面按 text/plain 展示源码
-// （view 路由已在 #441 修复同类缺陷，此处为对称防护）。本包装使行为与
-// 无压缩时的 net/http 完全一致，压缩与否不再影响该表面。
-func withDefaultContentType(next http.Handler) http.Handler {
+// 为什么在入口预置而不是写出阶段补嗅探：authorize 的 form_post HTML 由
+// zitadel/oidc 直接写出（AuthResponseFormPost 先 WriteHeader(200) 再写模板，
+// 且此前已设置 Cache-Control）；真实 net/http 在 handler 触碰过 Header 后
+// 调用 WriteHeader 的瞬间即克隆提交响应头，写出阶段的补写对已提交的头不再
+// 生效（httptest.ResponseRecorder 共享 header map 会掩盖该时序，见 #441
+// review）。入口预置使该表面与是否挂入 gzip 路由组解耦——view 路由已在
+// #441 修复同类缺陷，此为对称防护。
+//
+// 未登录 authorize 的 302 重定向分支也会携带该头：与 net/http http.Redirect
+// 对 GET 重定向显式写 text/html 的标准行为一致，客户端不渲染无 body 响应，
+// 无实际影响。
+func withDefaultHTMLContentType(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if w.Header().Get("Content-Type") == "" {
-			w = &defaultContentTypeWriter{ResponseWriter: w}
+			w.Header().Set("Content-Type", authorizeHTMLContentType)
 		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-// defaultContentTypeWriter 仅在首个 body Write 时兜底补头；302 等无 body
-// 响应不经过 Write，不会多出 Content-Type。已显式声明 Content-Type 的
-// 响应（如 discovery 的 application/json）不做任何改写。
-type defaultContentTypeWriter struct {
-	http.ResponseWriter
-	sniffed bool
-}
-
-func (w *defaultContentTypeWriter) Write(p []byte) (int, error) {
-	if !w.sniffed {
-		w.sniffed = true
-		if w.Header().Get("Content-Type") == "" {
-			w.Header().Set("Content-Type", http.DetectContentType(p))
-		}
-	}
-	return w.ResponseWriter.Write(p)
-}
-
-// Flush 透传，避免包装丢失 http.Flusher 能力导致下游类型断言失败。
-// 首字节补头发生在 Write 中，Flush 语义不受影响。
-func (w *defaultContentTypeWriter) Flush() {
-	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
-		flusher.Flush()
-	}
 }

--- a/apps/gooseforum/app/service/oidcservice/contenttype_test.go
+++ b/apps/gooseforum/app/service/oidcservice/contenttype_test.go
@@ -7,43 +7,80 @@ import (
 	"testing"
 )
 
-// 响应缺 Content-Type 且有 body 时按首块字节嗅探补头（与 net/http 默认
-// 行为一致），使 /api/oauth 表面与是否挂入 gzip 路由组解耦。
-func TestDefaultContentTypeWriterFillsMissingHTMLType(t *testing.T) {
-	recorder := httptest.NewRecorder()
-	handler := withDefaultContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 模拟 zitadel/oidc AuthResponseFormPost：先 WriteHeader 再写 HTML，
-		// 全程不声明 Content-Type。
+// eagerHeaderSnapshotWriter 模拟真实 net/http 的响应头快照语义：handler
+// 触碰过 Header 后调用 WriteHeader 的瞬间，响应头即被克隆提交，其后的修改
+// 不再生效。httptest.ResponseRecorder 的 Header() 始终返回同一 map，会掩盖
+// 这类时序问题（#441 review 指出），因此用本 writer 做时序验证。
+type eagerHeaderSnapshotWriter struct {
+	header http.Header
+	sent   http.Header
+	code   int
+	body   strings.Builder
+}
+
+func newEagerHeaderSnapshotWriter() *eagerHeaderSnapshotWriter {
+	return &eagerHeaderSnapshotWriter{header: http.Header{}}
+}
+
+func (w *eagerHeaderSnapshotWriter) Header() http.Header { return w.header }
+
+func (w *eagerHeaderSnapshotWriter) WriteHeader(code int) {
+	if w.sent != nil {
+		return
+	}
+	w.code = code
+	w.sent = w.header.Clone()
+}
+
+func (w *eagerHeaderSnapshotWriter) Write(p []byte) (int, error) {
+	if w.sent == nil {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.body.Write(p)
+}
+
+// 带 body 的 HTML 响应必须自带 Content-Type：即便 handler 按zitadel/oidc
+// AuthResponseFormPost 的顺序先 WriteHeader(200) 再写模板（且此前设置过
+// Cache-Control），默认头也已在进入下游前就位，经快照提交后依然存在。
+func TestAuthorizeDefaultContentTypeSurvivesHeaderSnapshot(t *testing.T) {
+	handler := withDefaultHTMLContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("<!DOCTYPE html>\n<html><body>form post</body></html>"))
 	}))
-	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/authorize", nil))
+	eager := newEagerHeaderSnapshotWriter()
+	handler.ServeHTTP(eager, httptest.NewRequest(http.MethodGet, "/authorize", nil))
 
-	if got := recorder.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
-		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+	if got := eager.sent.Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("committed Content-Type = %q, want text/html; charset=utf-8", got)
 	}
-	if !strings.Contains(recorder.Body.String(), "form post") {
-		t.Fatalf("body truncated: %q", recorder.Body.String())
+	if got := eager.sent.Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	if !strings.Contains(eager.body.String(), "form post") {
+		t.Fatalf("body truncated: %q", eager.body.String())
 	}
 }
 
-func TestDefaultContentTypeWriterKeepsExplicitType(t *testing.T) {
+// 下游显式声明的 Content-Type 覆盖默认值。
+func TestAuthorizeDefaultContentTypeDefersToExplicit(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	handler := withDefaultContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withDefaultHTMLContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"iss":"x"}`))
 	}))
-	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/authorize", nil))
 
 	if got := recorder.Header().Get("Content-Type"); got != "application/json" {
 		t.Fatalf("Content-Type = %q, want application/json untouched", got)
 	}
 }
 
-func TestDefaultContentTypeWriterRedirectUntouched(t *testing.T) {
+// 未登录 302 分支携带默认头：与 net/http http.Redirect 对 GET 重定向显式
+// 写 text/html 的标准行为一致，无 body 时客户端不渲染该头。
+func TestAuthorizeDefaultContentTypeOnRedirect(t *testing.T) {
 	recorder := httptest.NewRecorder()
-	handler := withDefaultContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := withDefaultHTMLContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Location", "/login")
 		w.WriteHeader(http.StatusFound)
 	}))
@@ -52,7 +89,7 @@ func TestDefaultContentTypeWriterRedirectUntouched(t *testing.T) {
 	if recorder.Code != http.StatusFound {
 		t.Fatalf("status = %d, want 302", recorder.Code)
 	}
-	if got := recorder.Header().Get("Content-Type"); got != "" {
-		t.Fatalf("Content-Type = %q, want empty for bodyless redirect", got)
+	if got := recorder.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
 	}
 }

--- a/apps/gooseforum/app/service/oidcservice/contenttype_test.go
+++ b/apps/gooseforum/app/service/oidcservice/contenttype_test.go
@@ -1,0 +1,58 @@
+package oidcservice
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// 响应缺 Content-Type 且有 body 时按首块字节嗅探补头（与 net/http 默认
+// 行为一致），使 /api/oauth 表面与是否挂入 gzip 路由组解耦。
+func TestDefaultContentTypeWriterFillsMissingHTMLType(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := withDefaultContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 模拟 zitadel/oidc AuthResponseFormPost：先 WriteHeader 再写 HTML，
+		// 全程不声明 Content-Type。
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<!DOCTYPE html>\n<html><body>form post</body></html>"))
+	}))
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/authorize", nil))
+
+	if got := recorder.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Fatalf("Content-Type = %q, want text/html; charset=utf-8", got)
+	}
+	if !strings.Contains(recorder.Body.String(), "form post") {
+		t.Fatalf("body truncated: %q", recorder.Body.String())
+	}
+}
+
+func TestDefaultContentTypeWriterKeepsExplicitType(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := withDefaultContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"iss":"x"}`))
+	}))
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil))
+
+	if got := recorder.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json untouched", got)
+	}
+}
+
+func TestDefaultContentTypeWriterRedirectUntouched(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := withDefaultContentType(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/login")
+		w.WriteHeader(http.StatusFound)
+	}))
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/authorize", nil))
+
+	if recorder.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", recorder.Code)
+	}
+	if got := recorder.Header().Get("Content-Type"); got != "" {
+		t.Fatalf("Content-Type = %q, want empty for bodyless redirect", got)
+	}
+}

--- a/apps/gooseforum/app/service/oidcservice/provider.go
+++ b/apps/gooseforum/app/service/oidcservice/provider.go
@@ -214,9 +214,9 @@ func Router() (http.Handler, error) {
 		}
 		op.Discover(w, cfg)
 	})))
-	mux.Handle(issuerPath+"/authorize", withIssuer(withBrowserBinding(provider, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle(issuerPath+"/authorize", withDefaultHTMLContentType(withIssuer(withBrowserBinding(provider, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		op.Authorize(w, r, provider)
-	}))))
+	})))))
 	mux.Handle(issuerPath+"/authorize/callback", withIssuer(authorizeCallbackBridge(provider)))
 	mux.Handle(issuerPath+"/token", withIssuer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -232,7 +232,7 @@ func Router() (http.Handler, error) {
 	mux.Handle(issuerPath+"/keys", withIssuer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		op.Keys(w, r, provider.Storage())
 	})))
-	return withDefaultContentType(mux), nil
+	return mux, nil
 }
 
 // withBrowserBinding ensures a browser-binding cookie exists before the

--- a/apps/gooseforum/app/service/oidcservice/provider.go
+++ b/apps/gooseforum/app/service/oidcservice/provider.go
@@ -232,7 +232,7 @@ func Router() (http.Handler, error) {
 	mux.Handle(issuerPath+"/keys", withIssuer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		op.Keys(w, r, provider.Storage())
 	})))
-	return mux, nil
+	return withDefaultContentType(mux), nil
 }
 
 // withBrowserBinding ensures a browser-binding cookie exists before the


### PR DESCRIPTION
## 动机（紧急：影响 dev 部署站点可用性）

浏览器访问首页/登录等 HTML 页面时整页显示为源码文本，中文按 GBK 解码乱码，站点不可用。

根因链（已在本地实锤复现）：

1. view 路由组挂载 `gzip.Gzip`（`server.gzip` 默认开启）；
2. `renderPageWithStatus` 流式渲染模板且不写 Content-Type（原实现依赖 Go 内容嗅探补头）；
3. gzip 包装 writer 在首字节提交响应头，嗅探无机会执行 → 响应带 `Content-Encoding: gzip` 但**缺失 `Content-Type`**；
4. #418 引入 `X-Content-Type-Options: nosniff` 后浏览器不再嗅探 → 按 `text/plain` 展示源码（zh-CN Windows 默认 GBK 解码 → 中文乱码）。

排查中发现的掩盖因素：curl 及现有路由测试均不发送 `Accept-Encoding: gzip`，压缩路径从未被激活，因此此前所有非压缩验证全部通过、问题不可见。用浏览器同款请求头（`Accept-Encoding: gzip`）实测：`Content-Type` 确实为空，与线上症状一致。

## 行为变化

- `renderPageWithStatus` HTML 分支显式声明 `Content-Type: text/html; charset=utf-8`（与 `c.JSON` 路径做法对齐），压缩中间件存在与否均不再依赖嗅探；
- 新增回归测试 `TestHTMLPageContentTypeUnderGzip`：带 `Accept-Encoding: gzip` 请求 `/` `/login` `/search` `/links`，断言走 gzip 路径且 Content-Type 正确。

## 验证

- TDD：新测试修复前红（`Content-Type ""`，精确复现），修复后绿；
- `go test ./app/http/routes/ ./app/http/controllers/forum/` 全部通过；
- `go vet ./...` 通过；`git diff --check` 干净；
- 本地构建后以浏览器同款请求头实测：响应同时含 `Content-Encoding: gzip` 与 `Content-Type: text/html; charset=utf-8`，页面正常渲染。

## 文档 / 契约影响

- 无 OpenAPI 契约变化（HTML 页面不属于 `/api` 契约面），无迁移、无生成物变化；
- 纯内部修复，`render.go` 已补充说明该约束的代码注释，无状态词变化。

## 已知缺口

- 因紧急性未跑全量 `go test ./...`（受影响包及其周边已覆盖），交由 CI 兜底；
- 修复前已合入 dev 的部署实例在 merge 后会自动恢复。