### PR TITLE
fix(frontend): 顶部搜索栏提交改走 router.push，消除游离 anchor 整页导航白屏

### DIFF
--- a/apps/gooseforum/resource/src/site/components/AppShell.vue
+++ b/apps/gooseforum/resource/src/site/components/AppShell.vue
@@ -28,7 +28,7 @@ import {
   UserRound,
 } from '@lucide/vue'
 import { useI18n } from 'vue-i18n'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import GlobalFlash from './GlobalFlash.vue'
 import { setLocale, supportedLocales, type Locale } from '@/runtime/i18n'
 import { queueFlashMessage } from '@/runtime/flash-message'
@@ -49,6 +49,7 @@ import QuickPublishModal from './QuickPublishModal.vue'
 import { useShellState } from '@/runtime/shell-state'
 
 const route = useRoute()
+const router = useRouter()
 const shellState = useShellState()
 const isPublishPage = computed(() => route?.path === '/publish' || route?.name === 'publish')
 const isTopicPage = computed(() => {
@@ -287,16 +288,23 @@ function closeDrawer() {
   drawerOpen.value = false
 }
 
-function submitSearch() {
+// 搜索提交走客户端路由跳转：与 SearchPage 同策略，复用 router.push 的
+// X-Goose-Page JSON 拉取路径（顶部 loading bar、旧页保持）。此前用游离
+// anchor 的 click() 触发全局 a[href] 拦截器，但游离节点事件冒泡不到
+// document，拦截器永远收不到，浏览器每次都执行默认整页导航白屏（issue #446）。
+// 异常时降级整页跳转，保留可用性。
+async function submitSearch() {
   const query = searchQuery.value.trim()
   if (!query) {
     searchInput.value?.focus()
     return
   }
-  // 复用全局 SPA 导航（router 拦截 a[href] 点击）；绕过则回退整页跳转。
-  const link = document.createElement('a')
-  link.href = `/search?q=${encodeURIComponent(query)}`
-  link.click()
+  const target = `/search?q=${encodeURIComponent(query)}`
+  try {
+    await router.push(target)
+  } catch {
+    window.location.assign(target)
+  }
 }
 
 async function logout() {

--- a/apps/gooseforum/resource/test/app-shell-search-submit.test.ts
+++ b/apps/gooseforum/resource/test/app-shell-search-submit.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { vi } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils'
+import { createMemoryHistory, createRouter, type Router } from 'vue-router'
+import { i18n } from '../src/runtime/i18n'
+import AppShell from '../src/site/components/AppShell.vue'
+import type { LayoutPayload } from '@gooseforum/client'
+
+function minimalLayout(): LayoutPayload {
+  return {
+    site: {
+      name: 'yourtj',
+      description: '',
+      logo: '',
+      favicon: '',
+      brandType: 'text',
+      brandText: 'yourtj',
+      brandImage: '',
+    },
+    viewer: {
+      id: 0,
+      username: '',
+      email: '',
+      avatarUrl: '',
+      isAuthenticated: false,
+      canAccessAdmin: false,
+      isModerator: false,
+      requiresEmailVerification: false,
+      adminPermissions: [],
+    },
+    sidebar: { main: [], resources: [], groups: [], categories: [], activeKey: 'topics' },
+    footer: { links: [], primary: [] },
+    unread: { notifications: false, messages: false, moderationReports: false },
+    theme: { enabled: false, current: 'gf-light', themeColor: '#fbfdff' },
+  }
+}
+
+function makeRouter(): Router {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
+  })
+}
+
+async function mountShell(router: Router): Promise<VueWrapper> {
+  const wrapper = mount(AppShell, {
+    props: { layout: minimalLayout() },
+    global: { plugins: [i18n, router] },
+    attachTo: document.body,
+  })
+  return wrapper
+}
+
+// 回归测试（issue #446，与 SearchPage 提交同一体验问题的另一处实例）：
+// navbar 搜索栏此前用 document.createElement('a').click() 触发全局 a[href]
+// 点击拦截器转成 SPA 路由，但游离节点的事件路径只有它自己，冒泡不到
+// document，拦截器永远收不到，浏览器执行默认行为——整页导航白屏
+// （无顶部 loading bar）。提交必须走 router.push 的 X-Goose-Page JSON
+// 拉取路径，与 SearchPage 对齐。
+describe('AppShell navbar 搜索表单提交', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  test('回车提交走客户端路由跳转（不再整页导航）', async () => {
+    const router = makeRouter()
+    const wrapper = await mountShell(router)
+    await wrapper.get('input[type="search"]').setValue('Vue 白屏')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/search')
+    expect(router.currentRoute.value.query.q).toBe('Vue 白屏')
+    wrapper.unmount()
+  })
+
+  test('查询词首尾空白被裁剪（与后端 buildSearchURL 语义一致）', async () => {
+    const router = makeRouter()
+    const wrapper = await mountShell(router)
+    await wrapper.get('input[type="search"]').setValue('  选课  ')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.query.q).toBe('选课')
+    wrapper.unmount()
+  })
+
+  test('空查询不导航、聚焦输入框', async () => {
+    const router = makeRouter()
+    const wrapper = await mountShell(router)
+    const input = wrapper.get('input[type="search"]')
+    const focusSpy = vi.spyOn(input.element, 'focus')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/')
+    expect(focusSpy).toHaveBeenCalled()
+    focusSpy.mockRestore()
+    wrapper.unmount()
+  })
+})

--- a/apps/gooseforum/resource/test/app-shell-search-submit.test.ts
+++ b/apps/gooseforum/resource/test/app-shell-search-submit.test.ts
@@ -43,13 +43,13 @@ function makeRouter(): Router {
   })
 }
 
-async function mountShell(router: Router): Promise<VueWrapper> {
-  const wrapper = mount(AppShell, {
+// mount 与内部 setup/onMounted 均同步完成，无需 Promise 包装
+function mountShell(router: Router): VueWrapper {
+  return mount(AppShell, {
     props: { layout: minimalLayout() },
     global: { plugins: [i18n, router] },
     attachTo: document.body,
   })
-  return wrapper
 }
 
 // 回归测试（issue #446，与 SearchPage 提交同一体验问题的另一处实例）：
@@ -65,7 +65,7 @@ describe('AppShell navbar 搜索表单提交', () => {
 
   test('回车提交走客户端路由跳转（不再整页导航）', async () => {
     const router = makeRouter()
-    const wrapper = await mountShell(router)
+    const wrapper = mountShell(router)
     await wrapper.get('input[type="search"]').setValue('Vue 白屏')
     await wrapper.get('form').trigger('submit')
     await flushPromises()
@@ -76,7 +76,7 @@ describe('AppShell navbar 搜索表单提交', () => {
 
   test('查询词首尾空白被裁剪（与后端 buildSearchURL 语义一致）', async () => {
     const router = makeRouter()
-    const wrapper = await mountShell(router)
+    const wrapper = mountShell(router)
     await wrapper.get('input[type="search"]').setValue('  选课  ')
     await wrapper.get('form').trigger('submit')
     await flushPromises()
@@ -86,7 +86,7 @@ describe('AppShell navbar 搜索表单提交', () => {
 
   test('空查询不导航、聚焦输入框', async () => {
     const router = makeRouter()
-    const wrapper = await mountShell(router)
+    const wrapper = mountShell(router)
     const input = wrapper.get('input[type="search"]')
     const focusSpy = vi.spyOn(input.element, 'focus')
     await wrapper.get('form').trigger('submit')
@@ -94,6 +94,41 @@ describe('AppShell navbar 搜索表单提交', () => {
     expect(router.currentRoute.value.path).toBe('/')
     expect(focusSpy).toHaveBeenCalled()
     focusSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('duplicated navigation 不触发整页回退', async () => {
+    const router = makeRouter()
+    const wrapper = mountShell(router)
+    const assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => {})
+    await wrapper.get('input[type="search"]').setValue('选课')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.query.q).toBe('选课')
+    // 重复提交相同查询：duplicated navigation 属正常取消（resolve 非 reject），
+    // 绝不落入 location.assign 整页回退
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(router.currentRoute.value.query.q).toBe('选课')
+    expect(assignSpy).not.toHaveBeenCalled()
+    assignSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  test('router.push 真异常时降级整页跳转', async () => {
+    const router = makeRouter()
+    const wrapper = mountShell(router)
+    // guard 抛未捕获异常 → push promise reject → 落入 catch 整页回退保留可用性
+    router.beforeEach(() => {
+      throw new Error('guard exploded')
+    })
+    const assignSpy = vi.spyOn(window.location, 'assign').mockImplementation(() => {})
+    await wrapper.get('input[type="search"]').setValue('Vue 白屏')
+    await wrapper.get('form').trigger('submit')
+    await flushPromises()
+    expect(assignSpy).toHaveBeenCalledWith('/search?q=Vue%20%E7%99%BD%E5%B1%8F')
+    expect(router.currentRoute.value.path).toBe('/')
+    assignSpy.mockRestore()
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Motivation

顶部 navbar 桌面搜索栏提交后是**整页导航**（issue #446），与 #400 报告的搜索页白屏同源：旧页卸载 → `#goose-app` 空壳 → 白屏后才呈现搜索结果，且没有顶部 loading bar。

根因是游离 DOM 陷阱：`AppShell.vue` 的 `submitSearch()` 用 `document.createElement('a').click()` 假设 anchor 点击会冒泡到 `document`、被全局 `a[href]` 拦截器（`src/runtime/router.ts`）转成 SPA 路由。但该 anchor **从未挂载进 DOM**——游离节点的事件路径只有它自己，冒泡不到 `document` 上的监听器，拦截器永远收不到，浏览器每次都执行默认整页导航。

对照：PR #414 只修复了 `SearchPage.vue` 的表单原生提交，未覆盖 AppShell 这条入口；本 PR 是同一体验问题的剩余未修处。

## Behavior change

- `AppShell.vue` 搜索提交改为与 SearchPage 对齐的 `router.push('/search?q=…')` 客户端路由跳转：旧页面保持显示、顶部出现统一 loading bar，不再整页卸载白屏。
- 动态游离 anchor hack 整个删除；空查询仍聚焦输入框。
- `router.push` 真异常（非 duplicated navigation）时才降级 `window.location.assign(target)` 整页跳转，保留可用性。

## Verification

- 红→绿：先写 `resource/test/app-shell-search-submit.test.ts`（3 用例）确认提交无路由跳转（红：`expected '/' to be '/search'`），实现后转绿。
- `npx vitest run --dir test app-shell-search-submit` — 3/3 passed
- `npx vitest run --dir test search-page-submit app-shell-search-submit` — 8/8 passed
- `pnpm test` — 60 files passed / 8 failed，**8 个失败均为既有环境问题**（Node 实验性 `localStorage` 需 `--localstorage-file`，`schedule-rough-list-drop` / `schedule-major-selector`），在未改动的 origin/dev 基线同样失败，与本 PR 无关。
- `pnpm typecheck` — exit 0
- `git diff --check` — 无空白错误

## Documentation / contract impact

无。纯前端交互 bug 修复，不涉及 OpenAPI 契约、数据库、公开行为；代码注释已同步更新根因说明。

## Known gaps

无 JS 环境仍走原生整页跳转——与站点其余部分（无 JS 只见 noscript 提示）一致，属预期回退。

Closes #446