### PR TITLE
fix(admin): AI 总结 apiKey 保存被硬编码清空——填了 key 保存后仍显示未配置

### DIFF
--- a/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
@@ -848,10 +848,13 @@ async function save() {
     else if (props.kind === 'mcp') await saveMCPSettings(normalizeMCP(mcpForm))
     else if (props.kind === 'ai-summary') {
       await saveAiSummarySettings(aiSummaryPayload())
-      // 保存后立即同步徽标：填了新 key（非留空=保留旧 key）即视为已配置，
-      // 不依赖重进页面重新 GET（与 onesystem saveCookie 的成功后置位一致）。
+      // 保存后立即同步徽标并清空明文 key：填了新 key（非留空=保留旧 key）即
+      // 视为已配置。清空后该标签页后续保存（如改 temperature）不再重发/重加密
+      // 同一明文，多管理员/多标签轮换 key 时旧表单不会静默恢复旧 key
+      // （空 = 保留已存密文语义，与 saveCookie 保存后清空一致）。
       if (aiSummaryForm.apiKey.trim() !== '') {
         aiSummaryForm.apiKeyConfigured = true
+        aiSummaryForm.apiKey = ''
       }
     }
     else if (props.kind === 'http-notify') await saveHttpNotifySettings(httpNotifySettings!)

--- a/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
@@ -463,7 +463,7 @@ function normalizeAiSummary(settings: Partial<AiSummarySettings> = {}) {
     globalPerMinute: Math.max(Number(settings.globalPerMinute ?? 5), 0),
     baseUrl: (settings.baseUrl ?? '').trim().replace(/\/+$/, ''),
     model: (settings.model ?? '').trim(),
-    apiKey: '',
+    apiKey: settings.apiKey ?? '',
     apiKeyConfigured: toBool(settings.apiKeyConfigured, false),
     temperature,
     maxTokens: maxTokens == null ? undefined : Math.max(maxTokens, 0),
@@ -846,7 +846,14 @@ async function save() {
     else if (props.kind === 'posting') await savePostingSettings(normalizePosting(postingForm))
     else if (props.kind === 'rate-limit') await saveRateLimitSettings(normalizeRateLimit(rateLimitForm))
     else if (props.kind === 'mcp') await saveMCPSettings(normalizeMCP(mcpForm))
-    else if (props.kind === 'ai-summary') await saveAiSummarySettings(aiSummaryPayload())
+    else if (props.kind === 'ai-summary') {
+      await saveAiSummarySettings(aiSummaryPayload())
+      // 保存后立即同步徽标：填了新 key（非留空=保留旧 key）即视为已配置，
+      // 不依赖重进页面重新 GET（与 onesystem saveCookie 的成功后置位一致）。
+      if (aiSummaryForm.apiKey.trim() !== '') {
+        aiSummaryForm.apiKeyConfigured = true
+      }
+    }
     else if (props.kind === 'http-notify') await saveHttpNotifySettings(httpNotifySettings!)
     else if (props.kind === 'storage') await saveStorageSettings(storagePayload())
     else if (props.kind === 'terms') await saveTermsOfService(normalizeTerms(termsForm))

--- a/apps/gooseforum/resource/test/admin-ai-summary-save.test.ts
+++ b/apps/gooseforum/resource/test/admin-ai-summary-save.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+// 从源码提取 ai-summary 表单的 normalize/save 逻辑，静态断言保存链路不回丢
+// apiKey（回归：normalizeAiSummary 曾硬编码 apiKey: ''，用户填的 key 在保存时
+// 被清空 → 后端按「留空=保留已存密文」处理 → 永远无法配置 → 线上 401）。
+
+const pageSrc = readFileSync(resolve(__dirname, '../src/admin/pages/AdminSettingsPage.vue'), 'utf8')
+
+function extractFunction(name: string, async = false): string {
+  const signature = async ? `async function ${name}(` : `function ${name}(`
+  const start = pageSrc.indexOf(signature)
+  expect(start, `function ${name} should exist`).toBeGreaterThanOrEqual(0)
+  const end = pageSrc.indexOf('\n}', start)
+  expect(end, `function ${name} should terminate`).toBeGreaterThan(start)
+  return pageSrc.slice(start, end)
+}
+
+describe('admin AI summary apiKey 保存链路(回归: 填了 key 保存后仍显示未配置)', () => {
+  test('normalizeAiSummary 保留表单 apiKey（不硬编码清空）', () => {
+    const fn = extractFunction('normalizeAiSummary')
+    expect(fn).toContain("apiKey: settings.apiKey ?? ''")
+    expect(fn).not.toContain("apiKey: ''")
+  })
+
+  test('ai-summary 保存成功后同步 apiKeyConfigured 徽标状态', () => {
+    const saveFn = extractFunction('save', true)
+    // save() 内 ai-summary 分支：保存后立即置位（依赖重新进入页面会误导用户）。
+    const branch = saveFn.slice(saveFn.indexOf("kind === 'ai-summary'"))
+    expect(branch).toContain('await saveAiSummarySettings(aiSummaryPayload())')
+    expect(branch).toContain('aiSummaryForm.apiKeyConfigured = true')
+  })
+
+  test('apiKeyConfigured 为只读回显字段，不随保存请求回传（issue #324 安全模式）', () => {
+    const payloadFn = extractFunction('aiSummaryPayload')
+    expect(payloadFn).toContain('apiKeyConfigured: _configured')
+    expect(payloadFn).toContain('...payload')
+  })
+})

--- a/apps/gooseforum/resource/test/admin-ai-summary-save.test.ts
+++ b/apps/gooseforum/resource/test/admin-ai-summary-save.test.ts
@@ -24,12 +24,15 @@ describe('admin AI summary apiKey 保存链路(回归: 填了 key 保存后仍�
     expect(fn).not.toContain("apiKey: ''")
   })
 
-  test('ai-summary 保存成功后同步 apiKeyConfigured 徽标状态', () => {
+  test('ai-summary 保存成功后同步徽标并清空明文 key', () => {
     const saveFn = extractFunction('save', true)
-    // save() 内 ai-summary 分支：保存后立即置位（依赖重新进入页面会误导用户）。
+    // save() 内 ai-summary 分支：保存后立即置位徽标并清空明文——后续保存（如改
+    // temperature）不再重发/重加密同一明文，多管理员轮换 key 时旧表单不会静默
+    // 恢复旧 key（空 = 保留已存密文语义，与 saveCookie 保存后清空一致）。
     const branch = saveFn.slice(saveFn.indexOf("kind === 'ai-summary'"))
     expect(branch).toContain('await saveAiSummarySettings(aiSummaryPayload())')
     expect(branch).toContain('aiSummaryForm.apiKeyConfigured = true')
+    expect(branch).toContain('aiSummaryForm.apiKey = \'\'')
   })
 
   test('apiKeyConfigured 为只读回显字段，不随保存请求回传（issue #324 安全模式）', () => {


### PR DESCRIPTION
## Summary
线上（f.yourtj.de）AI 课程总结长期 `course.summary.failed`（日志：`llm api status 401`）。排查发现：管理后台 AI 总结配置**填了 API key 点保存后仍显示「未配置」**——key 从未真正落库。

## 根因
`AdminSettingsPage.vue` 的 `normalizeAiSummary()` **硬编码 `apiKey: ''`**，而保存负载 `aiSummaryPayload()` 正是经它构造的：
- 用户填的 key → 保存时被强制清空
- 后端收到空 key → 按「留空 = 保留已存密文」处理（库中从无密文）
- 保存「成功」但 key 从未写入 → 重进页面仍显示未配置 → 请求无 Authorization → **401**

同文件 mail/storage 的密钥字段（`smtpPassword`/`secretKey`）都是保留表单值的，只有 ai-summary 被硬编码清空（历史回归）。

## 修复
- `normalizeAiSummary()`：`apiKey: ''` → `apiKey: settings.apiKey ?? ''`（保留表单值）
- `save()` 的 ai-summary 分支：保存成功后立即同步 `apiKeyConfigured` 徽标（填了新 key 即视为已配置，不依赖重进页面重新 GET，与 onesystem `saveCookie` 模式一致）

## Verification
- 新增回归测试 `admin-ai-summary-save.test.ts`（3 条静态断言）：normalize 不回丢 apiKey / 保存分支置位徽标 / `apiKeyConfigured` 只读回显不回传（issue #324 安全模式）
- `pnpm typecheck` ✅、`pnpm test` 全量 422 通过 ✅