### PR TITLE
fix(schedule): 同步最新按钮增加加载态反馈 (issue #445)

### DIFF
--- a/apps/gooseforum/resource/src/locales/de.ts
+++ b/apps/gooseforum/resource/src/locales/de.ts
@@ -479,6 +479,7 @@ export default {
     dropCourse: 'Entfernen',
     clear: 'Leeren',
     syncLatest: 'Synchronisieren',
+    syncSyncing: 'Wird synchronisiert…',
     syncSuccess: 'Synchronisiert',
     loading: 'Wird geladen…',
     emptyRequired: 'Keine Pflichtkurse verfügbar',

--- a/apps/gooseforum/resource/src/locales/en.ts
+++ b/apps/gooseforum/resource/src/locales/en.ts
@@ -479,6 +479,7 @@ export default {
     dropCourse: 'Drop',
     clear: 'Clear',
     syncLatest: 'Sync Latest',
+    syncSyncing: 'Syncing…',
     syncSuccess: 'Synced successfully',
     loading: 'Loading…',
     emptyRequired: 'No required courses available',

--- a/apps/gooseforum/resource/src/locales/ja.ts
+++ b/apps/gooseforum/resource/src/locales/ja.ts
@@ -479,6 +479,7 @@ export default {
     dropCourse: '解除',
     clear: 'クリア',
     syncLatest: '最新に同期',
+    syncSyncing: '同期中…',
     syncSuccess: '同期しました',
     loading: '読み込み中…',
     emptyRequired: '予定内の授業はありません',

--- a/apps/gooseforum/resource/src/locales/zh.ts
+++ b/apps/gooseforum/resource/src/locales/zh.ts
@@ -481,6 +481,7 @@ export default {
     dropCourse: '退课',
     clear: '清除',
     syncLatest: '同步最新',
+    syncSyncing: '同步中…',
     syncSuccess: '同步成功',
     loading: '正在加载…',
     emptyRequired: '暂无计划内课程',

--- a/apps/gooseforum/resource/src/site/pages/SchedulePage.vue
+++ b/apps/gooseforum/resource/src/site/pages/SchedulePage.vue
@@ -9,7 +9,7 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRoot, DialogTitle } from 'reka-ui'
-import { Download, RefreshCw, Star, X } from '@lucide/vue'
+import { Download, Loader2, RefreshCw, Star, X } from '@lucide/vue'
 import PageHeader from '@/site/components/PageHeader.vue'
 import ScheduleConfigSection from '@/site/components/schedule/ScheduleConfigSection.vue'
 import ScheduleStatsCard from '@/site/components/schedule/ScheduleStatsCard.vue'
@@ -333,10 +333,12 @@ onBeforeUnmount(() => {
             v-if="dataOutdated"
             type="button"
             class="gf-button gf-button-md gf-button-primary"
+            :disabled="syncing"
             @click="syncLatest"
           >
-            <RefreshCw class="h-4 w-4" />
-            {{ t('schedule.syncLatest') }}
+            <Loader2 v-if="syncing" class="h-4 w-4 animate-spin" />
+            <RefreshCw v-else class="h-4 w-4" />
+            {{ syncing ? t('schedule.syncSyncing') : t('schedule.syncLatest') }}
           </button>
           <div ref="exportRoot" class="relative">
             <button


### PR DESCRIPTION
## Motivation

Closes #445 — 排课器「同步最新」按钮点击后立即消失，无任何进行中反馈，交互体验差。

## Behavior change

- 「同步最新」按钮点击后进入加载态：旋转图标 + 文案变为「同步中…」+ 禁用（配合已有 `syncing` 防重入）
- 同步完成后才因 `dataOutdated` 清除而消失，期间用户可感知操作在进行
- 新增 i18n key `schedule.syncSyncing`（zh/en/ja；it 语言文件已在上游 #391 移除，不重新引入）

## Verification

- `pnpm typecheck` → exit 0
- `git diff --check` → OK
- `pnpm vitest run schedule` → 3 files / 25 tests failed：经核对为**环境性失败**（vitest 环境无 `localStorage`，`localStorage.clear()` 抛错），在纯 `origin/dev` 基线上同样失败，与本次改动无关

## Documentation / contract impact

- 纯前端 UX 改动，无 OpenAPI/契约、DB、文档影响

## Known gaps

- 无
