### PR TITLE
fix(schedule): prioritize planned teaching classes

### DIFF
--- a/apps/gooseforum/resource/src/site/components/schedule/ScheduleCellPicker.vue
+++ b/apps/gooseforum/resource/src/site/components/schedule/ScheduleCellPicker.vue
@@ -19,7 +19,7 @@ import { DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogRo
 import { useScheduleStore } from '@/site/composables/useScheduleStore'
 import { getPkCourseDetails, getPkCoursesByTime } from '@/runtime/pk-api'
 import { getCourseBaseCode, type PkConflictItem } from '@/site/utils/pkConflict'
-import { sortPlannedCoursesFirst } from '@/site/utils/pkCourseOrder'
+import { sortPlannedFirst, sortPlannedCoursesFirst } from '@/site/utils/pkCourseOrder'
 import { getRowSection, getSectionRangeText } from '@/site/utils/timetable'
 import type { PkCourse, PkCourseDetail, PkCourseOnTable, PkStagedCourse } from '@/site/types/pk'
 
@@ -112,7 +112,11 @@ const stagedCandidates = computed<CellCandidate[]>(() => {
       }
     }
   }
-  return sortPlannedCoursesFirst(list, store.state.commonLists.compulsoryCourses)
+  const plannedCodes = new Set(store.state.commonLists.compulsoryCourses.map((course) => course.courseCode))
+  return sortPlannedFirst(
+    list,
+    (candidate) => candidate.detail.isExclusive === true || plannedCodes.has(candidate.courseCode),
+  )
 })
 
 // ---- 该时段全校课程（P10 getPkCoursesByTime）----

--- a/apps/gooseforum/resource/src/site/components/schedule/ScheduleDetailList.vue
+++ b/apps/gooseforum/resource/src/site/components/schedule/ScheduleDetailList.vue
@@ -34,6 +34,7 @@ import { getPkCourseReviewBrief } from '@/runtime/pk-api'
 import { listCourseReviews, type ReviewPage, type ReviewPayload } from '@/runtime/api'
 import { reviewAvatarSrc } from '@/site/utils/course-review-share'
 import { getCourseBaseCode, type PkConflictItem } from '@/site/utils/pkConflict'
+import { sortPlannedFirst } from '@/site/utils/pkCourseOrder'
 import type { PkArrangement, PkCourseDetail, PkCourseReviewBrief, PkReviewBriefClass } from '@/site/types/pk'
 
 const { t } = useI18n()
@@ -82,6 +83,10 @@ const currentCourse = computed(() =>
   store.state.commonLists.stagedCourses.find(
     (course) => course.courseCode === store.state.clickedCourseInfo.courseCode,
   ),
+)
+
+const orderedCourseDetails = computed(() =>
+  sortPlannedFirst(currentCourse.value?.courseDetail ?? [], (detail) => detail.isExclusive === true),
 )
 
 /** 本学期课评摘要。 */
@@ -471,9 +476,9 @@ function tryStage(detail: PkCourseDetail) {
       </div>
 
       <!-- 教学班卡片列表 -->
-      <div v-if="currentCourse.courseDetail.length" class="space-y-3">
+      <div v-if="orderedCourseDetails.length" class="space-y-3">
         <div
-          v-for="detail in currentCourse.courseDetail"
+          v-for="detail in orderedCourseDetails"
           :key="detail.code"
           class="group relative rounded-xl border p-3.5 sm:p-4 shadow-xs transition-all cursor-pointer select-none"
           :class="[

--- a/apps/gooseforum/resource/src/site/utils/pkCourseOrder.ts
+++ b/apps/gooseforum/resource/src/site/utils/pkCourseOrder.ts
@@ -1,18 +1,23 @@
 type CourseCodeItem = { courseCode: string }
 
+/** 稳定地将满足计划条件的项目置顶，保留两组内的原始顺序。 */
+export function sortPlannedFirst<T>(items: readonly T[], isPlanned: (item: T) => boolean): T[] {
+  const planned: T[] = []
+  const other: T[] = []
+
+  for (const item of items) {
+    const bucket = isPlanned(item) ? planned : other
+    bucket.push(item)
+  }
+
+  return [...planned, ...other]
+}
+
 /** 将专业计划内课程置顶，同时保留两组内的接口/备选池顺序。 */
 export function sortPlannedCoursesFirst<T extends CourseCodeItem>(
   courses: readonly T[],
   compulsoryCourses: readonly CourseCodeItem[],
 ): T[] {
   const plannedCodes = new Set(compulsoryCourses.map((course) => course.courseCode))
-  const planned: T[] = []
-  const other: T[] = []
-
-  for (const course of courses) {
-    const bucket = plannedCodes.has(course.courseCode) ? planned : other
-    bucket.push(course)
-  }
-
-  return [...planned, ...other]
+  return sortPlannedFirst(courses, (course) => plannedCodes.has(course.courseCode))
 }

--- a/apps/gooseforum/resource/test/schedule-detail-list.test.ts
+++ b/apps/gooseforum/resource/test/schedule-detail-list.test.ts
@@ -23,9 +23,10 @@ import ScheduleDetailList from '../src/site/components/schedule/ScheduleDetailLi
 import { useScheduleStore } from '../src/site/composables/useScheduleStore'
 import type { PkCourseDetail, PkStagedCourse } from '../src/site/types/pk'
 
-function makeDetail(code: string): PkCourseDetail {
+function makeDetail(code: string, isExclusive = false): PkCourseDetail {
   return {
     code,
+    isExclusive,
     campus: '四平路校区',
     teachers: [{ teacherCode: 'T1', teacherName: '张伟' }],
     teachingLanguage: '中文',
@@ -122,6 +123,26 @@ describe('ScheduleDetailList 课评摘要与跳转', () => {
 
     expect(wrapper.find('a[href="/courses?keyword=110001"]').exists()).toBe(true)
     expect(wrapper.text()).toContain('Failed to load schedule data')
+  })
+
+  test('计划内教学班置顶，其他教学班保持原顺序', async () => {
+    const store = useScheduleStore()
+    store.clearStagedAndSelectedCourses()
+    store.setClickedCourseInfo({ courseCode: '110001', courseName: '高等数学A(上)' })
+    store.pushStagedCourse(
+      makeStaged('110001', [
+        makeDetail('110001.01'),
+        makeDetail('110001.02', true),
+        makeDetail('110001.03'),
+      ]),
+    )
+
+    const wrapper = mountList()
+    await flushPromises()
+
+    const cards = wrapper.findAll('div.group.relative.rounded-xl.border')
+    const codes = cards.map((card) => card.find('span.font-bold.tabular-nums').text())
+    expect(codes).toEqual(['110001.02', '110001.01', '110001.03'])
   })
   test('教学班行内显示 offering 级课评摘要并跳转聚焦', async () => {
     // P13 classes：教学班 code ↔ offering.class_code（去掉点号归一化）匹配。

--- a/apps/gooseforum/resource/test/schedule-detail-list.test.ts
+++ b/apps/gooseforum/resource/test/schedule-detail-list.test.ts
@@ -144,6 +144,7 @@ describe('ScheduleDetailList 课评摘要与跳转', () => {
     const codes = cards.map((card) => card.find('span.font-bold.tabular-nums').text())
     expect(codes).toEqual(['110001.02', '110001.01', '110001.03'])
   })
+
   test('教学班行内显示 offering 级课评摘要并跳转聚焦', async () => {
     // P13 classes：教学班 code ↔ offering.class_code（去掉点号归一化）匹配。
     getPkCourseReviewBrief.mockResolvedValue({


### PR DESCRIPTION
## Summary
- keep planned teaching classes at the top of the class picker
- preserve original order within planned and unplanned groups
- cover both course detail and cell picker paths

## Verification
- pnpm test
- pnpm typecheck
- pnpm build

Related to #484