### PR TITLE
fix(auth): unify activation gate across TOTP, unread cleanup, and re-login (issue #427)

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/authController.go
+++ b/apps/gooseforum/app/http/controllers/api/authController.go
@@ -231,12 +231,9 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	securityConfig := hotdataserve.GetSecuritySettingsConfigCache()
-	if securityConfig.EnableEmailVerification && userEntity.IsActivated == users.ActivationPending {
-		c.JSON(200, component.FailDataCode(component.MessageAuthEmailUnverified, nil))
-		return
-	}
-
+	// 待激活账号允许重新登录：写权限在权限层由 CheckWritableAccount 拦截
+	// （permission.emailRequired），会话本身不授予写能力，pending 用户借此
+	// 找回过期会话后可继续走 resend-activation-email 激活恢复（issue #427）。
 	// 封禁用户不允许登录（与 OIDC/goth 路径的冻结检查一致）。
 	if userEntity.IsFrozen == users.StatusFrozen {
 		c.JSON(200, component.FailDataCode(component.MessageAuthAccountFrozen, nil))

--- a/apps/gooseforum/app/http/controllers/api/oauthController.go
+++ b/apps/gooseforum/app/http/controllers/api/oauthController.go
@@ -79,14 +79,12 @@ func ProviderCallback(c *gin.Context) {
 		}
 
 		if user.IsActivated == users.ActivationPending {
-			// issue #155：OAuth 用户处于待激活状态（verified 邮箱未命中信任域名且
-			// 全局 EnableEmailVerification 开启）时，不发放会话——与密码登录对
-			// pending 用户的拒绝语义一致（authController 返回 auth.email.unverified）。
-			// 用户需通过激活邮件完成验证后重新登录。
-			slog.Info("OAuth callback rejected pending activation user",
+			// 待激活 OAuth 用户同样发放会话：写权限在权限层由
+			// CheckWritableAccount 拦截（permission.emailRequired），会话不授予
+			// 写能力，用户借此可在会话过期后重新登录并继续激活恢复流程
+			// （issue #427，与密码登录对 pending 用户的放行口径一致）。
+			slog.Info("OAuth callback issued session for pending activation user",
 				"userId", user.Id, "provider", gothUser.Provider)
-			forum.RenderOAuthErrorPage(c, http.StatusForbidden, component.MessageAuthEmailUnverified)
-			return
 		}
 
 		// 生成JWT token（会话凭证，写会话记录）

--- a/apps/gooseforum/app/http/controllers/api/oauth_callback_test.go
+++ b/apps/gooseforum/app/http/controllers/api/oauth_callback_test.go
@@ -245,3 +245,50 @@ func TestOAuthCallbackLoginRejectsUnverifiedEmail(t *testing.T) {
 		t.Fatalf("unverified OAuth identity was bound despite rejection: %#v", binding)
 	}
 }
+
+// TestOAuthCallbackLoginPendingUserIssuesSession 待激活 OAuth 用户登录口径
+// （issue #427）：pending 账号 OAuth 登录同样签发会话（写权限在权限层由
+// CheckWritableAccount 拦截，会话本身不授予写能力），用户借此在会话过期后
+// 重新登录并继续激活恢复流程——与密码登录对 pending 用户的放行口径一致。
+func TestOAuthCallbackLoginPendingUserIssuesSession(t *testing.T) {
+	setupOAuthCallbackTestDB(t)
+
+	user := &users.EntityComplete{
+		Username:    "oauthpending",
+		Email:       "oauthpending@example.com",
+		IsActivated: users.ActivationPending,
+	}
+	if err := users.Create(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := userOAuth.Create(&userOAuth.Entity{
+		UserId:      user.Id,
+		Provider:    oauthservice.ProviderGitHub,
+		ProviderUid: "gh-uid-pending",
+	}); err != nil {
+		t.Fatalf("create oauth binding: %v", err)
+	}
+
+	stubGothUser(t, goth.User{
+		Provider: oauthservice.ProviderGitHub,
+		UserID:   "gh-uid-pending",
+		NickName: "oauthpending",
+		Email:    "oauthpending@example.com",
+	})
+
+	recorder, c := oauthCallbackRequest(t)
+	ProviderCallback(c)
+
+	if recorder.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302 (body: %s)", recorder.Code, recorder.Body.String())
+	}
+	if loc := recorder.Header().Get("Location"); loc != "/" {
+		t.Fatalf("redirect location = %q, want /", loc)
+	}
+	if !hasAccessTokenCookie(recorder) {
+		t.Fatal("pending OAuth login must set access_token cookie")
+	}
+	if count := countSessions(t, user.Id); count != 1 {
+		t.Fatalf("pending user session rows = %d, want 1", count)
+	}
+}

--- a/apps/gooseforum/app/http/middleware/checkPermission.go
+++ b/apps/gooseforum/app/http/middleware/checkPermission.go
@@ -51,10 +51,13 @@ func CheckWritableAccount(c *gin.Context) {
 	checkWritableAccount(c, false)
 }
 
-// CheckWritableAccountAllowPendingActivation 是 CheckWritableAccount 的恢复路径
-// 变体：保留登录/冻结拦截，但不因待激活状态拒绝——仅用于激活恢复所需的重发
-// 激活邮件与修改邮箱（改邮箱会把账号重新置为 pending，账号借此继续走恢复流程；
-// 其余写操作仍被 CheckWritableAccount 拦截）。
+// CheckWritableAccountAllowPendingActivation 是 CheckWritableAccount 的放行变体：
+// 保留登录/冻结拦截，但不因待激活状态拒绝。用于不产生内容写的自有状态操作与
+// 恢复路径——激活恢复（resend-activation-email、set-user-email，改邮箱会把账号
+// 重新置为 pending，账号借此继续走恢复流程）、自服务生命周期
+// （account-close、content-privacy-erase，issue #415 review P2）以及未读清理
+// （notification/chat mark-read，仅变更用户自己的读状态，issue #427）。
+// 其余写操作仍被 CheckWritableAccount 拦截。
 func CheckWritableAccountAllowPendingActivation(c *gin.Context) {
 	checkWritableAccount(c, true)
 }

--- a/apps/gooseforum/app/http/routes/activation_write_gate_test.go
+++ b/apps/gooseforum/app/http/routes/activation_write_gate_test.go
@@ -1,8 +1,10 @@
 package routes
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/api"
@@ -212,5 +214,47 @@ func TestActivationWriteGateNoRegression(t *testing.T) {
 		if got := decodeContractEnvelope(t, recorder).MessageCode; got == string(component.MessagePermissionEmailRequired) {
 			t.Fatal("verification disabled must not emit permission.emailRequired")
 		}
+	})
+}
+
+// TestPendingUserCanReLogin 过期会话重登口径（issue #427）：pending 账号密码登录
+// 成功并签发会话（New-Token + Set-Cookie），但写权限仍被 CheckWritableAccount
+// 拦截——会话不授予写能力，pending 用户借此在会话过期后恢复激活流程
+// （resend-activation-email 需要会话）。
+func TestPendingUserCanReLogin(t *testing.T) {
+	t.Run("pending user password login issues session and keeps write gate", func(t *testing.T) {
+		conn, router := setupHTTPContractTest(t)
+		enableContractEmailVerification(t, conn)
+		user := createPendingContractUser(t, conn)
+
+		body, err := json.Marshal(map[string]string{
+			"username":          user.Username,
+			"encryptedPassword": encryptLoginPassword(t, "secret123"),
+		})
+		if err != nil {
+			t.Fatalf("marshal pending login request: %v", err)
+		}
+		recorder := serveJSON(router, "/api/login", string(body), "")
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("pending login status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		response := decodeContractEnvelope(t, recorder)
+		assertFixtureEnvelope(t, response, contractFixture(t, "login-success.json"))
+		if string(response.Result) != `"登录成功"` {
+			t.Fatalf("pending login result = %s, want login success message", response.Result)
+		}
+		if recorder.Header().Get("New-Token") == "" {
+			t.Fatal("pending login response missing New-Token header")
+		}
+		if !strings.Contains(recorder.Header().Get("Set-Cookie"), "access_token=") {
+			t.Fatal("pending login response missing access_token session cookie")
+		}
+
+		// 新会话仍不授予写能力：登录签发的 token 请求 topics/write 必须 403。
+		write := serveJSON(router, "/api/forum/topics/write", `{}`, recorder.Header().Get("New-Token"))
+		if write.Code != http.StatusForbidden {
+			t.Fatalf("pending re-login topics/write status = %d, want 403: %s", write.Code, write.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, write), contractFixture(t, "permission-email-required.json"))
 	})
 }

--- a/apps/gooseforum/app/http/routes/contract_notification_chat_test.go
+++ b/apps/gooseforum/app/http/routes/contract_notification_chat_test.go
@@ -36,13 +36,13 @@ func setupNotificationChatContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	forumLoginAPI := forumAPI.Use(middleware.JWTAuthCheck)
 	forumLoginAPI.GET("/unread-status", middleware.NoUpdateUserActivity, UpButterReq(api.GetUnreadStatus))
 	forumLoginAPI.GET("/notifications", middleware.NoUpdateUserActivity, UpQueryReq(api.NotificationList))
-	forumLoginAPI.POST("/notification/mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkAsRead))
-	forumLoginAPI.POST("/notification/mark-all-read", middleware.CheckWritableAccount, UpButterReq(api.MarkAllAsRead))
+	forumLoginAPI.POST("/notification/mark-read", middleware.CheckWritableAccountAllowPendingActivation, UpButterReq(api.MarkAsRead))
+	forumLoginAPI.POST("/notification/mark-all-read", middleware.CheckWritableAccountAllowPendingActivation, UpButterReq(api.MarkAllAsRead))
 
 	chatAPI := forumAPI.Group("/chat", middleware.JWTAuthCheck)
 	chatAPI.POST("/send", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitMessageSend), UpButterReq(api.SendMessage))
 	chatAPI.POST("/messages", UpButterReq(api.GetMessages))
-	chatAPI.POST("/mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkChatRead))
+	chatAPI.POST("/mark-read", middleware.CheckWritableAccountAllowPendingActivation, UpButterReq(api.MarkChatRead))
 	return conn, router
 }
 
@@ -345,6 +345,67 @@ func TestChatMarkReadHTTPContract(t *testing.T) {
 		recorder := serveJSON(router, "/api/forum/chat/mark-read", `{"convId":987654321}`, contractSessionToken(t, user))
 		if recorder.Code != http.StatusOK {
 			t.Fatalf("non-member status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "chat-mark-read-failed.json"))
+	})
+}
+
+// TestPendingUserReadStateCleanupAllowed 未读清理放行变体（issue #427）：
+// pending 用户仅清理自己的读状态、不产生内容写，notification/chat mark-read
+// 不被拦截；冻结拦截在放行变体中保留（已由上方 frozen 用例 pin 住）。
+func TestPendingUserReadStateCleanupAllowed(t *testing.T) {
+	t.Run("pending user can mark notification read", func(t *testing.T) {
+		conn, router := setupNotificationChatContractTest(t)
+		enableContractEmailVerification(t, conn)
+		user := createPendingContractUser(t, conn)
+		notificationID := contractTestID()
+		createContractNotification(t, conn, notificationID, user.Id, eventNotification.EventTypePostReply, false,
+			eventNotification.NotificationPayload{Title: "契约待读通知", ActorId: user.Id}, time.Now())
+		body := fmt.Sprintf(`{"notificationId":%d}`, notificationID)
+
+		recorder := serveJSON(router, "/api/forum/notification/mark-read", body, contractSessionToken(t, user))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("pending notification mark-read status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "notification-mark-read-success.json"))
+	})
+
+	t.Run("pending user can mark all notifications read", func(t *testing.T) {
+		conn, router := setupNotificationChatContractTest(t)
+		enableContractEmailVerification(t, conn)
+		user := createPendingContractUser(t, conn)
+
+		recorder := serveJSON(router, "/api/forum/notification/mark-all-read", `{}`, contractSessionToken(t, user))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("pending notification mark-all-read status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "notification-mark-all-read-success.json"))
+	})
+
+	t.Run("pending user can mark chat read", func(t *testing.T) {
+		conn, router := setupNotificationChatContractTest(t)
+		enableContractEmailVerification(t, conn)
+		user := createPendingContractUser(t, conn)
+		peer := createHTTPContractUser(t, conn, contractTestID())
+		convID := contractTestID()
+		createContractConversation(t, conn, convID, user.Id, peer.Id)
+		body := fmt.Sprintf(`{"convId":%d}`, convID)
+
+		recorder := serveJSON(router, "/api/forum/chat/mark-read", body, contractSessionToken(t, user))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("pending chat mark-read status = %d, want 200: %s", recorder.Code, recorder.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "chat-mark-read-success.json"))
+	})
+
+	t.Run("pending user cannot mark another conversation read", func(t *testing.T) {
+		conn, router := setupNotificationChatContractTest(t)
+		enableContractEmailVerification(t, conn)
+		user := createPendingContractUser(t, conn)
+		// 放行变体不豁免越权：非会话成员仍被拒绝（CWE-639 回归）。
+		recorder := serveJSON(router, "/api/forum/chat/mark-read", `{"convId":987654321}`, contractSessionToken(t, user))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("pending non-member status = %d, want 200: %s", recorder.Code, recorder.Body.String())
 		}
 		assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "chat-mark-read-failed.json"))
 	})

--- a/apps/gooseforum/app/http/routes/contract_totp_test.go
+++ b/apps/gooseforum/app/http/routes/contract_totp_test.go
@@ -22,11 +22,12 @@ func setupTotpSettingsContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	t.Helper()
 	conn, router := setupAuthSecurityContractTest(t)
 	loginAPI := router.Group("/api").Use(middleware.JWTAuthCheck)
-	// 与真实挂载保持一致：setup/enable/disable 校验账户密码或 6 位验证码，挂 RateLimit 防暴力破解；
-	// status 只读 enabled 标志，不限流。
-	loginAPI.POST("/user/totp/setup", middleware.RateLimit(middleware.RateLimitTotpSetup), UpButterReq(api.TotpSetup))
-	loginAPI.POST("/user/totp/enable", middleware.RateLimit(middleware.RateLimitTotpEnable), UpButterReq(api.TotpEnable))
-	loginAPI.POST("/user/totp/disable", middleware.RateLimit(middleware.RateLimitTotpDisable), UpButterReq(api.TotpDisable))
+	// 与真实挂载保持一致：setup/enable/disable 校验账户密码或 6 位验证码，挂
+	// CheckWritableAccount（pending/冻结拒绝，issue #427）与 RateLimit 防暴力破解；
+	// status 只读 enabled 标志，不限流也不挂写门禁。
+	loginAPI.POST("/user/totp/setup", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTotpSetup), UpButterReq(api.TotpSetup))
+	loginAPI.POST("/user/totp/enable", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTotpEnable), UpButterReq(api.TotpEnable))
+	loginAPI.POST("/user/totp/disable", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTotpDisable), UpButterReq(api.TotpDisable))
 	loginAPI.GET("/user/totp/status", UpButterReq(api.TotpStatus))
 	return conn, router
 }
@@ -193,12 +194,10 @@ func TestTotpSettingsHTTPContract(t *testing.T) {
 		assertFixtureEnvelope(t, decodeContractEnvelope(t, setupAgain), contractFixture(t, "totp-already-enabled.json"))
 	})
 
-	t.Run("frozen account is not rejected by TOTP settings routes", func(t *testing.T) {
-		// S5 契约测试：这 4 个路由未挂 CheckWritableAccount，冻结账户不被拒绝是当前实际行为
-		// （authsessionservice.ValidateToken 不检查 IsFrozen），契约如实描述并在此 pin 住，
-		// 防止未来挂载 CheckWritableAccount 时静默改变契约行为。与 change-password（冻结 403）
-		// 的行为差异是已知决策点：若后续给 TOTP 路由补上 CheckWritableAccount，
-		// 需同步更新契约（403 + auth.account.frozen）与本测试。
+	t.Run("frozen account is rejected by TOTP settings write routes", func(t *testing.T) {
+		// S5 契约测试：setup/enable/disable 挂 CheckWritableAccount 后，冻结账户被
+		// 稳定 403 拒绝（permission.userFrozen，与 change-password 等账户写操作口径
+		// 一致，issue #427）；status 只读不挂写门禁，冻结账户仍可读。
 		conn, router := setupTotpSettingsContractTest(t)
 		user := createHTTPContractUser(t, conn, contractTestID())
 		entity, err := users.Get(user.Id)
@@ -212,14 +211,50 @@ func TestTotpSettingsHTTPContract(t *testing.T) {
 		token := contractSessionToken(t, user)
 
 		setup := serveAuthSecurityJSON(router, http.MethodPost, "/api/user/totp/setup", `{"password":"secret123"}`, token)
-		if setup.Code != http.StatusOK {
-			t.Fatalf("frozen setup status = %d, want 200: %s", setup.Code, setup.Body.String())
+		if setup.Code != http.StatusForbidden {
+			t.Fatalf("frozen setup status = %d, want 403: %s", setup.Code, setup.Body.String())
 		}
-		assertResultObjectKeysMatchFixture(t, decodeContractEnvelope(t, setup), contractFixture(t, "totp-setup-success.json"))
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, setup), contractFixture(t, "account-frozen.json"))
+
+		enable := serveAuthSecurityJSON(router, http.MethodPost, "/api/user/totp/enable", `{"code":"000000"}`, token)
+		if enable.Code != http.StatusForbidden {
+			t.Fatalf("frozen enable status = %d, want 403: %s", enable.Code, enable.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, enable), contractFixture(t, "account-frozen.json"))
+
+		disable := serveAuthSecurityJSON(router, http.MethodPost, "/api/user/totp/disable", `{"code":"000000"}`, token)
+		if disable.Code != http.StatusForbidden {
+			t.Fatalf("frozen disable status = %d, want 403: %s", disable.Code, disable.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, disable), contractFixture(t, "account-frozen.json"))
 
 		status := serveAuthSecurityJSON(router, http.MethodGet, "/api/user/totp/status", "", token)
 		if status.Code != http.StatusOK {
 			t.Fatalf("frozen status status = %d, want 200: %s", status.Code, status.Body.String())
+		}
+		assertFixtureEnvelope(t, decodeContractEnvelope(t, status), contractFixture(t, "totp-status-disabled.json"))
+	})
+
+	t.Run("pending activation account is rejected by TOTP settings write routes", func(t *testing.T) {
+		// issue #427：邮箱验证开启时 pending 账号（注册即发会话）不得变更 2FA 状态，
+		// 与 CheckWritableAccount 的统一口径一致（permission.emailRequired）。
+		conn, router := setupTotpSettingsContractTest(t)
+		enableContractEmailVerification(t, conn)
+		user := createPendingContractUser(t, conn)
+		token := contractSessionToken(t, user)
+
+		for _, path := range []string{"/api/user/totp/setup", "/api/user/totp/enable", "/api/user/totp/disable"} {
+			recorder := serveAuthSecurityJSON(router, http.MethodPost, path, `{}`, token)
+			if recorder.Code != http.StatusForbidden {
+				t.Fatalf("pending %s status = %d, want 403: %s", path, recorder.Code, recorder.Body.String())
+			}
+			assertFixtureEnvelope(t, decodeContractEnvelope(t, recorder), contractFixture(t, "permission-email-required.json"))
+		}
+
+		// 只读 status 不被拦截，pending 用户可读 2FA 状态。
+		status := serveAuthSecurityJSON(router, http.MethodGet, "/api/user/totp/status", "", token)
+		if status.Code != http.StatusOK {
+			t.Fatalf("pending status status = %d, want 200: %s", status.Code, status.Body.String())
 		}
 		assertFixtureEnvelope(t, decodeContractEnvelope(t, status), contractFixture(t, "totp-status-disabled.json"))
 	})

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -193,10 +193,12 @@ func apiRoute(ginApp *gin.Engine) {
 	loginApi.POST("user/sessions/revoke", UpButterReq(api.RevokeSession))
 	loginApi.POST("user/sessions/revoke-all", UpButterReq(api.RevokeAllSessions))
 	// TOTP 写操作校验账户密码或 6 位验证码（setup/enable/disable），挂 RateLimit 防止暴力破解；
-	// status 只读 enabled 标志、不验证任何凭据，无需限流。
-	loginApi.POST("user/totp/setup", middleware.RateLimit(middleware.RateLimitTotpSetup), UpButterReq(api.TotpSetup))
-	loginApi.POST("user/totp/enable", middleware.RateLimit(middleware.RateLimitTotpEnable), UpButterReq(api.TotpEnable))
-	loginApi.POST("user/totp/disable", middleware.RateLimit(middleware.RateLimitTotpDisable), UpButterReq(api.TotpDisable))
+	// 同时挂 CheckWritableAccount：pending/冻结账号不得变更 2FA 状态（issue #427，与
+	// change-password 等账户写操作口径一致）；status 只读 enabled 标志、不验证任何凭据，
+	// 无需限流也不挂写门禁。
+	loginApi.POST("user/totp/setup", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTotpSetup), UpButterReq(api.TotpSetup))
+	loginApi.POST("user/totp/enable", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTotpEnable), UpButterReq(api.TotpEnable))
+	loginApi.POST("user/totp/disable", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTotpDisable), UpButterReq(api.TotpDisable))
 	loginApi.GET("user/totp/status", UpButterReq(api.TotpStatus))
 
 	// PK 排课器 13 端点（Issue #187）：公开只读，统一 {code,msg,data} 信封，
@@ -253,8 +255,11 @@ func apiRoute(ginApp *gin.Engine) {
 	forumLoginApi := forumApi.Use(middleware.CSRFProtection, middleware.JWTAuthCheck)
 	forumLoginApi.GET("unread-status", middleware.NoUpdateUserActivity, UpButterReq(api.GetUnreadStatus))
 	forumLoginApi.GET("notifications", middleware.NoUpdateUserActivity, UpQueryReq(api.NotificationList))
-	forumLoginApi.POST("notification/mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkAsRead))
-	forumLoginApi.POST("notification/mark-all-read", middleware.CheckWritableAccount, UpButterReq(api.MarkAllAsRead))
+	// 未读清理（notification/chat mark-read）用放行变体：pending 用户仅清理自己的
+	// 读状态、不产生内容写（issue #427），未读角标无需等待激活才能清除；冻结
+	// 拦截保留。
+	forumLoginApi.POST("notification/mark-read", middleware.CheckWritableAccountAllowPendingActivation, UpButterReq(api.MarkAsRead))
+	forumLoginApi.POST("notification/mark-all-read", middleware.CheckWritableAccountAllowPendingActivation, UpButterReq(api.MarkAllAsRead))
 	forumLoginApi.POST("topics/write", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTopicWrite), UpButterReq(api.WriteTopic))
 	forumLoginApi.POST("topics/status", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitTopicStatus), UpButterReq(api.UpdateTopicStatus))
 	forumLoginApi.POST("topics/delete", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitInteract), UpButterReq(api.DeleteTopicByUser))
@@ -334,7 +339,7 @@ func apiRoute(ginApp *gin.Engine) {
 	agentApi.GET("search", UpQueryReq(forum.SearchJSON))
 	chatApi.POST("send", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitMessageSend), UpButterReq(api.SendMessage))
 	chatApi.POST("messages", UpButterReq(api.GetMessages))
-	chatApi.POST("mark-read", middleware.CheckWritableAccount, UpButterReq(api.MarkChatRead))
+	chatApi.POST("mark-read", middleware.CheckWritableAccountAllowPendingActivation, UpButterReq(api.MarkChatRead))
 
 	adminApi := baseApi.Group("admin", middleware.CSRFProtection, middleware.JWTAuthCheck, middleware.CheckWritableAccount)
 

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -238,7 +238,9 @@ export interface paths {
         /**
          * Retrieve the authenticated user's TOTP status
          * @description Returns only whether TOTP is currently enabled. Recovery-code inventory is intentionally not
-         *     exposed by this endpoint. Frozen accounts are not rejected, allowing account recovery actions.
+         *     exposed by this endpoint. The route is read-only and not writable-account-gated: frozen and
+         *     pending (unactivated) accounts are not rejected, so 2FA status remains readable during
+         *     account recovery (issue #427).
          */
         get: operations["getTotpStatus"];
         put?: never;
@@ -262,8 +264,10 @@ export interface paths {
          * Provision a TOTP secret for the authenticated user
          * @description Requires the account password as re-authentication. The secret and otpauth URI are returned
          *     once for authenticator enrollment; setup leaves TOTP disabled until enable is called. Calling
-         *     setup for an already enabled account returns `totp.alreadyEnabled`. Frozen accounts are not
-         *     rejected by this route because it is not a writable-account operation.
+         *     setup for an already enabled account returns `totp.alreadyEnabled`. The route is a
+         *     writable-account operation (issue #427): frozen accounts are rejected with
+         *     `permission.userFrozen`, and pending accounts (email verification enabled) with
+         *     `permission.emailRequired`.
          */
         post: operations["setupTotp"];
         delete?: never;
@@ -286,7 +290,9 @@ export interface paths {
          * @description Verifies the current six-digit code for a provisioned secret, marks TOTP enabled, and returns
          *     ten one-time recovery codes. Recovery codes are shown only in this success response. Calling
          *     enable without setup returns `totp.notEnabled`; calling it after enable returns
-         *     `totp.alreadyEnabled`. Frozen accounts are not rejected by this route.
+         *     `totp.alreadyEnabled`. The route is a writable-account operation (issue #427): frozen
+         *     accounts are rejected with `permission.userFrozen`, and pending accounts (email
+         *     verification enabled) with `permission.emailRequired`.
          */
         post: operations["enableTotp"];
         delete?: never;
@@ -308,7 +314,9 @@ export interface paths {
          * Disable TOTP for the authenticated user
          * @description Accepts either the current TOTP code or the account password. Disabling removes all stored
          *     recovery codes and returns a human-readable success result. Calling disable when TOTP is not
-         *     enabled returns `totp.notEnabled`. Frozen accounts are not rejected by this route.
+         *     enabled returns `totp.notEnabled`. The route is a writable-account operation (issue #427):
+         *     frozen accounts are rejected with `permission.userFrozen`, and pending accounts (email
+         *     verification enabled) with `permission.emailRequired`.
          */
         post: operations["disableTotp"];
         delete?: never;
@@ -10451,7 +10459,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            /** @description Rejected by the account write gate or the CSRF gate. `permission.userFrozen` for frozen accounts, `permission.emailRequired` for pending accounts (issue #427), or a cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10503,7 +10511,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            /** @description Rejected by the account write gate or the CSRF gate. `permission.userFrozen` for frozen accounts, `permission.emailRequired` for pending accounts (issue #427), or a cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -10555,7 +10563,7 @@ export interface operations {
                     "application/json": components["schemas"]["ApiFailure"];
                 };
             };
-            /** @description Cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
+            /** @description Rejected by the account write gate or the CSRF gate. `permission.userFrozen` for frozen accounts, `permission.emailRequired` for pending accounts (issue #427), or a cross-site cookie-authenticated request rejected by the CSRF gate (missing or mismatched Origin/Referer, issue #406). The session cookie is not cleared. */
             403: {
                 headers: {
                     [name: string]: unknown;

--- a/docs/product/identity-and-access.md
+++ b/docs/product/identity-and-access.md
@@ -77,10 +77,15 @@
   endpoints reject pending accounts before the controller runs with HTTP 403 and the
   structured `permission.emailRequired` envelope (params actionCode=write) — the same
   envelope is returned by every `CheckWritableAccount` write endpoint and is parsed by the
-  web client into an actionable activation message. Recovery writes (resend-activation-email,
-  set-user-email) stay allowed, as do the self-service account-close and content
-  privacy-erase lifecycle endpoints (the controllers keep their ownership, password, and
-  rate-limit checks). Enabling the setting backfills pending manage-role accounts
+  web client into an actionable activation message. The gate covers content writes and
+  account-security writes (profile, password, OAuth unbind, TOTP setup/enable/disable);
+  recovery writes (resend-activation-email, set-user-email) stay allowed, as do the
+  self-service account-close and content privacy-erase lifecycle endpoints (the controllers
+  keep their ownership, password, and rate-limit checks) and unread cleanup
+  (notification/chat mark-read only mutates the user's own read state, no content write).
+  Pending accounts can re-login by password or OAuth — a session itself grants no write
+  capability, so re-login only restores the recovery path (resend-activation-email) after
+  the original session expires. Enabling the setting backfills pending manage-role accounts
   (admin/site/user/… permissions) and activates them immediately through the user-cache
   refresh path, so the admin console cannot lock itself out; ordinary pending users are left
   untouched and must still complete the activation email.

--- a/packages/api-contract/paths/auth-totp.yaml
+++ b/packages/api-contract/paths/auth-totp.yaml
@@ -8,7 +8,9 @@ status:
       - accessTokenCookie: []
     description: |
       Returns only whether TOTP is currently enabled. Recovery-code inventory is intentionally not
-      exposed by this endpoint. Frozen accounts are not rejected, allowing account recovery actions.
+      exposed by this endpoint. The route is read-only and not writable-account-gated: frozen and
+      pending (unactivated) accounts are not rejected, so 2FA status remains readable during
+      account recovery (issue #427).
     responses:
       '200':
         description: TOTP status or a legacy business failure envelope.
@@ -42,8 +44,10 @@ setup:
     description: |
       Requires the account password as re-authentication. The secret and otpauth URI are returned
       once for authenticator enrollment; setup leaves TOTP disabled until enable is called. Calling
-      setup for an already enabled account returns `totp.alreadyEnabled`. Frozen accounts are not
-      rejected by this route because it is not a writable-account operation.
+      setup for an already enabled account returns `totp.alreadyEnabled`. The route is a
+      writable-account operation (issue #427): frozen accounts are rejected with
+      `permission.userFrozen`, and pending accounts (email verification enabled) with
+      `permission.emailRequired`.
     requestBody:
       required: true
       content:
@@ -77,13 +81,19 @@ setup:
                 externalValue: ../fixtures/totp-settings-unauthenticated.json
       '403':
         description: >-
-          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
-          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+          Rejected by the account write gate or the CSRF gate. `permission.userFrozen` for frozen
+          accounts, `permission.emailRequired` for pending accounts (issue #427), or a cross-site
+          cookie-authenticated request rejected by the CSRF gate (missing or mismatched
+          Origin/Referer, issue #406). The session cookie is not cleared.
         content:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
             examples:
+              frozen:
+                externalValue: ../fixtures/account-frozen.json
+              pendingActivation:
+                externalValue: ../fixtures/permission-email-required.json
               csrfRejected:
                 externalValue: ../fixtures/csrf-rejected.json
       '429':
@@ -114,7 +124,9 @@ enable:
       Verifies the current six-digit code for a provisioned secret, marks TOTP enabled, and returns
       ten one-time recovery codes. Recovery codes are shown only in this success response. Calling
       enable without setup returns `totp.notEnabled`; calling it after enable returns
-      `totp.alreadyEnabled`. Frozen accounts are not rejected by this route.
+      `totp.alreadyEnabled`. The route is a writable-account operation (issue #427): frozen
+      accounts are rejected with `permission.userFrozen`, and pending accounts (email
+      verification enabled) with `permission.emailRequired`.
     requestBody:
       required: true
       content:
@@ -148,13 +160,19 @@ enable:
                 externalValue: ../fixtures/totp-settings-unauthenticated.json
       '403':
         description: >-
-          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
-          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+          Rejected by the account write gate or the CSRF gate. `permission.userFrozen` for frozen
+          accounts, `permission.emailRequired` for pending accounts (issue #427), or a cross-site
+          cookie-authenticated request rejected by the CSRF gate (missing or mismatched
+          Origin/Referer, issue #406). The session cookie is not cleared.
         content:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
             examples:
+              frozen:
+                externalValue: ../fixtures/account-frozen.json
+              pendingActivation:
+                externalValue: ../fixtures/permission-email-required.json
               csrfRejected:
                 externalValue: ../fixtures/csrf-rejected.json
       '429':
@@ -184,7 +202,9 @@ disable:
     description: |
       Accepts either the current TOTP code or the account password. Disabling removes all stored
       recovery codes and returns a human-readable success result. Calling disable when TOTP is not
-      enabled returns `totp.notEnabled`. Frozen accounts are not rejected by this route.
+      enabled returns `totp.notEnabled`. The route is a writable-account operation (issue #427):
+      frozen accounts are rejected with `permission.userFrozen`, and pending accounts (email
+      verification enabled) with `permission.emailRequired`.
     requestBody:
       required: true
       content:
@@ -216,13 +236,19 @@ disable:
                 externalValue: ../fixtures/totp-settings-unauthenticated.json
       '403':
         description: >-
-          Cross-site cookie-authenticated request rejected by the CSRF gate (missing or
-          mismatched Origin/Referer, issue #406). The session cookie is not cleared.
+          Rejected by the account write gate or the CSRF gate. `permission.userFrozen` for frozen
+          accounts, `permission.emailRequired` for pending accounts (issue #427), or a cross-site
+          cookie-authenticated request rejected by the CSRF gate (missing or mismatched
+          Origin/Referer, issue #406). The session cookie is not cleared.
         content:
           application/json:
             schema:
               $ref: ../components/schemas.yaml#/ApiFailure
             examples:
+              frozen:
+                externalValue: ../fixtures/account-frozen.json
+              pendingActivation:
+                externalValue: ../fixtures/permission-email-required.json
               csrfRejected:
                 externalValue: ../fixtures/csrf-rejected.json
       '429':


### PR DESCRIPTION
## Summary / 摘要

统一激活门禁口径（issue #427，PR #415 review 遗留清单）：TOTP 写操作挂上 `CheckWritableAccount`、pending 用户可清理未读、pending 账号可重新登录（密码 + OAuth），并补齐文档与契约。de locale 项经核实已在 PR #412 当前头包含 `permission.emailRequired`，无需协调。

## Behavior change / 行为变更

1. **TOTP 绑定挂门禁**（item 1）：`POST /api/user/totp/setup|enable|disable` 挂 `CheckWritableAccount`。冻结账号 403 `permission.userFrozen`、pending 账号（邮箱验证开启时）403 `permission.emailRequired`，与 change-password 等账户写操作口径一致；只读 `user/totp/status` 不挂门禁（冻结/pending 均可读）。S5 契约测试同步从「冻结不被拒绝」翻转为「冻结 403」。
2. **未读清理对 pending 放行**（item 2）：`notification/mark-read`、`notification/mark-all-read`、`chat/mark-read` 改用 `CheckWritableAccountAllowPendingActivation`——pending 用户可清除自己的未读角标（仅变更自有读状态、不产生内容写）；冻结拦截保留，越权（非会话成员）仍被拒。
3. **pending 可重新登录**（item 3）：`api.Login` 移除 `auth.email.unverified` 拒绝——pending 账号密码登录成功并签发会话（`New-Token` + `Set-Cookie`），写权限仍在权限层被 `CheckWritableAccount` 拦截（会话本身不授予写能力），借此可在会话过期后继续走 `resend-activation-email` 恢复（该路由需要会话）。**一致性扩展**：OAuth callback 对 pending 用户同样签发会话（原 issue #155 拒绝路径；OAuth 建号用户通常无密码，否则其过期会话后永久锁死）；未验证邮箱建号拒绝（`ErrOAuthEmailUnverified`）不变。
4. **de locale**（item 4）：核实 PR #412（it→de）当前分支已含 `serverMessages.permission.emailRequired` 德语键，无需本 PR 改动。

## Verification / 验证

- `git diff --check` ✅
- `go build ./...`、`go vet ./app/http/... ./app/service/oauthservice/` ✅
- `go test ./...`（apps/gooseforum）全绿 ✅（新增：TOTP 冻结/pending 403、pending mark-read 放行、pending 密码登录签发会话 + 写仍 403、OAuth pending 签发会话）
- `go test ./app/http/routes/ ./app/http/controllers/api/ ./app/http/middleware/ ./app/http/controllers/` ✅
- `pnpm run check`（api-contract）：lint/bundle/fixtures 1056 OK / TS-gen OK / route-coverage 284 = 224 + 0 + 60 ✅
- `pnpm typecheck` ✅；`pnpm test` 中 8 个失败为 `schedule-major-selector` / `schedule-rough-list-drop` **存量失败**（clean dev 同样失败，与本次改动无关）

## Docs & contract impact / 文档与契约影响

- `packages/api-contract/paths/auth-totp.yaml`：setup/enable/disable/status 描述更新 + 403 响应补充 `account-frozen.json` / `permission-email-required.json` 示例；生成 TS（`openapi.ts`）同步（仅描述变化，无类型变化 → 移动端 Dart mirror 无需改动）
- `docs/product/identity-and-access.md`：账户生命周期章节更新（pending 可重登、未读清理放行、TOTP 属于写门禁范围）

## Known gaps / 已知缺口

- pending 用户登录后的前端 UX：登录成功跳转首页后仅靠写接口 403 激活指引 + Settings 重发入口，无独立「待激活横幅」；`auth.unverified` 前端文案键因此保留未删。
- 冻结/pending 对 `chat/send`（内容写）仍走 `CheckWritableAccount`，不在本次放行范围。

---
**CI note**: ci-backend 首次运行在未触及的 `app/console` `TestServeRuntimeFatalMigrationSurfaces`（#370 引入的竞态：`wait()` 可能在 migrate goroutine 记录 fatal 前返回）上失败，重跑后 ci-backend 与 ci-backend-race 均通过；该测试本地 20 次连跑全绿，属存量 flake，与本改动无关。
