### PR TITLE
fix(admin): 批量导入弹层限高，修复粘贴大词表时无法滚动

### DIFF
--- a/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
@@ -1911,25 +1911,27 @@ onUnmounted(stopSyncPolling)
       </Dialog>
 
       <Dialog :open="bulkImportOpen" @update:open="bulkImportOpen = $event">
-        <DialogContent class="sm:max-w-lg">
-          <DialogHeader>
+        <!-- 限高弹层：Textarea 基类 field-sizing-content 随内容撑高，粘贴超长词表时
+             仅中部滚动区滚动、页眉/页脚固定，防止弹层超出视口被裁且无法滚动。 -->
+        <DialogContent class="flex max-h-[min(700px,calc(100vh-1.5rem))] flex-col overflow-hidden p-0 sm:max-w-lg">
+          <DialogHeader class="shrink-0 px-6 pt-6">
             <DialogTitle>{{ adminText('k00ug') }}：{{ adminText(bulkImportTitleKey) }}</DialogTitle>
             <DialogDescription>{{ bulkImportTarget === 'sensitiveWords' ? adminText('k00un') : adminText('k00uf') }}</DialogDescription>
           </DialogHeader>
-          <div class="space-y-3">
-            <Textarea v-model="bulkImportText" class="min-h-32 text-sm" />
+          <div class="min-h-0 flex-1 space-y-3 overflow-y-auto px-6 py-2">
+            <Textarea v-model="bulkImportText" class="max-h-56 min-h-32 text-sm" />
             <p v-if="bulkImportEmptyHint" class="text-sm text-destructive">{{ adminText('k00uj') }}</p>
             <template v-if="bulkImportPreview">
               <p class="text-sm font-medium">{{ adminText('k00ui', { added: bulkImportPreview.added.length, skipped: bulkImportPreview.skipped }) }}</p>
               <p v-if="bulkImportPreview.truncated" class="text-xs text-muted-foreground">{{ adminText('k00uk', { limit: BULK_IMPORT_LIMIT }) }}</p>
-              <div v-if="bulkImportPreview.added.length > 0" class="flex max-h-44 flex-wrap gap-2 overflow-y-auto rounded-lg border bg-muted/10 p-3">
+              <div v-if="bulkImportPreview.added.length > 0" class="flex flex-wrap gap-2 rounded-lg border bg-muted/10 p-3">
                 <span v-if="bulkImportPreview.added.length > BULK_IMPORT_PREVIEW_LIMIT" class="w-full text-xs text-muted-foreground">{{ adminText('k00um', { limit: BULK_IMPORT_PREVIEW_LIMIT }) }}</span>
                 <Badge v-for="item in bulkImportPreview.added.slice(0, BULK_IMPORT_PREVIEW_LIMIT)" :key="item" variant="secondary" class="gap-2 px-3 py-1.5 text-sm font-normal">{{ item }}</Badge>
               </div>
               <p v-if="bulkImportTarget === 'bannedUsernames'" class="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive">{{ adminText('k00ul') }}</p>
             </template>
           </div>
-          <DialogFooter>
+          <DialogFooter class="shrink-0 px-6 pb-6">
             <Button variant="outline" type="button" @click="closeBulkImport">{{ adminText('k009q') }}</Button>
             <Button type="button" @click="confirmBulkImport">
               <ClipboardPaste class="size-4" />


### PR DESCRIPTION
## Summary

- 修复安全设置页「批量导入」弹层的滚动缺陷：`Textarea` 基类带 `field-sizing-content` 随内容撑高，粘贴大词表（如 2000+ 行）时输入框无限增高；`DialogContent` 为 fixed 居中且无 max-height，弹层被撑出视口后上下两截被裁，且背景滚动被 reka-ui 锁定，用户完全无法滚动。
- 改用仓库既有限高弹层模式（同 `UsersManagementPage.vue`）：弹层 `max-h-[min(700px,calc(100vh-1.5rem))] + flex-col + overflow-hidden`，页眉/页脚 `shrink-0` 固定，中部 `min-h-0 flex-1 overflow-y-auto` 单一滚动区，textarea 自身 `max-h-56` 内部滚动。不动共享基类组件，避免全站影响。

## Verification

- `pnpm vitest run` → 64 文件 / 428 测试全绿；`pnpm typecheck` → exit 0；`pnpm build` → 成功
- 隔离实例浏览器实测（production 内嵌产物 + 管理员会话）：粘贴 500 行词表后——
  - 弹层 661px 高，完整处于 720px 视口内（`fits=true`），页眉/页脚固定可见
  - textarea 封顶 224px，内部滚动（scrollHeight 10016 / clientHeight 222）
  - 预览区渲染 200 条 chips + 截断提示，滚动区可滚至底部（scrollTop 4050 / scrollHeight 4542）
  - 截图确认弹层完整可操作（标题/说明/预览/Cancel+Import 按钮均在视口内）