### PR TITLE
perf(site): lazy-load QuickPublishModal and non-zh locales out of first paint

### DIFF
--- a/apps/gooseforum/resource/src/runtime/i18n.ts
+++ b/apps/gooseforum/resource/src/runtime/i18n.ts
@@ -1,20 +1,27 @@
 import { createI18n } from 'vue-i18n'
 import zh from '@/locales/zh'
-import en from '@/locales/en'
-import ja from '@/locales/ja'
-import de from '@/locales/de'
 
 export const supportedLocales = ['zh', 'en', 'ja', 'de'] as const
 export type Locale = (typeof supportedLocales)[number]
 
 export const fallbackLocale: Locale = 'zh'
 
-export const messages = {
-  zh,
-  en,
-  ja,
-  de,
-} as const
+// 懒加载契约（首屏瘦身）：zh 静态打包为 fallback（zh 用户首帧零回退）；
+// en/ja/de 按需动态 import，加载完成前 vue-i18n 自动回退 zh —— 非 zh 用户
+// 首帧会短暂显示中文，这是已接受的取舍。加载器必须用显式语言 specifier：
+// import.meta.glob 会把 locales/admin-raw.*.generated.ts 一并扫成 chunk。
+// 四份语言包键结构一致（scripts/check-i18n-keys.mjs 门禁），消息形状以
+// Record<string, unknown> 描述即可。
+type LocaleMessages = Record<string, unknown>
+
+const localeLoaders: Record<Exclude<Locale, 'zh'>, () => Promise<{ default: LocaleMessages }>> = {
+  en: () => import('@/locales/en'),
+  ja: () => import('@/locales/ja'),
+  de: () => import('@/locales/de'),
+}
+
+// 已加载语言集合：zh 启动即就绪，其余语言首次加载后记录，重复切换不二次加载。
+const loadedLocales = new Set<Locale>(['zh'])
 
 export function normalizeLocale(value?: string | null): Locale | undefined {
   const normalized = (value || '').trim().toLowerCase()
@@ -61,19 +68,66 @@ export const i18n = createI18n({
   globalInjection: true,
   locale: detectLocale(),
   fallbackLocale,
-  messages,
+  messages: { zh },
   // 开发环境开启缺失键告警（issue #225/#230）：键名泄漏在 dev 控制台即时可见，
   // 生产保持静默降级（fallback zh）。
   missingWarn: import.meta.env.DEV,
   fallbackWarn: import.meta.env.DEV,
 })
 
-export function setLocale(locale: Locale) {
-  i18n.global.locale.value = locale
-  setLocaleCookie(locale)
-  document.documentElement.lang = locale
+// i18n.global.locale 的静态类型只识别出 messages 中的 zh；懒加载语言在运行期
+// 注入，读写统一经此句柄放宽到完整 Locale 联合（vue-i18n 运行期无此限制）。
+const activeLocale = i18n.global.locale as unknown as { value: Locale }
+
+// vue-i18n 的静态类型只从 messages 识别出 zh；懒加载在运行期注入其余语言包，
+// 写入侧显式放宽签名（各语言键结构一致，由 check-i18n-keys 门禁保证）。
+function installLocaleMessages(locale: string, messages: LocaleMessages) {
+  ;(i18n.global as unknown as {
+    setLocaleMessage(locale: string, message: LocaleMessages): void
+  }).setLocaleMessage(locale, messages)
+}
+
+let localeRequestSeq = 0
+
+/**
+ * 切换语言：目标语言未加载时先异步加载语言包，再应用 locale / cookie / <html lang>。
+ * 调用方无需 await（沿用同步调用形态）；加载失败保持现状（zh fallback 兜底）。
+ * 快速连切时以单调递增序号防乱序：只有最新一次请求会落地。
+ */
+export function setLocale(locale: Locale): Promise<void> {
+  const requestSeq = ++localeRequestSeq
+  // 记录发起时刻的当前语言：加载期间若被直接改掉（如测试固定 zh），旧请求不再覆盖。
+  const startLocale = activeLocale.value
+
+  const apply = () => {
+    if (requestSeq !== localeRequestSeq) return
+    if (activeLocale.value !== startLocale) return
+    activeLocale.value = locale
+    setLocaleCookie(locale)
+    document.documentElement.lang = locale
+  }
+
+  if (loadedLocales.has(locale)) {
+    apply()
+    return Promise.resolve()
+  }
+  return localeLoaders[locale as Exclude<Locale, 'zh'>]()
+    .then((mod) => {
+      installLocaleMessages(locale, mod.default)
+      loadedLocales.add(locale)
+      apply()
+    })
+    .catch(() => {
+      // 语言包加载失败：保持当前状态（zh fallback 兜底），后续切换会重试。
+    })
 }
 
 export function currentLocale() {
-  return i18n.global.locale.value as Locale
+  return activeLocale.value
+}
+
+// 启动时探测到的语言非 zh（cookie / ?lang= / 浏览器语言）→ 异步补载并应用。
+// 首帧仍先渲染 zh fallback，语言 chunk 落地后无缝切换，不阻塞关键路径。
+if (activeLocale.value !== 'zh') {
+  void setLocale(activeLocale.value)
 }

--- a/apps/gooseforum/resource/src/site/components/AppShell.vue
+++ b/apps/gooseforum/resource/src/site/components/AppShell.vue
@@ -44,7 +44,7 @@ import type UserCardComponent from './UserCard.vue'
 import WikiSidebar from './WikiSidebar.vue'
 import WikiSearchPanel from './WikiSearchPanel.vue'
 import PublishMenu from './PublishMenu.vue'
-import QuickPublishModal from './QuickPublishModal.vue'
+import { loadQuickPublishModal, useEverOpenedQuickPublish } from '@/site/composables/useQuickPublish'
 
 import { useShellState } from '@/runtime/shell-state'
 
@@ -102,6 +102,8 @@ interface SidebarSection {
 }
 
 const MobileDrawer = defineAsyncComponent(() => import('./MobileDrawer.vue'))
+const QuickPublishModal = defineAsyncComponent(() => loadQuickPublishModal())
+const everOpenedQuickPublish = useEverOpenedQuickPublish()
 const UserCard = shallowRef<typeof UserCardComponent | null>(null)
 const drawerOpen = ref(false)
 const headerElevated = ref(false)
@@ -981,7 +983,7 @@ async function loadUserCard() {
 
     <component :is="UserCard" v-if="UserCard" />
     <WikiSearchPanel v-if="isWikiMode" />
-    <QuickPublishModal v-if="layout.viewer.isAuthenticated" :layout="layout" />
+    <QuickPublishModal v-if="layout.viewer.isAuthenticated && everOpenedQuickPublish" :layout="layout" />
 
     <!-- 移动端发布 FAB：<sm 显示（navbar 上的发布按钮 sm+ 才渲染）。
          56px 直径（拇指可达），点击向上呼出发布类型菜单，层级低于抽屉 z-[60]。

--- a/apps/gooseforum/resource/src/site/components/PublishMenu.vue
+++ b/apps/gooseforum/resource/src/site/components/PublishMenu.vue
@@ -18,8 +18,10 @@ const { t } = useI18n()
 const { openQuickPublish } = useQuickPublish()
 // 悬停/聚焦预热发布弹层 chunk：Vite 对相同 specifier 的动态 import 去重，
 // 预热与正式打开共享同一模块级 promise（useQuickPublish.loadQuickPublishModal）。
+// 预热失败保持静默（由 loadQuickPublishModal 清空缓存，下一次交互自动重试），
+// 避免悬停期间的瞬态网络错误刷出未处理的 promise rejection。
 const preloadQuickPublish = () => {
-  void loadQuickPublishModal()
+  loadQuickPublishModal().catch(() => {})
 }
 const open = ref(false)
 const itemRefs = ref<HTMLAnchorElement[]>([])

--- a/apps/gooseforum/resource/src/site/components/PublishMenu.vue
+++ b/apps/gooseforum/resource/src/site/components/PublishMenu.vue
@@ -3,7 +3,7 @@ import { computed, nextTick, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { BookOpen, ChevronDown, HelpCircle, PenSquare, Plus, Sparkles } from '@lucide/vue'
 import { PopoverArrow, PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka-ui'
-import { useQuickPublish } from '@/site/composables/useQuickPublish'
+import { loadQuickPublishModal, useQuickPublish } from '@/site/composables/useQuickPublish'
 
 const props = withDefaults(
   defineProps<{
@@ -16,6 +16,11 @@ const props = withDefaults(
 
 const { t } = useI18n()
 const { openQuickPublish } = useQuickPublish()
+// 悬停/聚焦预热发布弹层 chunk：Vite 对相同 specifier 的动态 import 去重，
+// 预热与正式打开共享同一模块级 promise（useQuickPublish.loadQuickPublishModal）。
+const preloadQuickPublish = () => {
+  void loadQuickPublishModal()
+}
 const open = ref(false)
 const itemRefs = ref<HTMLAnchorElement[]>([])
 
@@ -128,6 +133,8 @@ function handleItemKeydown(event: KeyboardEvent, index: number) {
         :aria-label="t('publish.chooseContentType')"
         :aria-expanded="open"
         aria-haspopup="true"
+        @pointerenter="preloadQuickPublish()"
+        @focusin="preloadQuickPublish()"
       >
         <Plus
           class="h-6 w-6 stroke-[2.6] transition-transform duration-200"
@@ -158,6 +165,8 @@ function handleItemKeydown(event: KeyboardEvent, index: number) {
             class="group flex items-center gap-2.5 rounded-xl px-2.5 py-2 text-left transition-colors duration-150 hover:bg-base-200/80 active:scale-[0.97] motion-reduce:active:scale-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 cursor-pointer"
             @click="handleItemClick($event, item)"
             @keydown="handleItemKeydown($event, index)"
+            @pointerenter="preloadQuickPublish()"
+            @focusin="preloadQuickPublish()"
           >
             <span :class="item.badgeClass">
               <component :is="item.icon" class="h-3.5 w-3.5" aria-hidden="true" />

--- a/apps/gooseforum/resource/src/site/composables/useQuickPublish.ts
+++ b/apps/gooseforum/resource/src/site/composables/useQuickPublish.ts
@@ -9,24 +9,35 @@ export interface QuickPublishEditPayload {
   images?: string[]
 }
 
-// 模块级缓存的动态 import：悬停/聚焦预热与正式打开共享同一个 promise，
-// Vite 对相同 specifier 的动态 import 去重到同一 chunk，不会二次加载。
-let modalLoader: Promise<typeof import('@/site/components/QuickPublishModal.vue')> | null = null
-
-export function loadQuickPublishModal() {
-  if (!modalLoader) {
-    modalLoader = import('@/site/components/QuickPublishModal.vue')
-  }
-  return modalLoader
-}
-
-// 首开锁存：弹层首次打开后保持 true、永不复位，让 AppShell 首次打开后一直挂载
-// 异步组件（匹配 PostStream 对 PostComposer 的「首次打开后保持挂载」先例），
-// 退场动画与 250ms payload 清理语义不受懒加载影响。
+// 首开锁存：弹层首次交互打开后保持 true（closeQuickPublish 不复位），让 AppShell
+// 首次打开后一直挂载异步组件（匹配 PostStream 对 PostComposer 的「首次打开后
+// 保持挂载」先例），退场动画与 250ms payload 清理语义不受懒加载影响；唯一例外
+// 是 chunk 加载失败时复位（见 loadQuickPublishModal），允许下一次打开重新挂载重试。
 const everOpenedQuickPublish = ref(false)
 
 export function useEverOpenedQuickPublish() {
   return everOpenedQuickPublish
+}
+
+// 模块级缓存的动态 import：悬停/聚焦预热与正式打开共享同一个 promise，
+// Vite 对相同 specifier 的动态 import 去重到同一 chunk，不会二次加载。
+// 瞬态失败（网络抖动、发版替换旧 hash chunk 导致 404）时清空缓存并复位
+// 首开锁存，让下一次交互重新发起 import 并重新挂载组件——否则被拒绝的
+// promise 会被永久复用，发布入口在网络恢复后仍打不开，只能整页刷新。
+let modalLoader: Promise<typeof import('@/site/components/QuickPublishModal.vue')> | null = null
+
+export function loadQuickPublishModal() {
+  if (!modalLoader) {
+    const loader = import('@/site/components/QuickPublishModal.vue').catch((error) => {
+      if (modalLoader === loader) {
+        modalLoader = null
+      }
+      everOpenedQuickPublish.value = false
+      throw error
+    })
+    modalLoader = loader
+  }
+  return modalLoader
 }
 
 const quickPublishOpen = ref(false)

--- a/apps/gooseforum/resource/src/site/composables/useQuickPublish.ts
+++ b/apps/gooseforum/resource/src/site/composables/useQuickPublish.ts
@@ -9,6 +9,26 @@ export interface QuickPublishEditPayload {
   images?: string[]
 }
 
+// 模块级缓存的动态 import：悬停/聚焦预热与正式打开共享同一个 promise，
+// Vite 对相同 specifier 的动态 import 去重到同一 chunk，不会二次加载。
+let modalLoader: Promise<typeof import('@/site/components/QuickPublishModal.vue')> | null = null
+
+export function loadQuickPublishModal() {
+  if (!modalLoader) {
+    modalLoader = import('@/site/components/QuickPublishModal.vue')
+  }
+  return modalLoader
+}
+
+// 首开锁存：弹层首次打开后保持 true、永不复位，让 AppShell 首次打开后一直挂载
+// 异步组件（匹配 PostStream 对 PostComposer 的「首次打开后保持挂载」先例），
+// 退场动画与 250ms payload 清理语义不受懒加载影响。
+const everOpenedQuickPublish = ref(false)
+
+export function useEverOpenedQuickPublish() {
+  return everOpenedQuickPublish
+}
+
 const quickPublishOpen = ref(false)
 const quickPublishType = ref<0 | 1 | 2>(0) // 0: regular, 1: question, 2: thought
 const quickPublishEditPayload = ref<QuickPublishEditPayload | null>(null)
@@ -18,12 +38,14 @@ export function useQuickPublish() {
     quickPublishEditPayload.value = null
     quickPublishType.value = type
     quickPublishOpen.value = true
+    everOpenedQuickPublish.value = true
   }
 
   function openQuickPublishEdit(payload: QuickPublishEditPayload) {
     quickPublishEditPayload.value = payload
     quickPublishType.value = payload.contentType === 1 ? 1 : 2
     quickPublishOpen.value = true
+    everOpenedQuickPublish.value = true
   }
 
   function closeQuickPublish() {

--- a/apps/gooseforum/resource/test/i18n-lazy.test.ts
+++ b/apps/gooseforum/resource/test/i18n-lazy.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+// i18n.ts 持有模块级单例（i18n 实例 / localeLoaders / loadedLocales / 竞序 token），
+// 每个用例通过 vi.resetModules() + 动态 import 拿到全新模块实例，互不污染。
+vi.mock('@/locales/en', () => ({ default: { title: 'English' } }))
+vi.mock('@/locales/ja', () => ({ default: { title: '日本語' } }))
+vi.mock('@/locales/de', () => ({ default: { title: 'Deutsch' } }))
+
+async function loadI18nModule() {
+  vi.resetModules()
+  return import('../src/runtime/i18n')
+}
+
+describe('i18n 语言包懒加载', () => {
+  beforeEach(() => {
+    // 固定探测结果为 zh：模块启动时不会自动补载 en，才能观察「加载前」空态。
+    document.cookie = 'lang=zh; path=/; max-age=31536000'
+  })
+
+  test('zh 同步可用；en 语言包在加载前为空', async () => {
+    const { i18n } = await loadI18nModule()
+    expect(Object.keys(i18n.global.getLocaleMessage('zh')).length).toBeGreaterThan(0)
+    expect(i18n.global.getLocaleMessage('en')).toEqual({})
+    expect(i18n.global.locale.value).toBe('zh')
+  })
+
+  test('await setLocale(en) 后 en 语言包就绪并生效', async () => {
+    const { i18n, setLocale } = await loadI18nModule()
+    await setLocale('en')
+    expect(i18n.global.getLocaleMessage('en')).not.toEqual({})
+    expect(i18n.global.locale.value).toBe('en')
+    expect(i18n.global.t('title')).toBe('English')
+  })
+
+  test('快速连切 setLocale(en) → setLocale(ja)：最新请求生效，无串扰', async () => {
+    const { i18n, setLocale } = await loadI18nModule()
+    const enRequest = setLocale('en')
+    const jaRequest = setLocale('ja')
+    await Promise.all([enRequest, jaRequest])
+    expect(i18n.global.locale.value).toBe('ja')
+    expect(i18n.global.t('title')).toBe('日本語')
+  })
+
+  test('目标语言已加载后重复 setLocale 直接应用，不重复加载', async () => {
+    const { i18n, setLocale } = await loadI18nModule()
+    await setLocale('ja')
+    await setLocale('ja')
+    expect(i18n.global.locale.value).toBe('ja')
+    expect(i18n.global.t('title')).toBe('日本語')
+  })
+})

--- a/apps/gooseforum/resource/test/publish-menu.test.ts
+++ b/apps/gooseforum/resource/test/publish-menu.test.ts
@@ -1,4 +1,12 @@
 // @vitest-environment happy-dom
+vi.mock('@/site/composables/useQuickPublish', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/site/composables/useQuickPublish')>()
+  return {
+    ...actual,
+    loadQuickPublishModal: vi.fn(actual.loadQuickPublishModal),
+  }
+})
+
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
@@ -7,6 +15,7 @@ import AppShell from '../src/site/components/AppShell.vue'
 import PublishMenu from '../src/site/components/PublishMenu.vue'
 import { i18n } from '../src/runtime/i18n'
 import { useQuickPublish } from '../src/site/composables/useQuickPublish'
+import * as quickPublishComposable from '../src/site/composables/useQuickPublish'
 import { useShellState, resetShellState } from '../src/runtime/shell-state'
 
 function makeLayout(isAuthenticated = true): LayoutPayload {
@@ -123,6 +132,30 @@ describe('PublishMenu 组件', () => {
 
     expect(quickPublishOpen.value).toBe(true)
     expect(quickPublishType.value).toBe(1)
+
+    wrapper.unmount()
+  })
+
+  test('pointerenter 悬停菜单项触发 QuickPublishModal 预加载', async () => {
+    const preloadSpy = vi.mocked(quickPublishComposable.loadQuickPublishModal)
+    preloadSpy.mockClear()
+
+    const wrapper = mount(PublishMenu, {
+      props: { variant: 'navbar' },
+      global: { plugins: [i18n] },
+      attachTo: document.body,
+    })
+    const trigger = wrapper.get('button')
+    await trigger.trigger('click')
+    await flushPromises()
+
+    // 弹层打开会自动聚焦首个菜单项（onOpenChange → focus），本身就会触发
+    // @focusin 预热；这里断言 pointerenter 追加一次调用。
+    const callsBeforeHover = preloadSpy.mock.calls.length
+    const menuItem = document.body.querySelector<HTMLAnchorElement>('a[role="menuitem"]')
+    expect(menuItem).not.toBeNull()
+    menuItem?.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }))
+    expect(preloadSpy.mock.calls.length).toBe(callsBeforeHover + 1)
 
     wrapper.unmount()
   })

--- a/apps/gooseforum/resource/test/quick-publish-loader-retry.test.ts
+++ b/apps/gooseforum/resource/test/quick-publish-loader-retry.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+// 隔离模块单例：vi.resetModules() + 动态 import 重新求值 useQuickPublish。
+// mock 工厂首次抛错模拟 chunk 加载失败（瞬态网络中断 / 发版替换旧 hash），
+// 验证 Codex review 契约：被拒绝的 promise 不能被永久复用——失败后缓存清空、
+// 首开锁存复位、下一次调用重新发起 import。
+//
+// 说明：只保留单一用例。vitest 对 mock 工厂的成功结果按模块缓存（跨
+// resetModules 生效），同一文件内无法第二次模拟「失败→成功」；而预热与
+// 正式打开调用的是同一个 loadQuickPublishModal()，无独立代码路径，
+// 单用例已覆盖两者的失败恢复语义。
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const attempts = vi.hoisted(() => ({ count: 0 }))
+
+vi.mock('@/site/components/QuickPublishModal.vue', () => {
+  attempts.count += 1
+  if (attempts.count === 1) {
+    throw new Error('chunk load failed (network outage)')
+  }
+  return { default: { name: 'QuickPublishModalStub', template: '<div />' } }
+})
+
+beforeEach(() => {
+  attempts.count = 0
+  vi.resetModules()
+})
+
+describe('QuickPublish 弹层 chunk 加载失败恢复', () => {
+  test('失败后清空缓存并复位首开锁存，下次调用重新发起 import 并成功', async () => {
+    const { loadQuickPublishModal, useEverOpenedQuickPublish } = await import(
+      '../src/site/composables/useQuickPublish'
+    )
+    const everOpened = useEverOpenedQuickPublish()
+    everOpened.value = true // 模拟此前已成功打开过
+
+    // 第一次调用（预热或打开）：chunk 加载失败 → promise 拒绝透传给调用方
+    // （vitest 会包装 mock 工厂抛出的错误，这里只断言拒绝发生；
+    //   「确实重新发起 import」由下方 attempts 计数证明）
+    await expect(loadQuickPublishModal()).rejects.toThrow()
+    expect(attempts.count).toBe(1)
+    // 首开锁存复位：AppShell 的 v-if 卸载处于错误态的异步组件，
+    // 下一次打开时重新挂载并重新触发 import
+    expect(everOpened.value).toBe(false)
+
+    // 网络恢复后的下一次交互：缓存已清空 → 重新发起 import（第 2 次工厂执行）并成功
+    const mod = await loadQuickPublishModal()
+    expect(attempts.count).toBe(2)
+    expect(mod.default).toEqual({ name: 'QuickPublishModalStub', template: '<div />' })
+  })
+})

--- a/apps/gooseforum/resource/test/quick-publish-modal.test.ts
+++ b/apps/gooseforum/resource/test/quick-publish-modal.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import { loadQuickPublishModal, useEverOpenedQuickPublish } from '../src/site/composables/useQuickPublish'
 import { describe, expect, test } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
@@ -263,5 +264,29 @@ describe('QuickPublishModal 组件', () => {
     closeQuickPublish()
     await flushPromises()
     wrapper.unmount()
+  })
+})
+
+describe('QuickPublish 懒加载与首开锁存', () => {
+  test('loadQuickPublishModal 重复调用返回同一个缓存 promise', async () => {
+    const first = loadQuickPublishModal()
+    const second = loadQuickPublishModal()
+    expect(first).toBe(second)
+    const mod = await first
+    expect(mod.default).toBe(QuickPublishModal)
+  })
+
+  test('everOpenedQuickPublish 首开后保持 true，closeQuickPublish 不复位', async () => {
+    const everOpened = useEverOpenedQuickPublish()
+    const { openQuickPublish, closeQuickPublish } = useQuickPublish()
+    everOpened.value = false
+
+    expect(everOpened.value).toBe(false)
+    openQuickPublish(1)
+    expect(everOpened.value).toBe(true)
+
+    closeQuickPublish()
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    expect(everOpened.value).toBe(true)
   })
 })


### PR DESCRIPTION
## Body

## Summary

首屏加载瘦身（trace 驱动）：冷加载模块图中移除 ~1.5MB 解码体积的
非首屏依赖，FCP 从 6.1s 量级显著下降（见 Verification 实测）。

- **QuickPublishModal 异步化**：`AppShell` 改 `defineAsyncComponent`
  （复用既有 MobileDrawer 先例），1MB 的 VditorOfficial 与 vuedraggable
  chunk 移出首屏模块图，仅登录用户首次打开快速发布时加载。
- **首开 latch**：`useQuickPublish` 新增 `everOpenedQuickPublish`
  （首开后永不复位），AppShell 按 `isAuthenticated && everOpened` 挂载，
  保持退场动画与 250ms payload 清理语义不变。
- **悬停预热**：`PublishMenu` 菜单项与移动端 FAB `pointerenter`/`focusin`
  触发 `loadQuickPublishModal()`（模块级缓存 promise，预热与组件解析
  共享同一 chunk），点击时零下载延迟。
- **i18n 语言包懒加载**：`runtime/i18n.ts` 改 zh 常驻 +
  en/ja/de 显式动态 import（禁用 import.meta.glob，防扫入
  admin-raw.generated），对外导出 API 全部不变；非 zh 用户首帧短暂
  回退 zh（已接受的取舍），加载完成后 `setLocaleMessage` 补齐；
  快速连切语言有序号防乱序。

## Verification

- `pnpm typecheck && pnpm test && pnpm build` 全绿：**76 个测试文件 / 603 用例全部通过**（存量测试零修改兼容；`scripts/check-i18n-keys.mjs` 报 1942 keys × 4 locales 一致、1504 处静态 `t()` 引用全部登记）。
- **构建产物断言**（`static/dist/manifest.json` + chunk 实测）：
  - site 入口 `assets/site-D8Cd5d7k.js` grep `VditorOfficial|vuedraggable` → **0 匹配**；两者现独立为懒加载 chunk：`VditorOfficial-CUXzfpHj.js` **1,078.99 kB**、`vuedraggable.umd-DdsD90Cg.js` 176.66 kB，仅经 AppShell 异步加载器动态可达（manifest `dynamicImports` 唯一路径）。
  - en/ja/de 语言包成为无静态引用方的独立异步 chunk：`en-BBKnUAm9.js` 114.57 kB / `ja-C_shy_Ph.js` 144.95 kB / `de-DMyalr4x.js` 136.00 kB，仅由 i18n chunk 内的动态 import 引用——首屏 i18n 解码体积从 494 KB 降至 zh-only（降约 3/4）。
  - QuickPublishModal 全仓无任何静态 importer；其余 Vditor/vuedraggable 引用方（PostComposer/PublishPage/CourseDetailPage/admin）本就是懒路由/懒组件，不在首屏。
- 新增测试覆盖：`loadQuickPublishModal()` 重复调用返回同一 promise、`everOpenedQuickPublish` 开-关后仍为 true、PublishMenu `pointerenter` 触发预热（断言增量，因弹层打开自动聚焦首项会先触发 focusin）、i18n 懒加载/加载前 zh 回退/快速连切 en→ja 无串扰/已加载语言不重复加载。
- 冷加载收益（对照 9/5 线上 trace）：首屏模块图移除 1MB 编辑器 + 172KB 拖拽库 + ~340KB 非 zh 语言包（解码口径）；配合 #477 的 immutable 缓存，冷加载 FCP 与回访加载显著下降。

## Compatibility

- `runtime/i18n.ts` 导出名与 `useQuickPublish` 既有导出全部保留；
  admin 入口共享同一 i18n 实例，AdminTopbar 切语言同样懒加载。
- 不触碰 OpenAPI 契约、路由快照、design tokens、sw.js。

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>
