### PR TITLE
fix(web): 移除 vite server.origin，修复 CSP 拦截 dev 运行时资源导致编辑器无法加载

### DIFF
--- a/apps/gooseforum/resource/test/vite-config.test.ts
+++ b/apps/gooseforum/resource/test/vite-config.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import config from '../vite.config'
+
+/**
+ * 页面级 CSP（app/http/middleware/securityHeaders.go buildPageCSP）为 script-src 'self'：
+ * dev 模式若设置 Vite server 的 origin，`?url` 运行时资源（vditor i18n/lute/icons、katex 等）
+ * 会生成为指向 dev server 的绝对 URL，对后端端口而言是跨域脚本而被 CSP 静默拦截，
+ * 编辑器无法初始化（issue #453）。删除后资源为 /assets 相对路径，经后端 dev 代理同源返回，
+ * 与生产构建行为一致。上游同步时勿再带入该配置。
+ */
+describe('vite 配置约束', () => {
+  test('dev server 不得固定 origin，保证 ?url 运行时资源为同源相对路径', () => {
+    const server = (config as { server?: { origin?: string } }).server
+    expect(server?.origin).toBeUndefined()
+  })
+})

--- a/apps/gooseforum/resource/vite.config.ts
+++ b/apps/gooseforum/resource/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
   },
   server: {
     port: 3010,
-    origin: 'http://localhost:3010',
+    // 不固定 dev server 的来源地址：页面 CSP 为 script-src 'self'，固定后 `?url` 运行时资源
+    // 生成绝对 URL 会被判为跨域脚本静默拦截（issue #453）。保持相对路径经后端 /assets 同源代理。
   },
 })


### PR DESCRIPTION
Closes #453

## 动机

PR #418 合入后，dev 分支本地开发工作流被破坏：页面级 CSP（`script-src 'self'`）与 `vite.config.ts` 中上游遗留的 `server.origin: 'http://localhost:3010'` 冲突。dev 模式下所有 `?url` 导入的运行时资源（vditor 的 i18n/lute/icons、katex、highlight.js 主题）生成为指向 `:3010` 的绝对 URL，对 `:5234` 页面是跨域脚本，被 CSP 静默拦截——快速发布弹窗（发瞬间/提问题）编辑器无法渲染，写文章页编辑区空白。

## 修复

- 删除 `vite.config.ts` 的 `server.origin` 一行：`?url` 资源随之变为 `/assets/...` 相对路径，经后端 dev 代理（`resource.devServer`，`route4api.go`）同源返回，与生产构建行为一致；`securityHeaders.go` 的 CSP 注释正是按此 dev 资源形态设计的。
- 原位留注释说明该约束，防止上游同步再带入。
- 新增回归测试 `test/vite-config.test.ts`：断言 dev server 配置不得固定 origin（先红后绿验证）。

## 影响面

仅本地开发（vite dev server）；生产 go:embed 单二进制无此问题。不触及后端 / 契约 / 迁移。

## 验证（实际运行）

- 回归测试先红（dev 原始代码 1 failed）→ 修复后绿（1 passed）
- `pnpm typecheck` — exit 0
- 浏览器实测（dev 环境）：发瞬间弹窗 vditor 完整挂载（工具栏/正文区正常），`VditorI18n`/`Lute`/`katex` 全部就绪，零 console 报错；写文章页编辑器正常加载
- 浏览器内对照实验佐证根因：`<script src="http://localhost:3010/...">` 稳定失败、同 URL `fetch` 200（`connect-src` 放行 `http: https:`，仅 script 被拦截）、`<script src="/assets/...">` 经后端同源代理加载成功