### PR TITLE
docs(operations): static asset cache contract and reverse-proxy acceptance

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-14
+> Last verified: 2026-09-06
 
 ## Deployment shape
 
@@ -45,6 +45,46 @@
     `docker images | awk '/yourtj-wiki/{print $3}' | xargs -r docker rmi -f`
     （`deploy.sh` 的镜像清理只保留 `yourtj-hub` 前缀 tag，不含 `yourtj-wiki:*`）。
   - 若反向代理仍把旧 wiki 域名指到 127.0.0.1:5284/5285，退役后需同步摘除路由。
+
+### 静态资产缓存（反向代理注意事项）
+
+单二进制自身负责静态资产与文件下载的生产缓存头（实现：
+`app/http/httputil/cache.go` + `app/http/middleware/browsercache.go`，
+`app.env=production` 才生效；本地/开发响应不带缓存头）：
+
+| 路径 | 2xx 响应头 | 说明 |
+| --- | --- | --- |
+| `/assets/*`（Vite 构建，文件名含内容哈希） | `public, max-age=31536000, immutable`（`AssetsCache`） | 字节变更必然换 URL，二次访问零重验证 |
+| `/static/*`（内嵌静态文件） | `public, max-age=18144000`（`BrowserCache`） | 长公共缓存 |
+| `/file/img/*`（用户/版面图片，成功路径） | `public, max-age=18144000`（`SetLongPublic`） | 文件名内容寻址 |
+| `/sw.js` | `no-cache` | Service Worker 更新必须及时可见 |
+| `/manifest.webmanifest` | `public, max-age=3600` | PWA manifest 短缓存 |
+| `/`（SSR HTML）与 `/api/*` | 路由自控（多为 `no-store`/无缓存头） | 登录态与动态内容，禁止代理层长缓存 |
+| 上述静态挂载的 404/错误 | `no-store`（`DeferCacheHeader` 按最终状态码决定） | 部署回滚窗口不得把缺失 chunk 钉进缓存 |
+
+**反向代理（1Panel/openresty）不得对以上响应追加或覆盖 `cache-control`。**
+nginx `add_header` 是追加而非覆盖：一旦代理层再发一个 `Cache-Control`
+（典型事故：站点 `proxy/*.conf` 里的 `add_header Cache-Control no-cache`），
+浏览器按多个头中最严格语义执行，等价于禁用全部缓存——静态资产每次导航
+全量回源，长缓存完全失效。
+
+1Panel 修复路径：网站 → 全部网站 → 站点设置 → 反向代理，逐个编辑代理条目，
+删除 `add_header Cache-Control ...` 行（同时检查站点 conf.d 主配置）。
+修改保存后 1Panel 自动 reload；手动重载：
+`docker exec <openresty容器> nginx -t && docker exec <openresty容器> nginx -s reload`。
+
+部署/变更后验收（每条响应必须只出现一行 `cache-control`）：
+
+```bash
+curl -sI https://f.yourtj.de/assets/assets/<当前entry>.js   # public, max-age=31536000, immutable
+curl -sI https://f.yourtj.de/static/pic/icon.webp           # public, max-age=18144000
+curl -sI https://f.yourtj.de/sw.js                          # no-cache
+curl -sI https://f.yourtj.de/                               # no-store 系（HTML 不缓存）
+```
+
+排查技巧：绕过代理直打上游可二分定位注入方——`curl -sI http://127.0.0.1:5234/assets/...`
+（宿主机上执行；上游无头而公网有头 ⇒ 代理层注入）。dev 实例同理
+（`dev.yourtj.de` → `127.0.0.1:5235`）。
 
 ### 旧 VitePress wiki 内容迁移（GitHub 唯一真实源）
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -48,9 +48,11 @@
 
 ### 静态资产缓存（反向代理注意事项）
 
-单二进制自身负责静态资产与文件下载的生产缓存头（实现：
-`app/http/httputil/cache.go` + `app/http/middleware/browsercache.go`，
-`app.env=production` 才生效；本地/开发响应不带缓存头）：
+单二进制自身负责静态资产与文件下载的缓存头（实现：
+`app/http/httputil/cache.go` + `app/http/middleware/browsercache.go`）。
+`/assets/*` 与 `/static/*` 的挂载级缓存中间件（`AssetsCache`/`BrowserCache`）
+仅在 `app.env=production` 生效，本地/开发响应不带缓存头；`/file/img/*` 与
+下方 PWA 文件（`servePWAStatic`）的缓存头不区分环境，恒定输出：
 
 | 路径 | 2xx 响应头 | 说明 |
 | --- | --- | --- |
@@ -73,13 +75,15 @@ nginx `add_header` 是追加而非覆盖：一旦代理层再发一个 `Cache-Co
 修改保存后 1Panel 自动 reload；手动重载：
 `docker exec <openresty容器> nginx -t && docker exec <openresty容器> nginx -s reload`。
 
-部署/变更后验收（每条响应必须只出现一行 `cache-control`）：
+部署/变更后验收（每条响应必须只出现一行 `cache-control`）。统一用 GET 探测
+（丢弃 body、保留响应头）：`/sw.js` 与 `/` 只注册了 GET 处理器，HEAD
+（`curl -I`）会落入 NoRoute 返回 404（HEAD 契约见 `contract_head_http_test.go`）：
 
 ```bash
-curl -sI https://f.yourtj.de/assets/assets/<当前entry>.js   # public, max-age=31536000, immutable
-curl -sI https://f.yourtj.de/static/pic/icon.webp           # public, max-age=18144000
-curl -sI https://f.yourtj.de/sw.js                          # no-cache
-curl -sI https://f.yourtj.de/                               # no-store 系（HTML 不缓存）
+curl -sS -D - -o /dev/null https://f.yourtj.de/assets/assets/<当前entry>.js   # public, max-age=31536000, immutable
+curl -sS -D - -o /dev/null https://f.yourtj.de/static/pic/icon.webp           # public, max-age=18144000
+curl -sS -D - -o /dev/null https://f.yourtj.de/sw.js                          # no-cache
+curl -sS -D - -o /dev/null https://f.yourtj.de/                               # no-store 系（HTML 不缓存）
 ```
 
 排查技巧：绕过代理直打上游可二分定位注入方——`curl -sI http://127.0.0.1:5234/assets/...`


### PR DESCRIPTION
## Summary

补全静态资产缓存契约的运维面文档（代码面已由 #477 落地并在 dev 实例验证）：

- `docs/operations/deployment.md` 新增「静态资产缓存（反向代理注意事项）」小节：
  - 固化单二进制各静态路由的生产缓存头契约表
    （`/assets` immutable、`/static` 长公共、`/file/img/*` 长公共、
    `/sw.js` no-cache、manifest 短缓存、错误响应 no-store）。
  - 明确反向代理（1Panel/openresty）**不得**对上述响应追加或覆盖
    `cache-control`——nginx `add_header` 是追加语义，双头取最严格，
    等价于禁用全部缓存（线上事故复现：代理层 `no-cache` 压制
    `immutable`，静态资产每次导航全量回源）。
  - 固化部署后 curl 验收命令（单头断言）与
    「直打上游二分定位注入方」的排查方法。
- 文头 `Last verified` 更新。

## Background

Trace-20260905T222313 显示 f.yourtj.de 首屏 FCP 6.1s：96 个带内容哈希的
静态资产每次导航全量回源（`fromCache=0`，公网响应带代理层注入的
`no-cache`）。#477 已在 Go 侧落地 `AssetsCache`/`BrowserCache` 按状态码
延迟决策的长缓存头；本 PR 补齐部署文档，防止代理层再次注入缓存头使
长缓存失效（本次会话已实际修复 f.yourtj.de 与 dev.yourtj.de 两处站点代理
配置，验收数据见下文 Verification）。

## Verification

- docs-only 变更，无代码路径改动（仓库纪律豁免测试）。
- dev.yourtj.de 实测（代理层 no-cache 移除 + reload 后）：
  - `GET /assets/assets/site-CDXBG1pk.js` → 单行
    `cache-control: public, max-age=31536000, immutable`
  - `GET /static/pic/icon.webp` → 单行 `cache-control: public, max-age=18144000`
  - `GET /` → 单行 `cache-control: no-store`
- f.yourtj.de（main 实例）代理层已同步修复，immutable 头随下次正式
  发布（dev → main）的二进制更新后达到相同状态。

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>
