### PR TITLE
fix: privacy.go markdown2html import 路径未跟随 #511 迁移，dev 编译失败

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/privacy.go
+++ b/apps/gooseforum/app/http/controllers/forum/privacy.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/i18n"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/markdown2html"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/setting"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/markdown2html"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/hotdataserve"
 	"github.com/gin-gonic/gin"


### PR DESCRIPTION
## 问题

**当前 `dev` 分支编译失败**（整个 Go 模块无法构建）。

PR #514（InsightFlare analytics）从 #511 合入之前的 dev 切出，其 `controllers/forum/privacy.go` 新增了对 `app/http/controllers/markdown2html` 的 import；而 #511 已把该包迁移至 `app/bundles/markdown2html`。#514 后合入，合并时该 import 作为新增行按字面采纳了旧路径——旧位置的包已不存在，导致：

```
app\http\controllers\forum\privacy.go:9:2: no required module provides package
github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/markdown2html
```

## 修复

单行改动：`privacy.go` 的 import 从 `app/http/controllers/markdown2html` 指向 `app/bundles/markdown2html`（`gofmt` 已过）。

## 验证

- `go build ./...`（整个模块）✅（本地两次因宿主机内存压力失败，重试后全量通过；失败信息均为 OOM，非代码问题）
- `go test ./app/bundles/markdown2html/ ./app/http/controllers/forum/` ✅
- 改动文件 `gofmt -l` 干净、`git diff --check` 干净

## 防再发建议（不在本 PR 内）

跨多包的移动/重命名类 PR 合入后，紧接着合入的其它 PR 若基于旧基线并新增了对被移动包的引用，CI 若只在 PR 自身基线上跑测试会漏检；可考虑对 dev 合入后的快速冒烟构建（或要求长寿命分支定期 rebase）。