### PR TITLE
perf: 图片读取路径 file_usage 索引 + /assets immutable 缓存头

### DIFF
--- a/apps/gooseforum/app/http/httputil/cache.go
+++ b/apps/gooseforum/app/http/httputil/cache.go
@@ -5,14 +5,74 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// Cache-Control values shared by the static asset mounts and the file
+// download controller.
+const (
+	LongPublicCacheControl = "public, max-age=18144000"
+	ImmutableCacheControl  = "public, max-age=31536000, immutable"
+	NoStoreCacheControl    = "no-store"
+)
+
 // SetLongPublic marks the response as publicly cacheable for static assets.
+// Used by the file download controller, which only reaches it on the success
+// path.
 func SetLongPublic(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=18144000")
+	c.Header("Cache-Control", LongPublicCacheControl)
 }
 
-// SetImmutable marks the response as immutable-cached for one year. Reserved
-// for content-addressed assets (Vite build output carries a content hash in
-// the filename), where any byte change is guaranteed to change the URL.
-func SetImmutable(c *gin.Context) {
-	c.Header("Cache-Control", "public, max-age=31536000, immutable")
+// statusAwareCacheWriter defers the Cache-Control decision until the response
+// status is known. The static mounts must cache long, but gin's StaticFS
+// answers a missing file by switching the same request onto the NoRoute chain
+// — the status is only final when gin flushes the response. Writing the
+// header up front would pin 404s (e.g. a missing content-hashed chunk during
+// a deploy rollback) into caches under the long max-age.
+type statusAwareCacheWriter struct {
+	gin.ResponseWriter
+	successHeader string
+	decided       bool
+}
+
+// decide applies the Cache-Control header exactly once: 2xx carries the
+// success header, every other status is explicitly no-store so failure
+// responses can never be cached by browsers or shared caches.
+func (w *statusAwareCacheWriter) decide(code int) {
+	if w.decided {
+		return
+	}
+	w.decided = true
+	if code >= 200 && code < 300 {
+		w.Header().Set("Cache-Control", w.successHeader)
+	} else {
+		w.Header().Set("Cache-Control", NoStoreCacheControl)
+	}
+}
+
+func (w *statusAwareCacheWriter) WriteHeader(code int) {
+	if code > 0 {
+		w.decide(code)
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *statusAwareCacheWriter) WriteHeaderNow() {
+	w.decide(w.Status())
+	w.ResponseWriter.WriteHeaderNow()
+}
+
+func (w *statusAwareCacheWriter) Write(data []byte) (int, error) {
+	w.decide(w.Status())
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *statusAwareCacheWriter) WriteString(s string) (int, error) {
+	w.decide(w.Status())
+	return w.ResponseWriter.WriteString(s)
+}
+
+// DeferCacheHeader wraps c.Writer so Cache-Control is chosen from the final
+// response status: 2xx → successHeader, anything else → no-store. Install it
+// in mount middleware before the handler, so the wrapper also covers the
+// NoRoute fallback gin uses for missing static files.
+func DeferCacheHeader(c *gin.Context, successHeader string) {
+	c.Writer = &statusAwareCacheWriter{ResponseWriter: c.Writer, successHeader: successHeader}
 }

--- a/apps/gooseforum/app/http/httputil/cache.go
+++ b/apps/gooseforum/app/http/httputil/cache.go
@@ -9,3 +9,10 @@ import (
 func SetLongPublic(c *gin.Context) {
 	c.Header("Cache-Control", "public, max-age=18144000")
 }
+
+// SetImmutable marks the response as immutable-cached for one year. Reserved
+// for content-addressed assets (Vite build output carries a content hash in
+// the filename), where any byte change is guaranteed to change the URL.
+func SetImmutable(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=31536000, immutable")
+}

--- a/apps/gooseforum/app/http/httputil/cache_test.go
+++ b/apps/gooseforum/app/http/httputil/cache_test.go
@@ -24,3 +24,20 @@ func TestSetLongPublic(t *testing.T) {
 		t.Fatalf("Cache-Control = %q, want long public cache", got)
 	}
 }
+
+func TestSetImmutable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/asset", func(c *gin.Context) {
+		SetImmutable(c)
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/asset", nil)
+	router.ServeHTTP(recorder, request)
+
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Fatalf("Cache-Control = %q, want immutable long cache", got)
+	}
+}

--- a/apps/gooseforum/app/http/httputil/cache_test.go
+++ b/apps/gooseforum/app/http/httputil/cache_test.go
@@ -20,24 +20,41 @@ func TestSetLongPublic(t *testing.T) {
 	request := httptest.NewRequest(http.MethodGet, "/asset", nil)
 	router.ServeHTTP(recorder, request)
 
-	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=18144000" {
+	if got := recorder.Header().Get("Cache-Control"); got != LongPublicCacheControl {
 		t.Fatalf("Cache-Control = %q, want long public cache", got)
 	}
 }
 
-func TestSetImmutable(t *testing.T) {
+// TestDeferCacheHeader 钉住状态感知缓存头决策：2xx 才带成功缓存头，其余状态
+// 显式 no-store——静态挂载的缺失文件会经 NoRoute 在同一请求内返回 404，
+// 绝不能被钉进长缓存（部署回滚窗口内的缺失 chunk 尤其致命）。
+func TestDeferCacheHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	router.GET("/asset", func(c *gin.Context) {
-		SetImmutable(c)
-		c.Status(http.StatusNoContent)
+	router.Use(func(c *gin.Context) {
+		DeferCacheHeader(c, ImmutableCacheControl)
+		c.Next()
+	})
+	router.GET("/ok", func(c *gin.Context) { c.Status(http.StatusOK) })
+	router.GET("/gone", func(c *gin.Context) { c.Status(http.StatusNotFound) })
+	// 隐式 200：不显式 WriteHeader，首个 Write 时按默认状态 200 决策。
+	router.GET("/stream", func(c *gin.Context) {
+		_, _ = c.Writer.WriteString("payload")
 	})
 
-	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodGet, "/asset", nil)
-	router.ServeHTTP(recorder, request)
-
-	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
-		t.Fatalf("Cache-Control = %q, want immutable long cache", got)
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/ok", ImmutableCacheControl},
+		{"/gone", NoStoreCacheControl},
+		{"/stream", ImmutableCacheControl},
+	}
+	for _, tc := range cases {
+		recorder := httptest.NewRecorder()
+		router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, tc.path, nil))
+		if got := recorder.Header().Get("Cache-Control"); got != tc.want {
+			t.Fatalf("GET %s Cache-Control = %q, want %q", tc.path, got, tc.want)
+		}
 	}
 }

--- a/apps/gooseforum/app/http/middleware/browsercache.go
+++ b/apps/gooseforum/app/http/middleware/browsercache.go
@@ -1,9 +1,9 @@
 package middleware
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/setting"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/httputil"
+	"github.com/gin-gonic/gin"
 )
 
 // BrowserCache applies long public cache headers in production.
@@ -13,5 +13,19 @@ func BrowserCache(c *gin.Context) {
 		return
 	}
 	httputil.SetLongPublic(c)
+	c.Next()
+}
+
+// AssetsCache applies immutable long cache headers to the /assets mount in
+// production. Vite build output carries a content hash in the filename, so a
+// byte change always changes the URL — a year-long immutable cache is safe
+// and removes revalidation requests on repeat visits. Local/dev responses
+// stay header-free so editors never fight a stale cached bundle.
+func AssetsCache(c *gin.Context) {
+	if !setting.IsProduction() {
+		c.Next()
+		return
+	}
+	httputil.SetImmutable(c)
 	c.Next()
 }

--- a/apps/gooseforum/app/http/middleware/browsercache.go
+++ b/apps/gooseforum/app/http/middleware/browsercache.go
@@ -6,26 +6,33 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// BrowserCache applies long public cache headers in production.
+// BrowserCache applies long public cache headers to successful /static
+// responses in production; error responses get no-store. The header decision
+// is deferred until the status is known (see httputil.DeferCacheHeader):
+// gin's StaticFS answers missing files through the NoRoute chain inside the
+// same request, so a 404 must never carry the long max-age.
 func BrowserCache(c *gin.Context) {
 	if !setting.IsProduction() {
 		c.Next()
 		return
 	}
-	httputil.SetLongPublic(c)
+	httputil.DeferCacheHeader(c, httputil.LongPublicCacheControl)
 	c.Next()
 }
 
-// AssetsCache applies immutable long cache headers to the /assets mount in
-// production. Vite build output carries a content hash in the filename, so a
-// byte change always changes the URL — a year-long immutable cache is safe
-// and removes revalidation requests on repeat visits. Local/dev responses
-// stay header-free so editors never fight a stale cached bundle.
+// AssetsCache applies immutable long cache headers to successful /assets
+// responses in production; error responses get no-store. Vite build output
+// carries a content hash in the filename, so a byte change always changes
+// the URL — a year-long immutable cache is safe for 200s and removes
+// revalidation requests on repeat visits, while a missing hashed chunk
+// (deploy rollback window) stays uncachable instead of being pinned for a
+// year. Local/dev responses stay header-free so editors never fight a stale
+// cached bundle.
 func AssetsCache(c *gin.Context) {
 	if !setting.IsProduction() {
 		c.Next()
 		return
 	}
-	httputil.SetImmutable(c)
+	httputil.DeferCacheHeader(c, httputil.ImmutableCacheControl)
 	c.Next()
 }

--- a/apps/gooseforum/app/http/middleware/browsercache_test.go
+++ b/apps/gooseforum/app/http/middleware/browsercache_test.go
@@ -78,3 +78,63 @@ func TestAssetsCacheLocal(t *testing.T) {
 		t.Fatalf("Cache-Control = %q, want empty local cache header", got)
 	}
 }
+
+func TestAssetsCacheSkipsErrorResponses(t *testing.T) {
+	oldEnv := preferences.GetString("app.env", "production")
+	t.Cleanup(func() {
+		preferences.Set("app.env", oldEnv)
+	})
+
+	preferences.Set("app.env", "production")
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(AssetsCache)
+	router.GET("/ok", func(c *gin.Context) { c.Status(http.StatusOK) })
+	router.GET("/gone", func(c *gin.Context) { c.Status(http.StatusNotFound) })
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/ok", nil))
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Fatalf("GET /ok Cache-Control = %q, want immutable long cache", got)
+	}
+
+	// 缺失 chunk 的 404 绝不能被钉进缓存（部署回滚窗口内浏览器/共享缓存
+	// 会把失败响应按 immutable 缓存一年）：错误响应必须显式 no-store。
+	recorder = httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/gone", nil))
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("GET /gone status = %d, want 404", recorder.Code)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("GET /gone Cache-Control = %q, want no-store", got)
+	}
+}
+
+func TestBrowserCacheSkipsErrorResponses(t *testing.T) {
+	oldEnv := preferences.GetString("app.env", "production")
+	t.Cleanup(func() {
+		preferences.Set("app.env", oldEnv)
+	})
+
+	preferences.Set("app.env", "production")
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(BrowserCache)
+	router.GET("/ok", func(c *gin.Context) { c.Status(http.StatusOK) })
+	router.GET("/gone", func(c *gin.Context) { c.Status(http.StatusNotFound) })
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/ok", nil))
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=18144000" {
+		t.Fatalf("GET /ok Cache-Control = %q, want long public cache", got)
+	}
+
+	recorder = httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/gone", nil))
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("GET /gone status = %d, want 404", recorder.Code)
+	}
+	if got := recorder.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("GET /gone Cache-Control = %q, want no-store", got)
+	}
+}

--- a/apps/gooseforum/app/http/middleware/browsercache_test.go
+++ b/apps/gooseforum/app/http/middleware/browsercache_test.go
@@ -50,3 +50,31 @@ func requestWithMiddleware(middleware gin.HandlerFunc, method string) *httptest.
 	router.ServeHTTP(recorder, request)
 	return recorder
 }
+
+func TestAssetsCacheProduction(t *testing.T) {
+	oldEnv := preferences.GetString("app.env", "production")
+	t.Cleanup(func() {
+		preferences.Set("app.env", oldEnv)
+	})
+
+	preferences.Set("app.env", "production")
+	recorder := requestWithMiddleware(AssetsCache, http.MethodGet)
+
+	if got := recorder.Header().Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Fatalf("Cache-Control = %q, want immutable long cache", got)
+	}
+}
+
+func TestAssetsCacheLocal(t *testing.T) {
+	oldEnv := preferences.GetString("app.env", "production")
+	t.Cleanup(func() {
+		preferences.Set("app.env", oldEnv)
+	})
+
+	preferences.Set("app.env", "local")
+	recorder := requestWithMiddleware(AssetsCache, http.MethodGet)
+
+	if got := recorder.Header().Get("Cache-Control"); got != "" {
+		t.Fatalf("Cache-Control = %q, want empty local cache header", got)
+	}
+}

--- a/apps/gooseforum/app/http/routes/contract_head_http_test.go
+++ b/apps/gooseforum/app/http/routes/contract_head_http_test.go
@@ -23,6 +23,11 @@ package routes
 //     byte change always changes the URL) — with an empty body.
 //     TestHeadContractAssetsMatchGet probes a file the Vite manifest actually
 //     emits and skips when the build output is missing.
+//   - both mounts answer *missing* files with 404 + Cache-Control: no-store:
+//     the cache middlewares defer the header decision to the final response
+//     status (httputil.DeferCacheHeader), so failure responses — e.g. a
+//     content-hashed chunk the previous bundle references during a deploy
+//     rollback — are never pinned into caches under the long max-age.
 //   - everything else (dynamic GET routes): HEAD 404 even when GET 200 —
 //     load balancer and monitor probes must use GET. HEAD never executes a
 //     write-side controller because no write route registers HEAD; that
@@ -57,11 +62,10 @@ const staticBadgeAsset = "/static/badges/commenter-50.svg"
 // does (RegisterByGin) with app.env pinned to production so the Vite dev
 // proxy is not registered and both static mounts apply their production
 // cache headers (BrowserCache long-public on /static, AssetsCache immutable
-// on /assets). The
-// gzip middleware is installed at router registration time (assertRouter
-// reads server.gzip once), so server.gzip is pinned on here and restored on
-// cleanup: the gzip negotiation assertions below must hold regardless of the
-// developer's local [server].gzip setting.
+// on /assets). The gzip middleware is installed at router registration time
+// (assertRouter reads server.gzip once), so server.gzip is pinned on here and
+// restored on cleanup: the gzip negotiation assertions below must hold
+// regardless of the developer's local [server].gzip setting.
 func setupHeadContractRouter(t *testing.T) *gin.Engine {
 	t.Helper()
 	setupMcpRouteTestDB(t) // mcpRoute needs the page_config table migrated
@@ -331,6 +335,41 @@ func TestHeadContractAssetsMatchGet(t *testing.T) {
 	}
 	if got := getResp.Header.Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
 		t.Errorf("GET %s Cache-Control = %q, want public, max-age=31536000, immutable", assetPath, got)
+	}
+}
+
+// TestHeadContractMissingAssetsAreNotCacheable pins the failure half of the
+// cache contract (Codex review): a *missing* asset answers the NoRoute 404
+// with Cache-Control: no-store — never the mount's long max-age. During a
+// deploy rollback the previous bundle can reference hashed chunks the current
+// binary does not embed; a 404 pinned under the immutable/long-public header
+// would keep serving that failure from browser and shared caches for months
+// even after the binary is restored.
+func TestHeadContractMissingAssetsAreNotCacheable(t *testing.T) {
+	router := setupHeadContractRouter(t)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+	client := headContractClient()
+
+	for _, path := range []string{
+		"/assets/missing-chunk-a1b2c3d4e5.js",
+		"/static/definitely-not-a-real-file-477.svg",
+	} {
+		resp := headContractRequest(t, client, http.MethodGet, srv.URL+path, "")
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read GET %s body: %v", path, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s status = %d, want 404", path, resp.StatusCode)
+		}
+		if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+			t.Errorf("GET %s Cache-Control = %q, want no-store (failure responses must never carry the mount max-age)", path, got)
+		}
+		if len(body) == 0 {
+			t.Errorf("GET %s body is empty, want the NoRoute JSON envelope", path)
+		}
 	}
 }
 

--- a/apps/gooseforum/app/http/routes/contract_head_http_test.go
+++ b/apps/gooseforum/app/http/routes/contract_head_http_test.go
@@ -14,16 +14,15 @@ package routes
 // HEAD responses never carry a body), which is what CDNs and reverse proxies
 // observe.
 //
-// The contract is therefore:
 //   - /static/*filepath: HEAD == GET status and headers — including the
-//     Cache-Control long-public header, which BrowserCache attaches to this
-//     mount only (assertRouter registers it after the /assets StaticFS) —
+//     Cache-Control long-public header from the BrowserCache mount middleware —
 //     with an empty body.
 //   - /assets/*filepath (frontend build output): HEAD == GET status and
-//     headers except Cache-Control, with an empty body; the mount carries no
-//     cache header to promise. TestHeadContractAssetsMatchGet probes a file
-//     the Vite manifest actually emits and skips when the build output is
-//     missing.
+//     headers — including the immutable Cache-Control header from the
+//     AssetsCache mount middleware (Vite filenames carry a content hash, so a
+//     byte change always changes the URL) — with an empty body.
+//     TestHeadContractAssetsMatchGet probes a file the Vite manifest actually
+//     emits and skips when the build output is missing.
 //   - everything else (dynamic GET routes): HEAD 404 even when GET 200 —
 //     load balancer and monitor probes must use GET. HEAD never executes a
 //     write-side controller because no write route registers HEAD; that
@@ -56,7 +55,9 @@ const staticBadgeAsset = "/static/badges/commenter-50.svg"
 
 // setupHeadContractRouter assembles the production router exactly like main
 // does (RegisterByGin) with app.env pinned to production so the Vite dev
-// proxy is not registered and BrowserCache long-public headers apply. The
+// proxy is not registered and both static mounts apply their production
+// cache headers (BrowserCache long-public on /static, AssetsCache immutable
+// on /assets). The
 // gzip middleware is installed at router registration time (assertRouter
 // reads server.gzip once), so server.gzip is pinned on here and restored on
 // cleanup: the gzip negotiation assertions below must hold regardless of the
@@ -176,9 +177,9 @@ func TestHeadRouteRegistrationContract(t *testing.T) {
 // TestHeadContractStaticAssetsMatchGet asserts the /static mount contract:
 // files served through gin StaticFS answer HEAD with the same status and
 // headers as GET — Content-Length, Content-Type, and the BrowserCache
-// long-public Cache-Control header that only this mount carries (assertRouter
-// attaches the middleware after the /assets registration) — plus an empty
-// body on the wire. server.gzip is pinned on by setupHeadContractRouter so
+// long-public Cache-Control header that this mount's subgroup carries
+// (assertRouter registers /static through a BrowserCache subgroup) — plus an
+// empty body on the wire. server.gzip is pinned on by setupHeadContractRouter so
 // the gzip negotiation assertions hold under any local [server].gzip config.
 func TestHeadContractStaticAssetsMatchGet(t *testing.T) {
 	router := setupHeadContractRouter(t)
@@ -282,11 +283,13 @@ func viteManifestEntryFile(t *testing.T, entry string) string {
 // TestHeadContractAssetsMatchGet asserts the /assets mount against a file the
 // Vite build actually emits (the site entry from the manifest), so the
 // successful-response path is exercised whenever the build output exists.
-// /assets carries no BrowserCache Cache-Control header — the contract only
-// promises HEAD == GET status and headers excluding Cache-Control plus an
-// empty body. Without `pnpm build` the manifest is absent and the test skips
-// (dist is never committed and CI never builds the frontend); a skip is not a
-// pass — the 200 path simply stays unasserted until the frontend is built.
+// /assets carries the AssetsCache immutable Cache-Control header (Vite
+// filenames carry a content hash, so a byte change always changes the URL) —
+// the contract promises HEAD == GET status and headers including
+// Cache-Control plus an empty body. Without `pnpm build` the manifest is
+// absent and the test skips (dist is never committed and CI never builds the
+// frontend); a skip is not a pass — the 200 path simply stays unasserted
+// until the frontend is built.
 func TestHeadContractAssetsMatchGet(t *testing.T) {
 	entryFile := viteManifestEntryFile(t, "src/site/main.ts")
 	router := setupHeadContractRouter(t)
@@ -319,8 +322,16 @@ func TestHeadContractAssetsMatchGet(t *testing.T) {
 	if got := headResp.Header.Get("Content-Type"); got == "" || got != getResp.Header.Get("Content-Type") {
 		t.Errorf("HEAD %s Content-Type = %q, GET Content-Type = %q; want equal and non-empty", assetPath, got, getResp.Header.Get("Content-Type"))
 	}
-	// Cache-Control is deliberately not compared: BrowserCache only applies
-	// to the /static mount, and /assets must not promise a cache header.
+	for _, header := range []string{"Cache-Control"} {
+		if got := headResp.Header.Get(header); got == "" {
+			t.Errorf("%s %s is empty on GET; want the /assets mount to set it", assetPath, header)
+		} else if got != getResp.Header.Get(header) {
+			t.Errorf("HEAD %s %s = %q, GET %s = %q; want equal", assetPath, header, got, header, getResp.Header.Get(header))
+		}
+	}
+	if got := getResp.Header.Get("Cache-Control"); got != "public, max-age=31536000, immutable" {
+		t.Errorf("GET %s Cache-Control = %q, want public, max-age=31536000, immutable", assetPath, got)
+	}
 }
 
 // TestHeadContractDynamicRoutesAreGetOnly asserts the unsupported side of

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -47,11 +47,17 @@ func assertRouter(ginApp *gin.Engine) {
 			slog.Info("assets proxied to vite dev server", "target", devServer)
 		}
 	} else {
-		staticRoute.StaticFS("assets", http.FS(assetsFs))
+		// 生产 /assets：Vite 产物文件名带内容哈希，字节变更必然换 URL ——
+		// 一年 immutable 缓存安全，二次访问零重验证请求。gin 组中间件随
+		// Use() 累加，挂载级子组保证 AssetsCache 只被本挂载捕获，不泄漏到
+		// /static（反之 BrowserCache 也不会改写 /assets 的 immutable 头）。
+		assetsRoute := staticRoute.Group("/")
+		assetsRoute.Use(middleware.AssetsCache)
+		assetsRoute.StaticFS("assets", http.FS(assetsFs))
 	}
-	staticRoute.
-		Use(middleware.BrowserCache).
-		StaticFS("static", http.FS(staticFS))
+	staticMount := staticRoute.Group("/")
+	staticMount.Use(middleware.BrowserCache)
+	staticMount.StaticFS("static", http.FS(staticFS))
 }
 
 func viteDevServerURL() string {

--- a/apps/gooseforum/app/migration/file_usage_index_schema_test.go
+++ b/apps/gooseforum/app/migration/file_usage_index_schema_test.go
@@ -1,0 +1,197 @@
+package migration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/fileUsage"
+	"github.com/glebarez/sqlite"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func openFileUsageIndexTestDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	conn, err := gorm.Open(
+		sqlite.Open("file:fileusage-index-"+name+"?mode=memory&cache=shared"),
+		&gorm.Config{Logger: logger.Default.LogMode(logger.Silent)},
+	)
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	return conn
+}
+
+// seedFileUsagePlannerData 写入代表性数据并执行 ANALYZE。无统计信息时 SQLite
+// 的静态成本模型在两个单列索引之间近似打平，规划器选择与数据无关（空表上
+// 可能选中 idx_file_usage_status——status='ACTIVE' 几乎匹配全表，恰恰是最差
+// 选择）。ANALYZE 写入真实选择率后，规划器稳定选择高选择率的 file_name 索引；
+// 这也是生产 PostgreSQL（auto-analyze）下的真实行为：status=ACTIVE 匹配近乎
+// 全表，file_name= 只匹配个位数行。
+func seedFileUsagePlannerData(t *testing.T, conn *gorm.DB) {
+	t.Helper()
+	rows := make([]fileUsage.Entity, 0, 200)
+	for filename := range 40 {
+		for variant := range 5 {
+			status := fileUsage.UsageStatusActive
+			usageType := fileUsage.UsageInlineImage
+			switch variant {
+			case 3:
+				status = fileUsage.UsageStatusRecovering
+			case 4:
+				status = fileUsage.UsageStatusPurged
+				usageType = fileUsage.UsageUploadOwner
+			}
+			rows = append(rows, fileUsage.Entity{
+				FileName:   fmt.Sprintf("2026/09/01/planner-%02d.png", filename),
+				TargetType: fileUsage.TargetTopic,
+				TargetId:   uint64(filename*10 + variant),
+				UsageType:  usageType,
+				UserId:     1,
+				Status:     status,
+			})
+		}
+	}
+	if err := conn.CreateInBatches(rows, 100).Error; err != nil {
+		t.Fatalf("seed planner rows: %v", err)
+	}
+	if err := conn.Exec("ANALYZE").Error; err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+}
+
+// TestFileNameLookupsUseIndex 钉住公开图片读取路径的索引契约（图片速率优化
+// P0）：/file/img/* 每次请求都按 file_name 做引用检查（HasAnyReferences /
+// HasActiveReferences 的 COUNT 查询）。唯一索引 idx_file_usage_target_file 的
+// 前缀是 (target_type, target_id, usage_type)，file_name 排在第四位、前缀不
+// 匹配，该查询只能全表扫描并随附件量线性劣化；模型必须声明独立的
+// idx_file_usage_file_name 让引用检查走索引查找。
+func TestFileNameLookupsUseIndex(t *testing.T) {
+	conn := openFileUsageIndexTestDB(t, t.Name())
+	if err := conn.AutoMigrate(&fileUsage.Entity{}); err != nil {
+		t.Fatalf("AutoMigrate file_usages: %v", err)
+	}
+	seedFileUsagePlannerData(t, conn)
+
+	cases := []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{
+			name: "HasAnyReferences",
+			sql:  "SELECT count(*) FROM file_usages WHERE file_name = ? AND usage_type <> ?",
+			args: []any{"2026/09/01/planner-07.png", fileUsage.UsageUploadOwner},
+		},
+		{
+			name: "HasActiveReferences",
+			sql:  "SELECT count(*) FROM file_usages WHERE file_name = ? AND status = ? AND usage_type <> ?",
+			args: []any{"2026/09/01/planner-07.png", fileUsage.UsageStatusActive, fileUsage.UsageUploadOwner},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var rows []struct {
+				ID      int
+				Parent  int
+				Notused int
+				Detail  string
+			}
+			if err := conn.Raw("EXPLAIN QUERY PLAN "+tc.sql, tc.args...).Scan(&rows).Error; err != nil {
+				t.Fatalf("explain query plan: %v", err)
+			}
+			joined := make([]string, 0, len(rows))
+			used := false
+			for _, row := range rows {
+				joined = append(joined, row.Detail)
+				if strings.Contains(row.Detail, "USING INDEX idx_file_usage_file_name") {
+					used = true
+				}
+			}
+			if !used {
+				t.Fatalf("query plan does not use idx_file_usage_file_name: %s", strings.Join(joined, " | "))
+			}
+		})
+	}
+}
+
+// legacyFileUsageEntity 旧版形态（与存量库一致）：只有 (target_type, target_id,
+// usage_type, file_name) 复合唯一索引，没有独立 file_name 索引。
+type legacyFileUsageEntity struct {
+	Id         uint64 `gorm:"primaryKey;column:id;autoIncrement;not null;"`
+	FileName   string `gorm:"column:file_name;type:varchar(512);not null;default:'';uniqueIndex:idx_file_usage_target_file,priority:4;"`
+	TargetType string `gorm:"column:target_type;type:varchar(32);not null;default:'';uniqueIndex:idx_file_usage_target_file,priority:1;"`
+	TargetId   uint64 `gorm:"column:target_id;not null;default:0;uniqueIndex:idx_file_usage_target_file,priority:2;"`
+	UsageType  string `gorm:"column:usage_type;type:varchar(32);not null;default:'';uniqueIndex:idx_file_usage_target_file,priority:3;"`
+	UserId     uint64 `gorm:"column:user_id;not null;default:0;"`
+	Status     string `gorm:"column:status;type:varchar(32);not null;default:'ACTIVE';index:idx_file_usage_status,priority:1;"`
+	ExpiresAt  *time.Time
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+func (legacyFileUsageEntity) TableName() string { return "file_usages" }
+
+// exerciseFileNameIndexUpgrade 在给定连接上执行完整升级路径并断言结果：
+// 旧 schema（无 file_name 索引）→ AutoMigrate 新模型补齐索引 → 幂等重跑。
+func exerciseFileNameIndexUpgrade(t *testing.T, conn *gorm.DB) {
+	t.Helper()
+	if err := conn.Migrator().DropTable(&fileUsage.Entity{}); err != nil {
+		t.Fatalf("reset file_usages: %v", err)
+	}
+	if err := conn.AutoMigrate(&legacyFileUsageEntity{}); err != nil {
+		t.Fatalf("migrate legacy schema: %v", err)
+	}
+	if conn.Migrator().HasIndex(&fileUsage.Entity{}, "idx_file_usage_file_name") {
+		t.Fatal("precondition failed: legacy schema should not have idx_file_usage_file_name")
+	}
+	seed := &fileUsage.Entity{FileName: "2026/09/01/legacy.png", TargetType: fileUsage.TargetTopic, TargetId: 1, UsageType: fileUsage.UsageInlineImage, UserId: 1}
+	if err := conn.Create(seed).Error; err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	// 部署新二进制：AutoMigrate 补齐索引
+	if err := conn.AutoMigrate(&fileUsage.Entity{}); err != nil {
+		t.Fatalf("upgrade AutoMigrate file_usages: %v", err)
+	}
+	if !conn.Migrator().HasIndex(&fileUsage.Entity{}, "idx_file_usage_file_name") {
+		t.Fatal("idx_file_usage_file_name missing after upgrade AutoMigrate")
+	}
+	var count int64
+	if err := conn.Model(&fileUsage.Entity{}).Where("file_name = ?", seed.FileName).Count(&count).Error; err != nil {
+		t.Fatalf("count legacy rows: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("legacy row count after upgrade = %d, want 1", count)
+	}
+	// 幂等：每次启动都会 AutoMigrate，重复执行不得报错。
+	if err := conn.AutoMigrate(&fileUsage.Entity{}); err != nil {
+		t.Fatalf("idempotent AutoMigrate file_usages: %v", err)
+	}
+}
+
+// TestFileNameIndexAddedOnLegacySchema 模拟存量库升级（SQLite）：旧 schema 上
+// AutoMigrate 新模型必须自动补齐 idx_file_usage_file_name，且存量数据不受影响。
+func TestFileNameIndexAddedOnLegacySchema(t *testing.T) {
+	conn := openFileUsageIndexTestDB(t, t.Name()+"-upgrade")
+	exerciseFileNameIndexUpgrade(t, conn)
+}
+
+// TestFileNameIndexAddedOnLegacySchemaOnPostgreSQL 同上，PostgreSQL 版（生产
+// 默认库方言，模型/迁移变更必须过 PG 门禁）。
+// 依赖 YOURTJ_TEST_PG_URL，未设置时跳过。
+func TestFileNameIndexAddedOnLegacySchemaOnPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL file_usage index test")
+	}
+	conn, err := gorm.Open(postgres.Open(dsn), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	exerciseFileNameIndexUpgrade(t, conn)
+}

--- a/apps/gooseforum/app/migration/file_usage_index_schema_test.go
+++ b/apps/gooseforum/app/migration/file_usage_index_schema_test.go
@@ -181,10 +181,12 @@ func TestFileNameIndexAddedOnLegacySchema(t *testing.T) {
 	exerciseFileNameIndexUpgrade(t, conn)
 }
 
-// TestFileNameIndexAddedOnLegacySchemaOnPostgreSQL 同上，PostgreSQL 版（生产
-// 默认库方言，模型/迁移变更必须过 PG 门禁）。
+// TestSchemaFileNameIndexAddedOnLegacySchemaOnPostgreSQL 同上，PostgreSQL 版
+// （生产默认库方言，模型/迁移变更必须过 PG 门禁）。TestSchema 前缀是刻意的：
+// CI 的 ci-backend-pg job 以 -run 'TestSchema' 圈定迁移包 PG 用例，同名模式的
+// 新用例自动纳入（workflow 注释即约定），PG 门禁之外的命名会在 CI 中静默跳过。
 // 依赖 YOURTJ_TEST_PG_URL，未设置时跳过。
-func TestFileNameIndexAddedOnLegacySchemaOnPostgreSQL(t *testing.T) {
+func TestSchemaFileNameIndexAddedOnLegacySchemaOnPostgreSQL(t *testing.T) {
 	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
 	if dsn == "" {
 		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL file_usage index test")

--- a/apps/gooseforum/app/models/forum/fileUsage/fileUsage.go
+++ b/apps/gooseforum/app/models/forum/fileUsage/fileUsage.go
@@ -28,7 +28,7 @@ const (
 
 type Entity struct {
 	Id         uint64     `gorm:"primaryKey;column:id;autoIncrement;not null;" json:"id"`
-	FileName   string     `gorm:"column:file_name;type:varchar(512);not null;default:'';uniqueIndex:idx_file_usage_target_file,priority:4;" json:"fileName"`
+	FileName   string     `gorm:"column:file_name;type:varchar(512);not null;default:'';index:idx_file_usage_file_name;uniqueIndex:idx_file_usage_target_file,priority:4;" json:"fileName"` // 公开图片读取路径按 file_name 检查附件引用（/file/img/*），独立索引避免全表扫描
 	TargetType string     `gorm:"column:target_type;type:varchar(32);not null;default:'';uniqueIndex:idx_file_usage_target_file,priority:1;" json:"targetType"`
 	TargetId   uint64     `gorm:"column:target_id;not null;default:0;uniqueIndex:idx_file_usage_target_file,priority:2;" json:"targetId"`
 	UsageType  string     `gorm:"column:usage_type;type:varchar(32);not null;default:'';uniqueIndex:idx_file_usage_target_file,priority:3;" json:"usageType"`

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -104,18 +104,17 @@ request.
 
 ### Supported HEAD surface (static assets)
 
-The two static mounts answer HEAD, but their header guarantees differ:
-`BrowserCache` (`Cache-Control: public, max-age=18144000`) is only attached
-to `/static/*filepath` — `assertRouter` registers the `/assets` StaticFS
-first and calls `staticRoute.Use(middleware.BrowserCache)` only before the
-`/static` registration, and Gin captures group middleware when each route is
-registered. The contract therefore promises:
+The two static mounts answer HEAD, and each carries its own production cache
+header via a mount-level subgroup in `assertRouter` (`AssetsCache` on
+`/assets`, `BrowserCache` on `/static`; Gin captures group middleware when
+each route is registered, so neither header leaks to the other mount). The
+contract therefore promises:
 
 - `/static/*filepath`: HEAD == GET status and headers, **including** the
-  long-public `Cache-Control`;
-- `/assets/*filepath`: HEAD == GET status and headers **except**
-  `Cache-Control` — the mount sets no cache header and the contract promises
-  none;
+  long-public `Cache-Control` (`public, max-age=18144000`);
+- `/assets/*filepath`: HEAD == GET status and headers, **including** the
+  immutable `Cache-Control` (`public, max-age=31536000, immutable` — Vite
+  filenames carry a content hash, so a byte change always changes the URL);
 
 both with an empty body on the wire.
 
@@ -124,10 +123,10 @@ both with an empty body on the wire.
 | `GET /static/...` | 200 | full file | set | set |
 | `HEAD /static/...` | 200 (same as GET) | empty (never sent) | set, same as GET | same as GET |
 | `HEAD /static/...` with `Accept-Encoding: gzip` | 200 | empty | unset (no body was written, so the gzip middleware cannot size it) | Content-Type present; no Content-Encoding |
-| `GET` / `HEAD /assets/...` (built entry) | 200 | full file / empty | set, same across methods | Content-Type set; **no `Cache-Control` promised** |
+| `GET` / `HEAD /assets/...` (built entry) | 200 | full file / empty | set, same across methods | Content-Type set; immutable `Cache-Control` |
 
 `HEAD` for an existing asset is therefore safe for cache existence checks
-(only `/static/...` additionally guarantees the long `Cache-Control`).
+(both mounts guarantee their production `Cache-Control`).
 `HEAD`/`GET` for a *missing* asset are both the same NoRoute 404: gin's
 StaticFS handler hands failed file opens to the engine's NoRoute chain
 (`controllers.NotFound`), so both methods answer the identical 404 JSON
@@ -170,7 +169,7 @@ Consequences for operators and integrators:
   surface.
 - **CDN origin checks**: if a CDN is configured to validate origin
   availability with HEAD against a page or API URL, point it at a `/static`
-  asset (supported; only this mount carries the cache header) or at
+  or `/assets` asset (both mounts carry their production cache header) or at
   `GET /health` (use GET).
 
 ### Guard tests
@@ -178,10 +177,11 @@ Consequences for operators and integrators:
 `apps/gooseforum/app/http/routes/contract_head_http_test.go` asserts this
 contract against the real `RegisterByGin` assembly over a real HTTP server:
 the registered HEAD route set is exactly the static mounts + `/mcp`; `/static`
-HEAD equals GET in status and headers (including `Cache-Control`); `/assets`
-HEAD equals GET except `Cache-Control`, probed against a manifest-emitted
-file and skipped without `pnpm build`; dynamic GET routes and write-only
-endpoints answer 404 to HEAD; and no body ever reaches the wire on HEAD. The
+HEAD equals GET in status and headers (including the long-public
+`Cache-Control`); `/assets` HEAD equals GET including the immutable
+`Cache-Control`, probed against a manifest-emitted file and skipped without
+`pnpm build`; dynamic GET routes and write-only endpoints answer 404 to HEAD;
+and no body ever reaches the wire on HEAD. The
 tests pin `server.gzip` on, so the gzip assertions hold under any local
 `[server].gzip` setting.
 

--- a/docs/architecture/contracts-and-data.md
+++ b/docs/architecture/contracts-and-data.md
@@ -130,7 +130,11 @@ both with an empty body on the wire.
 `HEAD`/`GET` for a *missing* asset are both the same NoRoute 404: gin's
 StaticFS handler hands failed file opens to the engine's NoRoute chain
 (`controllers.NotFound`), so both methods answer the identical 404 JSON
-envelope — HEAD simply never sends the body on the wire. The `/assets`
+envelope — HEAD simply never sends the body on the wire. Failure responses
+carry `Cache-Control: no-store`, never a mount max-age: both cache
+middlewares defer the header decision to the final response status
+(`httputil.DeferCacheHeader`), so a missing content-hashed chunk during a
+deploy rollback cannot be pinned into browser or shared caches. The `/assets`
 contract tests probe a file the Vite build actually emits
 (`static/dist/.vite/manifest.json`, site entry) and skip when the build
 output is absent — `dist/` is never committed and CI never builds the
@@ -180,8 +184,10 @@ the registered HEAD route set is exactly the static mounts + `/mcp`; `/static`
 HEAD equals GET in status and headers (including the long-public
 `Cache-Control`); `/assets` HEAD equals GET including the immutable
 `Cache-Control`, probed against a manifest-emitted file and skipped without
-`pnpm build`; dynamic GET routes and write-only endpoints answer 404 to HEAD;
-and no body ever reaches the wire on HEAD. The
+`pnpm build`; missing assets on both mounts answer 404 with
+`Cache-Control: no-store` (`TestHeadContractMissingAssetsAreNotCacheable`);
+dynamic GET routes and write-only endpoints answer 404 to HEAD; and no body
+ever reaches the wire on HEAD. The
 tests pin `server.gzip` on, so the gzip assertions hold under any local
 `[server].gzip` setting.
 


### PR DESCRIPTION
## Summary

图片全链路速率优化第一批（P0 + P1），两项独立改动：

### P0 — file_usage 按文件名引用检查索引

`GET /file/img/*` 每次请求都按 `file_name` 做附件引用检查（`HasAnyReferences` / `HasActiveReferences` 的 COUNT 查询），但 `file_usages` 的唯一索引 `(target_type, target_id, usage_type, file_name)` 前缀不匹配，引用检查只能全表扫描并随附件量线性劣化——是图片读取路径上最重的查询。

- `fileUsage.Entity.FileName` 新增独立索引 `idx_file_usage_file_name`（一条 model tag，AutoMigrate 自动在存量库补齐）
- 红测试用 `EXPLAIN QUERY PLAN` 钉住查询计划（修复前实测：`SCAN file_usages USING COVERING INDEX idx_file_usage_target_file` 全索引扫描 → 修复后 `SEARCH ... USING INDEX idx_file_usage_file_name`）
- 存量库升级路径 + 幂等性由 SQLite/PostgreSQL 双变体测试覆盖（`app/migration/file_usage_index_schema_test.go`）
- 测试种子数据 + `ANALYZE`：空表上 SQLite 规划器会在两个单列索引间近似打平（可能误选低选择率的 `idx_file_usage_status`），ANALYZE 后规划器稳定选择 file_name 索引，与生产 PG auto-analyze 行为一致

### P1 — /assets 生产挂 immutable 缓存头

Vite 产物文件名带内容哈希，字节变更必然换 URL，但 `/assets` 挂载此前没有任何显式缓存头（只有 `/static` 组挂了 `BrowserCache`），二次导航仍靠浏览器启发式缓存发条件请求。

- 新增 `middleware.AssetsCache`（生产环境 `public, max-age=31536000, immutable`），挂载到 `/assets` StaticFS
- `assertRouter` 改为挂载级子组装配：gin 组中间件随 `Use()` 累加，子组保证 `AssetsCache`/`BrowserCache` 各自只被本挂载捕获、互不泄漏
- HEAD 契约测试同步：`/assets` 现承诺 immutable `Cache-Control`（HEAD == GET 全头一致），`docs/architecture/contracts-and-data.md` 的 HEAD 契约矩阵与 CDN 指引同步更新

## Testing

- `go vet ./... && go test ./...` — 全部 PASS（含 `TestSchemaMigratesOnPostgreSQL` / `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL`）
- PostgreSQL 迁移门禁：`YOURTJ_TEST_PG_URL=... go test ./app/migration/ -run 'TestSchema|TestFileNameIndex'` — PASS（含新增的 `TestFileNameIndexAddedOnLegacySchemaOnPostgreSQL`）
- HEAD 契约：`go test ./app/http/routes/ -run 'TestHeadContract|TestAssetsGzip'` — PASS（本地已构建 dist，`TestHeadContractAssetsMatchGet` 真实断言了 manifest 产物路径与 immutable 头）
- 路由快照：`TestRoutesSnapshot` — 无漂移（无路由增删，仅挂载中间件变化）
- `golangci-lint run --new-from-rev=origin/dev` — 0 issues

## Notes

- 迁移无数据回填：索引由 AutoMigrate 在启动时自动补齐，SQLite 上为普通索引创建、PG 上为 `CREATE INDEX`，不重建表
- 读取拓扑不变：仍走服务端 `/file/img` 代理读（ADR-009 成本模型），本 PR 仅优化应用服务器内部查询与缓存头

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>