### PR TITLE
fix: allow new users to set profile covers

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/userController.go
+++ b/apps/gooseforum/app/http/controllers/api/userController.go
@@ -274,9 +274,6 @@ func EditUserProfileCover(req component.BetterRequest[EditUserProfileCoverReq]) 
 	if err != nil {
 		return component.FailResponseCode(component.MessageUserFetchFailed, nil)
 	}
-	if userEntity.RoleId == 0 {
-		return component.FailResponseCode(component.MessagePermissionDenied, nil)
-	}
 
 	userEntity.ProfileCoverUrl = strings.TrimSpace(req.Params.ProfileCoverUrl)
 	err = userservice.SaveUser(&userEntity)

--- a/apps/gooseforum/app/http/routes/contract_user_account_test.go
+++ b/apps/gooseforum/app/http/routes/contract_user_account_test.go
@@ -244,10 +244,7 @@ func TestSetUserProfileCoverHTTPContract(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		conn, router := setupAccountContractTest(t)
 		user := createHTTPContractUser(t, conn, contractTestID())
-		// 个人封面要求已分配角色（RoleId != 0）。
-		if err := conn.Model(user).Update("role_id", 1).Error; err != nil {
-			t.Fatalf("grant role to contract user: %v", err)
-		}
+		// 新注册用户默认 RoleId=0，仍应允许设置个人封面。
 		body := `{"profileCoverUrl":"/static/pic/cover.webp"}`
 		recorder := serveJSON(router, "/api/set-user-profile-cover", body, contractSessionToken(t, user))
 		if recorder.Code != http.StatusOK {

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -1067,10 +1067,10 @@ export interface paths {
         /**
          * Update the caller's profile cover image
          * @description Sets the profile cover URL (trimmed server-side; an empty string clears the
-         *     cover). Accounts with RoleId 0 are rejected with `permission.denied` (HTTP
-         *     200). JSON binding is lenient: a malformed body binds to zero values and
-         *     clears the cover. Other business failures: `user.fetchFailed`,
-         *     `user.updateFailed`.
+         *     cover). Any authenticated, writable account may update its own cover;
+         *     ordinary accounts with RoleId 0 are included. JSON binding is lenient: a
+         *     malformed body binds to zero values and clears the cover. Other business
+         *     failures: `user.fetchFailed`, `user.updateFailed`.
          */
         post: operations["setUserProfileCover"];
         delete?: never;

--- a/packages/api-contract/paths/user-account.yaml
+++ b/packages/api-contract/paths/user-account.yaml
@@ -144,10 +144,10 @@ setUserProfileCover:
     operationId: setUserProfileCover
     description: |
       Sets the profile cover URL (trimmed server-side; an empty string clears the
-      cover). Accounts with RoleId 0 are rejected with `permission.denied` (HTTP
-      200). JSON binding is lenient: a malformed body binds to zero values and
-      clears the cover. Other business failures: `user.fetchFailed`,
-      `user.updateFailed`.
+      cover). Any authenticated, writable account may update its own cover;
+      ordinary accounts with RoleId 0 are included. JSON binding is lenient: a
+      malformed body binds to zero values and clears the cover. Other business
+      failures: `user.fetchFailed`, `user.updateFailed`.
     security:
       - bearerAuth: []
       - accessTokenCookie: []


### PR DESCRIPTION
## Motivation
新注册用户默认 `RoleId=0`，设置个人背景时前端入口已显示，但后端 `set-user-profile-cover` 仍返回 `permission.denied`，导致用户无法保存封面。

## Changes
- 移除个人封面保存接口对 `RoleId==0` 的硬编码拒绝。
- 保留 `JWTAuthCheck`、`CheckWritableAccount`，因此未登录、冻结账号和待完成邮箱验证的写入边界不变。
- 将封面接口契约更新为所有已认证且可写账号均可更新，并重新生成 OpenAPI TypeScript 类型。
- 将契约测试改为覆盖默认 `RoleId=0` 的新用户场景。

## Verification
- `go test ./app/http/routes -run TestSetUserProfileCoverHTTPContract -count=1`
- `go test ./app/http/controllers/api ./app/http/routes`
- `go test ./...`
- `go vet ./...`
- `PATH="/home/walkerkiller/.local/share/mise/installs/go/1.26.0/bin:/home/walkerkiller/.local/share/mise/installs/go/1.27.0/bin:$PATH" scripts/hooks/check-golangci.sh` — 0 issues
- `pnpm typecheck`
- `make contract-check` — passed with the repository's existing 11 Redocly warnings
- `git diff --check`

## Documentation / contract impact
更新 `packages/api-contract/paths/user-account.yaml` 及生成的 `resource/packages/client/src/gen/openapi.ts`；无数据库迁移。

## Known gaps
未在生产或测试站点提交表单验证；本 PR 仅修复服务端权限不一致，图片上传本身仍遵循后台配置的新用户上传冷却。

#490 
