### PR TITLE
fix(web): Safari 插图上传以压缩实际产物声明类型与扩展名

### DIFF
--- a/apps/gooseforum/resource/src/runtime/image.ts
+++ b/apps/gooseforum/resource/src/runtime/image.ts
@@ -23,6 +23,11 @@ export function validateImageFile(file: File, maxSize = 10 * 1024 * 1024): strin
 
 export async function processImageFile(file: File, quality = 0.85): Promise<ImageProcessResult> {
   const originalSize = file.size
+  // GIF 不进压缩管线：canvas 无法编码 GIF（Safari 静默回退导出静态 PNG，
+  // Chrome 成功时也会丢掉动画帧），原样上传保留动图。
+  if (file.type === 'image/gif') {
+    return { file, converted: false, originalSize, newSize: originalSize }
+  }
   const targetType = supportsWebP() ? 'image/webp' : file.type || 'image/jpeg'
   const shouldConvert = targetType === 'image/webp' && !file.type.includes('webp')
 
@@ -81,6 +86,23 @@ export async function canvasToImageFile(
   })
 }
 
+// imageTypeExtension 把图片 MIME 映射为后端上传白名单内的扩展名；
+// canvas 实际只会产出 png/jpeg/webp，其余条目仅为完备性。
+function imageTypeExtension(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/png':
+      return '.png'
+    case 'image/gif':
+      return '.gif'
+    case 'image/webp':
+      return '.webp'
+    case 'image/bmp':
+      return '.bmp'
+    default:
+      return '.jpg'
+  }
+}
+
 async function compressImage(file: File, mimeType: string, quality: number): Promise<File> {
   const { default: Compressor } = await import('compressorjs') as { default: typeof CompressorType }
   return new Promise((resolve, reject) => {
@@ -90,13 +112,18 @@ async function compressImage(file: File, mimeType: string, quality: number): Pro
       checkOrientation: true,
       convertSize: 0,
       success: (result) => {
-        const extension = mimeType === 'image/webp' ? '.webp' : '.jpg'
-        if (result instanceof File && result.type === mimeType) {
+        // 输出以压缩器实际产物为准：convertTypes 改道（PNG→JPEG）或目标
+        // 编码不被 canvas 支持时（如 Safari 的 WebP/GIF），实际字节类型可能
+        // 与请求的 mimeType 不同。文件名扩展名与 File.type 必须跟随实际
+        // 产物，否则上传 init 的 filename↔contentType 严格校验会拒绝。
+        const actualType = result.type || mimeType
+        if (result instanceof File && result.type === actualType) {
           resolve(result)
           return
         }
-        resolve(new File([result], file.name.replace(/\.[^/.]+$/, extension), {
-          type: mimeType,
+        const baseName = file.name.replace(/\.[^/.]+$/, '')
+        resolve(new File([result], `${baseName}${imageTypeExtension(actualType)}`, {
+          type: actualType,
           lastModified: Date.now(),
         }))
       },

--- a/apps/gooseforum/resource/test/image-process.test.ts
+++ b/apps/gooseforum/resource/test/image-process.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+// 复现 Safari 插图上传被拒（「文件内容不是有效的图片格式」）的压缩错标链路：
+// compressorjs 的 convertTypes（默认含 PNG）+ convertSize=0 会把 PNG 输入内部
+// 改道为 JPEG 输出；Safari canvas 不支持 WebP/GIF 编码时会静默回退导出 PNG。
+// 返回的 File 必须以实际产物声明 type 与扩展名，否则 /file/img-upload/init 的
+// filename↔contentType 严格校验（以及 complete 的内容嗅探）会拒绝上传。
+const { compressorState } = vi.hoisted(() => ({
+  compressorState: { outputType: 'image/jpeg', calls: 0, fail: false },
+}))
+
+vi.mock('compressorjs', () => ({
+  default: class MockCompressor {
+    constructor(
+      _file: File,
+      options: { success: (blob: Blob) => void; error: (error: Error) => void },
+    ) {
+      compressorState.calls += 1
+      queueMicrotask(() => {
+        if (compressorState.fail) {
+          options.error(new Error('mock compress failed'))
+          return
+        }
+        options.success(new Blob(['mock-encoded-bytes'], { type: compressorState.outputType }))
+      })
+    }
+  },
+}))
+
+vi.mock('../src/runtime/i18n', () => ({
+  i18n: {
+    global: {
+      t: (key: string) => key,
+      te: () => false,
+      locale: { value: 'zh' },
+      getLocaleMessage: () => ({}),
+    },
+  },
+}))
+
+import { processImageFile } from '../src/runtime/image'
+
+function stubCanvasEncode(supportsWebPEncode: boolean) {
+  vi.stubGlobal('document', {
+    createElement: () => ({
+      width: 1,
+      height: 1,
+      toDataURL: (type: string) =>
+        supportsWebPEncode && type === 'image/webp'
+          ? 'data:image/webp;mock'
+          : 'data:image/png;base64,mock',
+    }),
+  })
+}
+
+function fileWith(name: string, type: string): File {
+  return new File(['original-bytes'], name, { type })
+}
+
+afterEach(() => {
+  compressorState.outputType = 'image/jpeg'
+  compressorState.calls = 0
+  compressorState.fail = false
+  vi.unstubAllGlobals()
+})
+
+describe('processImageFile', () => {
+  test('Safari：PNG 输入被压缩器改道为 JPEG 时，File 类型与扩展名跟随实际产物', async () => {
+    stubCanvasEncode(false)
+    compressorState.outputType = 'image/jpeg'
+    const png = fileWith('photo.png', 'image/png')
+
+    const result = await processImageFile(png)
+
+    expect(result.file.type).toBe('image/jpeg')
+    expect(result.file.name).toBe('photo.jpg')
+  })
+
+  test('Safari：WebP 输入在压缩时回退导出 PNG 时，类型与扩展名跟随实际产物', async () => {
+    stubCanvasEncode(false)
+    compressorState.outputType = 'image/png'
+    const webp = fileWith('pic.webp', 'image/webp')
+
+    const result = await processImageFile(webp)
+
+    expect(result.file.type).toBe('image/png')
+    expect(result.file.name).toBe('pic.png')
+  })
+
+  test('Safari：GIF 原样上传，不经过压缩器（保住动画，避免回退静态 PNG）', async () => {
+    stubCanvasEncode(false)
+    const gif = fileWith('anim.gif', 'image/gif')
+
+    const result = await processImageFile(gif)
+
+    expect(result.file).toBe(gif)
+    expect(result.converted).toBe(false)
+    expect(compressorState.calls).toBe(0)
+  })
+
+  test('支持 WebP 的浏览器：PNG 转 WebP 后类型与扩展名一致', async () => {
+    stubCanvasEncode(true)
+    compressorState.outputType = 'image/webp'
+    const png = fileWith('photo.png', 'image/png')
+
+    const result = await processImageFile(png)
+
+    expect(result.file.type).toBe('image/webp')
+    expect(result.file.name).toBe('photo.webp')
+  })
+
+  test('压缩器类型未变时保持原扩展名（JPEG 常规路径不回归）', async () => {
+    stubCanvasEncode(false)
+    compressorState.outputType = 'image/jpeg'
+    const jpg = fileWith('cat.jpg', 'image/jpeg')
+
+    const result = await processImageFile(jpg)
+
+    expect(result.file.type).toBe('image/jpeg')
+    expect(result.file.name).toBe('cat.jpg')
+  })
+
+  test('压缩失败时回退原文件', async () => {
+    stubCanvasEncode(false)
+    compressorState.fail = true
+    const png = fileWith('photo.png', 'image/png')
+
+    const result = await processImageFile(png)
+
+    expect(result.file).toBe(png)
+    expect(result.converted).toBe(false)
+  })
+})


### PR DESCRIPTION
## 问题

Safari 插图时报「文件内容不是有效的图片格式」(`upload.image.invalidContent`)，Chrome 正常。

## 根因

前端所有插图先过 compressorjs 压缩（`resource/src/runtime/image.ts`），但 success 回调用**请求的 mimeType** 覆盖压缩产物的实际类型，导致「文件名扩展名 ↔ File.type ↔ 实际字节」三者不一致，被 `/file/img-upload/init` 的 filename↔contentType 严格校验在第一个请求就拒绝（`image_upload_policy.go:86-91`）。

两条 Safari 特有的错标路径：

1. **PNG 输入**：仓库传 `convertSize: 0`，compressorjs 默认 `convertTypes: ['image/png']` → 内部改道输出 JPEG；文件名被改成 `.jpg` 但 `type` 仍声明 `image/png` → init 拒绝。
2. **GIF/WebP 输入**：Safari canvas 不支持 WebP/GIF 编码，`toBlob` 静默回退导出 PNG 字节，但 `type` 仍声明原格式 → init 拒绝（WebP 输入则由 complete 的内容嗅探拒绝）。

Chrome 因 canvas 可编码 WebP，全程「目标 WebP = 实际 WebP」自洽，故无人报。

## 修复

- 压缩产物跟随 `result.type` 推导扩展名与 `File.type`（单点根治，覆盖 PNG/GIF/WebP 全部错标路径）
- GIF 跳过压缩管线原样上传：canvas 无法编码 GIF，任何转码都丢动画（顺带修复 Chrome 上 GIF 被压成静态 WebP 的既有行为）

## 测试

- 新增 `resource/test/image-process.test.ts`（6 用例）：Safari PNG 改道 JPEG、WebP 回退 PNG、GIF 旁路三条错标路径 + Chrome WebP 转换、JPEG 常规路径、压缩失败回退三个回归守卫；按仓库规矩先红后绿（红测 3 failed → 修复后 6 passed）
- `pnpm test`：74 文件 / 592 用例全过
- `pnpm typecheck`：通过