### PR TITLE
docs: 移除 README 冗余 H1 标题

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
   </picture>
 </p>
 
-<h1 align="center">YourTJ Hub</h1>
-
 <p align="center">
   面向同济校园的社区平台，以论坛沉淀长期有价值的信息与讨论。<br>
   <sub>A community platform for Tongji University, built around durable, searchable conversations.</sub>


### PR DESCRIPTION
## Summary / 摘要

删除 README 头部的居中 H1 标题（`<h1 align="center">YourTJ Hub</h1>`）。GitHub 仓库页已显示仓库名，品牌图自带 `alt="YourTJ Hub"`，H1 与两者重复；去掉后头部为品牌图 + 简介 + 徽章的紧凑结构。

## Behavior change / 行为变更

无。纯 README 展示层删一行，不影响任何产品行为、接口或部署。

## Verification / 验证

- [x] `git diff --check`
- [x] `node scripts/run-gates.mjs` → OK（doc-links 38 文件 / placeholders 53 文件 / manifest 25 条 / decisions 11 records / postmortems）
- [x] pre-push（lefthook）：go vet ✔ · golangci-lint ✔ · frontend typecheck ✔

## Docs & contract impact / 文档与契约影响

仅 README 单行删除；无契约与生成产物影响，无其他文档引用该 H1 锚点（verify-doc-links 已确认全仓链接可解析）。

## Known gaps / 已知缺口

无。