### PR TITLE
fix(web): touch tap/drag disambiguation for quick-publish image strip (issue #455)

### DIFF
--- a/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
+++ b/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
@@ -362,13 +362,20 @@ async function handleSubmit() {
         <div class="flex-1 min-h-0 flex flex-col px-4 sm:px-6 py-2.5 sm:py-3 gap-2.5 sm:gap-3 overflow-hidden sm:overflow-y-auto">
           <!-- 首行入口：快捷传图与已上传图片预览横向滑动流（支持滑动预览与拖拽重排，移动端比例适度放大） -->
           <div class="gf-image-scroll-track shrink-0 flex items-center gap-3 overflow-x-auto pb-2 pt-0.5">
-            <!-- 已上传/正在上传的图片缩略图卡片列表（支持桌面拖拽与移动端触控拖拽排序） -->
+            <!-- 已上传/正在上传的图片缩略图卡片列表（支持桌面拖拽与移动端触控拖拽排序）
+                 触控点按/拖拽降级（issue #455）：✕/左右移按钮豁免拖拽热区（filter），
+                 触屏需长按 180ms 且位移超过阈值才进入拖拽，轻点按钮可正常触发点击 -->
             <Draggable
               v-model="uploadedImages"
               item-key="id"
               :animation="200"
               ghost-class="opacity-35"
               class="flex items-center gap-3 shrink-0"
+              filter=".gf-image-card-btn"
+              :prevent-on-filter="false"
+              :delay="180"
+              :delay-on-touch-only="true"
+              :touch-start-threshold="10"
             >
               <template #item="{ element: img, index: idx }">
                 <div
@@ -395,7 +402,7 @@ async function handleSubmit() {
                     <button
                       v-if="idx > 0"
                       type="button"
-                      class="flex h-5.5 w-5.5 items-center justify-center rounded-md bg-black/75 backdrop-blur-xs text-white hover:bg-black active:scale-90 transition-all cursor-pointer shadow-xs"
+                      class="gf-image-card-btn flex h-5.5 w-5.5 items-center justify-center rounded-md bg-black/75 backdrop-blur-xs text-white hover:bg-black active:scale-90 transition-all cursor-pointer shadow-xs"
                       :title="t('publish.modal.moveImageLeft')"
                       :aria-label="t('publish.modal.moveImageLeft')"
                       @click.stop="moveImage(idx, 'left')"
@@ -405,7 +412,7 @@ async function handleSubmit() {
                     <button
                       v-if="idx < uploadedImages.length - 1"
                       type="button"
-                      class="flex h-5.5 w-5.5 items-center justify-center rounded-md bg-black/75 backdrop-blur-xs text-white hover:bg-black active:scale-90 transition-all cursor-pointer shadow-xs"
+                      class="gf-image-card-btn flex h-5.5 w-5.5 items-center justify-center rounded-md bg-black/75 backdrop-blur-xs text-white hover:bg-black active:scale-90 transition-all cursor-pointer shadow-xs"
                       :title="t('publish.modal.moveImageRight')"
                       :aria-label="t('publish.modal.moveImageRight')"
                       @click.stop="moveImage(idx, 'right')"
@@ -418,7 +425,7 @@ async function handleSubmit() {
                   <button
                     v-if="!img.uploading"
                     type="button"
-                    class="absolute top-1.5 right-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-black/70 backdrop-blur-xs text-white hover:bg-error transition-all active:scale-90 shadow-xs cursor-pointer z-10"
+                    class="gf-image-card-btn absolute top-1.5 right-1.5 flex h-6 w-6 items-center justify-center rounded-full bg-black/70 backdrop-blur-xs text-white hover:bg-error transition-all active:scale-90 shadow-xs cursor-pointer z-10"
                     :aria-label="t('publish.modal.deleteImage')"
                     @click.stop="removeImage(idx)"
                   >

--- a/apps/gooseforum/resource/test/quick-publish-modal.test.ts
+++ b/apps/gooseforum/resource/test/quick-publish-modal.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, test } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import Draggable from 'vuedraggable'
 import QuickPublishModal from '../src/site/components/QuickPublishModal.vue'
 import { i18n } from '../src/runtime/i18n'
 import { useQuickPublish } from '../src/site/composables/useQuickPublish'
@@ -193,5 +194,74 @@ describe('QuickPublishModal 组件', () => {
     // 等待退场过渡结束后被异步清空
     await new Promise((resolve) => setTimeout(resolve, 300))
     expect(quickPublishEditPayload.value).toBeNull()
+  })
+  test('多图触控降级：删除/左右移按钮豁免拖拽热区，触屏启用长按延迟与位移阈值', async () => {
+    i18n.global.locale.value = 'zh'
+    const { openQuickPublish, closeQuickPublish } = useQuickPublish()
+    openQuickPublish(2) // 瞬间类型
+
+    const wrapper = mount(QuickPublishModal, {
+      props: { layout: mockLayout },
+      global: { plugins: [i18n, router] },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    const vm = wrapper.vm as any
+    vm.uploadedImages = [
+      { id: 'img_1', url: '/img/first.webp', alt: 'first' },
+      { id: 'img_2', url: '/img/second.webp', alt: 'second' },
+    ]
+    await flushPromises()
+
+    // 拖拽列表对触控做点按/拖拽降级配置（issue #455）
+    const draggableWrapper = wrapper.findComponent(Draggable)
+    expect(draggableWrapper.exists()).toBe(true)
+    const attrs = draggableWrapper.vm.$attrs as Record<string, unknown>
+    expect(String(attrs['filter'])).toContain('gf-image-card-btn')
+    expect(attrs['prevent-on-filter']).toBe(false)
+    expect(attrs['delay-on-touch-only']).toBe(true)
+    expect(Number(attrs['delay'])).toBeGreaterThanOrEqual(100)
+    expect(Number(attrs['touch-start-threshold'])).toBeGreaterThan(0)
+
+    // 2 张图 → 删除 ×2 + 右移 ×1 + 左移 ×1，均带豁免类
+    const actionButtons = document.body.querySelectorAll('button.gf-image-card-btn')
+    expect(actionButtons.length).toBe(4)
+
+    closeQuickPublish()
+    await flushPromises()
+    wrapper.unmount()
+  })
+
+  test('点击缩略图右上角删除按钮可移除对应图片', async () => {
+    i18n.global.locale.value = 'zh'
+    const { openQuickPublish, closeQuickPublish } = useQuickPublish()
+    openQuickPublish(2) // 瞬间类型
+
+    const wrapper = mount(QuickPublishModal, {
+      props: { layout: mockLayout },
+      global: { plugins: [i18n, router] },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    const vm = wrapper.vm as any
+    vm.uploadedImages = [
+      { id: 'img_1', url: '/img/first.webp', alt: 'first' },
+      { id: 'img_2', url: '/img/second.webp', alt: 'second' },
+    ]
+    await flushPromises()
+
+    const deleteBtn = document.body.querySelector(`button[aria-label="${i18n.global.t('publish.modal.deleteImage')}"]`) as HTMLButtonElement | null
+    expect(deleteBtn).not.toBeNull()
+    deleteBtn?.click()
+    await flushPromises()
+
+    expect(vm.uploadedImages.length).toBe(1)
+    expect(vm.uploadedImages[0].url).toBe('/img/second.webp')
+
+    closeQuickPublish()
+    await flushPromises()
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
Closes #455

## Problem

In the quick-publish modal (thought / question content types), the image thumbnail strip is wrapped in `vuedraggable` with no touch configuration. On touch devices a `touchstart` on a thumbnail immediately enters the drag-sort flow, so taps on the in-card action buttons (delete ✕, move-left, move-right) are swallowed by drag handling — deleting an uploaded image is effectively impossible on mobile, in both create and edit mode.

## Changes

`apps/gooseforum/resource/src/site/components/QuickPublishModal.vue` — keep drag-to-reorder, add tap/drag disambiguation:

1. **Action buttons excluded from the drag hot zone**: the ✕ / move-left / move-right buttons get a shared `.gf-image-card-btn` class, and `<Draggable>` is configured with `filter=".gf-image-card-btn"` + `:prevent-on-filter="false"` so a tap on those buttons always reaches the button's own click handler, even if a long-press threshold has been configured.
2. **Long-press delay, touch-only**: `:delay="180"` + `:delay-on-touch-only="true"` — on touch screens, drag only starts after a 180 ms hold; a quick tap never enters drag. Desktop mouse drag behavior is completely unchanged (the delay applies to touch only).
3. **Movement threshold**: `:touch-start-threshold="10"` — moving more than 10 px during the delay cancels the pending drag, so horizontally swiping the image strip to scroll through previews is no longer misread as a drag-sort.

Desktop drag-sort UX (grab anywhere on the card) is intentionally preserved instead of switching to a dedicated handle, and mobile reorder is kept (long-press to drag), so both delete and reorder work on touch screens as requested in the issue.

## Verification (run locally)

| Check | Result |
|---|---|
| `pnpm vitest run test/quick-publish-modal.test.ts` — 2 new cases (draggable touch-disambiguation config assertions + delete-button click behavior), written red first, green after the fix | ✅ 7/7 passed |
| `pnpm test` (full frontend suite) | ✅ 71 files / 569 tests passed |
| `pnpm typecheck` | ✅ exit 0 |
| `pnpm build` | ✅ exit 0, emitted into resource/static/dist |

No model/migration/contract changes — no PG migration gate or contract sync applicable; existing "drag to reorder" docs description stays accurate (bug fix, behavior on desktop unchanged).