### PR TITLE
fix(release): recover Android and iOS publication

### DIFF
--- a/docs/operations/mobile-releases.md
+++ b/docs/operations/mobile-releases.md
@@ -116,7 +116,10 @@ Flutter 3.44.9 produces three signed APKs. Their **actual** Android version code
 plus `1000` (armeabi-v7a), `2000` (arm64-v8a) or `4000` (x86_64). Asset names contain that actual
 code: `YourTJ-X.Y.Z+CODE-ABI.apk`. iOS uses the unmodified base `N`. The publisher verifies package,
 version, ABI and signing certificate before writing `SHA256SUMS.txt` or uploading. Changing Flutter's
-split-code algorithm requires updating the validator; a mismatch fails the release.
+split-code algorithm requires updating the validator; a mismatch fails the release. Certificate
+validation accepts both numbered signer output and Build Tools 37 scheme labels. Repeated identical
+certificates across schemes represent one identity; conflicting certificates, public-key digests and
+source-stamp-only output do not satisfy the release certificate check.
 
 APK assets are first uploaded to a draft GitHub release. GitHub-computed SHA-256 digests must match
 local files before it becomes public. Existing asset names with different bytes are never overwritten.
@@ -174,7 +177,17 @@ alone does not implement Sign in with Apple or enable Firebase push configuratio
   Verify the artifact belongs to the same tag/commit first.
 - **Uncertain Apple upload:** rerun to query the exact build. Existing uploads are not duplicated.
   An incomplete reservation without `uploadedDate` requires inspection with `asc builds uploads list`;
-  resolve that failed upload in ASC before resuming. Invalid processing fails immediately.
+  resolve that failed upload in ASC before resuming. Inspect its state with
+  `asc builds uploads view --id UPLOAD_ID` and files with
+  `asc builds uploads files list --upload UPLOAD_ID`. Only an abandoned `AWAITING_UPLOAD` reservation
+  with no uploaded files may be removed using `asc builds uploads delete --id UPLOAD_ID --confirm`;
+  first confirm no uploader is active. Never delete a processing upload or existing build. Invalid
+  processing fails immediately.
+- **Publisher repair after a tag exists:** the tag and retained signed artifacts remain immutable.
+  A workflow rerun checks out the original tagged source, so it does not pick up a later publisher
+  fix. Use the corrected publisher locally against the original run's verified signed artifacts
+  and the original version/build/tag, or publish a new reviewed source with a new version/build.
+  Never move the old tag merely to change the publisher script.
 - **Apple validation/rejection:** correct the reported store fields or app behavior. A binary change
   needs a new version/build release; metadata-only corrections can resume against the existing build.
   Already waiting/in-review/approved submissions using the same build are preserved.

--- a/docs/operations/mobile-releases.md
+++ b/docs/operations/mobile-releases.md
@@ -157,6 +157,8 @@ App Store Connect app ID is `6809457637`, team `4HJTS3G3T2`, bundle `tj.yourtj.f
 finds the exact version/build before uploading, waits for processing, submits to the existing
 **YourTJ TestFlight** external group, updates store localization/screenshots and review credentials,
 attaches the same build, validates and submits for App Store review with release after approval.
+The publisher recognizes ASC's absent-beta-review exit status on a first submission and normalizes
+single-resource lookup collections; ambiguous collections still fail instead of selecting arbitrarily.
 It does not add testers or publish a TestFlight public link. Store metadata says “选课社区” and
 accurately discloses posts, comments and messaging. Privacy labels, age rating, availability,
 agreements and pricing are managed in App Store Connect; source changes affecting disclosures

--- a/docs/operations/mobile-releases.md
+++ b/docs/operations/mobile-releases.md
@@ -122,7 +122,8 @@ certificates across schemes represent one identity; conflicting certificates, pu
 source-stamp-only output do not satisfy the release certificate check.
 
 APK assets are first uploaded to a draft GitHub release. GitHub-computed SHA-256 digests must match
-local files before it becomes public. Existing asset names with different bytes are never overwritten.
+local files before it becomes public. The publisher resolves drafts through `gh release view` and
+queries their database ID, since the REST tag lookup may return 404 for a draft. Existing asset names with different bytes are never overwritten.
 The release is published with `latest=false`, so server downloads keep their separate latest marker.
 
 On Android, startup/resume checks at most once every six hours; About exposes a manual check. The

--- a/scripts/mobile-release/publish_android.py
+++ b/scripts/mobile-release/publish_android.py
@@ -42,10 +42,20 @@ def check_package(badging, signatures, version, number, certificate):
 def gh(*args, allow_missing=False):
     result = subprocess.run(["gh", *args], capture_output=True, text=True)
     if result.returncode:
-        if allow_missing and "404" in result.stderr:
+        if allow_missing and ("404" in result.stderr or result.stderr.strip() == "release not found"):
             return None
         raise RuntimeError(result.stderr.strip())
     return result.stdout
+
+
+def find_release(tag):
+    # The tag REST endpoint does not reliably expose drafts. gh release view
+    # resolves drafts too; use the immutable database ID for subsequent API reads.
+    resolved = gh("release", "view", tag, "--repo", REPOSITORY, "--json", "databaseId", allow_missing=True)
+    if resolved is None:
+        return None
+    release_id = json.loads(resolved)["databaseId"]
+    return json.loads(gh("api", f"repos/{REPOSITORY}/releases/{release_id}"))
 
 
 def main():
@@ -84,8 +94,7 @@ def main():
         print("Verified three signed APKs and wrote SHA256SUMS.txt")
         return
 
-    endpoint = f"repos/{REPOSITORY}/releases/tags/{tag}"
-    release = gh("api", endpoint, allow_missing=True)
+    release = find_release(tag)
     if release is None:
         notes = output / "notes.md"
         notes.write_text((ROOT / "apps/mobile/store/zh-Hans/metadata.json").read_text())
@@ -93,8 +102,11 @@ def main():
         notes.write_text(metadata["whatsNew"] + "\n\nAndroid：按设备架构下载安装 APK。iOS：通过 TestFlight 或 App Store 分发，审核状态以 Apple 为准。\n")
         gh("release", "create", tag, "--repo", REPOSITORY, "--verify-tag", "--draft", "--latest=false",
            "--title", f"YourTJ {version}", "--notes-file", str(notes))
-        release = gh("api", endpoint)
-    existing = {asset["name"]: asset for asset in json.loads(release)["assets"]}
+        release = find_release(tag)
+        if release is None:
+            raise RuntimeError("Created release is not discoverable yet; retry to resume its draft")
+    endpoint = f"repos/{REPOSITORY}/releases/{release['id']}"
+    existing = {asset["name"]: asset for asset in release["assets"]}
     for path, digest in assets:
         if path.name in existing:
             if existing[path.name].get("digest") != "sha256:" + digest:

--- a/scripts/mobile-release/publish_android.py
+++ b/scripts/mobile-release/publish_android.py
@@ -27,8 +27,15 @@ def check_package(badging, signatures, version, number, certificate):
     match = re.search(r"package: name='([^']+)' versionCode='([^']+)' versionName='([^']+)'", badging)
     if not match or match.groups() != ("tj.yourtj.forum_app", number, version):
         raise ValueError("APK package/version does not match this release")
-    fingerprints = re.findall(r"Signer #\d+ certificate SHA-256 digest: ([0-9a-fA-F]+)", signatures)
-    if [fingerprint.lower() for fingerprint in fingerprints] != [certificate.lower()]:
+    # Build Tools 37 labels certificates by scheme (e.g. "V2 Signer:").
+    # The same identity can appear under multiple schemes. Public-key hashes and
+    # source-stamp certificates are not APK signer identities.
+    fingerprints = re.findall(
+        r"^(?:Signer #\d+|V[123](?:\.[12])? Signer:) certificate SHA-256 digest: ([0-9a-fA-F]{64})$",
+        signatures, re.M)
+    if not fingerprints:
+        raise ValueError("No supported APK signer certificate fingerprint found in apksigner output")
+    if {fingerprint.lower() for fingerprint in fingerprints} != {certificate.lower()}:
         raise ValueError("APK is not signed by the YourTJ release certificate")
 
 

--- a/scripts/mobile-release/publish_ios.py
+++ b/scripts/mobile-release/publish_ios.py
@@ -30,7 +30,12 @@ def asc(*args, allow_missing=False):
     result = subprocess.run([os.environ.get("ASC_BIN", "asc"), *args],
                             capture_output=True, text=True)
     if result.returncode:
-        if allow_missing and ("404" in result.stderr or "NOT_FOUND" in result.stderr):
+        # ASC 5 reports an absent beta review with exit 4 and a domain message,
+        # without an HTTP 404. This is expected before a build's first submission.
+        absent_beta_review = (args[:3] == ("builds", "beta-app-review-submission", "view")
+                              and result.returncode == 4
+                              and "no beta app review submission found for build" in result.stderr)
+        if allow_missing and ("404" in result.stderr or "NOT_FOUND" in result.stderr or absent_beta_review):
             return {"data": None}
         # Never echo argv: review fields include private credentials.
         raise RuntimeError(f"ASC {args[0]} {args[1]} failed (exit {result.returncode}); inspect the corresponding App Store Connect status")
@@ -38,7 +43,13 @@ def asc(*args, allow_missing=False):
 
 
 def resource(result):
-    return result.get("data", result) or {}
+    value = result.get("data", result)
+    # Some ASC single-app lookups return a one-element JSON:API collection.
+    if isinstance(value, list):
+        if len(value) > 1:
+            raise ValueError("Ambiguous ASC resource collection")
+        return value[0] if value else {}
+    return value or {}
 
 
 def find_build(version, number):

--- a/scripts/mobile-release/test_publish_android.py
+++ b/scripts/mobile-release/test_publish_android.py
@@ -16,6 +16,26 @@ class ApkIdentityTest(unittest.TestCase):
         check_package(self.package, 'Signer #1 certificate SHA-256 digest: ' + self.certificate,
                       '1.2.0', '12', self.certificate)
 
+    def test_build_tools_37_scheme_labels(self):
+        for label in ('V1 Signer', 'V2 Signer', 'V3 Signer', 'V3.1 Signer', 'V3.2 Signer'):
+            with self.subTest(label=label):
+                check_package(self.package, label + ': certificate SHA-256 digest: ' + self.certificate,
+                              '1.2.0', '12', self.certificate)
+
+    def test_same_certificate_across_schemes_is_one_identity(self):
+        signatures = '\n'.join(label + ': certificate SHA-256 digest: ' + self.certificate
+                               for label in ('V2 Signer', 'V3 Signer'))
+        check_package(self.package, signatures, '1.2.0', '12', self.certificate)
+
+    def test_rejects_unknown_or_conflicting_scheme_certificates(self):
+        valid = 'V2 Signer: certificate SHA-256 digest: ' + self.certificate
+        for signatures in (valid + '\nV3 Signer: certificate SHA-256 digest: ' + 'cd' * 32,
+                           'Source Stamp Signer certificate SHA-256 digest: ' + self.certificate,
+                           'V2 Signer: public key SHA-256 digest: ' + self.certificate,
+                           valid + 'ab', valid[:-2]):
+            with self.subTest(signatures=signatures), self.assertRaises(ValueError):
+                check_package(self.package, signatures, '1.2.0', '12', self.certificate)
+
     def test_rejects_wrong_identity_or_debug_certificate(self):
         signature = 'Signer #1 certificate SHA-256 digest: ' + self.certificate
         for package, signed in [(self.package.replace('forum_app', 'other'), signature),

--- a/scripts/mobile-release/test_publish_android.py
+++ b/scripts/mobile-release/test_publish_android.py
@@ -47,5 +47,35 @@ class ApkIdentityTest(unittest.TestCase):
                 check_package(package, signed, '1.2.0', '12', self.certificate)
 
 
+class DraftReleaseTest(unittest.TestCase):
+    def test_reads_existing_draft_by_id_instead_of_tag_endpoint(self):
+        import json
+        from unittest.mock import patch
+        import publish_android as publisher
+        draft = {'id': 123, 'tag_name': 'mobile-v1.0.1', 'draft': True, 'assets': []}
+        with patch.object(publisher, 'gh', side_effect=[json.dumps({'databaseId': 123}), json.dumps(draft)]) as gh:
+            self.assertEqual(publisher.find_release('mobile-v1.0.1'), draft)
+        self.assertEqual(gh.call_args_list[1].args, ('api', 'repos/YourTongji/YourTJ-Hub/releases/123'))
+
+    def test_missing_release_does_not_query_an_id(self):
+        from unittest.mock import patch
+        import publish_android as publisher
+        with patch.object(publisher, 'gh', return_value=None) as gh:
+            self.assertIsNone(publisher.find_release('mobile-v1.0.1'))
+        gh.assert_called_once()
+
+    def test_only_explicit_missing_release_is_treated_as_absent(self):
+        from unittest.mock import patch
+        from subprocess import CompletedProcess
+        import publish_android as publisher
+        for message in ('release not found', 'HTTP 403: Forbidden'):
+            with patch.object(publisher.subprocess, 'run', return_value=CompletedProcess([], 1, '', message)):
+                if message == 'release not found':
+                    self.assertIsNone(publisher.gh('release', 'view', 'mobile-v1.0.1', allow_missing=True))
+                else:
+                    with self.assertRaises(RuntimeError):
+                        publisher.gh('release', 'view', 'mobile-v1.0.1', allow_missing=True)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/mobile-release/test_publish_ios.py
+++ b/scripts/mobile-release/test_publish_ios.py
@@ -51,7 +51,7 @@ class IosResumeTest(unittest.TestCase):
                 return {'data': [{'id': 'build', 'attributes': {'processingState': 'VALID'}}]}
             if args[:3] == ('builds', 'beta-app-review-submission', 'view'):
                 return {'data': None}
-            if args[:3] == ('testflight', 'review', 'view'): return {'data': {'id': 'beta-details'}}
+            if args[:3] == ('testflight', 'review', 'view'): return {'data': [{'id': 'beta-details'}]}
             if prefix == ('versions', 'list'): return {'data': []}
             if prefix == ('versions', 'create'): return {'data': {'id': 'version'}}
             if prefix == ('localizations', 'list'): return {'data': []}
@@ -78,3 +78,22 @@ class IosResumeTest(unittest.TestCase):
             with self.assertRaises(RuntimeError) as error:
                 publisher.asc('review', 'details-update', '--demo-account-password', 'secret-demo-password')
         self.assertNotIn('secret-demo-password', str(error.exception))
+
+    def test_absent_beta_review_cli_message_is_missing_not_failure(self):
+        from subprocess import CompletedProcess
+        result = CompletedProcess([], 4, '', 'Error: builds beta-app-review-submission view: no beta app review submission found for build "new-build"')
+        with patch.object(publisher.subprocess, 'run', return_value=result):
+            self.assertEqual(publisher.asc('builds', 'beta-app-review-submission', 'view', '--build-id', 'new-build', allow_missing=True), {'data': None})
+
+    def test_beta_lookup_other_failures_are_not_treated_as_missing(self):
+        from subprocess import CompletedProcess
+        for code, message in [(4, 'Permission denied'), (1, 'no beta app review submission found for build "x"')]:
+            with patch.object(publisher.subprocess, 'run', return_value=CompletedProcess([], code, '', message)), self.assertRaises(RuntimeError):
+                publisher.asc('builds', 'beta-app-review-submission', 'view', '--build-id', 'x', allow_missing=True)
+
+    def test_single_resource_handles_cli_collections_and_rejects_ambiguity(self):
+        for value in ({'data': []}, {'data': None}):
+            self.assertEqual(publisher.resource(value), {})
+        self.assertEqual(publisher.resource({'data': [{'id': 'one'}]}), {'id': 'one'})
+        with self.assertRaisesRegex(ValueError, 'Ambiguous'):
+            publisher.resource({'data': [{'id': 'one'}, {'id': 'two'}]})


### PR DESCRIPTION
Mobile 1.0.1 built successfully, but publisher assumptions blocked both distribution channels. This fixes the observed CLI/API compatibility failures while preserving signing checks, immutable release assets and upload recovery.

- Accept Build Tools 37 scheme-labelled certificate fingerprints and repeated identical certificates across schemes; reject conflicting certificates, public-key hashes and source-stamp-only output.
- Resolve GitHub draft releases with gh release view, then read assets by database ID. The tag REST endpoint returned 404 for the existing draft.
- Treat ASC 5 exit 4 with the exact absent-beta-review message as a first submission, and normalize single-resource collection responses. Other failures and ambiguous collections remain errors.
- Document safe recovery of abandoned empty Apple upload reservations and retained signed artifacts when publisher fixes follow an immutable tag.

Validation: 31 release-script tests passed, including regressions observed failing before each fix. The real CI arm64 APK passes with official Build Tools 36 and 37. All five governance gates, whitespace checks and normal pre-push hooks passed.

Recovery evidence: the original CI APKs were verified and published as mobile-v1.0.1, with GitHub asset digests checked. The original signed IPA was uploaded as 1.0.1 (2), processed VALID and submitted to TestFlight (WAITING_FOR_REVIEW). App Store version creation is currently blocked by the existing 1.0.0 version waiting for review; the publisher does not automatically withdraw an existing submission. No signing keys or release tags were replaced.
