### PR TITLE
fix: prevent Vditor editor image lightbox deadlock

### DIFF
--- a/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
+++ b/apps/gooseforum/resource/src/site/components/VditorOfficial.vue
@@ -1381,6 +1381,10 @@ onMounted(async () => {
       i18n: window.VditorI18n,
       icon: 'ant',
       lang: language.lang,
+      // 编辑器内图片只保留 Vditor 的编辑浮层；关闭原生双击全屏预览，避免移动端误触打开无法退出的灯箱。
+      image: {
+        isPreview: false,
+      },
       // 所见即所得：显示悬浮在片段左侧的块级控制指示器（</>、H1/H2、$、ToC）
       mode: 'wysiwyg',
       placeholder: props.placeholder,

--- a/apps/gooseforum/resource/test/mobile-editor-toolbar.test.ts
+++ b/apps/gooseforum/resource/test/mobile-editor-toolbar.test.ts
@@ -279,4 +279,13 @@ describe('移动视图下 Vditor 编辑器工具栏架构与交互规范', () =>
     expect(componentSource).toContain('left: 12px !important')
     expect(componentSource).toContain('right: auto !important')
   })
+
+  test('编辑器图片不启用 Vditor 原生灯箱，避免预览阻断内容编辑', () => {
+    const componentSource = readFileSync(
+      resolve(process.cwd(), 'src/site/components/VditorOfficial.vue'),
+      'utf8',
+    )
+
+    expect(componentSource).toMatch(/image:\s*\{\s*isPreview:\s*false,\s*\}/)
+  })
 })


### PR DESCRIPTION
## Summary
- disable Vditor's built-in full-screen image preview in the WYSIWYG editor
- add a regression test protecting the editor image-preview setting

Fixes #482

## Verification
- `pnpm typecheck`
- `pnpm test` — 68 files, 496 tests passed
- `pnpm build`
- `git diff --check`

## Notes
- The local environment does not have lefthook/golangci-lint installed; frontend checks passed and remote CI should provide the repository hook/CI coverage.
- Build completed with existing Rolldown annotation and chunk-size warnings.