### PR TITLE
fix(backend): declare Go toolchain floor go1.26.6 + toolchain go1.26.8 (issue #447)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -79,6 +79,22 @@ jobs:
         if: steps.filter.outputs.backend == 'true'
         with:
           go-version: "1.26"
+      # Go 工具链下限门禁(issue #447): go.mod 声明 go 1.26.6 + toolchain go1.26.8,
+      # 但 setup-go 的 go-version "1.26"(check-latest) 只保证取最新 1.26.x patch。
+      # 显式断言解析到的实际工具链 >= 1.26.6, 防止缓存/回退导致旧 patch
+      # (go1.26.5 及更早的 7 个 stdlib CVE, 修复于 go1.26.6) 静默编译产物。
+      - name: Assert Go toolchain >= 1.26.6 (issue #447)
+        if: steps.filter.outputs.backend == 'true'
+        working-directory: apps/gooseforum
+        run: |
+          set -euo pipefail
+          min="1.26.6"
+          cur="$(go env GOVERSION | sed 's/^go//')"
+          if [[ "$(printf '%s\n%s\n' "$min" "$cur" | sort -V | head -n1)" != "$min" ]]; then
+            echo "::error::Go toolchain ${cur} is below the required minimum ${min} (stdlib CVEs fixed in Go 1.26.6, issue #447)"
+            exit 1
+          fi
+          echo "Go toolchain ${cur} >= ${min}: OK"
       - name: Vet
         if: steps.filter.outputs.backend == 'true'
         working-directory: apps/gooseforum

--- a/apps/gooseforum/go.mod
+++ b/apps/gooseforum/go.mod
@@ -1,6 +1,8 @@
 module github.com/YourTongji/YourTJ-Hub/apps/gooseforum
 
-go 1.26.0
+go 1.26.6
+
+toolchain go1.26.8
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0

--- a/docs/development/dependency-scanning.md
+++ b/docs/development/dependency-scanning.md
@@ -29,6 +29,7 @@
 - DB 上游：Go 官方 `vuln.go.dev`（`GOVULNDB` 环境变量可覆盖，见下）。
 - govulncheck 二进制本身用 `go install ...@latest`（CI action 内部）或 `go run ...@latest`（本地），每次取最新版。
 - Go 工具链：CI 用 `go-version-input: "1.26"`，action 内部 `check-latest: true` 会取最新 1.26.x patch。标准库漏洞随工具链升级消解：例如 go1.26.5 报告的 7 个 stdlib CVE（`net/url`、`html/template`、`crypto/tls`、`net/http`、`encoding/xml`、`encoding/asn1` 等）全部修复于 go1.26.6，升级 Go patch 即可清零，无需动任何依赖。
+- 仓库工具链下限（issue #447）：`apps/gooseforum/go.mod` 声明 `go 1.26.6` 且 `toolchain go1.26.8`。本地/部署构建在旧 patch 工具链下由 `GOTOOLCHAIN=auto`（默认）自动下载合规版本，或设置 `GOTOOLCHAIN=local` 时明确失败——不再可能静默用带 stdlib 漏洞的旧工具链编译单二进制。CI `ci-backend` job 另有 `go env GOVERSION` ≥ 1.26.6 的显式断言作为门禁。
 - 依赖版本升级由 Dependabot（`.github/dependabot.yml`，`go_modules` ecosystem，每周）提出 PR；升级 PR 会触发本扫描与 `ci-backend` 全量测试。
 
 ## 代理失败诊断
@@ -78,6 +79,6 @@ govulncheck 实测（2026-09-03，v0.54.0，text 格式）将 4 条 x/crypto 条
 
 报告与 issue 中区分三类，不要混为一谈：
 
-1. **应用可达漏洞**（Symbol Results）：当前实际基线为 **0 个**——CI run 33781751646（2026-09-03，action `check-latest` 取到 Go 1.26.8）显示 `No vulnerabilities found`。历史注记：go1.26.5 曾报告 7 个标准库漏洞（均修复于 go1.26.6，随工具链升级消解）；`x/image` VP8L `GO-2026-6222`（v0.44.0 → 修复于 v0.45.0）在本分支仅出现在 Package 层（import 但未调用、不可达，不影响退出码），随 issue #405 合入后条目整体消失。
+1. **应用可达漏洞**（Symbol Results）：当前实际基线为 **0 个**——CI run 33781751646（2026-09-03，action `check-latest` 取到 Go 1.26.8）显示 `No vulnerabilities found`。历史注记：go1.26.5 曾报告 7 个标准库漏洞（均修复于 go1.26.6，随工具链升级消解），issue #447 起仓库通过 `go.mod` 声明工具链下限（`go 1.26.6` + `toolchain go1.26.8`），本地与部署构建同样不会回退到带漏洞的旧 patch；`x/image` VP8L `GO-2026-6222`（v0.44.0 → 修复于 v0.45.0）在本分支仅出现在 Package 层（import 但未调用、不可达，不影响退出码），随 issue #405 合入后条目整体消失。
 2. **依赖存在但不可达提示**（Package/Module Results）：含本文 x/crypto 4 条。
 3. **扫描基础设施失败**：网络/代理错误，必须让 CI 红并按下节诊断。

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -10,7 +10,7 @@
 
 ## Dependencies
 
-- Go 1.26+
+- Go 1.26.6+（`apps/gooseforum/go.mod` 声明 `go 1.26.6` + `toolchain go1.26.8`，issue #447：更早的 patch 含 7 个已修复的 stdlib CVE；默认 `GOTOOLCHAIN=auto` 下旧工具链会自动下载合规版本，设 `GOTOOLCHAIN=local` 则明确报错而非静默编译）
 - Node 24 + pnpm 11 (the forum frontend workspace lives in `apps/gooseforum/resource/` with its own
   pnpm-workspace.yaml; **note**: the home-directory `/Users/yzxoi/pnpm-workspace.yaml` can interfere
   with pnpm's upward lookup — run pnpm from inside `resource/`)


### PR DESCRIPTION
Closes #447

## Problem

`apps/gooseforum/go.mod` declared `go 1.26.0` with no `toolchain` line, so local development and deployment builds could silently compile the single binary with any Go 1.26.0–1.26.5 patch — stdlibs carrying the 7 reachable CVEs (`net/url`, `html/template`, `crypto/tls`, `net/http`, `encoding/xml`, `encoding/asn1`, …) that were fixed in **go1.26.6**. CI was green because `setup-go`/govulncheck resolve the latest 1.26.x patch (`check-latest`), masking the gap.

## Changes

1. **`apps/gooseforum/go.mod`** — `go 1.26.0` → `go 1.26.6` (minimum floor, fixes the 7 stdlib CVEs) + `toolchain go1.26.8` (current latest patch as the declared toolchain). Under default `GOTOOLCHAIN=auto`, older patch toolchains now auto-download the compliant toolchain; with `GOTOOLCHAIN=local` the build fails explicitly instead of silently using the vulnerable stdlib.
2. **`.github/workflows/ci-backend.yml`** — explicit `go env GOVERSION ≥ 1.26.6` assertion step in the `ci-backend` build path, so a cache/regression to an old patch fails loudly rather than silently producing a vulnerable binary.
3. **Docs** — `docs/development/dependency-scanning.md` (repo toolchain floor recorded in the Go toolchain bullet + scanning conclusion) and `docs/development/local-development.md` (requirement updated to Go 1.26.6+).

## Verification (run locally)

| Check | Result |
|---|---|
| `cd apps/gooseforum && go build ./...` with local go1.26.6 | ✅ auto-switched to and built with **go1.26.8** (declared toolchain), exit 0 |
| `go mod tidy -diff` | ✅ no go.mod/go.sum drift |
| `go vet ./...` | ✅ exit 0 |
| `go test ./...` | ✅ 97 packages ok, exit 0 (2 flaky order-dependent HTTP contract tests in `app/http/routes` failed on the first full run, passed in isolation and on re-run) |
| `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` under declared toolchain | ✅ `No vulnerabilities found`, 0 reachable (acceptance criterion) |
| CI assertion snippet | ✅ accepts 1.26.8, correctly rejects simulated 1.26.5 |
| `git diff --check` | ✅ clean |
| Workflow YAML parse | ✅ valid |

No model/migration/contract changes — no PG migration gate or `make contract-check` applicable.