### PR TITLE
fix(admin): 公告标题保存被静默丢弃，legacy 单则统一迁移 items 模式（issue #465）

### DIFF
--- a/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
@@ -11,6 +11,7 @@ import { Bot, CheckCircle2, ClipboardPaste, Clock, Code, FileText, Globe, GripVe
 import { BULK_IMPORT_LIMIT, BULK_IMPORT_PREVIEW_LIMIT, parseImportText } from '@/admin/bulkImport'
 import type { BulkImportPreview } from '@/admin/bulkImport'
 import { isSupportedUploadExtension, normalizeExtensionToken } from '@/admin/uploadExtensions'
+import AdminActionButton from '@/admin/components/AdminActionButton.vue'
 import { normalizeAnnouncement, serializeAnnouncement } from '@/admin/utils/announcement'
 import { toBool } from '@/admin/utils/toBool'
 import { BasicPage } from '@/admin/components/global-layout'

--- a/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
+++ b/apps/gooseforum/resource/src/admin/pages/AdminSettingsPage.vue
@@ -11,7 +11,8 @@ import { Bot, CheckCircle2, ClipboardPaste, Clock, Code, FileText, Globe, GripVe
 import { BULK_IMPORT_LIMIT, BULK_IMPORT_PREVIEW_LIMIT, parseImportText } from '@/admin/bulkImport'
 import type { BulkImportPreview } from '@/admin/bulkImport'
 import { isSupportedUploadExtension, normalizeExtensionToken } from '@/admin/uploadExtensions'
-import AdminActionButton from '@/admin/components/AdminActionButton.vue'
+import { normalizeAnnouncement, serializeAnnouncement } from '@/admin/utils/announcement'
+import { toBool } from '@/admin/utils/toBool'
 import { BasicPage } from '@/admin/components/global-layout'
 import { Button } from '@/admin/components/ui/button'
 import { Badge } from '@/admin/components/ui/badge'
@@ -358,17 +359,6 @@ const httpNotifyGuideHtml = computed(() => {
   return guideMarkdown.render(guides[guideLocale as keyof typeof guides] || httpNotifyGuideZh)
 })
 
-function toBool(value: unknown, fallback = false) {
-  if (typeof value === 'boolean') return value
-  if (typeof value === 'number') return value === 1
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase()
-    if (['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) return true
-    if (['false', '0', 'no', 'off', 'disabled', ''].includes(normalized)) return false
-  }
-  return fallback
-}
-
 function normalizeSite(settings: Partial<SiteSettings> = {}) {
   return {
     siteName: settings.siteName ?? '',
@@ -622,32 +612,6 @@ function validateHttpNotify(settings: HttpNotifySettings) {
   return true
 }
 
-function normalizeAnnouncement(settings: Partial<AnnouncementConfig> = {}) {
-  const items = settings.items ?? []
-  // 旧版单则数据迁移为一条 legacy 公告，保证编辑入口不丢失
-  if (items.length === 0 && settings.content) {
-    return {
-      enabled: toBool(settings.enabled, false),
-      content: settings.content ?? '',
-      items: [{ id: 'legacy', title: '', content: settings.content, enabled: true }],
-    } satisfies AnnouncementConfig
-  }
-  return {
-    enabled: toBool(settings.enabled, false),
-    content: settings.content ?? '',
-    items,
-  } satisfies AnnouncementConfig
-}
-
-function serializeAnnouncement(): AnnouncementConfig {
-  const items = (announcementForm.items ?? []).filter((item) => item.content.trim())
-  const isLegacyOnly = items.length === 1 && items[0].id === 'legacy'
-  return {
-    enabled: announcementForm.enabled,
-    content: isLegacyOnly ? items[0].content : announcementForm.content,
-    items: isLegacyOnly ? [] : items,
-  }
-}
 
 function addAnnouncementItem() {
   if (!announcementForm.items) announcementForm.items = []
@@ -861,7 +825,7 @@ async function save() {
     else if (props.kind === 'storage') await saveStorageSettings(storagePayload())
     else if (props.kind === 'terms') await saveTermsOfService(normalizeTerms(termsForm))
     else if (props.kind === 'schedule') await saveScheduleSettings(normalizeSchedule(scheduleForm))
-    else await saveAnnouncement(serializeAnnouncement())
+    else await saveAnnouncement(serializeAnnouncement(announcementForm))
     adminToast.success(adminText('k000e'))
   } catch (err) {
     adminToast.error(err, adminText('k000f'))

--- a/apps/gooseforum/resource/src/admin/utils/announcement.ts
+++ b/apps/gooseforum/resource/src/admin/utils/announcement.ts
@@ -1,0 +1,35 @@
+import { toBool } from './toBool'
+import type { AnnouncementConfig, AnnouncementItemConfig } from '../types'
+
+export function normalizeAnnouncement(settings: Partial<AnnouncementConfig> = {}): AnnouncementConfig {
+  const items = settings.items ?? []
+  // 旧版 content-only 单则配置迁移为一条常规条目（issue #465）：直接换常规 id
+  // 并始终走 items 模式，保证标题（items[].title）从首次保存起即可持久化。
+  // 不再依赖「legacy 单则回退 content-only」路径——content-only 结构无法表达标题，
+  // 曾导致公告标题保存后被静默丢弃。
+  if (items.length === 0 && settings.content) {
+    return {
+      enabled: toBool(settings.enabled, false),
+      content: settings.content,
+      items: [{ id: `ann-${Date.now().toString(36)}`, title: '', content: settings.content, enabled: true }],
+    }
+  }
+  return {
+    enabled: toBool(settings.enabled, false),
+    content: settings.content ?? '',
+    items,
+  }
+}
+
+export function serializeAnnouncement(
+  form: Pick<AnnouncementConfig, 'enabled' | 'content'> & { items?: AnnouncementItemConfig[] },
+): AnnouncementConfig {
+  const items = (form.items ?? []).filter((item) => item.content.trim())
+  // 单则公告（含迁移自旧版的条目）时同步 content：服务端 items 非空时优先展示，
+  // content 仅作单则回退（GetHtmlContent），同步可保持单则语义一致（issue #465）
+  return {
+    enabled: form.enabled,
+    content: items.length === 1 ? items[0].content : form.content,
+    items,
+  }
+}

--- a/apps/gooseforum/resource/src/admin/utils/announcement.ts
+++ b/apps/gooseforum/resource/src/admin/utils/announcement.ts
@@ -22,14 +22,16 @@ export function normalizeAnnouncement(settings: Partial<AnnouncementConfig> = {}
 }
 
 export function serializeAnnouncement(
-  form: Pick<AnnouncementConfig, 'enabled' | 'content'> & { items?: AnnouncementItemConfig[] },
+  form: Pick<AnnouncementConfig, 'enabled'> & { items?: AnnouncementItemConfig[] },
 ): AnnouncementConfig {
   const items = (form.items ?? []).filter((item) => item.content.trim())
-  // 单则公告（含迁移自旧版的条目）时同步 content：服务端 items 非空时优先展示，
-  // content 仅作单则回退（GetHtmlContent），同步可保持单则语义一致（issue #465）
+  // content 仅作单则回退（服务端 items 非空时展示优先级更高，content 走
+  // GetHtmlContent），只在「单则且启用」时同步条目正文，其余一律清空——
+  // 否则已删除或已停用的公告会经 content 回退继续展示（issue #465 review P2）
+  const sole = items.length === 1 && items[0].enabled ? items[0] : null
   return {
     enabled: form.enabled,
-    content: items.length === 1 ? items[0].content : form.content,
+    content: sole ? sole.content : '',
     items,
   }
 }

--- a/apps/gooseforum/resource/src/admin/utils/toBool.ts
+++ b/apps/gooseforum/resource/src/admin/utils/toBool.ts
@@ -1,0 +1,10 @@
+export function toBool(value: unknown, fallback = false) {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') return value === 1
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (['true', '1', 'yes', 'on', 'enabled'].includes(normalized)) return true
+    if (['false', '0', 'no', 'off', 'disabled', ''].includes(normalized)) return false
+  }
+  return fallback
+}

--- a/apps/gooseforum/resource/test/announcement-serialize.test.ts
+++ b/apps/gooseforum/resource/test/announcement-serialize.test.ts
@@ -6,6 +6,8 @@ import { normalizeAnnouncement, serializeAnnouncement } from '../src/admin/utils
 // serializeAnnouncement 在唯一 legacy 项时无条件序列化回 content-only 结构
 // （items: []），而标题只存在于 items[].title，于是被静默丢弃。
 // 修复：加载时 legacy 条目换常规 id 并始终走 items 模式，序列化不再回退 content-only。
+// PR review 收紧：content 仅在「单则且启用」时同步条目正文，其余清空——
+// 已删除或已停用的公告不得经服务端 GetHtmlContent 单则回退继续展示。
 describe('announcement serialize round-trip (issue #465)', () => {
   test('legacy 单则公告编辑标题后保存，title 必须进 payload', () => {
     const form = normalizeAnnouncement({ enabled: true, content: '欢迎来到 YourTJHub' })
@@ -27,19 +29,31 @@ describe('announcement serialize round-trip (issue #465)', () => {
     expect(payload.items![0].title).toBe('')
   })
 
-  test('单则条目时 content 与条目正文同步（保持单则回退语义）', () => {
+  test('单则且启用的条目：content 与条目正文同步（保持单则回退语义）', () => {
     const payload = serializeAnnouncement({
       enabled: true,
-      content: '旧版遗留正文',
       items: [{ id: 'ann-x', title: '新标题', content: '编辑后的正文', enabled: true }],
     })
     expect(payload.content).toBe('编辑后的正文')
   })
 
-  test('多则公告 items 模式保存保持不变（content 透传表单值）', () => {
+  test('唯一条目停用时 content 清空（停用公告不得经 content 回退展示）', () => {
     const payload = serializeAnnouncement({
       enabled: true,
-      content: '',
+      items: [{ id: 'ann-x', title: '停用', content: '停用的正文', enabled: false }],
+    })
+    expect(payload.content).toBe('')
+    expect(payload.items).toHaveLength(1)
+  })
+
+  test('清空全部条目后 content 同步清空（已删除公告不得经 content 回退展示）', () => {
+    const payload = serializeAnnouncement({ enabled: true, items: [] })
+    expect(payload).toEqual({ enabled: true, content: '', items: [] })
+  })
+
+  test('多则公告保存保持 items 原样，content 不透传表单值（置空）', () => {
+    const payload = serializeAnnouncement({
+      enabled: true,
       items: [
         { id: 'ann-a', title: '第一条', content: '内容一', enabled: true },
         { id: 'ann-b', title: '第二条', content: '内容二', enabled: false },
@@ -58,7 +72,6 @@ describe('announcement serialize round-trip (issue #465)', () => {
   test('空正文项被过滤，与既有行为一致', () => {
     const payload = serializeAnnouncement({
       enabled: true,
-      content: '',
       items: [
         { id: 'ann-a', title: '有内容', content: '正文', enabled: true },
         { id: 'ann-b', title: '空条目', content: '   ', enabled: true },
@@ -69,7 +82,7 @@ describe('announcement serialize round-trip (issue #465)', () => {
   })
 
   test('全部清空后保存为空配置', () => {
-    const payload = serializeAnnouncement({ enabled: false, content: '', items: [] })
+    const payload = serializeAnnouncement({ enabled: false, items: [] })
     expect(payload).toEqual({ enabled: false, content: '', items: [] })
   })
 

--- a/apps/gooseforum/resource/test/announcement-serialize.test.ts
+++ b/apps/gooseforum/resource/test/announcement-serialize.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { normalizeAnnouncement, serializeAnnouncement } from '../src/admin/utils/announcement'
+
+// issue #465 回归：后台公告页保存时标题被静默丢弃。
+// 根因：normalizeAnnouncement 把旧版 content-only 配置迁移成 id='legacy' 的条目展示，
+// serializeAnnouncement 在唯一 legacy 项时无条件序列化回 content-only 结构
+// （items: []），而标题只存在于 items[].title，于是被静默丢弃。
+// 修复：加载时 legacy 条目换常规 id 并始终走 items 模式，序列化不再回退 content-only。
+describe('announcement serialize round-trip (issue #465)', () => {
+  test('legacy 单则公告编辑标题后保存，title 必须进 payload', () => {
+    const form = normalizeAnnouncement({ enabled: true, content: '欢迎来到 YourTJHub' })
+    expect(form.items).toHaveLength(1)
+    expect(form.items![0].id).toMatch(/^ann-/)
+
+    form.items![0].title = '维护通知'
+
+    const payload = serializeAnnouncement(form)
+    expect(payload.items).toHaveLength(1)
+    expect(payload.items![0]).toMatchObject({ title: '维护通知', content: '欢迎来到 YourTJHub', enabled: true })
+  })
+
+  test('存量 legacy 项（未编辑）保存后同样退出 content-only 形态', () => {
+    const form = normalizeAnnouncement({ enabled: true, content: '公告正文' })
+    const payload = serializeAnnouncement(form)
+    expect(payload.items).toHaveLength(1)
+    expect(payload.items![0]).toMatchObject({ id: expect.not.stringContaining('legacy'), content: '公告正文' })
+    expect(payload.items![0].title).toBe('')
+  })
+
+  test('单则条目时 content 与条目正文同步（保持单则回退语义）', () => {
+    const payload = serializeAnnouncement({
+      enabled: true,
+      content: '旧版遗留正文',
+      items: [{ id: 'ann-x', title: '新标题', content: '编辑后的正文', enabled: true }],
+    })
+    expect(payload.content).toBe('编辑后的正文')
+  })
+
+  test('多则公告 items 模式保存保持不变（content 透传表单值）', () => {
+    const payload = serializeAnnouncement({
+      enabled: true,
+      content: '',
+      items: [
+        { id: 'ann-a', title: '第一条', content: '内容一', enabled: true },
+        { id: 'ann-b', title: '第二条', content: '内容二', enabled: false },
+      ],
+    })
+    expect(payload).toEqual({
+      enabled: true,
+      content: '',
+      items: [
+        { id: 'ann-a', title: '第一条', content: '内容一', enabled: true },
+        { id: 'ann-b', title: '第二条', content: '内容二', enabled: false },
+      ],
+    })
+  })
+
+  test('空正文项被过滤，与既有行为一致', () => {
+    const payload = serializeAnnouncement({
+      enabled: true,
+      content: '',
+      items: [
+        { id: 'ann-a', title: '有内容', content: '正文', enabled: true },
+        { id: 'ann-b', title: '空条目', content: '   ', enabled: true },
+      ],
+    })
+    expect(payload.items).toHaveLength(1)
+    expect(payload.items![0].id).toBe('ann-a')
+  })
+
+  test('全部清空后保存为空配置', () => {
+    const payload = serializeAnnouncement({ enabled: false, content: '', items: [] })
+    expect(payload).toEqual({ enabled: false, content: '', items: [] })
+  })
+
+  test('normalizeAnnouncement 无公告数据时给空表单', () => {
+    expect(normalizeAnnouncement()).toEqual({ enabled: false, content: '', items: [] })
+  })
+
+  test('normalizeAnnouncement 迁移旧版 content-only 配置为常规可编辑条目', () => {
+    const form = normalizeAnnouncement({ enabled: true, content: '旧版单则公告' })
+    expect(form.items).toHaveLength(1)
+    expect(form.items![0]).toMatchObject({ title: '', content: '旧版单则公告', enabled: true })
+    expect(form.items![0].id).toMatch(/^ann-/)
+  })
+})


### PR DESCRIPTION
Closes #465

## Summary

- 修复后台「公告」设置页保存时标题被静默丢弃：`serializeAnnouncement()` 原对唯一 `id === 'legacy'` 条目无条件回退旧版 content-only 结构（`items: []`），而标题只存在于 `items[].title`——content-only 结构无法表达标题，保存提示成功但刷新即丢。
- 采用 issue 建议的统一迁移方案：`normalizeAnnouncement()` 加载时把旧版 content-only 配置直接迁移为常规 id 条目、始终走 items 模式；`serializeAnnouncement()` 删除 legacy 特例分支，单则条目时同步 `content` 保持服务端单则回退（`GetHtmlContent`）语义一致。存量数据在管理员首次保存公告页后即固化退出 legacy 形态。
- normalize/serialize 抽为纯函数 `src/admin/utils/announcement.ts` 并新增 8 个回归测试（`test/announcement-serialize.test.ts`）；页面本地 `toBool` 抽为共享 `src/admin/utils/toBool.ts`（页面 27 处调用改引用，消除重复）。
- 契约零变更：payload 字段不变（仅 `items` 由空变非空，属既有 schema 内取值）；站点端渲染行为一致（items 优先、单条无轮播点），移动端仅消费 `items`，OpenAPI/生成 TS/Dart 镜像均无需改动。

## Verification

- TDD：先按 buggy 逻辑移植纯函数确认 2 个用例红（title 丢失 / legacy 回退 `items: []`），修复后 `pnpm vitest run test/announcement-serialize.test.ts` → 8/8 绿
- `pnpm vitest run` → 73 文件 / 584 测试全绿
- `pnpm typecheck` → exit 0；`pnpm build` → 成功
- `git diff --check` → OK；pre-push hook（go vet + golangci-lint + pnpm typecheck）通过