### PR TITLE
fix(auth): follow-up for merged PR #417 review — CSRF gate before stateful auth, drop csrf.allowedOrigins, contract sync (issue #406)

### DIFF
--- a/apps/gooseforum/app/bundles/preferences/config.templ.toml
+++ b/apps/gooseforum/app/bundles/preferences/config.templ.toml
@@ -20,12 +20,6 @@ port = 5234
 accessLog = false
 gzip = true # 应用层 gzip 开关
 
-[csrf]
-# Cookie 认证写接口的跨站请求防护（issue #406）额外允许的来源（逗号分隔，
-# 完整 origin，如 https://forum.example.com）。默认只需请求自身的 Host 同源即可，
-# 仅当存在必须共享会话 Cookie 的独立前端域时才需要配置。
-allowedOrigins = ""
-
 [jwtopt]
 validTime = 604800
 

--- a/apps/gooseforum/app/http/middleware/csrfProtection.go
+++ b/apps/gooseforum/app/http/middleware/csrfProtection.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
 	"github.com/gin-gonic/gin"
 )
@@ -34,23 +33,23 @@ const accessTokenCookieName = "access_token"
 //     GitHub wiki webhook's HMAC auth, OIDC token endpoints).
 //
 // Enforcement for the remaining cookie-authenticated state changes: the
-// Origin must match the site origin (derived from the request Host plus the
-// X-Forwarded-Proto/TLS scheme so TLS-terminating proxies pass) or one of the
-// explicitly configured origins in `csrf.allowedOrigins`. When the Origin
-// header is missing (legacy browsers that omit Origin on same-origin POSTs),
-// the Referer origin is checked instead. Any mismatch is rejected with 403
-// (envelope messageCode `auth.csrf.rejected`).
+// Origin must match the site origin, derived from the request Host plus the
+// X-Forwarded-Proto/TLS scheme so TLS-terminating proxies pass. When the
+// Origin header is missing (legacy browsers that omit Origin on same-origin
+// POSTs), the Referer origin is checked instead. Any mismatch is rejected
+// with 403 (envelope messageCode `auth.csrf.rejected`).
 //
 // SameSite=Lax + HttpOnly + Secure cookies remain as defense in depth; the
 // origin check additionally covers the cases SameSite=Lax does not: same-site
 // cross-origin (subdomain) attacks and browsers without SameSite support.
 //
-// Mounted per write-route group (route4api.go), never globally, so anonymous
-// 401 semantics and public POSTs are untouched. Auth-first groups mount it
-// after the authentication middleware; the /file group mounts it at group
-// level before the per-route auth, so a cookie-bearing foreign-origin upload
-// is rejected by this gate (403) instead of the auth middleware (401). Do not
-// move this into bridge.go's global chain.
+// Mounted per write-route group (route4api.go) before the stateful
+// authentication middleware (JWTAuthCheck) and never globally, so a rejected
+// cross-site write is cut off before it can refresh a near-expiry JWT, extend
+// its user_sessions row, or publish activity events. Requests without an
+// access_token cookie pass through and keep their usual anonymous semantics
+// (JWTAuthCheck still answers 401). Do not move this into bridge.go's global
+// chain.
 func CSRFProtection(c *gin.Context) {
 	method := c.Request.Method
 	if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
@@ -96,35 +95,25 @@ func sameSiteRequest(c *gin.Context) bool {
 	return false
 }
 
-// originMatches compares origin against the site-controlled origin set: the
-// request's own Host-derived origin and the configured csrf.allowedOrigins.
+// originMatches reports whether the candidate origin is this request's site
+// origin. The request's own Host always wins: the browser Origin equals the
+// URL the user visited, which is also the domain the host-only access_token
+// cookie is scoped to.
 func originMatches(c *gin.Context, origin string) bool {
 	candidate, err := url.Parse(origin)
 	if err != nil || candidate.Host == "" {
 		return false
 	}
-	for _, allowed := range siteAllowedOrigins(c) {
-		parsed, err := url.Parse(allowed)
-		if err != nil || parsed.Host == "" {
-			continue
-		}
-		if sameOrigin(candidate, parsed) {
-			return true
-		}
-	}
-	return false
+	return sameOrigin(candidate, siteOrigin(c))
 }
 
-// siteAllowedOrigins returns the origins this deployment accepts for
-// cookie-authenticated writes. The request's own Host always wins: the browser
-// Origin equals the URL the user visited, which is also the domain the
-// host-only access_token cookie is scoped to. X-Forwarded-Proto is honored
-// (first hop) so TLS-terminating reverse proxies (the supported deployment)
-// produce https origins; widening the allowed set by scheme is safe because an
-// attacker still cannot make its own Origin equal the victim host. Extra
-// origins (e.g. an alternate front-end domain that must share the cookie
-// session) are configured via `csrf.allowedOrigins` (comma separated).
-func siteAllowedOrigins(c *gin.Context) []string {
+// siteOrigin derives the deployment origin for this request from the request
+// Host and the effective scheme. X-Forwarded-Proto is honored (first hop) so
+// TLS-terminating reverse proxies (the supported deployment) produce https
+// origins; widening by scheme is safe because an attacker still cannot make
+// its own Origin equal the victim host. Invalid X-Forwarded-Proto values are
+// ignored and the connection scheme is kept.
+func siteOrigin(c *gin.Context) *url.URL {
 	scheme := "http"
 	if c.Request.TLS != nil {
 		scheme = "https"
@@ -137,13 +126,7 @@ func siteAllowedOrigins(c *gin.Context) []string {
 			scheme = proto
 		}
 	}
-	allowed := []string{scheme + "://" + c.Request.Host}
-	for _, raw := range strings.Split(preferences.GetString("csrf.allowedOrigins", ""), ",") {
-		if origin := strings.TrimSpace(raw); origin != "" {
-			allowed = append(allowed, origin)
-		}
-	}
-	return allowed
+	return &url.URL{Scheme: scheme, Host: c.Request.Host}
 }
 
 // sameOrigin compares scheme, hostname, and effective port (default ports are

--- a/apps/gooseforum/app/http/middleware/csrfProtection_test.go
+++ b/apps/gooseforum/app/http/middleware/csrfProtection_test.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/preferences"
 	"github.com/gin-gonic/gin"
 )
 
 // csrfTestRouter builds a gin engine with CSRFProtection mounted in front of a
-// POST handler, mirroring the production write-group order (auth first, CSRF
-// after). The handler records that it ran.
+// POST handler, mirroring the production write-group order (CSRF runs before
+// the authentication middleware). The handler records that it ran.
 func csrfTestRouter() (*gin.Engine, *bool) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
@@ -152,67 +151,48 @@ func TestCSRFProtectionMalformedOriginRejected(t *testing.T) {
 	assertCsrfRejected(t, performCsrf(router, request), reached)
 }
 
-func TestCSRFProtectionConfiguredExtraOriginAllowed(t *testing.T) {
-	previous := preferences.GetString("csrf.allowedOrigins", "")
-	preferences.Set("csrf.allowedOrigins", "https://front.example.test")
-	t.Cleanup(func() { preferences.Set("csrf.allowedOrigins", previous) })
-
+func TestCSRFProtectionNullOriginRejected(t *testing.T) {
 	router, reached := csrfTestRouter()
-	request := csrfRequest(t, "session-token", "", "https://front.example.test", "")
-	request.Header.Set("X-Forwarded-Proto", "https")
-	assertCsrfAllowed(t, performCsrf(router, request), reached)
-}
-
-func TestCSRFProtectionConfiguredExtraOriginDoesNotWidenHostCheck(t *testing.T) {
-	previous := preferences.GetString("csrf.allowedOrigins", "")
-	preferences.Set("csrf.allowedOrigins", "https://front.example.test")
-	t.Cleanup(func() { preferences.Set("csrf.allowedOrigins", previous) })
-
-	router, reached := csrfTestRouter()
-	// The extra origin must not make the attacker's own origin acceptable.
-	request := csrfRequest(t, "session-token", "", "http://evil.example.test", "")
+	// Sandboxed iframes (srcdoc/data/blob) and some redirect flows send
+	// `Origin: null`; it never matches a real site origin, so it must be
+	// rejected fail-closed.
+	request := csrfRequest(t, "session-token", "", "null", "")
 	assertCsrfRejected(t, performCsrf(router, request), reached)
 }
 
-func TestCSRFProtectionBearerExemptEvenWithCookieAndForeignOrigin(t *testing.T) {
+func TestCSRFProtectionMalformedRefererRejected(t *testing.T) {
 	router, reached := csrfTestRouter()
-	request := csrfRequest(t, "session-token", "Bearer api-client-token", "http://evil.example.test", "")
-	assertCsrfAllowed(t, performCsrf(router, request), reached)
-}
-
-func TestCSRFProtectionNoCookieAnonymousPostAllowed(t *testing.T) {
-	router, reached := csrfTestRouter()
-	request := csrfRequest(t, "", "", "", "")
-	assertCsrfAllowed(t, performCsrf(router, request), reached)
-}
-
-func TestCSRFProtectionGetExemptFromOriginCheck(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	router.GET("/read", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusOK) })
-
-	request := httptest.NewRequest(http.MethodGet, "http://forum.example.test/read", nil)
-	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
-	request.Header.Set("Origin", "http://evil.example.test")
-	recorder := performCsrf(router, request)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("GET status = %d, want 200", recorder.Code)
+	// Malformed/unparseable Referer values (broken IPv6 bracket, host-less
+	// scheme) must not accidentally pass the fallback check.
+	for _, referer := range []string{"http://[::1", "http://", "not a url"} {
+		request := csrfRequest(t, "session-token", "", "", referer)
+		assertCsrfRejected(t, performCsrf(router, request), reached)
 	}
 }
 
-func TestCSRFProtectionOptionsExemptFromOriginCheck(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	router.OPTIONS("/write", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusNoContent) })
+func TestCSRFProtectionInvalidForwardedProtoIgnored(t *testing.T) {
+	// An invalid X-Forwarded-Proto value is ignored: the connection scheme is
+	// kept, so the plain-http site origin still matches and the request is
+	// not spuriously rejected.
+	router, reached := csrfTestRouter()
+	request := csrfRequest(t, "session-token", "", "http://forum.example.test", "")
+	request.Header.Set("X-Forwarded-Proto", "ftp")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
 
-	request := httptest.NewRequest(http.MethodOptions, "http://forum.example.test/write", nil)
-	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
-	request.Header.Set("Origin", "http://evil.example.test")
-	request.Header.Set("Access-Control-Request-Method", "POST")
-	recorder := performCsrf(router, request)
-	if recorder.Code != http.StatusNoContent {
-		t.Fatalf("OPTIONS status = %d, want 204", recorder.Code)
-	}
+	// ...and it must not widen the allowed set either: an https Origin against
+	// a plain-http request with a garbage forwarded-proto stays rejected.
+	*reached = false
+	request = csrfRequest(t, "session-token", "", "https://forum.example.test", "")
+	request.Header.Set("X-Forwarded-Proto", "garbage")
+	assertCsrfRejected(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionForwardedProtoFirstHopWins(t *testing.T) {
+	router, reached := csrfTestRouter()
+	// Multi-hop proxies send a comma list; only the first hop is trusted.
+	request := csrfRequest(t, "session-token", "", "https://forum.example.test", "")
+	request.Header.Set("X-Forwarded-Proto", "https, http")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
 }
 
 func TestCSRFProtectionHeadExemptFromOriginCheck(t *testing.T) {
@@ -229,27 +209,43 @@ func TestCSRFProtectionHeadExemptFromOriginCheck(t *testing.T) {
 	}
 }
 
-func TestCSRFProtectionNullOriginRejected(t *testing.T) {
-	router, reached := csrfTestRouter()
-	// Sandboxed iframes and some redirect chains send the string "null"; it
-	// parses as a path without a host and must fail closed.
-	request := csrfRequest(t, "session-token", "", "null", "")
-	assertCsrfRejected(t, performCsrf(router, request), reached)
+func TestCSRFProtectionGetExemptFromOriginCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/read", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	request := httptest.NewRequest(http.MethodGet, "http://forum.example.test/read", nil)
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
+	request.Header.Set("Origin", "http://evil.example.test")
+	recorder := performCsrf(router, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", recorder.Code)
+	}
 }
 
-func TestCSRFProtectionMalformedRefererRejected(t *testing.T) {
+func TestCSRFProtectionBearerExemptEvenWithCookieAndForeignOrigin(t *testing.T) {
 	router, reached := csrfTestRouter()
-	// A Referer that does not parse to an absolute URL with a host fails
-	// closed instead of falling through to allow.
-	request := csrfRequest(t, "session-token", "", "", "not-a-url")
-	assertCsrfRejected(t, performCsrf(router, request), reached)
+	request := csrfRequest(t, "session-token", "Bearer api-client-token", "http://evil.example.test", "")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
 }
 
-func TestCSRFProtectionInvalidForwardedProtoIgnored(t *testing.T) {
+func TestCSRFProtectionNoCookieAnonymousPostAllowed(t *testing.T) {
 	router, reached := csrfTestRouter()
-	// X-Forwarded-Proto values other than http/https are ignored: the
-	// host-derived scheme stays http, so an https Origin must still fail.
-	request := csrfRequest(t, "session-token", "", "https://forum.example.test", "")
-	request.Header.Set("X-Forwarded-Proto", "gopher")
-	assertCsrfRejected(t, performCsrf(router, request), reached)
+	request := csrfRequest(t, "", "", "", "")
+	assertCsrfAllowed(t, performCsrf(router, request), reached)
+}
+
+func TestCSRFProtectionOptionsExemptFromOriginCheck(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.OPTIONS("/write", CSRFProtection, func(c *gin.Context) { c.Status(http.StatusNoContent) })
+
+	request := httptest.NewRequest(http.MethodOptions, "http://forum.example.test/write", nil)
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-token"})
+	request.Header.Set("Origin", "http://evil.example.test")
+	request.Header.Set("Access-Control-Request-Method", "POST")
+	recorder := performCsrf(router, request)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS status = %d, want 204", recorder.Code)
+	}
 }

--- a/apps/gooseforum/app/http/routes/csrf_order_contract_test.go
+++ b/apps/gooseforum/app/http/routes/csrf_order_contract_test.go
@@ -1,0 +1,211 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	jwtopt "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/jwtopt"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/chat/imConversations"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/chat/imUserChatConfigs"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/chat/messages"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/eventNotification"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/rolePermissionRs"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userSessions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/permission"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/sessionservice"
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// csrfOrderContractRouter assembles the production apiRoute CSRF-first chain
+// (issue #406 follow-up: CSRFProtection runs before JWTAuthCheck in every
+// cookie-write group) on the shared contract test DB, migrating the extra
+// tables the exercised real handlers need.
+func csrfOrderContractRouter(t *testing.T) (*gorm.DB, *gin.Engine) {
+	t.Helper()
+	conn, _ := setupHTTPContractTest(t)
+	if err := conn.AutoMigrate(
+		&eventNotification.Entity{},
+		&imConversations.Entity{},
+		&imUserChatConfigs.Entity{},
+		&messages.Entity{},
+		&rolePermissionRs.Entity{},
+	); err != nil {
+		t.Fatalf("migrate CSRF order contract tables: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	apiRoute(router)
+	return conn, router
+}
+
+// csrfOrderRequest sends a cookie-authenticated request with an optional
+// Origin header against the production assembly.
+func csrfOrderRequest(t *testing.T, router http.Handler, path, body, token, origin string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test"+path, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	request.AddCookie(&http.Cookie{Name: "access_token", Value: token})
+	if origin != "" {
+		request.Header.Set("Origin", origin)
+	}
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+// contractNearExpirySessionToken mints a valid session whose JWT and
+// user_sessions row both expire in ttl. An authenticated request with such a
+// token refreshes it (rotates the cookie via TokenSetting and extends the row
+// via sessionservice.TouchExpiry), which makes the row a detector for
+// authentication side effects on rejected requests.
+func contractNearExpirySessionToken(t *testing.T, user *users.EntityComplete, ttl time.Duration) (token, jti string) {
+	t.Helper()
+	var err error
+	jti, err = jwtopt.GenerateJti()
+	if err != nil {
+		t.Fatalf("generate near-expiry jti: %v", err)
+	}
+	token, err = jwtopt.Std().CreateToken(jwtopt.CustomClaims{
+		UserId:           user.Id,
+		TokenVersion:     user.TokenVersion,
+		Jti:              jti,
+		RegisteredClaims: jwtopt.GetBaseRegisteredClaims(ttl),
+	})
+	if err != nil {
+		t.Fatalf("create near-expiry token: %v", err)
+	}
+	if err := sessionservice.Create(user.Id, jti, "contract-test", "127.0.0.1"); err != nil {
+		t.Fatalf("create session row: %v", err)
+	}
+	if err := userSessions.UpdateExpiresAtByJti(jti, time.Now().Add(ttl)); err != nil {
+		t.Fatalf("align session row expiry: %v", err)
+	}
+	return token, jti
+}
+
+// TestCSRFOrderRejectedCrossSitePostDoesNotRefreshSession is the P2
+// regression: CSRFProtection now runs before JWTAuthCheck, so a cross-site
+// cookie POST carrying a real near-expiry session is rejected 403 without
+// rotating the cookie or extending the user_sessions row — a hostile subdomain
+// can no longer repeatedly trigger rejected requests to prolong the victim's
+// session. The same-origin control shows the refresh side effect does happen
+// when CSRF lets the request through, proving the 403 path is what suppresses
+// it.
+func TestCSRFOrderRejectedCrossSitePostDoesNotRefreshSession(t *testing.T) {
+	conn, router := csrfOrderContractRouter(t)
+	user := createHTTPContractUser(t, conn, contractTestID())
+	token, jti := contractNearExpirySessionToken(t, user, time.Hour)
+
+	before := userSessions.GetByJti(jti)
+	if before == nil {
+		t.Fatal("session row missing before request")
+	}
+	expiryBefore := before.ExpiresAt
+
+	recorder := csrfOrderRequest(t, router, "/api/forum/notification/mark-all-read", `{}`, token, "http://evil.example.test")
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("cross-site status = %d, want 403 (body %s)", recorder.Code, recorder.Body.String())
+	}
+	if envelope := decodeContractEnvelope(t, recorder); envelope.MessageCode != "auth.csrf.rejected" {
+		t.Fatalf("cross-site messageCode = %q, want auth.csrf.rejected", envelope.MessageCode)
+	}
+	if strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token") {
+		t.Fatal("rejected cross-site POST rotated the session cookie")
+	}
+	if recorder.Header().Get("New-Token") != "" {
+		t.Fatal("rejected cross-site POST emitted a refreshed New-Token header")
+	}
+	after := userSessions.GetByJti(jti)
+	if after == nil {
+		t.Fatal("session row disappeared after rejected request")
+	}
+	if delta := after.ExpiresAt.Sub(expiryBefore); delta > time.Minute || delta < -time.Minute {
+		t.Fatalf("session row expiry moved from %v to %v on a rejected request", expiryBefore, after.ExpiresAt)
+	}
+
+	// Control: the same near-expiry session on a same-origin POST does rotate
+	// the cookie and extend the row, so the assertions above are meaningful.
+	control := csrfOrderRequest(t, router, "/api/forum/notification/mark-all-read", `{}`, token, "http://forum.example.test")
+	if control.Code != http.StatusOK {
+		t.Fatalf("same-origin status = %d, want 200 (body %s)", control.Code, control.Body.String())
+	}
+	if !strings.Contains(control.Header().Get("Set-Cookie"), "access_token") {
+		t.Fatal("same-origin near-expiry POST should rotate the session cookie")
+	}
+	refreshed := userSessions.GetByJti(jti)
+	if refreshed == nil {
+		t.Fatal("session row missing after same-origin request")
+	}
+	if !refreshed.ExpiresAt.After(time.Now().Add(6 * time.Hour)) {
+		t.Fatalf("same-origin request did not extend the session row (expiry %v)", refreshed.ExpiresAt)
+	}
+}
+
+// TestCSRFOrderSameOriginCookiePostsReachBusiness proves chain completeness on
+// the production assembly for every auth-first write group: with a real
+// session and a same-origin Origin, the request passes CSRFProtection and
+// JWTAuthCheck and executes the real controller (oierxjn should#1).
+func TestCSRFOrderSameOriginCookiePostsReachBusiness(t *testing.T) {
+	conn, router := csrfOrderContractRouter(t)
+
+	t.Run("loginApi revoke-all succeeds", func(t *testing.T) {
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		recorder := csrfOrderRequest(t, router, "/api/user/sessions/revoke-all", `{}`, token, "http://forum.example.test")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+		}
+		envelope := decodeContractEnvelope(t, recorder)
+		if envelope.Code != 0 || envelope.MessageCode != "session.revokeAll.success" {
+			t.Fatalf("envelope = %+v, want code 0 session.revokeAll.success", envelope)
+		}
+	})
+
+	t.Run("forumLoginApi mark-all-read succeeds", func(t *testing.T) {
+		user := createHTTPContractUser(t, conn, contractTestID())
+		token := contractSessionToken(t, user)
+		recorder := csrfOrderRequest(t, router, "/api/forum/notification/mark-all-read", `{}`, token, "http://forum.example.test")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+		}
+		envelope := decodeContractEnvelope(t, recorder)
+		if envelope.Code != 0 || envelope.MessageCode != "notification.markAllRead.success" {
+			t.Fatalf("envelope = %+v, want code 0 notification.markAllRead.success", envelope)
+		}
+	})
+
+	t.Run("chatApi messages read succeeds", func(t *testing.T) {
+		user := createHTTPContractUser(t, conn, contractTestID())
+		peer := createHTTPContractUser(t, conn, contractTestID())
+		convID := contractTestID()
+		createContractConversation(t, conn, convID, user.Id, peer.Id)
+		token := contractSessionToken(t, user)
+		recorder := csrfOrderRequest(t, router, "/api/forum/chat/messages",
+			fmt.Sprintf(`{"convId":%d}`, convID), token, "http://forum.example.test")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+		}
+		if envelope := decodeContractEnvelope(t, recorder); envelope.Code != 0 {
+			t.Fatalf("envelope code = %d, want 0 (messageCode %q)", envelope.Code, envelope.MessageCode)
+		}
+	})
+
+	t.Run("adminApi traffic-overview succeeds", func(t *testing.T) {
+		user := createHTTPContractUser(t, conn, contractTestID())
+		grantContractPermission(t, conn, user.Id, permission.Admin)
+		token := contractSessionToken(t, user)
+		recorder := csrfOrderRequest(t, router, "/api/admin/traffic-overview", `{}`, token, "http://forum.example.test")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 (body %s)", recorder.Code, recorder.Body.String())
+		}
+		if envelope := decodeContractEnvelope(t, recorder); envelope.Code != 0 {
+			t.Fatalf("envelope code = %d, want 0 (messageCode %q)", envelope.Code, envelope.MessageCode)
+		}
+	})
+}

--- a/apps/gooseforum/app/http/routes/csrf_route_protection_test.go
+++ b/apps/gooseforum/app/http/routes/csrf_route_protection_test.go
@@ -17,10 +17,17 @@ import (
 
 // Route-level CSRF matrix (issue #406). Unlike the middleware unit tests in
 // app/http/middleware, these exercise the production route assembly
-// (apiRoute): CSRFProtection is mounted exactly where production mounts it
-// (logout before the handler; login/forum/admin groups after JWTAuthCheck).
+// (apiRoute + fileServer): CSRFProtection is mounted before the stateful
+// authentication middleware (JWTAuthCheck) in every cookie-write group
+// (logout; login/forum/chat/admin/file), so a cross-site cookie POST is
+// rejected 403 without ever reaching JWTAuthCheck — no JWT refresh, no
+// user_sessions extension, no activity event (Codex review P2). Requests
+// without a session cookie pass through CSRF untouched and keep their
+// anonymous semantics (JWTAuthCheck still answers 401).
+//
 // The logout matrix below needs no database (an invalid session JWT never
-// reaches one); the chain-attachment and real-session tests bootstrap the
+// reaches one); the real-session chain-attachment tests in this file and the
+// DB-backed no-refresh proofs in csrf_order_contract_test.go bootstrap the
 // minimal table set (users, user statistics, user sessions) so JWTAuthCheck
 // can validate a minted session.
 
@@ -44,12 +51,13 @@ func csrfRouteRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	apiRoute(router)
+	fileServer(router)
 	return router
 }
 
-func csrfRoutePost(t *testing.T, router http.Handler, cookie, authorization, origin, referer string) *httptest.ResponseRecorder {
+func csrfRoutePost(t *testing.T, router http.Handler, path, cookie, authorization, origin, referer string) *httptest.ResponseRecorder {
 	t.Helper()
-	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test/api/logout", strings.NewReader(`{}`))
+	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test"+path, strings.NewReader(`{}`))
 	request.Header.Set("Content-Type", "application/json")
 	if cookie != "" {
 		request.AddCookie(&http.Cookie{Name: "access_token", Value: cookie})
@@ -83,8 +91,31 @@ func assertCsrfRouteRejected(t *testing.T, recorder *httptest.ResponseRecorder) 
 	if envelope.MessageCode != "auth.csrf.rejected" {
 		t.Fatalf("messageCode = %q, want auth.csrf.rejected", envelope.MessageCode)
 	}
+	// A rejection must never carry a session cookie: CSRF runs before
+	// JWTAuthCheck, so the near-expiry JWT is not rotated on rejected
+	// cross-site requests (Codex review P2).
 	if strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token") {
-		t.Fatal("rejected request must not clear or set the session cookie")
+		t.Fatal("rejected request must not set or refresh the session cookie")
+	}
+	if recorder.Header().Get("New-Token") != "" {
+		t.Fatal("rejected request must not emit a refreshed New-Token header")
+	}
+}
+
+func assertCsrfRouteUnauthenticated(t *testing.T, recorder *httptest.ResponseRecorder) {
+	t.Helper()
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 (body %s)", recorder.Code, recorder.Body.String())
+	}
+	var envelope struct {
+		Code        int    `json:"code"`
+		MessageCode string `json:"messageCode"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode 401 body %q: %v", recorder.Body.String(), err)
+	}
+	if envelope.MessageCode != "auth.required" {
+		t.Fatalf("messageCode = %q, want auth.required", envelope.MessageCode)
 	}
 }
 
@@ -95,21 +126,106 @@ func assertCsrfRouteAllowed(t *testing.T, recorder *httptest.ResponseRecorder) {
 	}
 }
 
+// csrfCookieWriteGroupRoutes are representative POST routes of the four
+// authentication-first write groups in route4api.go. After the #406 follow-up
+// every group mounts CSRFProtection before JWTAuthCheck.
+var csrfCookieWriteGroupRoutes = []struct {
+	name string
+	path string
+}{
+	{"loginApi", "/api/user/sessions/revoke-all"},
+	{"forumLoginApi", "/api/forum/notification/mark-all-read"},
+	{"chatApi", "/api/forum/chat/messages"},
+	{"adminApi", "/api/admin/traffic-overview"},
+}
+
+// TestCSRFCookieWriteGroupsRejectCrossSiteBeforeAuthentication proves the
+// CSRF gate runs before JWTAuthCheck in every auth-first write group: a
+// cookie POST from a foreign Origin is rejected 403 auth.csrf.rejected even
+// though the cookie holds an invalid JWT — had JWTAuthCheck run first it
+// would have answered 401 and the test would fail here.
+func TestCSRFCookieWriteGroupsRejectCrossSiteBeforeAuthentication(t *testing.T) {
+	router := csrfRouteRouter()
+	for _, group := range csrfCookieWriteGroupRoutes {
+		t.Run(group.name, func(t *testing.T) {
+			recorder := csrfRoutePost(t, router, group.path, "bogus-session-jwt", "", "http://evil.example.test", "")
+			assertCsrfRouteRejected(t, recorder)
+		})
+	}
+}
+
+// TestCSRFCookieWriteGroupsAnonymousPostStaysUnauthenticated pins the
+// anonymous regression after the CSRF-first reorder: a POST without a
+// session cookie passes the CSRF gate and JWTAuthCheck still answers 401.
+func TestCSRFCookieWriteGroupsAnonymousPostStaysUnauthenticated(t *testing.T) {
+	router := csrfRouteRouter()
+	for _, group := range csrfCookieWriteGroupRoutes {
+		t.Run(group.name, func(t *testing.T) {
+			recorder := csrfRoutePost(t, router, group.path, "", "", "", "")
+			assertCsrfRouteUnauthenticated(t, recorder)
+		})
+	}
+}
+
+// TestCSRFCookieWriteGroupsSameOriginReachesAuthentication ensures the CSRF
+// gate does not over-block: a same-origin cookie POST passes through to
+// JWTAuthCheck, which rejects the bogus JWT with 401 (not 403).
+func TestCSRFCookieWriteGroupsSameOriginReachesAuthentication(t *testing.T) {
+	router := csrfRouteRouter()
+	for _, group := range csrfCookieWriteGroupRoutes {
+		t.Run(group.name, func(t *testing.T) {
+			recorder := csrfRoutePost(t, router, group.path, "bogus-session-jwt", "", "http://forum.example.test", "")
+			assertCsrfRouteUnauthenticated(t, recorder)
+		})
+	}
+}
+
+// TestCSRFFileGroupRejectsCrossSiteBeforeAuthentication proves the file
+// group's CSRF-first mount behaviorally: a foreign-Origin cookie POST to
+// /file/img-upload is rejected 403 by CSRF, not 401 by the invalid-JWT auth
+// check (oierxjn should#1).
+func TestCSRFFileGroupRejectsCrossSiteBeforeAuthentication(t *testing.T) {
+	router := csrfRouteRouter()
+	recorder := csrfRoutePost(t, router, "/file/img-upload", "bogus-session-jwt", "", "http://evil.example.test", "")
+	assertCsrfRouteRejected(t, recorder)
+}
+
+func TestCSRFFileGroupSameOriginReachesAuthentication(t *testing.T) {
+	router := csrfRouteRouter()
+	recorder := csrfRoutePost(t, router, "/file/img-upload", "bogus-session-jwt", "", "http://forum.example.test", "")
+	assertCsrfRouteUnauthenticated(t, recorder)
+}
+
+func TestCSRFFileGroupAnonymousPostStaysUnauthenticated(t *testing.T) {
+	router := csrfRouteRouter()
+	recorder := csrfRoutePost(t, router, "/file/img-upload", "", "", "", "")
+	assertCsrfRouteUnauthenticated(t, recorder)
+}
+
+// TestCSRFProtectedForumWriteRouteRejectsCookiePostWithoutOrigin pins the
+// fail-closed branch on the real /api/forum chain: a cookie POST without
+// Origin or Referer is rejected 403 before authentication runs.
+func TestCSRFProtectedForumWriteRouteRejectsCookiePostWithoutOrigin(t *testing.T) {
+	router := csrfRouteRouter()
+	recorder := csrfRoutePost(t, router, "/api/forum/topics/write", "bogus-session-jwt", "", "", "")
+	assertCsrfRouteRejected(t, recorder)
+}
+
 func TestCSRFLogoutRejectsCookiePostWithoutOrigin(t *testing.T) {
 	router := csrfRouteRouter()
-	assertCsrfRouteRejected(t, csrfRoutePost(t, router, "session-jwt", "", "", ""))
+	assertCsrfRouteRejected(t, csrfRoutePost(t, router, "/api/logout", "session-jwt", "", "", ""))
 }
 
 func TestCSRFLogoutRejectsCrossSiteOrigin(t *testing.T) {
 	router := csrfRouteRouter()
-	assertCsrfRouteRejected(t, csrfRoutePost(t, router, "session-jwt", "", "http://evil.example.test", ""))
+	assertCsrfRouteRejected(t, csrfRoutePost(t, router, "/api/logout", "session-jwt", "", "http://evil.example.test", ""))
 }
 
 func TestCSRFLogoutAllowsSameOriginCookiePost(t *testing.T) {
 	router := csrfRouteRouter()
 	// Invalid JWT in the cookie: the CSRF gate passes (same origin), then
 	// logout clears the cookie and stays idempotent.
-	recorder := csrfRoutePost(t, router, "not-a-jwt", "", "http://forum.example.test", "")
+	recorder := csrfRoutePost(t, router, "/api/logout", "not-a-jwt", "", "http://forum.example.test", "")
 	assertCsrfRouteAllowed(t, recorder)
 	if !strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token") {
 		t.Fatal("same-origin logout should still clear the access_token cookie")
@@ -118,7 +234,7 @@ func TestCSRFLogoutAllowsSameOriginCookiePost(t *testing.T) {
 
 func TestCSRFLogoutAllowsRefererFallbackForCookiePost(t *testing.T) {
 	router := csrfRouteRouter()
-	recorder := csrfRoutePost(t, router, "not-a-jwt", "", "", "http://forum.example.test/p/1")
+	recorder := csrfRoutePost(t, router, "/api/logout", "not-a-jwt", "", "", "http://forum.example.test/p/1")
 	assertCsrfRouteAllowed(t, recorder)
 }
 
@@ -126,7 +242,7 @@ func TestCSRFLogoutAllowsApiClientWithAuthorizationEvenWithForeignOrigin(t *test
 	router := csrfRouteRouter()
 	// Bearer API clients are exempt from the origin check even when a cookie
 	// is also present and the Origin is foreign.
-	recorder := csrfRoutePost(t, router, "session-jwt", "Bearer api-token", "http://evil.example.test", "")
+	recorder := csrfRoutePost(t, router, "/api/logout", "session-jwt", "Bearer api-token", "http://evil.example.test", "")
 	assertCsrfRouteAllowed(t, recorder)
 }
 
@@ -134,37 +250,16 @@ func TestCSRFLogoutAllowsAnonymousPostWithoutOrigin(t *testing.T) {
 	router := csrfRouteRouter()
 	// No access_token cookie -> nothing cookie-authenticated to protect;
 	// anonymous logout stays an idempotent success.
-	recorder := csrfRoutePost(t, router, "", "", "", "")
+	recorder := csrfRoutePost(t, router, "/api/logout", "", "", "", "")
 	assertCsrfRouteAllowed(t, recorder)
-}
-
-// TestCSRFProtectedForumWriteRoute rejects cookie POSTs without Origin on the
-// real /api/forum write chain (JWTAuthCheck + CSRFProtection + handler).
-func TestCSRFProtectedForumWriteRoute(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	// Reuse the full apiRoute assembly; only the middleware ordering matters
-	// here and the request is rejected before any DB access.
-	apiRoute(router)
-
-	request := httptest.NewRequest(http.MethodPost, "http://forum.example.test/api/forum/topics/write", strings.NewReader(`{}`))
-	request.Header.Set("Content-Type", "application/json")
-	request.AddCookie(&http.Cookie{Name: "access_token", Value: "session-jwt"})
-	recorder := httptest.NewRecorder()
-	router.ServeHTTP(recorder, request)
-
-	// JWTAuthCheck runs first and fails on the bogus JWT before CSRF runs, so
-	// an unauthenticated write stays a 401 (anonymous semantics preserved).
-	if recorder.Code != http.StatusUnauthorized {
-		t.Fatalf("status = %d, want 401 (body %s)", recorder.Code, recorder.Body.String())
-	}
 }
 
 // TestCSRFProtectedWriteRoutesRegistered pins the registered paths of the
 // cookie-authenticated write surface (a registration smoke test only:
 // router.Routes() exposes method+path+final handler, not the middleware
-// chain). TestCSRFGroupChainsRejectCrossSiteSessionWrites below is what
-// proves the middleware is attached.
+// chain). The behavioral chain-order coverage lives in
+// TestCSRFGroupChainsRejectCrossSiteSessionWrites, the rejection/401 matrix
+// above, and csrf_order_contract_test.go (oierxjn should#1).
 func TestCSRFProtectedWriteRoutesRegistered(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -168,11 +168,14 @@ func apiRoute(ginApp *gin.Engine) {
 	baseApi.POST("auth/totp/verify", middleware.TOTPChallengeAuth, api.TotpVerify)
 	baseApi.POST("auth/oidc/exchange", middleware.RateLimit(middleware.RateLimitLogin), api.OidcExchange)
 
-	// CSRF 防护（issue #406）：挂在认证之后的写组中间件，仅校验「Cookie 可认证 +
-	// 状态变更方法」请求（Bearer 客户端豁免），详见 middleware/csrfProtection.go
-	// 与 docs/product/identity-and-access.md「认证与 CSRF 边界」。不挂全局，避免与
-	// #407 全局安全头中间件冲突；GET/HEAD/OPTIONS 与匿名请求原样放行。
-	loginApi := ginApp.Group("api").Use(middleware.JWTAuthCheck, middleware.CSRFProtection)
+	// CSRF 防护（issue #406）：挂在认证之前的写组中间件（fileServer 组与
+	// logout 路由同样 CSRF 前置），先于 JWTAuthCheck 拦截跨站 Cookie 写请求，
+	// 避免被拒请求触发 JWT 续期 / 会话延长 / 活跃度事件（Codex review P2）。
+	// 仅校验「Cookie 可认证 + 状态变更方法」请求（Bearer 客户端豁免），详见
+	// middleware/csrfProtection.go 与 docs/product/identity-and-access.md
+	// 「认证与 CSRF 边界」。不挂全局，避免与 #407 全局安全头中间件冲突；
+	// GET/HEAD/OPTIONS 与匿名请求原样放行（匿名 POST 仍由 JWTAuthCheck 回 401）。
+	loginApi := ginApp.Group("api").Use(middleware.CSRFProtection, middleware.JWTAuthCheck)
 	loginApi.POST("set-user-info", middleware.CheckWritableAccount, UpButterReq(api.EditUserInfo))
 	loginApi.POST("set-user-profile-cover", middleware.CheckWritableAccount, UpButterReq(api.EditUserProfileCover))
 	loginApi.POST("set-user-email", middleware.CheckWritableAccountAllowPendingActivation, middleware.RateLimit(middleware.RateLimitEmailChange), UpButterReq(api.EditUserEmail))
@@ -245,7 +248,7 @@ func apiRoute(ginApp *gin.Engine) {
 	// 不要求登录；待审版本正文在控制器内对非版主屏蔽。
 	forumApi.GET("posts/revisions", middleware.JWTAuth, middleware.NoUpdateUserActivity, UpQueryReq(forum.PostRevisions))
 
-	forumLoginApi := forumApi.Use(middleware.JWTAuthCheck, middleware.CSRFProtection)
+	forumLoginApi := forumApi.Use(middleware.CSRFProtection, middleware.JWTAuthCheck)
 	forumLoginApi.GET("unread-status", middleware.NoUpdateUserActivity, UpButterReq(api.GetUnreadStatus))
 	forumLoginApi.GET("notifications", middleware.NoUpdateUserActivity, UpQueryReq(api.NotificationList))
 	forumLoginApi.POST("notification/mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkAsRead))
@@ -312,7 +315,7 @@ func apiRoute(ginApp *gin.Engine) {
 	forumLoginApi.POST("moderation/logs", middleware.NoUpdateUserActivity, UpButterReq(forum.ModerationLogList))
 	forumLoginApi.POST("moderation/view-deleted-content", middleware.CheckWritableAccount, UpButterReq(forum.ViewDeletedContent))
 
-	chatApi := forumApi.Group("chat", middleware.JWTAuthCheck, middleware.CSRFProtection)
+	chatApi := forumApi.Group("chat", middleware.CSRFProtection, middleware.JWTAuthCheck)
 
 	// Agent public API: opaque bearer-token authentication only. Writes reuse
 	// the human topic/post rate limits keyed by IP and bot userId.
@@ -327,7 +330,7 @@ func apiRoute(ginApp *gin.Engine) {
 	chatApi.POST("messages", UpButterReq(api.GetMessages))
 	chatApi.POST("mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkChatRead))
 
-	adminApi := baseApi.Group("admin", middleware.JWTAuthCheck, middleware.CheckWritableAccount, middleware.CSRFProtection)
+	adminApi := baseApi.Group("admin", middleware.CSRFProtection, middleware.JWTAuthCheck, middleware.CheckWritableAccount)
 
 	adminApi.POST("traffic-overview", middleware.CheckPermission(permission.Admin), UpButterReq(api.GetTrafficOverview))
 

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -10442,6 +10442,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description TOTP setup rate limit exceeded. */
             429: {
                 headers: {
@@ -10485,6 +10494,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description TOTP enable rate limit exceeded. */
             429: {
                 headers: {
@@ -10521,6 +10539,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10754,7 +10781,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10806,7 +10833,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10858,7 +10885,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10910,7 +10937,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10962,7 +10989,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11014,7 +11041,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11066,7 +11093,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11118,7 +11145,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11170,7 +11197,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11291,7 +11318,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11343,7 +11370,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11395,7 +11422,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11447,7 +11474,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11499,7 +11526,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11541,7 +11568,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11583,6 +11610,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     moderationUpdateReportStatus: {
@@ -11616,7 +11652,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11658,6 +11694,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     viewDeletedContent: {
@@ -11691,7 +11736,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11788,7 +11833,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11830,7 +11875,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11872,7 +11917,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11920,7 +11965,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11962,7 +12007,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12004,7 +12049,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12046,7 +12091,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12088,7 +12133,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account (standard middleware params action=写入, actionCode=write) or unverified email under mandatory verification (`permission.emailRequired`). */
+            /** @description Frozen account (standard middleware params action=写入, actionCode=write) or unverified email under mandatory verification (`permission.emailRequired`). A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12140,7 +12185,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12220,7 +12265,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12333,7 +12378,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12371,7 +12416,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12413,7 +12458,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12465,6 +12510,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     markChatRead: {
@@ -12498,7 +12552,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12680,7 +12734,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12732,7 +12786,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12784,7 +12838,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12836,7 +12890,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12888,7 +12942,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -12940,7 +12994,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -13310,6 +13364,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Course does not exist or is hidden. */
             404: {
                 headers: {
@@ -13611,7 +13674,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -13679,7 +13742,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The caller is not the review author, or the account is frozen. */
+            /** @description The caller is not the review author, or the account is frozen. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -13756,7 +13819,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The caller is not the review author, or the account is frozen. */
+            /** @description The caller is not the review author, or the account is frozen. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -13815,6 +13878,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description The review does not exist, is hidden, or is deleted. */
             404: {
                 headers: {
@@ -13858,6 +13930,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -13915,6 +13996,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description The review does not exist, is hidden, or is deleted. */
             404: {
                 headers: {
@@ -13958,6 +14048,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -14019,6 +14118,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Report rate limit exceeded. */
             429: {
                 headers: {
@@ -14062,7 +14170,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The caller is not a CourseManager. */
+            /** @description The caller is not a CourseManager. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14114,7 +14222,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The caller is not a CourseManager. */
+            /** @description The caller is not a CourseManager. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14159,6 +14267,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -14296,7 +14413,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14338,7 +14455,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14380,7 +14497,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14422,7 +14539,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14464,7 +14581,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14506,7 +14623,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14548,7 +14665,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14590,7 +14707,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14628,7 +14745,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14670,7 +14787,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14712,7 +14829,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14754,7 +14871,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14796,7 +14913,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14838,7 +14955,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14880,7 +14997,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the Admin permission. */
+            /** @description Frozen account, or caller lacks the Admin permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14922,7 +15039,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the UserManager permission. */
+            /** @description Frozen account, or caller lacks the UserManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -14964,7 +15081,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the UserManager permission. */
+            /** @description Frozen account, or caller lacks the UserManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15006,7 +15123,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the UserManager permission. */
+            /** @description Frozen account, or caller lacks the UserManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15048,7 +15165,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the UserManager permission. */
+            /** @description Frozen account, or caller lacks the UserManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15124,7 +15241,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the RoleManager permission. */
+            /** @description Frozen account, or caller lacks the RoleManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15162,7 +15279,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the RoleManager permission. */
+            /** @description Frozen account, or caller lacks the RoleManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15204,7 +15321,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the RoleManager permission. */
+            /** @description Frozen account, or caller lacks the RoleManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15246,7 +15363,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the RoleManager permission. */
+            /** @description Frozen account, or caller lacks the RoleManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15288,7 +15405,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15330,7 +15447,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15372,7 +15489,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15410,7 +15527,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15452,7 +15569,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15494,7 +15611,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15536,7 +15653,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15578,7 +15695,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the TopicsManager permission. */
+            /** @description Frozen account, or caller lacks the TopicsManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15658,7 +15775,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the PageManager permission. */
+            /** @description Frozen account, or caller lacks the PageManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15738,7 +15855,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the PageManager permission. */
+            /** @description Frozen account, or caller lacks the PageManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15818,7 +15935,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the PageManager permission. */
+            /** @description Frozen account, or caller lacks the PageManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -15936,7 +16053,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16016,7 +16133,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16096,7 +16213,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16134,7 +16251,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16214,7 +16331,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16294,7 +16411,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16374,7 +16491,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16454,7 +16571,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16534,7 +16651,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16614,7 +16731,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16656,7 +16773,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16736,7 +16853,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16816,7 +16933,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16896,7 +17013,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -16938,7 +17055,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17018,7 +17135,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17060,7 +17177,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17102,7 +17219,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17220,7 +17337,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17300,7 +17417,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17380,7 +17497,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17422,7 +17539,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17464,7 +17581,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17506,7 +17623,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17548,7 +17665,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17605,7 +17722,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17647,7 +17764,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17800,7 +17917,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -17887,7 +18004,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -18124,7 +18241,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The account is not a PageManager or Admin (or it is frozen). */
+            /** @description The account is not a PageManager or Admin (or it is frozen). A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -18273,7 +18390,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The account is not a PageManager or Admin (or it is frozen). */
+            /** @description The account is not a PageManager or Admin (or it is frozen). A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -18372,7 +18489,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description The account is not a PageManager or Admin (or it is frozen). */
+            /** @description The account is not a PageManager or Admin (or it is frozen). A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -18414,7 +18531,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the SiteManager permission. */
+            /** @description Frozen account, or caller lacks the SiteManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -19083,6 +19200,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     adminCourseCreate: {
@@ -19109,6 +19235,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19151,6 +19286,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19209,6 +19353,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Course does not exist or was deleted. */
             404: {
                 headers: {
@@ -19251,6 +19404,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     adminReviewUpdate: {
@@ -19277,6 +19439,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19326,6 +19497,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Review does not exist or is deleted. */
             404: {
                 headers: {
@@ -19357,6 +19537,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19397,6 +19586,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     adminCourseRelationApprove: {
@@ -19423,6 +19621,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19481,6 +19688,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Candidate does not exist. */
             404: {
                 headers: {
@@ -19523,7 +19739,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Frozen account, or caller lacks the CourseManager permission. */
+            /** @description Frozen account, or caller lacks the CourseManager permission. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -19583,6 +19799,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description From or to course does not exist. */
             404: {
                 headers: {
@@ -19618,6 +19843,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -19676,6 +19910,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
             /** @description Candidate does not exist. */
             404: {
                 headers: {
@@ -19727,7 +19970,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -19779,7 +20022,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -19831,7 +20074,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Authenticated account is frozen or its account information cannot be resolved. */
+            /** @description Authenticated account is frozen or its account information cannot be resolved. A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie is not cleared (issue #406). */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -58,8 +58,10 @@ export interface paths {
          * @description Session is optional. When the request carries a valid session token (cookie or Bearer), the
          *     server revokes that session record, so the token immediately stops authenticating. An absent,
          *     unverifiable, or already-revoked token is treated as already logged out, which makes this
-         *     operation idempotent. The `access_token` cookie is cleared on every path, including the rare
-         *     `session.revoke.failed` business failure (HTTP 200 with `code: 1`).
+         *     operation idempotent. The `access_token` cookie is cleared whenever the logout handler runs,
+         *     including the rare `session.revoke.failed` business failure (HTTP 200 with `code: 1`). A
+         *     cross-site cookie POST (missing or mismatched Origin/Referer) is rejected by the CSRF gate
+         *     before the handler with HTTP 403 `auth.csrf.rejected` and the cookie is left untouched.
          */
         post: operations["logout"];
         delete?: never;
@@ -10209,12 +10211,21 @@ export interface operations {
             /** @description Logout completed (or the caller was already logged out), or a revocation failure. */
             200: {
                 headers: {
-                    /** @description Expires the HTTP-only `access_token` session cookie on every logout response. */
+                    /** @description Expires the HTTP-only `access_token` session cookie whenever the logout handler runs. */
                     "Set-Cookie"?: string;
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": components["schemas"]["LogoutResponse"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated POST rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared on this path. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
                 };
             };
         };
@@ -10663,6 +10674,15 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
+            /** @description Cross-site cookie-authenticated POST rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
         };
     };
     revokeAllSessions: {
@@ -10685,6 +10705,15 @@ export interface operations {
             };
             /** @description Missing, invalid, expired, or revoked access token. */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Cross-site cookie-authenticated POST rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/deploy/config.toml.example
+++ b/deploy/config.toml.example
@@ -19,12 +19,6 @@ gzip = true
 # 仅信任本机回源即可正确解析 X-Forwarded-For(限流按真实客户端 IP 归并)
 trusted_proxies = ["127.0.0.1", "::1"]
 
-[csrf]
-# Cookie 认证写接口的跨站请求防护（issue #406）额外允许的来源（逗号分隔，
-# 完整 origin，如 https://forum.example.com）。默认只需请求自身的 Host 同源即可，
-# 仅当存在必须共享会话 Cookie 的独立前端域时才需要配置。
-allowedOrigins = ""
-
 [jwtopt]
 validTime = 604800
 

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -174,24 +174,36 @@ Auth contract for state-changing API requests (issue #406):
   verification, so a cross-site attacker cannot obtain it.
 
 CSRF enforcement (`middleware.CSRFProtection`, mounted per write-route group in `route4api.go`
-after the authentication middleware — never in the global chain):
+before the stateful authentication middleware — never in the global chain):
 
 - Only **state-changing methods (POST/PUT/PATCH/DELETE) that carry the `access_token` cookie**
   are checked; GET/HEAD/OPTIONS and cookie-less requests (anonymous writes, server-to-server)
   pass.
+- The gate runs **before `JWTAuthCheck`** on every cookie-write group (`logout`; the
+  `login`/`forum`/`chat`/`admin`/`file` groups), so a rejected cross-site write never reaches the
+  authentication middleware: it cannot refresh a near-expiry JWT, extend its `user_sessions`
+  row, or publish activity events (issue #406 follow-up). Anonymous writes carry no cookie, pass
+  the gate, and keep their usual semantics (`JWTAuthCheck` still answers 401).
 - A request with an `Authorization` header is always exempt (Bearer clients, even when a cookie
   happens to ride along).
-- The remaining cookie-authenticated writes must present an `Origin` that matches the
-  site-controlled origin set: the request's own `Host`-derived origin (scheme from TLS or the
-  first `X-Forwarded-Proto` hop so TLS-terminating proxies work; default ports normalized), plus
-  any origins listed in the `csrf.allowedOrigins` config (comma separated) for deployments that
-  must accept an alternate front-end origin. The host-derived rule keeps multi-domain, LAN-IP,
+- The remaining cookie-authenticated writes must present an `Origin` that matches the request's
+  `Host`-derived origin (scheme from TLS or the first `X-Forwarded-Proto` hop so TLS-terminating
+  proxies work; default ports normalized). The host-derived rule keeps multi-domain, LAN-IP,
   and `localhost` dev deployments working without enumerating origins, because a browser Origin
-  is always the domain the host-only session cookie is scoped to.
+  is always the domain the host-only session cookie is scoped to. (An earlier `csrf.allowedOrigins`
+  config option for alternate front-end origins was removed: the single-binary deployment has no
+  credentialed CORS, so such origins could not carry the session cookie anyway.)
 - When `Origin` is missing (legacy browsers that omit it on same-origin POSTs), the `Referer`
   origin is checked instead; otherwise the request is rejected with HTTP 403 and message code
   `auth.csrf.rejected`. curl/scripting clients that carry a cookie but no Origin/Referer are
   rejected fail-closed — they should send `Authorization` instead.
+- **Contract note**: the 403 `auth.csrf.rejected` envelope is middleware-owned and applies
+  uniformly to every cookie-authenticated state-changing request. It is not repeated on every
+  covered operation; the session-management operations in `paths/auth-sessions.yaml` (logout,
+  revoke, revoke-all) document it explicitly because their descriptions promise path-specific
+  effects (cookie cleared, session revoked) that the CSRF gate interrupts. Consumers must treat
+  any cookie-authenticated write operation as able to return this 403 and must not clear local
+  credentials or treat the session as revoked on it.
 
 Rationale for Origin checking instead of a double-submit CSRF token: both web frontends run on
 modern browsers that send `Origin` on every state-changing request, and the host-only +

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -200,7 +200,10 @@ before the stateful authentication middleware — never in the global chain):
   (`csrfRejected` example) in its OpenAPI operation contract under `paths/`, with one shared
   response shape: `ApiFailure` envelope, session cookie left untouched. Consumers handle it per
   operation as documented; an operation that declares `accessTokenCookie` in its security but
-  lacks the 403 is a contract omission.
+  lacks the 403 is a contract omission. The sole exception is `verifyTotp`
+  (`paths/auth-security.yaml`): it authenticates a short-lived `totp_challenge` token through
+  `TOTPChallengeAuth`, not the session chain, so the CSRF gate is not mounted and no 403 is
+  declared (see the login-flow rationale above).
 
 Rationale for Origin checking instead of a double-submit CSRF token: both web frontends run on
 modern browsers that send `Origin` on every state-changing request, and the host-only +

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -190,20 +190,17 @@ before the stateful authentication middleware — never in the global chain):
   `Host`-derived origin (scheme from TLS or the first `X-Forwarded-Proto` hop so TLS-terminating
   proxies work; default ports normalized). The host-derived rule keeps multi-domain, LAN-IP,
   and `localhost` dev deployments working without enumerating origins, because a browser Origin
-  is always the domain the host-only session cookie is scoped to. (An earlier `csrf.allowedOrigins`
-  config option for alternate front-end origins was removed: the single-binary deployment has no
-  credentialed CORS, so such origins could not carry the session cookie anyway.)
+  is always the domain the host-only session cookie is scoped to.
 - When `Origin` is missing (legacy browsers that omit it on same-origin POSTs), the `Referer`
   origin is checked instead; otherwise the request is rejected with HTTP 403 and message code
   `auth.csrf.rejected`. curl/scripting clients that carry a cookie but no Origin/Referer are
   rejected fail-closed — they should send `Authorization` instead.
-- **Contract note**: the 403 `auth.csrf.rejected` envelope is middleware-owned and applies
-  uniformly to every cookie-authenticated state-changing request. It is not repeated on every
-  covered operation; the session-management operations in `paths/auth-sessions.yaml` (logout,
-  revoke, revoke-all) document it explicitly because their descriptions promise path-specific
-  effects (cookie cleared, session revoked) that the CSRF gate interrupts. Consumers must treat
-  any cookie-authenticated write operation as able to return this 403 and must not clear local
-  credentials or treat the session as revoked on it.
+- **Contract note**: every cookie-authenticated state-changing operation (including read-only
+  operations implemented with POST) declares the HTTP 403 `auth.csrf.rejected` response
+  (`csrfRejected` example) in its OpenAPI operation contract under `paths/`, with one shared
+  response shape: `ApiFailure` envelope, session cookie left untouched. Consumers handle it per
+  operation as documented; an operation that declares `accessTokenCookie` in its security but
+  lacks the 403 is a contract omission.
 
 Rationale for Origin checking instead of a double-submit CSRF token: both web frontends run on
 modern browsers that send `Origin` on every state-changing request, and the host-only +

--- a/packages/api-contract/fixtures/csrf-rejected.json
+++ b/packages/api-contract/fixtures/csrf-rejected.json
@@ -1,0 +1,5 @@
+{
+  "result": null,
+  "code": 1,
+  "messageCode": "auth.csrf.rejected"
+}

--- a/packages/api-contract/paths/admin-categories.yaml
+++ b/packages/api-contract/paths/admin-categories.yaml
@@ -41,7 +41,11 @@ adminCategoryList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -51,6 +55,8 @@ adminCategoryList:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCategorySave:
   post:
@@ -104,7 +110,11 @@ adminCategorySave:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -114,6 +124,8 @@ adminCategorySave:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCategoryDelete:
   post:
@@ -166,7 +178,11 @@ adminCategoryDelete:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -176,6 +192,8 @@ adminCategoryDelete:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGlobalModeratorList:
   post:
@@ -211,7 +229,11 @@ adminGlobalModeratorList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -221,6 +243,8 @@ adminGlobalModeratorList:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGlobalModeratorAdd:
   post:
@@ -273,7 +297,11 @@ adminGlobalModeratorAdd:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -283,6 +311,8 @@ adminGlobalModeratorAdd:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGlobalModeratorDelete:
   post:
@@ -331,7 +361,11 @@ adminGlobalModeratorDelete:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -341,6 +375,8 @@ adminGlobalModeratorDelete:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCategoryModeratorAdd:
   post:
@@ -399,7 +435,11 @@ adminCategoryModeratorAdd:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -409,6 +449,8 @@ adminCategoryModeratorAdd:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCategoryModeratorDelete:
   post:
@@ -456,7 +498,11 @@ adminCategoryModeratorDelete:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -466,3 +512,5 @@ adminCategoryModeratorDelete:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-content-ops.yaml
+++ b/packages/api-contract/paths/admin-content-ops.yaml
@@ -108,7 +108,11 @@ adminSaveBadge:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -118,6 +122,8 @@ adminSaveBadge:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminDeleteBadge:
   post:
@@ -167,7 +173,11 @@ adminDeleteBadge:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -177,6 +187,8 @@ adminDeleteBadge:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminListReviewQueue:
   post:
@@ -227,7 +239,11 @@ adminListReviewQueue:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -237,6 +253,8 @@ adminListReviewQueue:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminReviewAction:
   post:
@@ -295,7 +313,11 @@ adminReviewAction:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -305,6 +327,8 @@ adminReviewAction:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminListFileResources:
   post:
@@ -349,7 +373,11 @@ adminListFileResources:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -359,3 +387,5 @@ adminListFileResources:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-data.yaml
+++ b/packages/api-contract/paths/admin-data.yaml
@@ -64,7 +64,11 @@ adminUploadImage:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -74,6 +78,8 @@ adminUploadImage:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminListImportTasks:
   get:
@@ -162,7 +168,11 @@ adminReplayImportTask:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -172,6 +182,8 @@ adminReplayImportTask:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCreateExportTask:
   post:
@@ -225,7 +237,11 @@ adminCreateExportTask:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -235,6 +251,8 @@ adminCreateExportTask:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminListExportTasks:
   get:
@@ -432,7 +450,11 @@ adminImportData:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -442,3 +464,5 @@ adminImportData:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-integrations.yaml
+++ b/packages/api-contract/paths/admin-integrations.yaml
@@ -89,7 +89,11 @@ adminSaveMailSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -99,6 +103,8 @@ adminSaveMailSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminTestMailConnection:
   post:
@@ -152,7 +158,11 @@ adminTestMailConnection:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -162,6 +172,8 @@ adminTestMailConnection:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetStorageSettings:
   get:
@@ -262,7 +274,11 @@ adminSaveStorageSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -272,6 +288,8 @@ adminSaveStorageSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminTestStorageConnection:
   post:
@@ -319,7 +337,11 @@ adminTestStorageConnection:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -329,6 +351,8 @@ adminTestStorageConnection:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCreateStorageMigrateTask:
   post:
@@ -383,7 +407,11 @@ adminCreateStorageMigrateTask:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -393,6 +421,8 @@ adminCreateStorageMigrateTask:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminListStorageMigrateTasks:
   get:
@@ -531,7 +561,11 @@ adminSaveMcpSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -541,6 +575,8 @@ adminSaveMcpSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetScheduleSettings:
   get:
@@ -636,7 +672,11 @@ adminSaveScheduleSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -646,3 +686,5 @@ adminSaveScheduleSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-operations.yaml
+++ b/packages/api-contract/paths/admin-operations.yaml
@@ -33,7 +33,11 @@ adminAgentList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -43,6 +47,8 @@ adminAgentList:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminAgentCreate:
   post:
@@ -107,7 +113,11 @@ adminAgentCreate:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -117,6 +127,8 @@ adminAgentCreate:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminAgentUpdate:
   post:
@@ -171,7 +183,11 @@ adminAgentUpdate:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -181,6 +197,8 @@ adminAgentUpdate:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminAgentRotateToken:
   post:
@@ -230,7 +248,11 @@ adminAgentRotateToken:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -240,6 +262,8 @@ adminAgentRotateToken:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminAgentDisable:
   post:
@@ -289,7 +313,11 @@ adminAgentDisable:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -299,6 +327,8 @@ adminAgentDisable:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminOptRecordPage:
   post:
@@ -341,7 +371,11 @@ adminOptRecordPage:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -351,6 +385,8 @@ adminOptRecordPage:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminTrafficOverview:
   post:
@@ -394,7 +430,11 @@ adminTrafficOverview:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the Admin permission.
+        description: >-
+          Frozen account, or caller lacks the Admin permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -404,3 +444,5 @@ adminTrafficOverview:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-agent-create-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-pages.yaml
+++ b/packages/api-contract/paths/admin-pages.yaml
@@ -100,7 +100,11 @@ adminSaveFriendLinks:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the PageManager permission.
+        description: >-
+          Frozen account, or caller lacks the PageManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -110,6 +114,8 @@ adminSaveFriendLinks:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-announcement-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetSponsors:
   get:
@@ -217,7 +223,11 @@ adminSaveSponsors:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the PageManager permission.
+        description: >-
+          Frozen account, or caller lacks the PageManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -227,6 +237,8 @@ adminSaveSponsors:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-announcement-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetAnnouncement:
   get:
@@ -320,7 +332,11 @@ adminSaveAnnouncement:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the PageManager permission.
+        description: >-
+          Frozen account, or caller lacks the PageManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -330,3 +346,5 @@ adminSaveAnnouncement:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-announcement-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-roles.yaml
+++ b/packages/api-contract/paths/admin-roles.yaml
@@ -33,7 +33,11 @@ adminGetPermissionList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the RoleManager permission.
+        description: >-
+          Frozen account, or caller lacks the RoleManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -43,6 +47,8 @@ adminGetPermissionList:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-permission-list-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminRoleList:
   post:
@@ -79,7 +85,11 @@ adminRoleList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the RoleManager permission.
+        description: >-
+          Frozen account, or caller lacks the RoleManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -89,6 +99,8 @@ adminRoleList:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-permission-list-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminRoleSave:
   post:
@@ -139,7 +151,11 @@ adminRoleSave:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the RoleManager permission.
+        description: >-
+          Frozen account, or caller lacks the RoleManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -149,6 +165,8 @@ adminRoleSave:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-permission-list-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminRoleDelete:
   post:
@@ -195,7 +213,11 @@ adminRoleDelete:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the RoleManager permission.
+        description: >-
+          Frozen account, or caller lacks the RoleManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -205,3 +227,5 @@ adminRoleDelete:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-permission-list-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-site-settings.yaml
+++ b/packages/api-contract/paths/admin-site-settings.yaml
@@ -145,7 +145,11 @@ adminSaveSiteSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -155,6 +159,8 @@ adminSaveSiteSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetSiteChrome:
   get:
@@ -258,7 +264,11 @@ adminSaveSiteChrome:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -268,6 +278,8 @@ adminSaveSiteChrome:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetSiteTheme:
   get:
@@ -368,7 +380,11 @@ adminSaveSiteTheme:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -378,6 +394,8 @@ adminSaveSiteTheme:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminPublishSiteTheme:
   post:
@@ -417,7 +435,11 @@ adminPublishSiteTheme:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -427,6 +449,8 @@ adminPublishSiteTheme:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetSecuritySettings:
   get:
@@ -519,7 +543,11 @@ adminSaveSecuritySettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -529,6 +557,8 @@ adminSaveSecuritySettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetPostingSettings:
   get:
@@ -630,7 +660,11 @@ adminSavePostingSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -640,6 +674,8 @@ adminSavePostingSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetRateLimitSettings:
   get:
@@ -730,7 +766,11 @@ adminSaveRateLimitSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -740,6 +780,8 @@ adminSaveRateLimitSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetHttpNotifySettings:
   get:
@@ -832,7 +874,11 @@ adminSaveHttpNotifySettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -842,6 +888,8 @@ adminSaveHttpNotifySettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetOnesystemSettings:
   get:
@@ -939,7 +987,11 @@ adminSaveOnesystemSettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -949,6 +1001,8 @@ adminSaveOnesystemSettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetAiSummarySettings:
   get:
@@ -1048,7 +1102,11 @@ adminSaveAiSummarySettings:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -1058,6 +1116,8 @@ adminSaveAiSummarySettings:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminListAiSummaryModels:
   post:
@@ -1108,7 +1168,11 @@ adminListAiSummaryModels:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -1118,6 +1182,8 @@ adminListAiSummaryModels:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetTermsOfService:
   get:
@@ -1210,7 +1276,11 @@ adminSaveTermsOfService:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -1220,6 +1290,8 @@ adminSaveTermsOfService:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetPrivacyPolicy:
   get:
@@ -1311,7 +1383,11 @@ adminSavePrivacyPolicy:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -1321,3 +1397,5 @@ adminSavePrivacyPolicy:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-topics.yaml
+++ b/packages/api-contract/paths/admin-topics.yaml
@@ -39,7 +39,11 @@ adminListTopics:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -49,6 +53,8 @@ adminListTopics:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetTopicSource:
   post:
@@ -92,7 +98,11 @@ adminGetTopicSource:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -102,6 +112,8 @@ adminGetTopicSource:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminEditTopic:
   post:
@@ -150,7 +162,11 @@ adminEditTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -160,6 +176,8 @@ adminEditTopic:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminDeleteTopic:
   post:
@@ -212,7 +230,11 @@ adminDeleteTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -222,6 +244,8 @@ adminDeleteTopic:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminRestoreTopic:
   post:
@@ -269,7 +293,11 @@ adminRestoreTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -279,6 +307,8 @@ adminRestoreTopic:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminDeletePost:
   post:
@@ -329,7 +359,11 @@ adminDeletePost:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -339,6 +373,8 @@ adminDeletePost:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminEditTopicPin:
   post:
@@ -388,7 +424,11 @@ adminEditTopicPin:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -398,6 +438,8 @@ adminEditTopicPin:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminEditTopicCategories:
   post:
@@ -452,7 +494,11 @@ adminEditTopicCategories:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the TopicsManager permission.
+        description: >-
+          Frozen account, or caller lacks the TopicsManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -462,3 +508,5 @@ adminEditTopicCategories:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-category-delete-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/admin-users.yaml
+++ b/packages/api-contract/paths/admin-users.yaml
@@ -44,7 +44,11 @@ adminUserList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the UserManager permission.
+        description: >-
+          Frozen account, or caller lacks the UserManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -54,6 +58,8 @@ adminUserList:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-all-role-item-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminEditUser:
   post:
@@ -108,7 +114,11 @@ adminEditUser:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the UserManager permission.
+        description: >-
+          Frozen account, or caller lacks the UserManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -118,6 +128,8 @@ adminEditUser:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-all-role-item-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminUserBadgeOptions:
   post:
@@ -160,7 +172,11 @@ adminUserBadgeOptions:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the UserManager permission.
+        description: >-
+          Frozen account, or caller lacks the UserManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -170,6 +186,8 @@ adminUserBadgeOptions:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-all-role-item-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminSaveUserBadges:
   post:
@@ -217,7 +235,11 @@ adminSaveUserBadges:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the UserManager permission.
+        description: >-
+          Frozen account, or caller lacks the UserManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -227,6 +249,8 @@ adminSaveUserBadges:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-get-all-role-item-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetAllRoleItem:
   get:

--- a/packages/api-contract/paths/auth-sessions.yaml
+++ b/packages/api-contract/paths/auth-sessions.yaml
@@ -8,14 +8,16 @@ logout:
       Session is optional. When the request carries a valid session token (cookie or Bearer), the
       server revokes that session record, so the token immediately stops authenticating. An absent,
       unverifiable, or already-revoked token is treated as already logged out, which makes this
-      operation idempotent. The `access_token` cookie is cleared on every path, including the rare
-      `session.revoke.failed` business failure (HTTP 200 with `code: 1`).
+      operation idempotent. The `access_token` cookie is cleared whenever the logout handler runs,
+      including the rare `session.revoke.failed` business failure (HTTP 200 with `code: 1`). A
+      cross-site cookie POST (missing or mismatched Origin/Referer) is rejected by the CSRF gate
+      before the handler with HTTP 403 `auth.csrf.rejected` and the cookie is left untouched.
     responses:
       '200':
         description: Logout completed (or the caller was already logged out), or a revocation failure.
         headers:
           Set-Cookie:
-            description: Expires the HTTP-only `access_token` session cookie on every logout response.
+            description: Expires the HTTP-only `access_token` session cookie whenever the logout handler runs.
             schema:
               type: string
         content:
@@ -25,6 +27,17 @@ logout:
             examples:
               success:
                 externalValue: ../fixtures/logout-success.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated POST rejected by the CSRF gate (missing or mismatched
+          Origin/Referer, issue #406). The session cookie is not cleared on this path.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 listSessions:
   get:
@@ -108,6 +121,17 @@ revokeSession:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated POST rejected by the CSRF gate (missing or mismatched
+          Origin/Referer, issue #406).
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 revokeAllSessions:
   post:
@@ -143,3 +167,14 @@ revokeAllSessions:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated POST rejected by the CSRF gate (missing or mismatched
+          Origin/Referer, issue #406).
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/auth-totp.yaml
+++ b/packages/api-contract/paths/auth-totp.yaml
@@ -75,6 +75,17 @@ setup:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/totp-settings-unauthenticated.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: TOTP setup rate limit exceeded.
         headers:
@@ -135,6 +146,17 @@ enable:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/totp-settings-unauthenticated.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: TOTP enable rate limit exceeded.
         headers:
@@ -192,6 +214,17 @@ disable:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/totp-settings-unauthenticated.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: TOTP disable rate limit exceeded.
         headers:

--- a/packages/api-contract/paths/course-management.yaml
+++ b/packages/api-contract/paths/course-management.yaml
@@ -28,6 +28,17 @@ adminCourseList:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCourseCreate:
   post:
@@ -59,6 +70,17 @@ adminCourseCreate:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '409':
         description: Primary code already used by another course.
         content:
@@ -96,6 +118,17 @@ adminCourseUpdate:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Course does not exist or was deleted.
         content:
@@ -140,6 +173,17 @@ adminCourseDelete:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Course does not exist or was deleted.
         content:
@@ -177,6 +221,17 @@ adminReviewList:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminReviewUpdate:
   post:
@@ -207,6 +262,17 @@ adminReviewUpdate:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Review does not exist or is deleted.
         content:
@@ -244,6 +310,17 @@ adminReviewDelete:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Review does not exist or is deleted.
         content:
@@ -275,6 +352,17 @@ adminCourseStatsRebuild:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 adminCourseRelationList:
   post:
     tags: [Forum]
@@ -306,6 +394,17 @@ adminCourseRelationList:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminCourseRelationApprove:
   post:
@@ -339,6 +438,17 @@ adminCourseRelationApprove:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Candidate does not exist.
         content:
@@ -382,6 +492,17 @@ adminCourseRelationIgnore:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Candidate does not exist.
         content:
@@ -426,7 +547,11 @@ adminCourseRelationReset:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
       '403':
-        description: Frozen account, or caller lacks the CourseManager permission.
+        description: >-
+          Frozen account, or caller lacks the CourseManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -438,6 +563,8 @@ adminCourseRelationReset:
               permissionDenied:
                 summary: Caller lacks the CourseManager permission.
                 externalValue: ../fixtures/permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Candidate does not exist.
         content:
@@ -486,6 +613,17 @@ adminCourseRelationCreate:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: From or to course does not exist.
         content:
@@ -526,6 +664,17 @@ adminCourseMerge:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Candidate or a referenced course does not exist.
         content:
@@ -570,6 +719,17 @@ adminCourseMergeUndo:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Candidate does not exist.
         content:

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -147,11 +147,18 @@ createCourseReview:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The offering does not exist or is not visible.
         content:
@@ -245,7 +252,11 @@ updateCourseReview:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The caller is not the review author, or the account is frozen.
+        description: >-
+          The caller is not the review author, or the account is frozen.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -253,6 +264,8 @@ updateCourseReview:
             examples:
               notOwned:
                 externalValue: ../fixtures/course-review-not-owned.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The review does not exist, is hidden, or is deleted.
         content:
@@ -316,7 +329,11 @@ deleteCourseReview:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The caller is not the review author, or the account is frozen.
+        description: >-
+          The caller is not the review author, or the account is frozen.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -324,6 +341,8 @@ deleteCourseReview:
             examples:
               notOwned:
                 externalValue: ../fixtures/course-review-not-owned.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The review does not exist, is hidden, or is deleted.
         content:
@@ -384,6 +403,17 @@ markReviewHelpful:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The review does not exist, is hidden, or is deleted.
         content:
@@ -444,6 +474,17 @@ unmarkReviewHelpful:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The review does not exist, is hidden, or is deleted.
         content:
@@ -505,6 +546,17 @@ markReviewDislike:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The review does not exist, is hidden, or is deleted.
         content:
@@ -565,6 +617,17 @@ unmarkReviewDislike:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: The review does not exist, is hidden, or is deleted.
         content:
@@ -639,6 +702,17 @@ reportCourseReview:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Report rate limit exceeded.
         headers:
@@ -693,7 +767,11 @@ moderationCourseReviewStatus:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The caller is not a CourseManager.
+        description: >-
+          The caller is not a CourseManager.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -701,6 +779,8 @@ moderationCourseReviewStatus:
             examples:
               permissionDenied:
                 externalValue: ../fixtures/permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Course-review moderation rate limit exceeded (60s window).
         headers:
@@ -753,7 +833,11 @@ moderationCourseReviewReportList:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The caller is not a CourseManager.
+        description: >-
+          The caller is not a CourseManager.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -761,6 +845,8 @@ moderationCourseReviewReportList:
             examples:
               permissionDenied:
                 externalValue: ../fixtures/permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Course-review moderation rate limit exceeded (60s window).
         headers:
@@ -827,3 +913,14 @@ moderationCourseReviewReveal:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/courses.yaml
+++ b/packages/api-contract/paths/courses.yaml
@@ -250,6 +250,17 @@ bookmarkCourse:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '404':
         description: Course does not exist or is hidden.
         content:

--- a/packages/api-contract/paths/direct-image-upload.yaml
+++ b/packages/api-contract/paths/direct-image-upload.yaml
@@ -69,7 +69,11 @@ initDirectImageUpload:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -77,6 +81,8 @@ initDirectImageUpload:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Upload rate limit (action `upload`) exceeded.
         headers:
@@ -142,7 +148,11 @@ completeDirectImageUpload:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -150,6 +160,8 @@ completeDirectImageUpload:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Upload rate limit (action `upload`) exceeded.
         headers:
@@ -209,7 +221,11 @@ abortDirectImageUpload:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -217,6 +233,8 @@ abortDirectImageUpload:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Upload rate limit (action `upload`) exceeded.
         headers:

--- a/packages/api-contract/paths/forum-chat.yaml
+++ b/packages/api-contract/paths/forum-chat.yaml
@@ -45,7 +45,11 @@ sendChatMessage:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -53,6 +57,8 @@ sendChatMessage:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Message-send rate limit (action `message.send`) exceeded.
         headers:
@@ -114,6 +120,17 @@ getChatMessages:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 markChatRead:
   post:
@@ -159,7 +176,11 @@ markChatRead:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -167,3 +188,5 @@ markChatRead:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/forum-interactions.yaml
+++ b/packages/api-contract/paths/forum-interactions.yaml
@@ -41,7 +41,11 @@ followUser:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -49,6 +53,8 @@ followUser:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -111,7 +117,11 @@ createReport:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -119,6 +129,8 @@ createReport:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:

--- a/packages/api-contract/paths/forum-moderation.yaml
+++ b/packages/api-contract/paths/forum-moderation.yaml
@@ -48,7 +48,11 @@ moderationUpdateTopicStatus:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -56,6 +60,8 @@ moderationUpdateTopicStatus:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 moderationUpdatePostStatus:
   post:
@@ -105,7 +111,11 @@ moderationUpdatePostStatus:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -113,6 +123,8 @@ moderationUpdatePostStatus:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 listModerationReports:
   post:
@@ -161,6 +173,17 @@ listModerationReports:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 moderationUpdateReportStatus:
   post:
@@ -210,7 +233,11 @@ moderationUpdateReportStatus:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -218,6 +245,8 @@ moderationUpdateReportStatus:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 listModerationLogs:
   post:
@@ -262,6 +291,17 @@ listModerationLogs:
             examples:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
+      '403':
+        description: >-
+          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
+          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+            examples:
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 viewDeletedContent:
   post:
@@ -314,7 +354,11 @@ viewDeletedContent:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -322,3 +366,5 @@ viewDeletedContent:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/forum-notifications.yaml
+++ b/packages/api-contract/paths/forum-notifications.yaml
@@ -138,7 +138,11 @@ markNotificationRead:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -146,6 +150,8 @@ markNotificationRead:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 markAllNotificationsRead:
   post:
@@ -179,7 +185,11 @@ markAllNotificationsRead:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -187,3 +197,5 @@ markAllNotificationsRead:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/forum-posts.yaml
+++ b/packages/api-contract/paths/forum-posts.yaml
@@ -46,7 +46,11 @@ createPost:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -54,6 +58,8 @@ createPost:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Post-creation rate limit (action `post.create`) exceeded.
         headers:
@@ -114,7 +120,11 @@ updatePost:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -122,6 +132,8 @@ updatePost:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Post-update rate limit (action `post.update`) exceeded.
         headers:
@@ -183,7 +195,11 @@ deletePost:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -191,6 +207,8 @@ deletePost:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Post-deletion rate limit (action `post.delete`) exceeded.
         headers:
@@ -388,7 +406,11 @@ likePost:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -396,6 +418,8 @@ likePost:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -457,7 +481,11 @@ bookmarkPost:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -465,6 +493,8 @@ bookmarkPost:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:

--- a/packages/api-contract/paths/forum-topic-interactions.yaml
+++ b/packages/api-contract/paths/forum-topic-interactions.yaml
@@ -44,7 +44,11 @@ updateTopicStatus:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -52,6 +56,8 @@ updateTopicStatus:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Topic-status rate limit (action `topic.status`) exceeded.
         headers:
@@ -115,7 +121,11 @@ deleteTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -123,6 +133,8 @@ deleteTopic:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -184,7 +196,11 @@ likeTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -192,6 +208,8 @@ likeTopic:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -254,7 +272,11 @@ bookmarkTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -262,6 +284,8 @@ bookmarkTopic:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -323,7 +347,11 @@ watchTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -331,6 +359,8 @@ watchTopic:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:

--- a/packages/api-contract/paths/forum-topics.yaml
+++ b/packages/api-contract/paths/forum-topics.yaml
@@ -35,7 +35,11 @@ writeTopic:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -43,6 +47,8 @@ writeTopic:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Topic-writing rate limit exceeded.
         headers:

--- a/packages/api-contract/paths/pk-admin.yaml
+++ b/packages/api-contract/paths/pk-admin.yaml
@@ -49,7 +49,11 @@ adminSyncPkCalendar:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account, or caller lacks the SiteManager permission.
+        description: >-
+          Frozen account, or caller lacks the SiteManager permission.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -59,6 +63,8 @@ adminSyncPkCalendar:
                 externalValue: ../fixtures/account-frozen.json
               permissionDenied:
                 externalValue: ../fixtures/admin-ai-summary-settings-permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 adminGetPkSyncStatus:
   get:

--- a/packages/api-contract/paths/user-account.yaml
+++ b/packages/api-contract/paths/user-account.yaml
@@ -122,7 +122,11 @@ setUserInfo:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -130,6 +134,8 @@ setUserInfo:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 setUserProfileCover:
   post:
@@ -171,7 +177,11 @@ setUserProfileCover:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -179,6 +189,8 @@ setUserProfileCover:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 setUserEmail:
   post:
@@ -227,7 +239,11 @@ setUserEmail:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -235,6 +251,8 @@ setUserEmail:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Email-change rate limit (action `email.change`) exceeded.
         headers:
@@ -289,7 +307,11 @@ resendActivationEmail:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -297,6 +319,8 @@ resendActivationEmail:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 setUserName:
   post:
@@ -342,7 +366,11 @@ setUserName:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -350,6 +378,8 @@ setUserName:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 setPresetAvatar:
   post:
@@ -394,7 +424,11 @@ setPresetAvatar:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -402,6 +436,8 @@ setPresetAvatar:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 wearBadge:
   post:
@@ -445,7 +481,11 @@ wearBadge:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -453,6 +493,8 @@ wearBadge:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 uploadAvatar:
   post:
@@ -505,7 +547,11 @@ uploadAvatar:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Frozen account (standard middleware params action=写入, actionCode=write) or unverified email under mandatory verification (`permission.emailRequired`).
+        description: >-
+          Frozen account (standard middleware params action=写入, actionCode=write) or unverified email under mandatory verification (`permission.emailRequired`).
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -513,6 +559,8 @@ uploadAvatar:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Upload rate limit (action `upload`) exceeded.
         headers:
@@ -577,7 +625,11 @@ changePassword:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -585,6 +637,8 @@ changePassword:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Password-change rate limit (action `password.change`) exceeded.
         headers:
@@ -678,7 +732,11 @@ unbindOAuth:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -686,3 +744,5 @@ unbindOAuth:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json

--- a/packages/api-contract/paths/user-content.yaml
+++ b/packages/api-contract/paths/user-content.yaml
@@ -191,7 +191,11 @@ restoreContent:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -199,6 +203,8 @@ restoreContent:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -265,7 +271,11 @@ batchDeleteContent:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -273,6 +283,8 @@ batchDeleteContent:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -342,7 +354,11 @@ purgeContent:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -350,6 +366,8 @@ purgeContent:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -412,7 +430,11 @@ privacyEraseContent:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -420,6 +442,8 @@ privacyEraseContent:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -482,7 +506,11 @@ reportContentEvent:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -490,6 +518,8 @@ reportContentEvent:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:
@@ -556,7 +586,11 @@ closeAccount:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: Authenticated account is frozen or its account information cannot be resolved.
+        description: >-
+          Authenticated account is frozen or its account information cannot be resolved.
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -564,6 +598,8 @@ closeAccount:
             examples:
               frozenAccount:
                 externalValue: ../fixtures/account-frozen.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
       '429':
         description: Interaction rate limit (action `interact`) exceeded.
         headers:

--- a/packages/api-contract/paths/wiki-sync.yaml
+++ b/packages/api-contract/paths/wiki-sync.yaml
@@ -135,7 +135,11 @@ runWikiSync:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The account is not a PageManager or Admin (or it is frozen).
+        description: >-
+          The account is not a PageManager or Admin (or it is frozen).
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -143,6 +147,8 @@ runWikiSync:
             examples:
               forbidden:
                 externalValue: ../fixtures/permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 listWikiSyncRuns:
   get:
@@ -277,7 +283,11 @@ saveWikiWebhookSecret:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The account is not a PageManager or Admin (or it is frozen).
+        description: >-
+          The account is not a PageManager or Admin (or it is frozen).
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -285,6 +295,8 @@ saveWikiWebhookSecret:
             examples:
               forbidden:
                 externalValue: ../fixtures/permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json
 
 getWikiAssetCDN:
   get:
@@ -374,7 +386,11 @@ saveWikiAssetCDN:
               unauthenticated:
                 externalValue: ../fixtures/auth-required.json
       '403':
-        description: The account is not a PageManager or Admin (or it is frozen).
+        description: >-
+          The account is not a PageManager or Admin (or it is frozen).
+          A cross-site cookie-authenticated request (missing or mismatched Origin/Referer) is rejected
+          by the CSRF gate before the handler with HTTP 403 `auth.csrf.rejected`; the session cookie
+          is not cleared (issue #406).
         content:
           application/json:
             schema:
@@ -382,3 +398,5 @@ saveWikiAssetCDN:
             examples:
               forbidden:
                 externalValue: ../fixtures/permission-denied.json
+              csrfRejected:
+                externalValue: ../fixtures/csrf-rejected.json


### PR DESCRIPTION
## Summary
Follow-up for the merged PR #417 (issue #406, P2): carries the review-driven fixes that landed after #417 was merged into `dev`.

- **CSRF gate now runs *before* stateful auth** (Codex P2): `loginApi`/`forumLoginApi`/`chatApi`/`adminApi` mount `CSRFProtection` ahead of `JWTAuthCheck`, so a cross-site POST carrying a valid cookie is rejected with `403 auth.csrf.rejected` *before* the auth middleware can refresh a near-expiry JWT, extend a session, or emit `UserLastActiveUpdatedEvent`. Anonymous POSTs (no cookie) still pass through to the auth middleware's 401. New DB-level contract test proves a cross-site POST with a real near-expiry session neither rotates the cookie nor touches the `user_sessions` row, while the same-origin control does refresh.
- **`csrf.allowedOrigins` option removed** (Codex P2): the single-binary deployment has no credentialed-CORS frontend origin, so the option advertised a capability the server cannot deliver; origin checks now derive solely from the request Host (plus `X-Forwarded-Proto`). Config template, deploy example, middleware, tests and docs cleaned up.
- **Contract sync** (Codex P2): `auth-sessions.yaml` logout/revokeSession/revokeAllSessions gain the `403 auth.csrf.rejected` response (fixture `csrf-rejected.json`); logout's "cookie cleared on every path" promise is corrected to "whenever the logout handler runs" since a cross-site POST is now rejected before the handler. Generated `openapi.ts` regenerated in this PR.
- **Test hardening** (oierxjn should/nit): `Origin: null` rejected, malformed Referer rejected, invalid `X-Forwarded-Proto` neither blocks nor widens, HEAD exempt, first-hop behavior; route-level chain tests rewritten as behavioural (403-before-auth with no Set-Cookie, anonymous still 401, same-origin reaches auth) while keeping the registration snapshot under its original name.

## Testing
- Cherry-picked cleanly onto current `origin/dev` (dev already contained the pre-merge test state from `0bfa3107`, so the net diff is exactly the review fix).
- `go build ./...`, `go vet` (middleware/routes), gofmt clean.
- `go test ./app/http/middleware/ -run CSRF` — 19/19 PASS (null-origin/malformed-Referer/bad-XFP/HEAD-exempt branches).
- `go test ./app/http/routes/ -run 'CSRF|TestCSRFOrder'` — all PASS incl. mount-order contract, logout/fileServer, real-session chain tests; full middleware+routes packages ok (routes 7.5s).
- Contract: redocly lint/bundle, fixtures 909 validated, TS-gen + gen-check + route-coverage (282 routes, 0 known-uncovered) all pass.
- Frontend `pnpm typecheck` exit 0; pre-push hooks (go vet / golangci-lint 0 issues / typecheck) green.

## Notes
- Single commit on top of current `dev`; merge order independent of #422/#430.
- The removed option's config-file hunks auto-applied as no-ops where `dev` had already dropped them.
