### PR TITLE
fix(web): 禁用构建期资产内联，修复 CSP 拦截 data: 运行时资源导致编辑器无法加载 (issue #461)

### DIFF
--- a/apps/gooseforum/resource/test/vite-config.test.ts
+++ b/apps/gooseforum/resource/test/vite-config.test.ts
@@ -13,4 +13,17 @@ describe('vite 配置约束', () => {
     const server = (config as { server?: { origin?: string } }).server
     expect(server?.origin).toBeUndefined()
   })
+
+  /**
+   * 页面级 CSP 的 script-src 'self' 与 style-src 均不放行 data:（issue #461）。
+   * Vite 构建默认把小于 4096B 的 ?url 资产内联为 data: URL：vditor 四个语言包
+   * （data:text/javascript）会因 CSP 拦截导致编辑器无法挂载，content-theme 与
+   * hljs 主题四个小 CSS（data:text/css）静默丢失。assetsInlineLimit 必须为 0，
+   * 强制所有 ?url 运行时资产落成 /assets 同源文件。dev server 恒不内联，
+   * 因此本约束只在生产构建生效，上游同步或后续改动勿再放宽。
+   */
+  test('构建不得内联运行时资产为 data: URL，assetsInlineLimit 必须为 0', () => {
+    const build = (config as { build?: { assetsInlineLimit?: number | boolean } }).build
+    expect(build?.assetsInlineLimit).toBe(0)
+  })
 })

--- a/apps/gooseforum/resource/vite.config.ts
+++ b/apps/gooseforum/resource/vite.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
     assetsDir: 'assets',
     manifest: true,
     emptyOutDir: true,
+    // 页面级 CSP（securityHeaders.go buildPageCSP）的 script-src/style-src 均不放行 data:。
+    // 默认 4096B 内联阈值会把 ?url 导入的小资产（vditor 语言包、content-theme/hljs 主题 CSS）
+    // 内联成 data:text/javascript|css 而被 CSP 拦截：语言包报错令编辑器无法挂载，主题 CSS 静默丢失
+    // （issue #461）。必须保持 0，让所有 ?url 运行时资产落成 /assets 同源文件；dev server 恒不内联，
+    // 此约束只在生产构建生效。
+    assetsInlineLimit: 0,
     rollupOptions: {
       input: {
         site: 'src/site/main.ts',


### PR DESCRIPTION
Fixes #461

## 问题与根因

PR #418 为所有 HTML 页面附加页面级 CSP：`script-src 'self'`、`style-src` 均不放行 `data:`。而 Vite 生产构建默认把小于 4096B 的 `?url` 资产内联为 data: URL——`VditorOfficial.vue` 的 4 个 vditor 语言包（2419–3068B）因此变成 `data:text/javascript;base64`，被 CSP 拦截后编辑器无法挂载（写文章/回复/快发/课评页红框报错）；content-theme 与 hljs 主题 4 个小 CSS 同样被内联成 `data:text/css`，**静默丢失**。#453 修的是同一 CSP 约束下的 dev server 路径（`server.origin` 跨域），本 PR 补上生产构建路径。

dev server 恒不内联资产，因此该回归在本地开发全绿、仅在构建产物中暴露。

## 修改

- `vite.config.ts`：`build.assetsInlineLimit: 0`，所有 `?url` 运行时资产一律落成 `/assets/` 同源哈希文件，满足 `script-src 'self'` / `style-src`；附注释说明 CSP 约束来源，防止后续放宽或上游同步带回。不给 CSP 加 `data:`（避免削弱反 XSS 防线）。
- `test/vite-config.test.ts`：沿 #453 先例新增配置约束断言（先红后绿）。

## 验证

- [x] `pnpm vitest run test/vite-config.test.ts`：修复前 1 failed → 修复后 2 passed
- [x] `pnpm typecheck` 通过；`pnpm test` 68 文件 / 496 测试全部通过
- [x] `pnpm build` 成功；产物审计：`static/dist/assets/` 中无任何 `data:text/javascript` / `data:text/css`；4 个语言包 + content-theme light/dark + hljs github/github-dark 共 8 个资产均落成同源文件
- [x] pre-push 钩子（go vet + golangci-lint + pnpm typecheck）通过

部署到 dev 实例后建议以生产形态 smoke 一次编辑器页（写文章页编辑器挂载、深浅色下正文主题与代码高亮样式正常）。
