### PR TITLE
fix(mobile): polish reading and personal course review management

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/own_course_reviews.go
+++ b/apps/gooseforum/app/http/controllers/forum/own_course_reviews.go
@@ -1,0 +1,34 @@
+package forum
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/component"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/courseservice"
+)
+
+type OwnCourseReviewsReq struct {
+	Cursor   string `form:"cursor"`
+	PageSize *int   `form:"pageSize"`
+}
+
+func OwnCourseReviews(req component.BetterRequest[OwnCourseReviewsReq]) component.Response {
+	var before uint64
+	var err error
+	if req.Params.Cursor != "" {
+		before, err = strconv.ParseUint(req.Params.Cursor, 10, 64)
+	}
+	pageSize := courseservice.DefaultReviewPageSize
+	if req.Params.PageSize != nil {
+		pageSize = *req.Params.PageSize
+	}
+	if err != nil || pageSize < 1 || pageSize > courseservice.MaxReviewPageSize {
+		return component.BuildResponse(http.StatusBadRequest, component.FailDataCode(component.MessageRequestInvalidParams, nil))
+	}
+	page, err := courseservice.ListOwnReviews(req.UserId, before, pageSize)
+	if err != nil {
+		return component.BuildResponse(http.StatusInternalServerError, component.FailDataCode(component.MessageReviewListFailed, nil))
+	}
+	return component.SuccessResponse(page)
+}

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -76,6 +76,7 @@ func setupCourseReviewContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 	forumAPI := router.Group("/api/forum")
 	forumAPI.GET("courses/:courseId/reviews", middleware.JWTAuth, UpUriQueryReq(forum.ListCourseReviews))
 	forumLoginAPI := forumAPI.Use(middleware.JWTAuthCheck)
+	forumLoginAPI.GET("my-course-reviews", UpQueryReq(forum.OwnCourseReviews))
 	forumLoginAPI.POST("course-reviews", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewWrite), UpJsonReq(forum.CreateCourseReview))
 	forumLoginAPI.PATCH("course-reviews/:reviewId", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewWrite), UpUriJsonReq(forum.UpdateCourseReview))
 	forumLoginAPI.DELETE("course-reviews/:reviewId", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewWrite), UpUriReq(forum.DeleteCourseReview))
@@ -1352,5 +1353,66 @@ func TestCourseReviewOwnerFirstHTTPContract(t *testing.T) {
 	}
 	if len(page.List) != 1 || page.List[0]["id"] != float64(2) {
 		t.Fatalf("lost next review: %+v", page)
+	}
+}
+
+func TestOwnCourseReviewsHTTPContract(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 901)
+	alice := createHTTPContractUser(t, conn, contractTestID())
+	bob := createHTTPContractUser(t, conn, contractTestID())
+	// Different offerings allow multiple reviews by the same author.
+	if err := conn.Create(&course.OfferingEntity{Id: 902, CourseId: 42, TermId: 101, Status: course.OfferingStatusVisible}).Error; err != nil {
+		t.Fatal(err)
+	}
+	seedCourseReview(t, conn, 1, 901, alice.Id, intPtr(5), "my anonymous", true, "", course.ReviewStatusVisible)
+	seedCourseReview(t, conn, 2, 902, alice.Id, intPtr(4), "my hidden", true, "", course.ReviewStatusHidden)
+	seedCourseReview(t, conn, 3, 901, bob.Id, intPtr(5), "not mine", true, "", course.ReviewStatusVisible)
+	rec := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/my-course-reviews", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous status: %d", rec.Code)
+	}
+	token := contractSessionToken(t, alice)
+	rec = serveAuthSecurityJSON(router, http.MethodGet, fmt.Sprintf("/api/forum/my-course-reviews?pageSize=1&userId=%d", bob.Id), "", token)
+	var page courseservice.OwnReviewPage
+	if err := json.Unmarshal(decodeContractEnvelope(t, rec).Result, &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.List) != 1 || page.List[0].Review.Id != 2 || page.List[0].Review.Viewer.CanEdit || !page.List[0].Review.Viewer.CanDelete || page.List[0].CanOpenCourse {
+		t.Fatalf("hidden owner page: %+v", page)
+	}
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/my-course-reviews?pageSize=1&cursor="+page.NextCursor, "", token)
+	page = courseservice.OwnReviewPage{}
+	if err := json.Unmarshal(decodeContractEnvelope(t, rec).Result, &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.List) != 1 || page.List[0].Review.Id != 1 || page.List[0].CourseId != 42 || !page.List[0].CanOpenCourse || page.NextCursor != "" {
+		t.Fatalf("owner next page: %+v", page)
+	}
+	// Private management retains reviews when their course is unavailable, but
+	// does not offer a public link that would return 404.
+	if err := conn.Model(&course.Entity{}).Where("id = ?", 42).Update("status", course.StatusHidden).Error; err != nil {
+		t.Fatal(err)
+	}
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/my-course-reviews?cursor=2", "", token)
+	page = courseservice.OwnReviewPage{}
+	if err := json.Unmarshal(decodeContractEnvelope(t, rec).Result, &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.List) != 1 || page.List[0].CanOpenCourse || page.List[0].CourseId != 42 {
+		t.Fatalf("unavailable course owner page: %+v", page)
+	}
+	for _, query := range []string{"cursor=garbage", "pageSize=51", "pageSize=0", "pageSize=-1"} {
+		rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/my-course-reviews?"+query, "", token)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("invalid query: %d", rec.Code)
+		}
+	}
+	if err := conn.Model(&course.ReviewEntity{}).Where("author_user_id = ?", alice.Id).Update("status", course.ReviewStatusDeleted).Error; err != nil {
+		t.Fatal(err)
+	}
+	rec = serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/my-course-reviews", "", token)
+	if !strings.Contains(rec.Body.String(), `"list":[]`) {
+		t.Fatalf("deleted reviews remain: %s", rec.Body.String())
 	}
 }

--- a/apps/gooseforum/app/http/routes/contract_course_review_test.go
+++ b/apps/gooseforum/app/http/routes/contract_course_review_test.go
@@ -1319,3 +1319,38 @@ func TestCourseReviewPaginationOfferingStats(t *testing.T) {
 		}
 	}
 }
+
+func TestCourseReviewOwnerFirstHTTPContract(t *testing.T) {
+	conn, router := setupCourseReviewContractTest(t)
+	seedCourseReviewCatalog(t, conn, 901)
+	alice := createHTTPContractUser(t, conn, contractTestID())
+	token := contractSessionToken(t, alice)
+	seedCourseReview(t, conn, 1, 901, alice.Id, intPtr(5), "own anonymous", true, "", course.ReviewStatusVisible)
+	seedCourseReview(t, conn, 2, 901, alice.Id+1, intPtr(4), "other", true, "", course.ReviewStatusVisible)
+	first := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=1", "", token)
+	if first.Code != http.StatusOK {
+		t.Fatal(first.Body.String())
+	}
+	var page struct {
+		List       []map[string]any `json:"list"`
+		NextCursor string           `json:"nextCursor"`
+	}
+	if err := json.Unmarshal(decodeContractEnvelope(t, first).Result, &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.List) != 1 || page.List[0]["id"] != float64(1) {
+		t.Fatalf("owner not first: %+v", page)
+	}
+	assertNoReviewIdentityKeys(t, page.List[0])
+	// A deleted cursor row must not change phase or hide the remaining reviews.
+	if err := conn.Where("id = ?", 1).Delete(&course.ReviewEntity{}).Error; err != nil {
+		t.Fatal(err)
+	}
+	second := serveAuthSecurityJSON(router, http.MethodGet, "/api/forum/courses/42/reviews?pageSize=1&cursor="+url.QueryEscape(page.NextCursor), "", token)
+	if err := json.Unmarshal(decodeContractEnvelope(t, second).Result, &page); err != nil {
+		t.Fatal(err)
+	}
+	if len(page.List) != 1 || page.List[0]["id"] != float64(2) {
+		t.Fatalf("lost next review: %+v", page)
+	}
+}

--- a/apps/gooseforum/app/http/routes/route4api.go
+++ b/apps/gooseforum/app/http/routes/route4api.go
@@ -333,6 +333,7 @@ func apiRoute(ginApp *gin.Engine) {
 	forumLoginApi.POST("follow-user", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitInteract), UpButterReq(api.FollowUser))
 	forumLoginApi.POST("report", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitInteract), UpButterReq(forum.CreateReport))
 	// 课评写接口：登录 + 可写账号 + 独立限流。
+	forumLoginApi.GET("my-course-reviews", UpQueryReq(forum.OwnCourseReviews))
 	forumLoginApi.POST("course-reviews", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewWrite), UpJsonReq(forum.CreateCourseReview))
 	forumLoginApi.PATCH("course-reviews/:reviewId", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewWrite), UpUriJsonReq(forum.UpdateCourseReview))
 	forumLoginApi.DELETE("course-reviews/:reviewId", middleware.CheckWritableAccount, middleware.RateLimit(middleware.RateLimitReviewWrite), UpUriReq(forum.DeleteCourseReview))

--- a/apps/gooseforum/app/models/forum/course/review_rep.go
+++ b/apps/gooseforum/app/models/forum/course/review_rep.go
@@ -379,6 +379,7 @@ func GetOfferingMapByIds(ids []uint64) map[uint64]OfferingEntity {
 
 // ReviewPageQuery cursor 分页查询条件。排序：course 级按
 // (offering_id DESC, id DESC)，offering 级按 id DESC（时间倒序）。
+// OwnerId 非零时优先本人；cursor 包含所在分组，不依赖游标行仍然存在。
 // Cursor 语义：返回 (offering_id, id) 严格小于 cursor 的可见评价
 // （位置游标——删除/隐藏行不影响后续页游标稳定性）。
 type ReviewPageQuery struct {
@@ -388,6 +389,8 @@ type ReviewPageQuery struct {
 	CursorOfferingId uint64   // cursor 中的 offering_id（offering 级时为 0）
 	CursorReviewId   uint64   // cursor 中的 review_id（无 cursor 时为 0）
 	Limit            int
+	OwnerId          uint64
+	CursorOwnReview  bool
 }
 
 // ListReviewsPage 按 cursor 分页列出可见评价（时间倒序）。
@@ -398,10 +401,6 @@ func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
 		Where("deleted_at IS NULL")
 	if q.OfferingId > 0 {
 		build = build.Where(queryopt.Eq("offering_id", q.OfferingId))
-		if q.CursorReviewId > 0 {
-			build = build.Where("id < ?", q.CursorReviewId)
-		}
-		build = build.Order("id DESC")
 	} else {
 		// course 级：仅统计可见 offering——隐藏 offering 的评价不出现，
 		// 与 ListOfferingsByCourse/详情页可见性一致（PR #201 security F1）。
@@ -417,14 +416,34 @@ func ListReviewsPage(q ReviewPageQuery) (entities []ReviewEntity, err error) {
 				q.CourseId, OfferingStatusVisible,
 			)
 		}
-		if q.CursorOfferingId > 0 || q.CursorReviewId > 0 {
-			build = build.Where(
-				"(offering_id < ? OR (offering_id = ? AND id < ?))",
-				q.CursorOfferingId, q.CursorOfferingId, q.CursorReviewId,
-			)
-		}
-		build = build.Order("offering_id DESC, id DESC")
 	}
+	// Preserve the existing order within each ownership group. CASE treats
+	// legacy NULL author IDs as other authors on both PostgreSQL and SQLite.
+	if q.CursorReviewId > 0 || (q.OfferingId == 0 && q.CursorOfferingId > 0) {
+		position := "id < ?"
+		args := []any{q.CursorReviewId}
+		if q.OfferingId == 0 {
+			position = "(offering_id < ? OR (offering_id = ? AND id < ?))"
+			args = []any{q.CursorOfferingId, q.CursorOfferingId, q.CursorReviewId}
+		}
+		if q.OwnerId == 0 {
+			build = build.Where(position, args...)
+		} else if q.CursorOwnReview {
+			build = build.Where("(author_user_id IS NULL OR author_user_id <> ? OR ("+position+"))", append([]any{q.OwnerId}, args...)...)
+		} else {
+			build = build.Where("(author_user_id IS NULL OR author_user_id <> ?)", q.OwnerId).Where(position, args...)
+		}
+	}
+	order := "offering_id DESC, id DESC"
+	if q.OfferingId > 0 {
+		order = "id DESC"
+	}
+	if q.OwnerId > 0 {
+		build = build.Order(clause.OrderBy{Expression: clause.Expr{SQL: "CASE WHEN author_user_id = ? THEN 0 ELSE 1 END ASC, " + order, Vars: []any{q.OwnerId}}})
+	} else {
+		build = build.Order(order)
+	}
+
 	if q.Limit > 0 {
 		build = build.Limit(q.Limit)
 	}

--- a/apps/gooseforum/app/models/forum/course/review_rep.go
+++ b/apps/gooseforum/app/models/forum/course/review_rep.go
@@ -764,3 +764,27 @@ func GetRatingDistributionsByCourseIds(courseIds []uint64) map[uint64]RatingDist
 	}
 	return ratingDistributionFromRows(rows)
 }
+
+// OwnedReviewRecord joins only course-domain metadata for the private management list.
+// Hidden reviews remain manageable; deleted reviews and detached authors are excluded.
+type OwnedReviewRecord struct {
+	ReviewEntity
+	CourseId      uint64
+	CourseName    string
+	CourseCode    string
+	CanOpenCourse bool
+}
+
+func ListOwnedReviews(userID, beforeID uint64, limit int) ([]OwnedReviewRecord, error) {
+	records := []OwnedReviewRecord{}
+	query := reviewBuilder().Table(reviewTableName+" r").
+		Select("r.*, COALESCE(c.id, 0) AS course_id, COALESCE(c.name, '') AS course_name, COALESCE(c.primary_code, '') AS course_code, CASE WHEN c.status = ? AND c.deleted_at IS NULL AND o.status = ? AND o.deleted_at IS NULL AND c.id IS NOT NULL THEN true ELSE false END AS can_open_course", StatusVisible, OfferingStatusVisible).
+		Joins("LEFT JOIN "+offeringTableName+" o ON o.id = r.offering_id").
+		Joins("LEFT JOIN "+tableName+" c ON c.id = o.course_id").
+		Where("r.author_user_id = ? AND r.status <> ? AND r.deleted_at IS NULL", userID, ReviewStatusDeleted)
+	if beforeID > 0 {
+		query = query.Where("r.id < ?", beforeID)
+	}
+	err := query.Order("r.id DESC").Limit(limit).Scan(&records).Error
+	return records, err
+}

--- a/apps/gooseforum/app/service/courseservice/own_reviews.go
+++ b/apps/gooseforum/app/service/courseservice/own_reviews.go
@@ -1,0 +1,57 @@
+package courseservice
+
+import (
+	"strconv"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/course"
+)
+
+type OwnReviewItem struct {
+	Review        ReviewPayload `json:"review"`
+	CourseId      uint64        `json:"courseId"`
+	CourseName    string        `json:"courseName"`
+	CourseCode    string        `json:"courseCode"`
+	Hidden        bool          `json:"hidden"`
+	CanOpenCourse bool          `json:"canOpenCourse"`
+}
+
+type OwnReviewPage struct {
+	List       []OwnReviewItem `json:"list"`
+	NextCursor string          `json:"nextCursor,omitempty"`
+}
+
+// ListOwnReviews uses the session identity, never a caller-supplied author ID.
+func ListOwnReviews(userID, beforeID uint64, pageSize int) (OwnReviewPage, error) {
+	result := OwnReviewPage{List: []OwnReviewItem{}}
+	if userID == 0 {
+		return result, ErrReviewNotOwned
+	}
+	if pageSize <= 0 {
+		pageSize = DefaultReviewPageSize
+	}
+	if pageSize > MaxReviewPageSize {
+		pageSize = MaxReviewPageSize
+	}
+	records, err := course.ListOwnedReviews(userID, beforeID, pageSize+1)
+	if err != nil {
+		return result, err
+	}
+	if len(records) > pageSize {
+		records = records[:pageSize]
+		result.NextCursor = strconv.FormatUint(records[len(records)-1].Id, 10)
+	}
+	entities := make([]course.ReviewEntity, 0, len(records))
+	for _, r := range records {
+		entities = append(entities, r.ReviewEntity)
+	}
+	payloads, err := listReviewPayloads(entities, userID)
+	if err != nil {
+		return result, err
+	}
+	for i, r := range records {
+		hidden := r.Status != course.ReviewStatusVisible
+		payloads[i].Viewer.CanEdit = !hidden
+		result.List = append(result.List, OwnReviewItem{Review: payloads[i], CourseId: r.CourseId, CourseName: r.CourseName, CourseCode: r.CourseCode, Hidden: hidden, CanOpenCourse: r.CanOpenCourse && !hidden})
+	}
+	return result, nil
+}

--- a/apps/gooseforum/app/service/courseservice/review.go
+++ b/apps/gooseforum/app/service/courseservice/review.go
@@ -423,16 +423,26 @@ type ReviewPageResult struct {
 	Total      int64           `json:"total"`
 }
 
-// ReviewCursor 复合游标（offering_id, review_id）。
+// ReviewCursor includes the owner/non-owner phase for personalized pagination.
+// The phase survives cursor-row deletion; older two-part cursors remain supported.
 // Course 级列表按 (offering_id DESC, id DESC) 排序，cursor 是上一页
 // 最后一条的 (offeringId, id)；offering 级列表只用 reviewId。
 type ReviewCursor struct {
 	OfferingId uint64
 	ReviewId   uint64
+	OwnerFirst bool
+	OwnReview  bool
 }
 
-// EncodeCursor 编码 cursor 为明文 "offeringId:reviewId"。
+// EncodeCursor returns an opaque cursor; personalized cursors append the owner phase.
 func EncodeCursor(c ReviewCursor) string {
+	if c.OwnerFirst {
+		phase := 0
+		if c.OwnReview {
+			phase = 1
+		}
+		return fmt.Sprintf("%d:%d:%d", c.OfferingId, c.ReviewId, phase)
+	}
 	return fmt.Sprintf("%d:%d", c.OfferingId, c.ReviewId)
 }
 
@@ -443,7 +453,7 @@ func DecodeCursor(raw string) (ReviewCursor, error) {
 		return ReviewCursor{}, nil
 	}
 	parts := strings.Split(raw, ":")
-	if len(parts) != 2 {
+	if len(parts) != 2 && len(parts) != 3 {
 		return ReviewCursor{}, ErrReviewInvalidCursor
 	}
 	oid, err1 := strconv.ParseUint(parts[0], 10, 64)
@@ -451,7 +461,15 @@ func DecodeCursor(raw string) (ReviewCursor, error) {
 	if err1 != nil || err2 != nil {
 		return ReviewCursor{}, ErrReviewInvalidCursor
 	}
-	return ReviewCursor{OfferingId: oid, ReviewId: rid}, nil
+	c := ReviewCursor{OfferingId: oid, ReviewId: rid}
+	if len(parts) == 3 {
+		if parts[2] != "0" && parts[2] != "1" {
+			return ReviewCursor{}, ErrReviewInvalidCursor
+		}
+		c.OwnerFirst = true
+		c.OwnReview = parts[2] == "1"
+	}
+	return c, nil
 }
 
 // ListReviewsPage 按 cursor 分页返回课程（或指定 offering）的可见评价。
@@ -475,6 +493,11 @@ func ListReviewsPage(courseId, offeringId, viewerId uint64, cursor ReviewCursor,
 		CursorOfferingId: cursor.OfferingId,
 		CursorReviewId:   cursor.ReviewId,
 		Limit:            pageSize + 1,
+	}
+	// Legacy two-part cursors retain their ordering; new signed-in lists pin the owner.
+	if viewerId > 0 && ((cursor.ReviewId == 0 && cursor.OfferingId == 0) || cursor.OwnerFirst) {
+		query.OwnerId = viewerId
+		query.CursorOwnReview = cursor.OwnReview
 	}
 	// team 档：先取团队全部可见卡 id，列表与 total 都按多卡口径。
 	var teamIds []uint64
@@ -526,7 +549,7 @@ func ListReviewsPage(courseId, offeringId, viewerId uint64, cursor ReviewCursor,
 	}
 	if hasNext {
 		last := entities[len(entities)-1]
-		result.NextCursor = EncodeCursor(ReviewCursor{OfferingId: last.OfferingId, ReviewId: last.Id})
+		result.NextCursor = EncodeCursor(ReviewCursor{OfferingId: last.OfferingId, ReviewId: last.Id, OwnerFirst: query.OwnerId > 0, OwnReview: last.AuthorID() == viewerId})
 	}
 	return result, nil
 }

--- a/apps/gooseforum/app/service/courseservice/review_test.go
+++ b/apps/gooseforum/app/service/courseservice/review_test.go
@@ -661,3 +661,59 @@ func TestListReviewsPageTeamScopeAggregation(t *testing.T) {
 		t.Fatalf("offering-filtered = total %d list %d, want 1/1 on offering %d", filtered.Total, len(filtered.List), aOffering)
 	}
 }
+
+func TestReviewsOwnerFirstAcrossPages(t *testing.T) {
+	courseID, offeringID := setupReviewTest(t)
+	own, err := CreateReview(7001, CreateReviewInput{OfferingId: offeringID, Rating: 5, Content: "my older anonymous review", IsAnonymous: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for user := uint64(7002); user < 7027; user++ {
+		if _, err := CreateReview(user, CreateReviewInput{OfferingId: offeringID, Rating: 4, Content: "newer review", IsAnonymous: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, filter := range []uint64{0, offeringID} {
+		cursor := ReviewCursor{}
+		seen := map[uint64]bool{}
+		for page := 0; page < 30; page++ {
+			result, err := ListReviewsPage(courseID, filter, 7001, cursor, 3)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if page == 0 && (len(result.List) == 0 || result.List[0].Id != own.Id) {
+				t.Fatalf("own review missing from first position: %+v", result.List)
+			}
+			for _, r := range result.List {
+				if seen[r.Id] {
+					t.Fatalf("duplicate review %d", r.Id)
+				}
+				seen[r.Id] = true
+			}
+			if result.NextCursor == "" {
+				break
+			}
+			cursor, err = DecodeCursor(result.NextCursor)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(seen) != 26 {
+			t.Fatalf("lost reviews: %d", len(seen))
+		}
+	}
+}
+
+func TestReviewCursorOwnershipPhase(t *testing.T) {
+	for _, raw := range []string{"1:2", "1:2:0", "1:2:1"} {
+		cursor, err := DecodeCursor(raw)
+		if err != nil || EncodeCursor(cursor) != raw {
+			t.Fatalf("cursor roundtrip %q: %+v %v", raw, cursor, err)
+		}
+	}
+	for _, raw := range []string{"1:2:3", "1:2:-1", "1:2:1:0", "x:2:1"} {
+		if _, err := DecodeCursor(raw); err == nil {
+			t.Fatalf("accepted malformed cursor %q", raw)
+		}
+	}
+}

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -2195,6 +2195,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/forum/my-course-reviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Manage the current user's course reviews across courses
+         * @description Private session-scoped list, newest review ID first. Includes the caller's anonymous
+         *     and hidden reviews; excludes deleted reviews. No author selector is accepted.
+         *     Hidden reviews can be deleted but cannot be edited or opened publicly. Course metadata
+         *     remains available for management when the corresponding course is unavailable.
+         */
+        get: operations["listOwnCourseReviews"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/forum/course-reviews": {
         parameters: {
             query?: never;
@@ -10351,6 +10374,24 @@ export interface components {
              */
             action: 1 | 2;
         };
+        OwnCourseReviewItem: {
+            review: components["schemas"]["ReviewPayload"];
+            /** Format: uint64 */
+            courseId: number;
+            courseName: string;
+            courseCode: string;
+            hidden: boolean;
+            /** @description False when the review, offering or course is unavailable publicly. */
+            canOpenCourse: boolean;
+        };
+        OwnCourseReviewResponse: {
+            /** @constant */
+            code: 0;
+            result: {
+                list: components["schemas"]["OwnCourseReviewItem"][];
+                nextCursor?: string;
+            };
+        };
         ModerationPostRevealRequest: {
             /** Format: uint64 */
             postId: number;
@@ -14332,6 +14373,56 @@ export interface operations {
                 };
             };
             /** @description Review listing failed. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+        };
+    };
+    listOwnCourseReviews: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                pageSize?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Private course review page; list is empty rather than null. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OwnCourseReviewResponse"];
+                };
+            };
+            /** @description Invalid cursor or page size. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description A valid session is required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiFailure"];
+                };
+            };
+            /** @description Could not load the user's reviews. */
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -2181,7 +2181,8 @@ export interface paths {
         /**
          * List visible course reviews for a course or a single offering
          * @description Public read endpoint. An optional valid JWT (cookie or Bearer) only personalizes the
-         *     `viewer` state (canEdit/canDelete/isHelpful); anonymous callers receive the same reviews
+         *     `viewer` state (canEdit/canDelete/isHelpful) and places the caller's own reviews first,
+         *     preserving newest-first ordering within each ownership group. Anonymous callers receive the same reviews
          *     with viewer flags false. Review payloads never contain author identity fields
          *     (userId/username/avatar): anonymous and legacy reviews expose only a kind/label pair.
          */
@@ -7224,8 +7225,8 @@ export interface components {
             list: components["schemas"]["ReviewPayload"][];
             /**
              * @description Cursor for the next page, present only when more reviews exist.
-             *     Format is "offeringId:reviewId" of the last item of the current page
-             *     (course-level ordering is (offering_id DESC, id DESC)). Omit to stop paging.
+             *     Opaque position cursor including the ownership phase for personalized lists.
+             *     Pass it back unchanged. Legacy two-part cursors remain accepted. Omit to stop paging.
              */
             nextCursor?: string;
             /**
@@ -14299,7 +14300,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Visible reviews ordered newest first. */
+            /** @description Visible reviews with the authenticated caller's reviews first, newest first within each group. */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/apps/mobile/packages/core/lib/core.dart
+++ b/apps/mobile/packages/core/lib/core.dart
@@ -58,3 +58,5 @@ export 'src/api/repositories/content_repository.dart';
 export 'src/gen/post_revision.dart';
 
 export 'src/gen/wiki_search.dart';
+
+export 'src/gen/own_course_reviews.dart';

--- a/apps/mobile/packages/core/lib/src/api/repositories/course_repository.dart
+++ b/apps/mobile/packages/core/lib/src/api/repositories/course_repository.dart
@@ -1,3 +1,4 @@
+import '../../gen/own_course_reviews.dart';
 import '../../gen/content_pages.dart';
 import '../../gen/course_catalog.dart';
 import '../../gen/course_review.dart';
@@ -7,7 +8,7 @@ import '../gf_api_client.dart';
 /// 课程目录/详情/课评域（`/api/forum/courses*`、`/api/forum/course-reviews*`）。
 ///
 /// forum 信封 `{code,result,messageCode,params}` 由 [GfApiClient.get/post]
-/// 统一解包；读操作公开（可选 JWT 个性化 viewer 态），写操作需登录。
+/// 统一解包；公开读操作可选 JWT 个性化 viewer 态；我的课评与写操作需登录。
 class CourseRepository {
   CourseRepository(this._client);
 
@@ -105,6 +106,20 @@ class CourseRepository {
     },
     parser: (json) =>
         ReviewListResult.fromJson(Map<String, dynamic>.from(json as Map)),
+  );
+
+  /// Private, session-scoped review management across all courses.
+  Future<OwnCourseReviewPage> ownReviews({
+    String cursor = '',
+    int pageSize = 20,
+  }) => _client.get<OwnCourseReviewPage>(
+    '$_base/my-course-reviews',
+    queryParameters: {
+      if (cursor.isNotEmpty) 'cursor': cursor,
+      'pageSize': pageSize,
+    },
+    parser: (json) =>
+        OwnCourseReviewPage.fromJson(Map<String, dynamic>.from(json as Map)),
   );
 
   /// 写课评。

--- a/apps/mobile/packages/core/lib/src/gen/course_review.dart
+++ b/apps/mobile/packages/core/lib/src/gen/course_review.dart
@@ -53,6 +53,7 @@ abstract class ReviewPayload with _$ReviewPayload {
 abstract class ReviewListResult with _$ReviewListResult {
   const factory ReviewListResult({
     required List<ReviewPayload> list,
+    // Opaque pagination cursor; preserve the server ownership phase unchanged.
     String? nextCursor,
     required int total,
   }) = _ReviewListResult;

--- a/apps/mobile/packages/core/lib/src/gen/own_course_reviews.dart
+++ b/apps/mobile/packages/core/lib/src/gen/own_course_reviews.dart
@@ -1,0 +1,55 @@
+import 'course_review.dart';
+
+/// Mirrors the authenticated OwnCourseReviewItem OpenAPI schema.
+class OwnCourseReviewItem {
+  const OwnCourseReviewItem({
+    required this.review,
+    required this.courseId,
+    required this.courseName,
+    required this.courseCode,
+    required this.hidden,
+    required this.canOpenCourse,
+  });
+  final ReviewPayload review;
+  final int courseId;
+  final String courseName;
+  final String courseCode;
+  final bool hidden;
+  final bool canOpenCourse;
+  factory OwnCourseReviewItem.fromJson(Map<String, dynamic> json) =>
+      OwnCourseReviewItem(
+        review: ReviewPayload.fromJson(
+          Map<String, dynamic>.from(json['review'] as Map),
+        ),
+        courseId: (json['courseId'] as num).toInt(),
+        courseName: json['courseName'] as String,
+        courseCode: json['courseCode'] as String,
+        hidden: json['hidden'] as bool,
+        canOpenCourse: json['canOpenCourse'] as bool,
+      );
+  OwnCourseReviewItem withReview(ReviewPayload value) => OwnCourseReviewItem(
+    review: value,
+    courseId: courseId,
+    courseName: courseName,
+    courseCode: courseCode,
+    hidden: hidden,
+    canOpenCourse: canOpenCourse,
+  );
+}
+
+class OwnCourseReviewPage {
+  const OwnCourseReviewPage({required this.list, this.nextCursor = ''});
+  final List<OwnCourseReviewItem> list;
+  final String nextCursor;
+  factory OwnCourseReviewPage.fromJson(Map<String, dynamic> json) =>
+      OwnCourseReviewPage(
+        list: (json['list'] as List)
+            .map(
+              (item) => OwnCourseReviewItem.fromJson(
+                Map<String, dynamic>.from(item as Map),
+              ),
+            )
+            .toList(),
+        nextCursor: json['nextCursor'] as String? ?? '',
+      );
+}

--- a/apps/mobile/packages/core/test/api_client_test.dart
+++ b/apps/mobile/packages/core/test/api_client_test.dart
@@ -59,6 +59,28 @@ void main() {
       expect(adapter.requests.single.path, '/api/forum/topics/status');
     });
 
+    test(
+      'own course reviews sends session and pagination without author selector',
+      () async {
+        setupClient(initialToken: 'owner-token');
+        dio.httpClientAdapter = MockAdapter((request) async {
+          expect(request.path, '/api/forum/my-course-reviews');
+          expect(request.method, 'GET');
+          expect(request.headers['Authorization'], 'Bearer owner-token');
+          expect(request.queryParameters, {'cursor': '23', 'pageSize': 10});
+          return ResponseData(200, {
+            'code': 0,
+            'result': {'list': []},
+          });
+        });
+        final result = await CourseRepository(
+          client,
+        ).ownReviews(cursor: '23', pageSize: 10);
+        expect(result.list, isEmpty);
+        expect(result.nextCursor, isEmpty);
+      },
+    );
+
     test('无令牌时不带 Authorization 头', () async {
       setupClient();
       final adapter = MockAdapter((request) async {
@@ -467,29 +489,31 @@ void main() {
       );
     });
 
-    test('page-channel 404 非 error.index(如 JSON 错误体)降级为 ApiFailureException',
-        () async {
-      setupClient();
-      final adapter = MockAdapter((request) async {
-        return ResponseData(404, {
-          'error': 'not found',
-          'path': '/api/unknown',
+    test(
+      'page-channel 404 非 error.index(如 JSON 错误体)降级为 ApiFailureException',
+      () async {
+        setupClient();
+        final adapter = MockAdapter((request) async {
+          return ResponseData(404, {
+            'error': 'not found',
+            'path': '/api/unknown',
+          });
         });
-      });
-      dio.httpClientAdapter = adapter;
+        dio.httpClientAdapter = adapter;
 
-      // 后端已应答的 404 属于服务端错误(#143 语义):非 error.index 页面
-      // 不提升 messageCode,降级为无 messageCode 的 ApiFailureException,
-      // 不再是 NetworkException(后者仅限无 HTTP 状态码的传输层故障)。
-      await expectLater(
-        client.get<bool>('/api/unknown'),
-        throwsA(
-          isA<ApiFailureException>()
-              .having((e) => e.statusCode, 'statusCode', 404)
-              .having((e) => e.messageCode, 'messageCode', isNull),
-        ),
-      );
-    });
+        // 后端已应答的 404 属于服务端错误(#143 语义):非 error.index 页面
+        // 不提升 messageCode,降级为无 messageCode 的 ApiFailureException,
+        // 不再是 NetworkException(后者仅限无 HTTP 状态码的传输层故障)。
+        await expectLater(
+          client.get<bool>('/api/unknown'),
+          throwsA(
+            isA<ApiFailureException>()
+                .having((e) => e.statusCode, 'statusCode', 404)
+                .having((e) => e.messageCode, 'messageCode', isNull),
+          ),
+        );
+      },
+    );
   });
 
   group('repositories 请求体', () {

--- a/apps/mobile/packages/core/test/contract_fixtures_test.dart
+++ b/apps/mobile/packages/core/test/contract_fixtures_test.dart
@@ -560,6 +560,18 @@ void main() {
     });
   });
 
+  test('private course reviews decode the shared contract fixture', () {
+    final response = _contractFixture('own-course-reviews-success.json');
+    final page = OwnCourseReviewPage.fromJson(
+      response['result'] as Map<String, dynamic>,
+    );
+    expect(page.list.single.courseId, 42);
+    expect(page.list.single.canOpenCourse, isTrue);
+    expect(page.list.single.review.viewer.canDelete, isTrue);
+    expect(page.nextCursor, '2');
+    expect(OwnCourseReviewPage.fromJson({'list': []}).nextCursor, isEmpty);
+  });
+
   group('GfResponse 响应包装', () {
     test('code == 0 成功', () {
       final response = GfResponse<int>.fromJson({

--- a/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
@@ -1,4 +1,5 @@
 {
+  "commonHideKeyboard": "Tastatur ausblenden",
   "@@locale": "de",
   "appTitle": "YourTJ",
   "navHome": "Startseite",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
@@ -1,4 +1,9 @@
 {
+  "myCourseReviewsTitle": "Meine Kursbewertungen",
+  "myCourseReviewsEmpty": "Noch keine Bewertungen. Entdecke den Kurskatalog.",
+  "myCourseReviewHidden": "Diese Bewertung ist ausgeblendet. Du kannst sie hier löschen.",
+  "myCourseReviewUnavailable": "Dieser Kurs ist nicht verfügbar. Du kannst deine Bewertung weiterhin verwalten.",
+  "myCourseReviewOpen": "Details ansehen",
   "courseReviewNetworkError": "Verbindung fehlgeschlagen. Bitte Verbindung prüfen und erneut versuchen; deine Bewertung bleibt erhalten.",
   "courseReviewUnknownError": "Die Bewertung konnte nicht gespeichert werden. Der Server hat keinen konkreten Grund angegeben. Bitte später erneut versuchen.",
   "commonHideKeyboard": "Tastatur ausblenden",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
@@ -1,4 +1,6 @@
 {
+  "courseReviewNetworkError": "Verbindung fehlgeschlagen. Bitte Verbindung prüfen und erneut versuchen; deine Bewertung bleibt erhalten.",
+  "courseReviewUnknownError": "Die Bewertung konnte nicht gespeichert werden. Der Server hat keinen konkreten Grund angegeben. Bitte später erneut versuchen.",
   "commonHideKeyboard": "Tastatur ausblenden",
   "@@locale": "de",
   "appTitle": "YourTJ",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
@@ -1,4 +1,5 @@
 {
+  "commonHideKeyboard": "Hide keyboard",
   "@@locale": "en",
   "appTitle": "YourTJ",
   "navHome": "Home",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
@@ -1,4 +1,9 @@
 {
+  "myCourseReviewsTitle": "My course reviews",
+  "myCourseReviewsEmpty": "No reviews yet. Explore the course catalog to get started.",
+  "myCourseReviewHidden": "This review is hidden. You can delete it here.",
+  "myCourseReviewUnavailable": "This course is unavailable. You can still manage your review.",
+  "myCourseReviewOpen": "View details",
   "courseReviewNetworkError": "Could not connect. Check your connection and retry; your review has been kept.",
   "courseReviewUnknownError": "Your review could not be saved. The server did not provide a specific reason; please retry later.",
   "commonHideKeyboard": "Hide keyboard",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
@@ -1,4 +1,6 @@
 {
+  "courseReviewNetworkError": "Could not connect. Check your connection and retry; your review has been kept.",
+  "courseReviewUnknownError": "Your review could not be saved. The server did not provide a specific reason; please retry later.",
   "commonHideKeyboard": "Hide keyboard",
   "@@locale": "en",
   "appTitle": "YourTJ",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
@@ -1,4 +1,6 @@
 {
+  "courseReviewNetworkError": "接続できませんでした。通信環境を確認して再試行してください。評価内容は保持されています。",
+  "courseReviewUnknownError": "評価を保存できませんでした。サーバーから具体的な理由が返されませんでした。後でもう一度お試しください。",
   "commonHideKeyboard": "キーボードを閉じる",
   "@@locale": "ja",
   "appTitle": "YourTJ",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
@@ -1,4 +1,9 @@
 {
+  "myCourseReviewsTitle": "自分の授業評価",
+  "myCourseReviewsEmpty": "まだ評価がありません。科目一覧から探してみましょう。",
+  "myCourseReviewHidden": "この評価は非表示です。ここで削除できます。",
+  "myCourseReviewUnavailable": "この科目は現在表示できませんが、自分の評価は管理できます。",
+  "myCourseReviewOpen": "詳細を見る",
   "courseReviewNetworkError": "接続できませんでした。通信環境を確認して再試行してください。評価内容は保持されています。",
   "courseReviewUnknownError": "評価を保存できませんでした。サーバーから具体的な理由が返されませんでした。後でもう一度お試しください。",
   "commonHideKeyboard": "キーボードを閉じる",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
@@ -1,4 +1,5 @@
 {
+  "commonHideKeyboard": "キーボードを閉じる",
   "@@locale": "ja",
   "appTitle": "YourTJ",
   "navHome": "ホームへ",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
@@ -102,6 +102,18 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @courseReviewNetworkError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not connect. Check your connection and retry; your review has been kept.'**
+  String get courseReviewNetworkError;
+
+  /// No description provided for @courseReviewUnknownError.
+  ///
+  /// In en, this message translates to:
+  /// **'Your review could not be saved. The server did not provide a specific reason; please retry later.'**
+  String get courseReviewUnknownError;
+
   /// No description provided for @commonHideKeyboard.
   ///
   /// In en, this message translates to:

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
@@ -102,6 +102,36 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @myCourseReviewsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'My course reviews'**
+  String get myCourseReviewsTitle;
+
+  /// No description provided for @myCourseReviewsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No reviews yet. Explore the course catalog to get started.'**
+  String get myCourseReviewsEmpty;
+
+  /// No description provided for @myCourseReviewHidden.
+  ///
+  /// In en, this message translates to:
+  /// **'This review is hidden. You can delete it here.'**
+  String get myCourseReviewHidden;
+
+  /// No description provided for @myCourseReviewUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'This course is unavailable. You can still manage your review.'**
+  String get myCourseReviewUnavailable;
+
+  /// No description provided for @myCourseReviewOpen.
+  ///
+  /// In en, this message translates to:
+  /// **'View details'**
+  String get myCourseReviewOpen;
+
   /// No description provided for @courseReviewNetworkError.
   ///
   /// In en, this message translates to:

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
@@ -102,6 +102,12 @@ abstract class AppLocalizations {
     Locale('zh'),
   ];
 
+  /// No description provided for @commonHideKeyboard.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide keyboard'**
+  String get commonHideKeyboard;
+
   /// No description provided for @appTitle.
   ///
   /// In en, this message translates to:

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get commonHideKeyboard => 'Tastatur ausblenden';
+
+  @override
   String get appTitle => 'YourTJ';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,24 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get myCourseReviewsTitle => 'Meine Kursbewertungen';
+
+  @override
+  String get myCourseReviewsEmpty =>
+      'Noch keine Bewertungen. Entdecke den Kurskatalog.';
+
+  @override
+  String get myCourseReviewHidden =>
+      'Diese Bewertung ist ausgeblendet. Du kannst sie hier löschen.';
+
+  @override
+  String get myCourseReviewUnavailable =>
+      'Dieser Kurs ist nicht verfügbar. Du kannst deine Bewertung weiterhin verwalten.';
+
+  @override
+  String get myCourseReviewOpen => 'Details ansehen';
+
+  @override
   String get courseReviewNetworkError =>
       'Verbindung fehlgeschlagen. Bitte Verbindung prüfen und erneut versuchen; deine Bewertung bleibt erhalten.';
 

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,14 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get courseReviewNetworkError =>
+      'Verbindung fehlgeschlagen. Bitte Verbindung prüfen und erneut versuchen; deine Bewertung bleibt erhalten.';
+
+  @override
+  String get courseReviewUnknownError =>
+      'Die Bewertung konnte nicht gespeichert werden. Der Server hat keinen konkreten Grund angegeben. Bitte später erneut versuchen.';
+
+  @override
   String get commonHideKeyboard => 'Tastatur ausblenden';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,14 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get courseReviewNetworkError =>
+      'Could not connect. Check your connection and retry; your review has been kept.';
+
+  @override
+  String get courseReviewUnknownError =>
+      'Your review could not be saved. The server did not provide a specific reason; please retry later.';
+
+  @override
   String get commonHideKeyboard => 'Hide keyboard';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,24 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get myCourseReviewsTitle => 'My course reviews';
+
+  @override
+  String get myCourseReviewsEmpty =>
+      'No reviews yet. Explore the course catalog to get started.';
+
+  @override
+  String get myCourseReviewHidden =>
+      'This review is hidden. You can delete it here.';
+
+  @override
+  String get myCourseReviewUnavailable =>
+      'This course is unavailable. You can still manage your review.';
+
+  @override
+  String get myCourseReviewOpen => 'View details';
+
+  @override
   String get courseReviewNetworkError =>
       'Could not connect. Check your connection and retry; your review has been kept.';
 

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get commonHideKeyboard => 'Hide keyboard';
+
+  @override
   String get appTitle => 'YourTJ';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
@@ -9,6 +9,9 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get commonHideKeyboard => 'キーボードを閉じる';
+
+  @override
   String get appTitle => 'YourTJ';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
@@ -9,6 +9,14 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get courseReviewNetworkError =>
+      '接続できませんでした。通信環境を確認して再試行してください。評価内容は保持されています。';
+
+  @override
+  String get courseReviewUnknownError =>
+      '評価を保存できませんでした。サーバーから具体的な理由が返されませんでした。後でもう一度お試しください。';
+
+  @override
   String get commonHideKeyboard => 'キーボードを閉じる';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
@@ -9,6 +9,21 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get myCourseReviewsTitle => '自分の授業評価';
+
+  @override
+  String get myCourseReviewsEmpty => 'まだ評価がありません。科目一覧から探してみましょう。';
+
+  @override
+  String get myCourseReviewHidden => 'この評価は非表示です。ここで削除できます。';
+
+  @override
+  String get myCourseReviewUnavailable => 'この科目は現在表示できませんが、自分の評価は管理できます。';
+
+  @override
+  String get myCourseReviewOpen => '詳細を見る';
+
+  @override
   String get courseReviewNetworkError =>
       '接続できませんでした。通信環境を確認して再試行してください。評価内容は保持されています。';
 

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,21 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get myCourseReviewsTitle => '我的课评';
+
+  @override
+  String get myCourseReviewsEmpty => '还没有发布课评，去课程目录看看吧。';
+
+  @override
+  String get myCourseReviewHidden => '这条评价已被隐藏，可在此删除。';
+
+  @override
+  String get myCourseReviewUnavailable => '课程暂不可访问，你仍可管理自己的评价。';
+
+  @override
+  String get myCourseReviewOpen => '查看详情';
+
+  @override
   String get courseReviewNetworkError => '网络连接失败，请检查网络后重试，已保留你的评价。';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,12 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get courseReviewNetworkError => '网络连接失败，请检查网络后重试，已保留你的评价。';
+
+  @override
+  String get courseReviewUnknownError => '评价未能保存，服务端没有提供具体原因，请稍后重试。';
+
+  @override
   String get commonHideKeyboard => '收起键盘';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
@@ -9,6 +9,9 @@ class AppLocalizationsZh extends AppLocalizations {
   AppLocalizationsZh([String locale = 'zh']) : super(locale);
 
   @override
+  String get commonHideKeyboard => '收起键盘';
+
+  @override
   String get appTitle => 'YourTJ';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
@@ -1,4 +1,6 @@
 {
+  "courseReviewNetworkError": "网络连接失败，请检查网络后重试，已保留你的评价。",
+  "courseReviewUnknownError": "评价未能保存，服务端没有提供具体原因，请稍后重试。",
   "commonHideKeyboard": "收起键盘",
   "@@locale": "zh",
   "appTitle": "YourTJ",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
@@ -1,4 +1,5 @@
 {
+  "commonHideKeyboard": "收起键盘",
   "@@locale": "zh",
   "appTitle": "YourTJ",
   "navHome": "首页",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
@@ -1,4 +1,9 @@
 {
+  "myCourseReviewsTitle": "我的课评",
+  "myCourseReviewsEmpty": "还没有发布课评，去课程目录看看吧。",
+  "myCourseReviewHidden": "这条评价已被隐藏，可在此删除。",
+  "myCourseReviewUnavailable": "课程暂不可访问，你仍可管理自己的评价。",
+  "myCourseReviewOpen": "查看详情",
   "courseReviewNetworkError": "网络连接失败，请检查网络后重试，已保留你的评价。",
   "courseReviewUnknownError": "评价未能保存，服务端没有提供具体原因，请稍后重试。",
   "commonHideKeyboard": "收起键盘",

--- a/apps/mobile/packages/forum_app/lib/src/pages/campus/campus_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/campus/campus_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../providers.dart';
 import '../../navigation/tab_scroll_registry.dart';
@@ -56,7 +57,8 @@ class _CampusPageState extends ConsumerState<CampusPage> {
         controller: _scroll,
         showButton: false,
         semanticLabel: l10n.commonBackToTop,
-        builder: (_, controller) => RefreshIndicator(
+        builder: (_, controller) => AppRefreshIndicator(
+          edgeOffset: top,
           onRefresh: () => ref.refresh(campusCoursesProvider.future),
           child: ListView(
             controller: controller,

--- a/apps/mobile/packages/forum_app/lib/src/pages/category/category_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/category/category_page.dart
@@ -4,6 +4,7 @@ import 'package:ui_kit/ui_kit.dart';
 
 import 'package:core/core.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../format.dart';
 import '../../providers.dart';
@@ -137,16 +138,17 @@ class _CategoryPageState extends ConsumerState<CategoryPage> {
               Expanded(
                 child: GfScrollToTop(
                   semanticLabel: AppLocalizations.of(context).commonBackToTop,
-                  builder: (_, ScrollController controller) => RefreshIndicator(
-                    onRefresh: () => _load(silent: true),
-                    child: GfTopicList(
-                      controller: controller,
-                      loading: _loadingMore,
-                      topics: _topics,
-                      hasMore: props.pagination.hasNext,
-                      onLoadMore: _loadMore,
-                    ),
-                  ),
+                  builder: (_, ScrollController controller) =>
+                      AppRefreshIndicator(
+                        onRefresh: () => _load(silent: true),
+                        child: GfTopicList(
+                          controller: controller,
+                          loading: _loadingMore,
+                          topics: _topics,
+                          hasMore: props.pagination.hasNext,
+                          onLoadMore: _loadMore,
+                        ),
+                      ),
                 ),
               ),
             ],

--- a/apps/mobile/packages/forum_app/lib/src/pages/content/content_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/content/content_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../providers.dart';
 import '../../server_messages.dart';
@@ -289,7 +290,7 @@ class _ContentPageState extends ConsumerState<ContentPage> {
           Expanded(
             child: _loading && _items.isEmpty
                 ? const GfLoading()
-                : RefreshIndicator(
+                : AppRefreshIndicator(
                     onRefresh: _load,
                     child: ListView.builder(
                       physics: const AlwaysScrollableScrollPhysics(),

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/catalog_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/catalog_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:core/core.dart';
 import 'package:ui_kit/ui_kit.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../providers.dart';
 import '../../server_messages.dart';
@@ -596,7 +597,7 @@ class _CourseCatalogPageState extends ConsumerState<CourseCatalogPage> {
 
   Widget _buildList(AppLocalizations l10n) {
     final CourseCopy copy = CourseCopy(l10n);
-    return RefreshIndicator(
+    return AppRefreshIndicator(
       onRefresh: _load,
       child: _courses.isEmpty
           ? ListView(

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/course_common.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/course_common.dart
@@ -1,3 +1,5 @@
+import 'package:core/core.dart';
+import '../../server_messages.dart';
 import '../../../l10n/app_localizations.dart';
 
 /// 课程域页面文案与纯格式化工具。
@@ -177,4 +179,14 @@ String formatCreditText(int creditX10) {
 String formatRating(double? ratingAvg) {
   if (ratingAvg == null || ratingAvg <= 0) return '—';
   return ratingAvg.toStringAsFixed(1);
+}
+
+/// Keep server-provided business reasons localized; never expose transport internals.
+String courseReviewError(AppLocalizations l10n, Object error) {
+  if (error is NetworkException) return l10n.courseReviewNetworkError;
+  if (error is ApiException) {
+    final reason = resolveErrorMessage(l10n, error);
+    if (reason != l10n.commonLoadFailed) return reason;
+  }
+  return l10n.courseReviewUnknownError;
 }

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/detail_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/detail_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:core/core.dart';
 import 'package:ui_kit/ui_kit.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../format.dart';
 import '../../providers.dart';
@@ -407,7 +408,7 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
     return Stack(
       children: <Widget>[
         Positioned.fill(
-          child: RefreshIndicator(
+          child: AppRefreshIndicator(
             onRefresh: () async {
               await _load();
               await _loadRelated();

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/detail_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/detail_page.dart
@@ -343,7 +343,9 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
       _toast(copy.reviewDeleted);
     } catch (e) {
       if (!mounted) return;
-      if (!_isUnauthorized(e)) _toast(copy.operationFailed, error: true);
+      if (!_isUnauthorized(e)) {
+        _toast(courseReviewError(AppLocalizations.of(context), e), error: true);
+      }
     }
   }
 
@@ -538,7 +540,10 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
         else if (_reviewsLoaded && _reviews.isEmpty)
           GfEmpty(icon: Icons.rate_review_outlined, message: l10n.reviewsEmpty)
         else if (_reviewsLoaded)
-          for (final ReviewPayload review in _reviews) ...<Widget>[
+          for (final ReviewPayload review in [
+            ..._reviews.where((review) => review.viewer.canEdit),
+            ..._reviews.where((review) => !review.viewer.canEdit),
+          ]) ...<Widget>[
             _ReviewRow(
               review: review,
               offeringLabel: _offeringLabel(detail, review.offeringId),
@@ -884,30 +889,25 @@ class _RatingSection extends StatelessWidget {
             Row(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
-                // 均分大数字。
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: <Widget>[
-                        Icon(Icons.star, size: 22, color: colors.warning),
-                        const SizedBox(width: 4),
-                        Text(
-                          formatRating(avg),
-                          style: type.title1.copyWith(
-                            color: colors.baseContent,
-                          ),
+                // One text baseline for the score and denominator.
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(
+                        text: formatRating(avg),
+                        style: type.title1.copyWith(
+                          fontWeight: FontWeight.w700,
                         ),
-                      ],
-                    ),
-                    Text(
-                      copy.ratingOutOf,
-                      style: type.meta.copyWith(
-                        color: colors.baseContent.withValues(alpha: 0.45),
                       ),
-                    ),
-                  ],
+                      TextSpan(
+                        text: ' ${copy.ratingOutOf}',
+                        style: type.small.copyWith(
+                          color: colors.baseContent.withValues(alpha: .5),
+                        ),
+                      ),
+                    ],
+                  ),
+                  key: const ValueKey('course-rating-score'),
                 ),
                 const SizedBox(width: 20),
                 // 分布条 5★ → 1★。
@@ -959,7 +959,7 @@ class _DistributionRow extends StatelessWidget {
       child: Row(
         children: <Widget>[
           SizedBox(
-            width: 28,
+            width: 16 + MediaQuery.textScalerOf(context).scale(12),
             child: Row(
               children: <Widget>[
                 Icon(
@@ -2301,7 +2301,7 @@ class _ReviewFormSheetState extends State<_ReviewFormSheet> {
       if (!mounted) return;
       setState(() => _submitting = false);
       if (e is! UnauthorizedException) {
-        _toast(copy.operationFailed, error: true);
+        _toast(courseReviewError(AppLocalizations.of(context), e), error: true);
       }
     }
   }
@@ -2438,7 +2438,7 @@ class _ReviewFormSheetState extends State<_ReviewFormSheet> {
                 const SizedBox(width: 12),
                 Expanded(
                   child: GfButton(
-                    label: editing ? copy.submitSuccess : l10n.reviewSubmit,
+                    label: editing ? l10n.commonSave : l10n.reviewSubmit,
                     loading: _submitting,
                     onPressed: _submit,
                   ),

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/detail_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/detail_page.dart
@@ -14,6 +14,8 @@ import '../../providers.dart';
 import '../../server_messages.dart';
 import '../../widgets/status_views.dart';
 import 'course_common.dart';
+import 'review_form_sheet.dart';
+import 'review_delete_dialog.dart';
 
 /// 课程详情页（web CourseDetailPage.vue 的移动端形态，路由 `/courses/:courseId`）。
 ///
@@ -27,10 +29,12 @@ class CourseDetailPage extends ConsumerStatefulWidget {
     super.key,
     required this.courseId,
     this.focusOfferingId,
+    this.focusReviewId,
   });
 
   final int courseId;
   final int? focusOfferingId;
+  final int? focusReviewId;
 
   @override
   ConsumerState<CourseDetailPage> createState() => _CourseDetailPageState();
@@ -41,6 +45,8 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
 
   final ScrollController _scrollController = ScrollController();
   final GlobalKey _reviewsSectionKey = GlobalKey();
+  final GlobalKey _targetReviewKey = GlobalKey();
+  bool _reviewRevealed = false;
 
   AsyncValue<CourseDetailPayload> _detail = const AsyncValue.loading();
   AsyncValue<CourseRelatedResult> _related = const AsyncValue.loading();
@@ -162,6 +168,9 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
         _reviewsLoading = false;
         _reviewsLoaded = true;
       });
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _revealTargetReview(),
+      );
     } catch (_) {
       if (!mounted || seq != _reviewsSeq) return;
       setState(() {
@@ -169,6 +178,40 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
         _reviewsLoaded = true;
       });
       _toast(_copy().reviewsLoadFailed, error: true);
+    }
+  }
+
+  Future<void> _revealTargetReview() async {
+    if (_reviewRevealed ||
+        widget.focusReviewId == null ||
+        !_reviews.any((review) => review.id == widget.focusReviewId)) {
+      return;
+    }
+    _reviewRevealed = true;
+    // The review section is lazy-built after the summary. Advance only until
+    // the requested row mounts, then align that row below the app bar.
+    for (var attempt = 0; mounted && attempt < 12; attempt++) {
+      final target = _targetReviewKey.currentContext;
+      if (target != null && target.mounted) {
+        await Scrollable.ensureVisible(
+          target,
+          alignment: .1,
+          duration: const Duration(milliseconds: 200),
+        );
+        return;
+      }
+      if (!_scrollController.hasClients) return;
+      final position = _scrollController.position;
+      final next = (position.pixels + position.viewportDimension * .7).clamp(
+        0.0,
+        position.maxScrollExtent,
+      );
+      if (next == position.pixels) return;
+      await _scrollController.animateTo(
+        next,
+        duration: const Duration(milliseconds: 120),
+        curve: Curves.easeOut,
+      );
     }
   }
 
@@ -266,7 +309,7 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
       context,
       height: 600,
       keyboardAware: true,
-      builder: (BuildContext ctx) => _ReviewFormSheet(
+      builder: (BuildContext ctx) => CourseReviewFormSheet(
         pageContext: context,
         repository: _repository,
         offerings: offerings,
@@ -294,7 +337,7 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
       context,
       height: 600,
       keyboardAware: true,
-      builder: (BuildContext ctx) => _ReviewFormSheet(
+      builder: (BuildContext ctx) => CourseReviewFormSheet(
         pageContext: context,
         repository: _repository,
         offerings: offerings,
@@ -313,25 +356,7 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
 
   Future<void> _confirmDeleteReview(ReviewPayload review) async {
     final CourseCopy copy = _copy();
-    final bool? confirmed = await showGfAlertDialog<bool>(
-      context,
-      builder: (BuildContext ctx) => GfAlertDialog(
-        title: Text(copy.deleteReviewTitle),
-        content: Text(copy.confirmDeleteReview),
-        actions: <Widget>[
-          GfButton(
-            label: AppLocalizations.of(context).commonCancel,
-            variant: GfButtonVariant.ghost,
-            onPressed: () => Navigator.pop(ctx, false),
-          ),
-          GfButton(
-            label: copy.delete,
-            variant: GfButtonVariant.danger,
-            onPressed: () => Navigator.pop(ctx, true),
-          ),
-        ],
-      ),
-    );
+    final bool confirmed = await confirmCourseReviewDeletion(context, review);
     if (confirmed != true || !mounted) return;
     try {
       await _repository.deleteReview(review.id);
@@ -545,6 +570,9 @@ class _CourseDetailPageState extends ConsumerState<CourseDetailPage> {
             ..._reviews.where((review) => !review.viewer.canEdit),
           ]) ...<Widget>[
             _ReviewRow(
+              key: review.id == widget.focusReviewId
+                  ? _targetReviewKey
+                  : ValueKey(review.id),
               review: review,
               offeringLabel: _offeringLabel(detail, review.offeringId),
               onHelpful: () => _toggleHelpful(review),
@@ -1497,6 +1525,7 @@ class _ProConList extends StatelessWidget {
 
 class _ReviewRow extends StatelessWidget {
   const _ReviewRow({
+    super.key,
     required this.review,
     required this.offeringLabel,
     required this.onHelpful,
@@ -2189,345 +2218,6 @@ class _LineageRow extends StatelessWidget {
                 : GfBadgeVariant.info,
           ),
         ],
-      ),
-    );
-  }
-}
-
-// ---- 写评 / 编辑表单 sheet ----
-
-class _ReviewFormSheet extends StatefulWidget {
-  const _ReviewFormSheet({
-    required this.pageContext,
-    required this.repository,
-    required this.offerings,
-    this.editing,
-    this.initialOfferingId,
-  });
-
-  final BuildContext pageContext;
-  final CourseRepository repository;
-
-  /// 开课实例（编辑模式不可换班，沿用原 offering）。
-  final List<CourseOfferingPayload> offerings;
-
-  /// null = 写新评价。
-  final ReviewPayload? editing;
-
-  final int? initialOfferingId;
-
-  @override
-  State<_ReviewFormSheet> createState() => _ReviewFormSheetState();
-}
-
-class _ReviewFormSheetState extends State<_ReviewFormSheet> {
-  final TextEditingController _contentController = TextEditingController();
-  late int? _offeringId;
-  late int _rating;
-  late bool _anonymous;
-  bool _submitting = false;
-
-  late final CourseRepository _repo = widget.repository;
-
-  @override
-  void initState() {
-    super.initState();
-    final ReviewPayload? editing = widget.editing;
-    if (editing != null) {
-      _offeringId = editing.offeringId;
-      _rating = editing.rating ?? 0;
-      _contentController.text = editing.content;
-      _anonymous = editing.author.kind == 'anonymous';
-    } else {
-      _offeringId = widget.initialOfferingId;
-      _rating = 0;
-      _anonymous = true;
-    }
-  }
-
-  @override
-  void dispose() {
-    _contentController.dispose();
-    super.dispose();
-  }
-
-  void _toast(String message, {bool error = false}) {
-    if (!mounted) return;
-    showGfToast(widget.pageContext, message, error: error);
-  }
-
-  Future<void> _submit() async {
-    final CourseCopy copy = CourseCopy(AppLocalizations.of(context));
-    if (_rating < 1) {
-      _toast(copy.ratingRequired, error: true);
-      return;
-    }
-    final String content = _contentController.text.trim();
-    if (content.isEmpty) {
-      _toast(copy.contentRequired, error: true);
-      return;
-    }
-    final int? offeringId = _offeringId;
-    if (offeringId == null) {
-      _toast(copy.operationFailed, error: true);
-      return;
-    }
-    setState(() => _submitting = true);
-    try {
-      final ReviewPayload? result;
-      final ReviewPayload? editing = widget.editing;
-      if (editing != null) {
-        result = await _repo.updateReview(
-          editing.id,
-          UpdateCourseReviewInput(
-            rating: _rating,
-            content: content,
-            isAnonymous: _anonymous,
-          ),
-        );
-      } else {
-        result = await _repo.createReview(
-          CreateCourseReviewInput(
-            offeringId: offeringId,
-            rating: _rating,
-            content: content,
-            isAnonymous: _anonymous,
-          ),
-        );
-      }
-      if (!mounted) return;
-      Navigator.pop(context, result);
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _submitting = false);
-      if (e is! UnauthorizedException) {
-        _toast(courseReviewError(AppLocalizations.of(context), e), error: true);
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final AppLocalizations l10n = AppLocalizations.of(context);
-    final CourseCopy copy = CourseCopy(l10n);
-    final GfColors colors = GfTheme.colorsOf(context);
-    final GfTypography type = GfTheme.typographyOf(context);
-    final bool editing = widget.editing != null;
-
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Text(
-              editing ? copy.editReviewTitle : copy.writeReviewTitle,
-              style: type.heading.copyWith(fontWeight: FontWeight.w700),
-            ),
-            const SizedBox(height: 10),
-            // 开课实例选择（编辑模式只读展示）。
-            Expanded(
-              child: ListView(
-                shrinkWrap: true,
-                children: <Widget>[
-                  Text(
-                    copy.selectOffering,
-                    style: type.caption.copyWith(
-                      color: colors.baseContent.withValues(alpha: 0.7),
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  for (final CourseOfferingPayload offering in widget.offerings)
-                    _offeringOption(offering, copy, colors, type),
-                  const SizedBox(height: 12),
-                  Text(
-                    copy.ratingLabel,
-                    style: type.caption.copyWith(
-                      color: colors.baseContent.withValues(alpha: 0.7),
-                    ),
-                  ),
-                  const SizedBox(height: 4),
-                  Row(
-                    children: <Widget>[
-                      for (int star = 1; star <= 5; star++)
-                        Padding(
-                          padding: const EdgeInsets.only(right: 4),
-                          child: InkWell(
-                            borderRadius: BorderRadius.circular(999),
-                            onTap: _submitting
-                                ? null
-                                : () => setState(() => _rating = star),
-                            child: Icon(
-                              star <= _rating ? Icons.star : Icons.star_border,
-                              size: 30,
-                              color: star <= _rating
-                                  ? colors.warning
-                                  : colors.baseContent.withValues(alpha: 0.25),
-                            ),
-                          ),
-                        ),
-                      if (_rating > 0) ...<Widget>[
-                        const SizedBox(width: 8),
-                        Text(
-                          '$_rating.0',
-                          style: type.small.copyWith(
-                            fontWeight: FontWeight.w600,
-                            color: colors.baseContent.withValues(alpha: 0.7),
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    copy.contentLabel,
-                    style: type.caption.copyWith(
-                      color: colors.baseContent.withValues(alpha: 0.7),
-                    ),
-                  ),
-                  const SizedBox(height: 6),
-                  GfTextarea(
-                    controller: _contentController,
-                    hintText: copy.contentPlaceholder,
-                    maxLength: 2000,
-                    enabled: !_submitting,
-                  ),
-                  const SizedBox(height: 4),
-                  Row(
-                    children: <Widget>[
-                      Icon(
-                        _anonymous
-                            ? Icons.visibility_off_outlined
-                            : Icons.visibility_outlined,
-                        size: 16,
-                        color: colors.baseContent.withValues(alpha: 0.5),
-                      ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          copy.anonymousLabel,
-                          style: type.small.copyWith(
-                            color: colors.baseContent.withValues(alpha: 0.7),
-                          ),
-                        ),
-                      ),
-                      Switch(
-                        value: _anonymous,
-                        onChanged: _submitting
-                            ? null
-                            : (bool value) =>
-                                  setState(() => _anonymous = value),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: GfButton(
-                    label: l10n.commonCancel,
-                    variant: GfButtonVariant.ghost,
-                    onPressed: _submitting
-                        ? null
-                        : () => Navigator.pop(context),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: GfButton(
-                    label: editing ? l10n.commonSave : l10n.reviewSubmit,
-                    loading: _submitting,
-                    onPressed: _submit,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _offeringOption(
-    CourseOfferingPayload offering,
-    CourseCopy copy,
-    GfColors colors,
-    GfTypography type,
-  ) {
-    final String classLabel = (offering.className?.isNotEmpty ?? false)
-        ? offering.className!
-        : (offering.classCode ?? '');
-    final String detailLine = <String>[
-      offering.campus ?? '',
-      offering.instructors?.join('、') ?? '',
-    ].where((String s) => s.isNotEmpty).join(' · ');
-    final bool selected = _offeringId == offering.id;
-    return InkWell(
-      onTap: _submitting || widget.editing != null
-          ? null
-          : () => setState(() => _offeringId = offering.id),
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 6),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        decoration: BoxDecoration(
-          color: selected ? colors.info.withValues(alpha: 0.1) : colors.base100,
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(
-            color: selected
-                ? colors.primary.withValues(alpha: 0.4)
-                : colors.line.withValues(alpha: 0.6),
-          ),
-        ),
-        child: Row(
-          children: <Widget>[
-            Icon(
-              selected
-                  ? Icons.radio_button_checked
-                  : Icons.radio_button_unchecked,
-              size: 18,
-              color: selected
-                  ? colors.primary
-                  : colors.baseContent.withValues(alpha: 0.3),
-            ),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    <String>[
-                      shortTerm(
-                        offering.termCode,
-                        locale: AppLocalizations.of(context).localeName,
-                      ),
-                      classLabel,
-                    ].join(' · '),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: type.small.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: colors.baseContent,
-                    ),
-                  ),
-                  if (detailLine.isNotEmpty) ...<Widget>[
-                    const SizedBox(height: 1),
-                    Text(
-                      detailLine,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: type.meta.copyWith(
-                        color: colors.baseContent.withValues(alpha: 0.55),
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/my_reviews_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/my_reviews_page.dart
@@ -1,0 +1,313 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:core/core.dart';
+import 'package:ui_kit/ui_kit.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../providers.dart';
+import '../../server_messages.dart';
+import '../../widgets/app_refresh_indicator.dart';
+import '../../widgets/status_views.dart';
+import 'course_common.dart';
+import 'review_form_sheet.dart';
+import 'review_delete_dialog.dart';
+
+class MyCourseReviewsPage extends ConsumerStatefulWidget {
+  const MyCourseReviewsPage({super.key});
+  @override
+  ConsumerState<MyCourseReviewsPage> createState() =>
+      _MyCourseReviewsPageState();
+}
+
+class _MyCourseReviewsPageState extends ConsumerState<MyCourseReviewsPage> {
+  List<OwnCourseReviewItem> _items = [];
+  String _cursor = '';
+  bool _loading = true;
+  bool _loadingMore = false;
+  Object? _error;
+  int _sequence = 0;
+  final _busy = <int>{};
+  CourseRepository get _repository => ref.read(courseRepositoryProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load({bool more = false}) async {
+    if (more && (_loading || _loadingMore || _cursor.isEmpty)) return;
+    final seq = more ? _sequence : ++_sequence;
+    final epoch = ref.read(offlineCacheEpochProvider);
+    setState(() {
+      if (more) {
+        _loadingMore = true;
+      } else {
+        _loading = true;
+        _error = null;
+      }
+    });
+    try {
+      final page = await _repository.ownReviews(cursor: more ? _cursor : '');
+      if (!mounted ||
+          seq != _sequence ||
+          epoch != ref.read(offlineCacheEpochProvider)) {
+        return;
+      }
+      setState(() {
+        final combined = [
+          ...(more ? _items : <OwnCourseReviewItem>[]),
+          ...page.list,
+        ];
+        _items = {
+          for (final item in combined) item.review.id: item,
+        }.values.toList();
+        _cursor = page.nextCursor;
+      });
+    } catch (error) {
+      if (!mounted ||
+          seq != _sequence ||
+          epoch != ref.read(offlineCacheEpochProvider)) {
+        return;
+      }
+      if (more) {
+        showGfToast(
+          context,
+          resolveErrorMessage(AppLocalizations.of(context), error),
+          error: true,
+        );
+      } else {
+        setState(() => _error = error);
+      }
+    } finally {
+      if (mounted && seq == _sequence) {
+        setState(() {
+          _loading = false;
+          _loadingMore = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _edit(OwnCourseReviewItem item) async {
+    final epoch = ref.read(offlineCacheEpochProvider);
+    final updated = await showGfBottomSheet<ReviewPayload>(
+      context,
+      height: 600,
+      keyboardAware: true,
+      builder: (_) => CourseReviewFormSheet(
+        pageContext: context,
+        repository: _repository,
+        offerings: const [],
+        editing: item.review,
+      ),
+    );
+    if (!mounted ||
+        updated == null ||
+        epoch != ref.read(offlineCacheEpochProvider)) {
+      return;
+    }
+    _sequence++;
+    setState(() {
+      _loading = false;
+      _loadingMore = false;
+      _items = [
+        for (final value in _items)
+          if (value.review.id == updated.id)
+            value.withReview(updated)
+          else
+            value,
+      ];
+    });
+    showGfToast(
+      context,
+      CourseCopy(AppLocalizations.of(context)).updateSuccess,
+    );
+  }
+
+  Future<void> _delete(OwnCourseReviewItem item) async {
+    final epoch = ref.read(offlineCacheEpochProvider);
+    if (!await confirmCourseReviewDeletion(context, item.review) ||
+        !mounted ||
+        epoch != ref.read(offlineCacheEpochProvider)) {
+      return;
+    }
+    setState(() => _busy.add(item.review.id));
+    try {
+      await _repository.deleteReview(item.review.id);
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) return;
+      _sequence++;
+      setState(() {
+        _loading = false;
+        _loadingMore = false;
+        _items.removeWhere((value) => value.review.id == item.review.id);
+      });
+      showGfToast(
+        context,
+        CourseCopy(AppLocalizations.of(context)).reviewDeleted,
+      );
+    } catch (error) {
+      if (mounted && epoch == ref.read(offlineCacheEpochProvider)) {
+        showGfToast(
+          context,
+          courseReviewError(AppLocalizations.of(context), error),
+          error: true,
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy.remove(item.review.id));
+    }
+  }
+
+  Future<void> _open(OwnCourseReviewItem item) async {
+    await context.push(
+      '/courses/${item.courseId}?offeringId=${item.review.offeringId}&reviewId=${item.review.id}',
+    );
+    if (mounted) await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colors = GfTheme.colorsOf(context);
+    final type = GfTheme.typographyOf(context);
+    return Scaffold(
+      appBar: GfAppBar(title: Text(l10n.myCourseReviewsTitle)),
+      body: AppRefreshIndicator(
+        onRefresh: _load,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: EdgeInsets.fromLTRB(
+            16,
+            8,
+            16,
+            24 + MediaQuery.paddingOf(context).bottom,
+          ),
+          children: [
+            if (_loading)
+              const Padding(
+                padding: EdgeInsets.all(32),
+                child: Center(child: GfLoadingIndicator()),
+              )
+            else if (_error != null)
+              GfErrorRetry(
+                message: resolveErrorMessage(l10n, _error!),
+                onRetry: _load,
+              )
+            else if (_items.isEmpty)
+              GfEmpty(
+                icon: Icons.rate_review_outlined,
+                message: l10n.myCourseReviewsEmpty,
+              )
+            else
+              for (final item in _items)
+                Container(
+                  key: ValueKey('own-review-${item.review.id}'),
+                  margin: const EdgeInsets.only(bottom: 12),
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    color: colors.base100,
+                    border: Border.all(color: colors.line),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.courseName.isEmpty
+                            ? '#${item.courseId}'
+                            : item.courseName,
+                        style: type.heading,
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        '${item.courseCode} · ${item.review.createdAt.split('T').first}',
+                        style: type.caption.copyWith(
+                          color: colors.baseContent.withValues(alpha: .55),
+                        ),
+                      ),
+                      const SizedBox(height: 10),
+                      Row(
+                        children: [
+                          GfSymbol('star', size: 16, color: colors.warning),
+                          const SizedBox(width: 6),
+                          Text(
+                            item.review.rating == null
+                                ? '—'
+                                : '${item.review.rating} / 5',
+                            style: type.small,
+                          ),
+                          if (item.review.author.kind == 'anonymous') ...[
+                            const SizedBox(width: 12),
+                            Text(
+                              CourseCopy(l10n).anonymousLabel,
+                              style: type.caption,
+                            ),
+                          ],
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        item.review.content,
+                        maxLines: 5,
+                        overflow: TextOverflow.ellipsis,
+                        style: type.body,
+                      ),
+                      if (!item.canOpenCourse)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: Text(
+                            item.hidden
+                                ? l10n.myCourseReviewHidden
+                                : l10n.myCourseReviewUnavailable,
+                            style: type.caption.copyWith(
+                              color: colors.baseContent.withValues(alpha: .55),
+                            ),
+                          ),
+                        ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 4,
+                        children: [
+                          if (item.canOpenCourse)
+                            TextButton(
+                              onPressed: () => _open(item),
+                              child: Text(l10n.myCourseReviewOpen),
+                            ),
+                          if (item.review.viewer.canEdit)
+                            TextButton(
+                              onPressed: _busy.contains(item.review.id)
+                                  ? null
+                                  : () => _edit(item),
+                              child: Text(l10n.commonEdit),
+                            ),
+                          if (item.review.viewer.canDelete)
+                            TextButton(
+                              onPressed: _busy.contains(item.review.id)
+                                  ? null
+                                  : () => _delete(item),
+                              style: TextButton.styleFrom(
+                                foregroundColor: colors.error,
+                              ),
+                              child: Text(CourseCopy(l10n).delete),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+            if (!_loading && _cursor.isNotEmpty)
+              Center(
+                child: _loadingMore
+                    ? const GfLoadingIndicator()
+                    : TextButton(
+                        onPressed: () => _load(more: true),
+                        child: Text(l10n.commonLoadMore),
+                      ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/review_delete_dialog.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/review_delete_dialog.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:core/core.dart';
+import 'package:ui_kit/ui_kit.dart';
+import '../../../l10n/app_localizations.dart';
+import 'course_common.dart';
+
+/// Shared, explicit confirmation for deleting one owned course review.
+Future<bool> confirmCourseReviewDeletion(
+  BuildContext context,
+  ReviewPayload review,
+) async {
+  final l10n = AppLocalizations.of(context);
+  final copy = CourseCopy(l10n);
+  final colors = GfTheme.colorsOf(context);
+  return await showDialog<bool>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          backgroundColor: colors.base100,
+          surfaceTintColor: Colors.transparent,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(24),
+          ),
+          insetPadding: const EdgeInsets.symmetric(
+            horizontal: 24,
+            vertical: 24,
+          ),
+          titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
+          contentPadding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
+          actionsPadding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+          title: Text(
+            copy.deleteReviewTitle,
+            style: GfTheme.typographyOf(context).heading,
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                copy.confirmDeleteReview,
+                style: GfTheme.typographyOf(context).body,
+              ),
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: colors.base200,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  review.content,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: GfTheme.typographyOf(context).small,
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            Row(
+              children: [
+                Expanded(
+                  child: GfButton(
+                    label: l10n.commonCancel,
+                    variant: GfButtonVariant.ghost,
+                    onPressed: () => Navigator.pop(dialogContext, false),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: GfButton(
+                    label: copy.delete,
+                    variant: GfButtonVariant.danger,
+                    onPressed: () => Navigator.pop(dialogContext, true),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ) ??
+      false;
+}

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/review_delete_dialog.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/review_delete_dialog.dart
@@ -25,8 +25,8 @@ Future<bool> confirmCourseReviewDeletion(
             vertical: 24,
           ),
           titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
-          contentPadding: const EdgeInsets.fromLTRB(24, 0, 24, 8),
-          actionsPadding: const EdgeInsets.fromLTRB(24, 12, 24, 24),
+          contentPadding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
+          actionsPadding: const EdgeInsets.fromLTRB(24, 12, 24, 12),
           title: Text(
             copy.deleteReviewTitle,
             style: GfTheme.typographyOf(context).heading,

--- a/apps/mobile/packages/forum_app/lib/src/pages/courses/review_form_sheet.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/courses/review_form_sheet.dart
@@ -1,0 +1,345 @@
+import 'package:flutter/material.dart';
+import 'package:core/core.dart';
+import 'package:ui_kit/ui_kit.dart';
+import '../../../l10n/app_localizations.dart';
+import 'course_common.dart';
+
+// ---- 写评 / 编辑表单 sheet ----
+
+class CourseReviewFormSheet extends StatefulWidget {
+  const CourseReviewFormSheet({
+    super.key,
+    required this.pageContext,
+    required this.repository,
+    required this.offerings,
+    this.editing,
+    this.initialOfferingId,
+  });
+
+  final BuildContext pageContext;
+  final CourseRepository repository;
+
+  /// 开课实例（编辑模式不可换班，沿用原 offering）。
+  final List<CourseOfferingPayload> offerings;
+
+  /// null = 写新评价。
+  final ReviewPayload? editing;
+
+  final int? initialOfferingId;
+
+  @override
+  State<CourseReviewFormSheet> createState() => CourseReviewFormSheetState();
+}
+
+class CourseReviewFormSheetState extends State<CourseReviewFormSheet> {
+  final TextEditingController _contentController = TextEditingController();
+  late int? _offeringId;
+  late int _rating;
+  late bool _anonymous;
+  bool _submitting = false;
+
+  late final CourseRepository _repo = widget.repository;
+
+  @override
+  void initState() {
+    super.initState();
+    final ReviewPayload? editing = widget.editing;
+    if (editing != null) {
+      _offeringId = editing.offeringId;
+      _rating = editing.rating ?? 0;
+      _contentController.text = editing.content;
+      _anonymous = editing.author.kind == 'anonymous';
+    } else {
+      _offeringId = widget.initialOfferingId;
+      _rating = 0;
+      _anonymous = true;
+    }
+  }
+
+  @override
+  void dispose() {
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  void _toast(String message, {bool error = false}) {
+    if (!mounted) return;
+    showGfToast(widget.pageContext, message, error: error);
+  }
+
+  Future<void> _submit() async {
+    final CourseCopy copy = CourseCopy(AppLocalizations.of(context));
+    if (_rating < 1) {
+      _toast(copy.ratingRequired, error: true);
+      return;
+    }
+    final String content = _contentController.text.trim();
+    if (content.isEmpty) {
+      _toast(copy.contentRequired, error: true);
+      return;
+    }
+    final int? offeringId = _offeringId;
+    if (offeringId == null) {
+      _toast(copy.operationFailed, error: true);
+      return;
+    }
+    setState(() => _submitting = true);
+    try {
+      final ReviewPayload? result;
+      final ReviewPayload? editing = widget.editing;
+      if (editing != null) {
+        result = await _repo.updateReview(
+          editing.id,
+          UpdateCourseReviewInput(
+            rating: _rating,
+            content: content,
+            isAnonymous: _anonymous,
+          ),
+        );
+      } else {
+        result = await _repo.createReview(
+          CreateCourseReviewInput(
+            offeringId: offeringId,
+            rating: _rating,
+            content: content,
+            isAnonymous: _anonymous,
+          ),
+        );
+      }
+      if (!mounted) return;
+      Navigator.pop(context, result);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      if (e is! UnauthorizedException) {
+        _toast(courseReviewError(AppLocalizations.of(context), e), error: true);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations l10n = AppLocalizations.of(context);
+    final CourseCopy copy = CourseCopy(l10n);
+    final GfColors colors = GfTheme.colorsOf(context);
+    final GfTypography type = GfTheme.typographyOf(context);
+    final bool editing = widget.editing != null;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            Text(
+              editing ? copy.editReviewTitle : copy.writeReviewTitle,
+              style: type.heading.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: 10),
+            // 开课实例选择（编辑模式只读展示）。
+            Expanded(
+              child: ListView(
+                shrinkWrap: true,
+                children: <Widget>[
+                  Text(
+                    copy.selectOffering,
+                    style: type.caption.copyWith(
+                      color: colors.baseContent.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  for (final CourseOfferingPayload offering in widget.offerings)
+                    _offeringOption(offering, copy, colors, type),
+                  const SizedBox(height: 12),
+                  Text(
+                    copy.ratingLabel,
+                    style: type.caption.copyWith(
+                      color: colors.baseContent.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: <Widget>[
+                      for (int star = 1; star <= 5; star++)
+                        Padding(
+                          padding: const EdgeInsets.only(right: 4),
+                          child: InkWell(
+                            borderRadius: BorderRadius.circular(999),
+                            onTap: _submitting
+                                ? null
+                                : () => setState(() => _rating = star),
+                            child: Icon(
+                              star <= _rating ? Icons.star : Icons.star_border,
+                              size: 30,
+                              color: star <= _rating
+                                  ? colors.warning
+                                  : colors.baseContent.withValues(alpha: 0.25),
+                            ),
+                          ),
+                        ),
+                      if (_rating > 0) ...<Widget>[
+                        const SizedBox(width: 8),
+                        Text(
+                          '$_rating.0',
+                          style: type.small.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: colors.baseContent.withValues(alpha: 0.7),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    copy.contentLabel,
+                    style: type.caption.copyWith(
+                      color: colors.baseContent.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  GfTextarea(
+                    controller: _contentController,
+                    hintText: copy.contentPlaceholder,
+                    maxLength: 2000,
+                    enabled: !_submitting,
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: <Widget>[
+                      Icon(
+                        _anonymous
+                            ? Icons.visibility_off_outlined
+                            : Icons.visibility_outlined,
+                        size: 16,
+                        color: colors.baseContent.withValues(alpha: 0.5),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          copy.anonymousLabel,
+                          style: type.small.copyWith(
+                            color: colors.baseContent.withValues(alpha: 0.7),
+                          ),
+                        ),
+                      ),
+                      Switch(
+                        value: _anonymous,
+                        onChanged: _submitting
+                            ? null
+                            : (bool value) =>
+                                  setState(() => _anonymous = value),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: GfButton(
+                    label: l10n.commonCancel,
+                    variant: GfButtonVariant.ghost,
+                    onPressed: _submitting
+                        ? null
+                        : () => Navigator.pop(context),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: GfButton(
+                    label: editing ? l10n.commonSave : l10n.reviewSubmit,
+                    loading: _submitting,
+                    onPressed: _submit,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _offeringOption(
+    CourseOfferingPayload offering,
+    CourseCopy copy,
+    GfColors colors,
+    GfTypography type,
+  ) {
+    final String classLabel = (offering.className?.isNotEmpty ?? false)
+        ? offering.className!
+        : (offering.classCode ?? '');
+    final String detailLine = <String>[
+      offering.campus ?? '',
+      offering.instructors?.join('、') ?? '',
+    ].where((String s) => s.isNotEmpty).join(' · ');
+    final bool selected = _offeringId == offering.id;
+    return InkWell(
+      onTap: _submitting || widget.editing != null
+          ? null
+          : () => setState(() => _offeringId = offering.id),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected ? colors.info.withValues(alpha: 0.1) : colors.base100,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: selected
+                ? colors.primary.withValues(alpha: 0.4)
+                : colors.line.withValues(alpha: 0.6),
+          ),
+        ),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              selected
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              size: 18,
+              color: selected
+                  ? colors.primary
+                  : colors.baseContent.withValues(alpha: 0.3),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    <String>[
+                      shortTerm(
+                        offering.termCode,
+                        locale: AppLocalizations.of(context).localeName,
+                      ),
+                      classLabel,
+                    ].join(' · '),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: type.small.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colors.baseContent,
+                    ),
+                  ),
+                  if (detailLine.isNotEmpty) ...<Widget>[
+                    const SizedBox(height: 1),
+                    Text(
+                      detailLine,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: type.meta.copyWith(
+                        color: colors.baseContent.withValues(alpha: 0.55),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile/packages/forum_app/lib/src/pages/drafts/drafts_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/drafts/drafts_page.dart
@@ -5,6 +5,7 @@ import 'package:ui_kit/ui_kit.dart';
 
 import 'package:core/core.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../format.dart';
 import '../../providers.dart';
@@ -65,7 +66,7 @@ class _DraftsPageState extends ConsumerState<DraftsPage> {
           semanticLabel: l10n.commonBackToTop,
           threshold: 360,
           builder: (BuildContext context, ScrollController controller) {
-            return RefreshIndicator(
+            return AppRefreshIndicator(
               onRefresh: () => _load(silent: true),
               child: props.drafts.isEmpty
                   ? CustomScrollView(

--- a/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -16,6 +14,7 @@ import '../../widgets/skeletons.dart';
 import '../../widgets/status_views.dart';
 import '../../widgets/topic_list.dart';
 import '../../widgets/root_surface.dart';
+import '../../widgets/announcement_banner.dart';
 
 /// 首页:公告 + 话题流(web HomePage.vue 的移动端形态)。
 class HomePage extends ConsumerStatefulWidget {
@@ -182,7 +181,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             child: GfTopicList(
               controller: controller,
               padding: EdgeInsets.only(top: top, bottom: bottom),
-              header: _AnnouncementBanner(props: props),
+              header: AnnouncementBanner(announcement: props.announcement),
               loading: _loadingMore,
               topics: _topics,
               feedMode: _feedMode,
@@ -190,124 +189,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               onLoadMore: _loadMore,
             ),
           ),
-        ),
-      ),
-    );
-  }
-}
-
-/// 公告横幅:多条公告自动轮播(PageView + Timer),单条静态展示。
-class _AnnouncementBanner extends ConsumerStatefulWidget {
-  const _AnnouncementBanner({required this.props});
-
-  final HomeProps props;
-
-  @override
-  ConsumerState<_AnnouncementBanner> createState() =>
-      _AnnouncementBannerState();
-}
-
-class _AnnouncementBannerState extends ConsumerState<_AnnouncementBanner> {
-  static const Duration _interval = Duration(seconds: 5);
-
-  final PageController _controller = PageController();
-  Timer? _timer;
-  int _current = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    final items = widget.props.announcement.items ?? const [];
-    if (items.length > 1) {
-      // 自动轮播:每 5s 切到下一条,循环。
-      _timer = Timer.periodic(_interval, (_) {
-        if (!mounted || !_controller.hasClients) return;
-        final int next = (_current + 1) % items.length;
-        _controller.animateToPage(
-          next,
-          duration: GfMotion.content,
-          curve: GfMotion.standardEase,
-        );
-        _current = next;
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _timer?.cancel();
-    _controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (!widget.props.announcement.enabled) return const SizedBox.shrink();
-    final items = widget.props.announcement.items ?? const [];
-    if (items.isEmpty) return const SizedBox.shrink();
-    final GfColors colors = GfTheme.colorsOf(context);
-
-    // 对齐 web 公告面板(gf-panel + primary/15 边框 + primary/5 渐变底)。
-    return Container(
-      width: double.infinity,
-      decoration: BoxDecoration(
-        color: colors.primary.withValues(alpha: 0.05),
-        border: Border(
-          bottom: BorderSide(color: colors.primary.withValues(alpha: 0.15)),
-        ),
-      ),
-      child: items.length == 1
-          ? _bannerText(colors, items.first.title)
-          : SizedBox(
-              height: 38,
-              child: Stack(
-                children: [
-                  PageView.builder(
-                    controller: _controller,
-                    itemCount: items.length,
-                    onPageChanged: (i) => setState(() => _current = i),
-                    itemBuilder: (context, i) =>
-                        _bannerText(colors, items[i].title),
-                  ),
-                  // 轮播指示点(web active bg-primary)。
-                  Positioned(
-                    right: 10,
-                    bottom: 5,
-                    child: Row(
-                      children: [
-                        for (int i = 0; i < items.length; i++)
-                          Container(
-                            width: i == _current ? 14 : 6,
-                            height: 4,
-                            margin: const EdgeInsets.only(left: 3),
-                            decoration: BoxDecoration(
-                              color: i == _current
-                                  ? colors.primary
-                                  : colors.baseContent.withValues(alpha: 0.3),
-                              borderRadius: BorderRadius.circular(2),
-                            ),
-                          ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-    );
-  }
-
-  Widget _bannerText(GfColors colors, String title) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 11),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          title,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: GfTheme.typographyOf(
-            context,
-          ).small.copyWith(color: colors.primary),
         ),
       ),
     );

--- a/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:core/core.dart';
 import 'package:ui_kit/ui_kit.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../providers.dart';
 import '../../navigation/tab_scroll_registry.dart';
@@ -176,7 +177,8 @@ class _HomePageState extends ConsumerState<HomePage> {
           semanticLabel: l10n.commonBackToTop,
           controller: _scrollToTopController,
           showButton: false,
-          builder: (_, controller) => RefreshIndicator(
+          builder: (_, controller) => AppRefreshIndicator(
+            edgeOffset: top,
             onRefresh: () => _load(silent: true),
             child: GfTopicList(
               controller: controller,

--- a/apps/mobile/packages/forum_app/lib/src/pages/info/site_info_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/info/site_info_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../asset_url.dart';
 import '../../providers.dart';
@@ -150,7 +151,7 @@ class _SiteInfoPageState extends ConsumerState<SiteInfoPage> {
         loading: () => const GfLoading(),
         error: (_, _) =>
             GfErrorRetry(message: l10n.commonLoadFailed, onRetry: _load),
-        data: (content) => RefreshIndicator(
+        data: (content) => AppRefreshIndicator(
           onRefresh: _load,
           child: ListView(
             physics: const AlwaysScrollableScrollPhysics(),

--- a/apps/mobile/packages/forum_app/lib/src/pages/notifications/notifications_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/notifications/notifications_page.dart
@@ -5,6 +5,7 @@ import 'package:ui_kit/ui_kit.dart';
 
 import 'package:core/core.dart';
 import 'notification_text.dart';
+import '../../widgets/app_refresh_indicator.dart';
 import '../../server_messages.dart';
 
 import '../../../l10n/app_localizations.dart';
@@ -180,7 +181,8 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
                 threshold: 360,
                 showButton: false,
                 builder: (BuildContext context, ScrollController controller) {
-                  return RefreshIndicator(
+                  return AppRefreshIndicator(
+                    edgeOffset: top,
                     onRefresh: () => _load(silent: true),
                     child: _items.isEmpty
                         ? CustomScrollView(

--- a/apps/mobile/packages/forum_app/lib/src/pages/profile/profile_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/profile/profile_page.dart
@@ -278,6 +278,10 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
                       child: Text(l10n.draftsTitle),
                     ),
                     PopupMenuItem(
+                      value: '/my-course-reviews',
+                      child: Text(l10n.myCourseReviewsTitle),
+                    ),
+                    PopupMenuItem(
                       value: '/my-content',
                       child: Text(l10n.profileContent),
                     ),
@@ -354,6 +358,18 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
                     SliverToBoxAdapter(
                       child: _profileCard(_headerProps ?? props),
                     ),
+                    if (props.isOwnProfile)
+                      SliverToBoxAdapter(
+                        child: ListTile(
+                          leading: GfSymbol(
+                            'star',
+                            color: GfTheme.colorsOf(context).primary,
+                          ),
+                          title: Text(l10n.myCourseReviewsTitle),
+                          trailing: const Icon(Icons.chevron_right),
+                          onTap: () => context.push('/my-course-reviews'),
+                        ),
+                      ),
                     const SliverToBoxAdapter(child: GfDivider()),
                     if (tabs.isNotEmpty)
                       SliverLayoutBuilder(

--- a/apps/mobile/packages/forum_app/lib/src/pages/profile/profile_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/profile/profile_page.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:core/core.dart';
 import 'package:ui_kit/ui_kit.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../asset_url.dart';
 import '../../current_user.dart';
@@ -344,7 +345,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
             controller: _isShellProfile ? _scrollToTopController : null,
             threshold: 360,
             builder: (BuildContext context, ScrollController controller) {
-              return RefreshIndicator(
+              return AppRefreshIndicator(
                 onRefresh: () => _load(silent: true),
                 child: CustomScrollView(
                   controller: controller,

--- a/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
@@ -588,6 +588,21 @@ class _PublishPageState extends ConsumerState<PublishPage> {
           ],
         ),
         body: AbsorbPointer(absorbing: _submitting, child: _buildBody(l10n)),
+        bottomNavigationBar:
+            _mode == _ComposeMode.edit && !_loading && _loadError.isEmpty
+            ? Padding(
+                padding: EdgeInsets.only(
+                  bottom: MediaQuery.viewInsetsOf(context).bottom,
+                ),
+                child: SafeArea(
+                  top: false,
+                  child: AbsorbPointer(
+                    absorbing: _submitting,
+                    child: _buildWritingToolbar(l10n),
+                  ),
+                ),
+              )
+            : null,
       ),
     );
   }
@@ -627,7 +642,7 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                     ],
                     if (_mode == _ComposeMode.edit || wide) ...[
                       _buildTopicFields(l10n),
-                      const SizedBox(height: 16),
+                      const SizedBox(height: 4),
                     ],
                     if (wide) ...[
                       _buildBodyHeader(l10n),
@@ -690,7 +705,7 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                       ),
                     if (_error.isNotEmpty || _message.isNotEmpty)
                       const SizedBox(height: 12),
-                    _buildFooter(l10n),
+                    if (_mode == _ComposeMode.preview) _buildFooter(l10n),
                   ],
                 ),
               ),
@@ -717,6 +732,10 @@ class _PublishPageState extends ConsumerState<PublishPage> {
             maxLength: 100,
             decoration: InputDecoration(
               hintText: l10n.publishTitleHint,
+              hintStyle: TextStyle(
+                color: colors.iconMuted.withValues(alpha: 0.75),
+                fontWeight: FontWeight.w500,
+              ),
               border: InputBorder.none,
               enabledBorder: InputBorder.none,
               focusedBorder: InputBorder.none,
@@ -795,10 +814,6 @@ class _PublishPageState extends ConsumerState<PublishPage> {
   );
 
   Widget _buildEditor(AppLocalizations l10n) {
-    final GfColors colors = GfTheme.colorsOf(context);
-    final GfRadii radii = GfTheme.radiiOf(context);
-    final GfBorders borders = GfTheme.bordersOf(context);
-
     if (_contentType != 3) {
       return TextField(
         key: const Key('publish-editor'),
@@ -816,53 +831,109 @@ class _PublishPageState extends ConsumerState<PublishPage> {
           filled: false,
           contentPadding: const EdgeInsets.symmetric(vertical: 8),
         ),
-        minLines: 10,
+        minLines: 6,
         maxLines: 80,
         onChanged: (_) {
           _handleEditorChanged();
         },
       );
     }
-    return Container(
+    final type = GfTheme.typographyOf(context);
+    final defaults = DefaultStyles.getInstance(context);
+    return ConstrainedBox(
       key: const Key('publish-editor'),
+      constraints: const BoxConstraints(minHeight: 220),
+      child: QuillEditor.basic(
+        controller: _quill,
+        config: QuillEditorConfig(
+          scrollable: false,
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          placeholder: l10n.publishBodyPlaceholder,
+          customStyles: DefaultStyles(
+            paragraph: defaults.paragraph!.copyWith(
+              style: type.body,
+              verticalSpacing: const VerticalSpacing(4, 4),
+            ),
+            placeHolder: defaults.placeHolder!.copyWith(
+              style: type.body.copyWith(
+                color: GfTheme.colorsOf(context).iconMuted,
+              ),
+            ),
+          ),
+          embedBuilders: [_ComposerImageBuilder()],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWritingToolbar(AppLocalizations l10n) {
+    final colors = GfTheme.colorsOf(context);
+    return DecoratedBox(
+      key: const Key('publish-writing-tools'),
       decoration: BoxDecoration(
         color: colors.base100,
-        border: Border.all(color: colors.line, width: borders.width),
-        borderRadius: BorderRadius.circular(radii.box),
+        border: Border(top: BorderSide(color: colors.line)),
       ),
-      clipBehavior: Clip.antiAlias,
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Row(
-            children: [
-              _toolButton(
-                icon: Icons.text_fields,
-                tooltip: l10n.publishFormatting,
-                onPressed: () => setState(() => _formatting = !_formatting),
-              ),
-              Text(l10n.publishFormatting),
-              const Spacer(),
-              _toolButton(
-                icon: Icons.image_outlined,
-                tooltip: l10n.publishToolImage,
-                onPressed: _uploading ? null : _pickAndInsertImage,
-              ),
-            ],
-          ),
-          if (_formatting) _buildToolbar(l10n),
-          const GfDivider(),
-          ConstrainedBox(
-            constraints: const BoxConstraints(minHeight: 340),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: QuillEditor.basic(
-                controller: _quill,
-                config: QuillEditorConfig(
-                  placeholder: l10n.publishBodyPlaceholder,
-                  embedBuilders: [_ComposerImageBuilder()],
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (_contentType == 3 && _formatting) _buildToolbar(l10n),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+            child: Row(
+              children: [
+                if (_contentType == 3)
+                  Flexible(
+                    child: TextButton.icon(
+                      onPressed: () =>
+                          setState(() => _formatting = !_formatting),
+                      icon: Icon(
+                        _formatting
+                            ? Icons.keyboard_arrow_down_rounded
+                            : Icons.text_fields_rounded,
+                        size: 20,
+                      ),
+                      label: Text(
+                        l10n.publishFormatting,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      style: TextButton.styleFrom(
+                        foregroundColor: _formatting
+                            ? colors.primary
+                            : colors.iconMuted,
+                        backgroundColor: _formatting
+                            ? colors.primary.withValues(alpha: 0.08)
+                            : colors.base200,
+                        minimumSize: const Size(44, 44),
+                      ),
+                    ),
+                  ),
+                _toolButton(
+                  icon: _uploading
+                      ? Icons.hourglass_top_rounded
+                      : Icons.image_outlined,
+                  tooltip: l10n.publishToolImage,
+                  onPressed:
+                      _uploading || (_contentType != 3 && _images.length >= 9)
+                      ? null
+                      : _pickAndInsertImage,
                 ),
-              ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: GfButton(
+                      key: const Key('publish-save-draft'),
+                      label: l10n.publishSaveDraft,
+                      variant: GfButtonVariant.ghost,
+                      loading: _submitting,
+                      onPressed: _uploading
+                          ? null
+                          : () => _submit(topicStatus: 0),
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ],
@@ -982,13 +1053,6 @@ class _PublishPageState extends ConsumerState<PublishPage> {
               tooltip: l10n.publishToolOrderedList,
               onPressed: () => _toggleFormat(Attribute.ol),
             ),
-            _toolButton(
-              icon: _uploading
-                  ? Icons.hourglass_top_rounded
-                  : Icons.image_outlined,
-              tooltip: l10n.publishToolImage,
-              onPressed: _uploading ? null : _pickAndInsertImage,
-            ),
           ],
         ),
       ),
@@ -1076,6 +1140,49 @@ class _PublishPageState extends ConsumerState<PublishPage> {
   }
 
   Widget _buildGallery(AppLocalizations l10n, {required bool editing}) {
+    if (editing && _images.isEmpty) {
+      final colors = GfTheme.colorsOf(context);
+      final type = GfTheme.typographyOf(context);
+      return Material(
+        color: colors.base200,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          onTap: _uploading ? null : _pickAndInsertImage,
+          borderRadius: BorderRadius.circular(16),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              children: [
+                _uploading
+                    ? const SizedBox.square(
+                        dimension: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(
+                        Icons.add_photo_alternate_outlined,
+                        size: 28,
+                        color: colors.primary,
+                      ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(l10n.publishGallery, style: type.bodyStrong),
+                      const SizedBox(height: 4),
+                      Text(
+                        l10n.publishGalleryHint,
+                        style: type.caption.copyWith(color: colors.iconMuted),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
@@ -155,6 +155,7 @@ class _PublishPageState extends ConsumerState<PublishPage> {
 
   void _selectMode(_ComposeMode mode) {
     if (mode == _mode) return;
+    FocusManager.instance.primaryFocus?.unfocus();
     _previewDebounce?.cancel();
     _previewDebounce = null;
     final String preview = mode == _ComposeMode.preview
@@ -563,6 +564,13 @@ class _PublishPageState extends ConsumerState<PublishPage> {
             ),
           ),
           actions: <Widget>[
+            if (MediaQuery.viewInsetsOf(context).bottom > 0)
+              GfIconButton(
+                icon: Icons.keyboard_hide_rounded,
+                tooltip: l10n.commonHideKeyboard,
+                size: 44,
+                onPressed: () => FocusManager.instance.primaryFocus?.unfocus(),
+              ),
             GfButton(
               key: const Key('publish-appbar-submit'),
               label: _mode == _ComposeMode.edit
@@ -599,6 +607,7 @@ class _PublishPageState extends ConsumerState<PublishPage> {
         );
 
         return SingleChildScrollView(
+          keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           padding: pagePadding.copyWith(
             bottom: pagePadding.bottom + MediaQuery.paddingOf(context).bottom,
           ),
@@ -798,7 +807,7 @@ class _PublishPageState extends ConsumerState<PublishPage> {
         textInputAction: TextInputAction.newline,
         style: GfTheme.typographyOf(
           context,
-        ).body.copyWith(fontSize: 16, height: 1.7),
+        ).body.copyWith(fontSize: 17, height: 1.45),
         decoration: InputDecoration(
           hintText: l10n.publishBodyPlaceholder,
           border: InputBorder.none,
@@ -1059,7 +1068,7 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                 else
                   SelectableText(
                     _simple.text,
-                    style: type.body.copyWith(fontSize: 16, height: 1.7),
+                    style: type.body.copyWith(fontSize: 17, height: 1.45),
                   ),
               ],
             ),

--- a/apps/mobile/packages/forum_app/lib/src/pages/search/search_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/search/search_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
 
 import 'package:core/core.dart';
+import '../../widgets/app_refresh_indicator.dart';
 import '../../asset_url.dart';
 import '../../server_messages.dart';
 
@@ -367,7 +368,7 @@ class _SearchResults extends StatelessWidget {
         props.categories.isNotEmpty;
     final bool hasResults = showUsers || showTopics || showCategories;
 
-    return RefreshIndicator(
+    return AppRefreshIndicator(
       onRefresh: onRefresh,
       child: ListView(
         controller: controller,

--- a/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/settings/settings_page.dart
@@ -9,6 +9,7 @@ import 'package:ui_kit/ui_kit.dart';
 
 import 'package:core/core.dart';
 
+import '../../widgets/app_refresh_indicator.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../providers.dart';
 import '../../format.dart';
@@ -869,7 +870,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     return GfScrollToTop(
       semanticLabel: l10n.commonBackToTop,
       key: ValueKey<_SettingsTab>(_tab),
-      builder: (_, ScrollController controller) => RefreshIndicator(
+      builder: (_, ScrollController controller) => AppRefreshIndicator(
         onRefresh: _refresh,
         child: switch (_tab) {
           _SettingsTab.profile => _buildProfileTab(l10n, controller),

--- a/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
@@ -729,6 +729,8 @@ class _TopicPageState extends ConsumerState<TopicPage> {
                     return RefreshIndicator(
                       onRefresh: () => _load(silent: true),
                       child: CustomScrollView(
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
                         controller: scrollController,
                         physics: const AlwaysScrollableScrollPhysics(),
                         slivers: <Widget>[
@@ -839,6 +841,7 @@ class _TopicPageState extends ConsumerState<TopicPage> {
                               valueListenable: _replyController,
                               builder: (context, value, _) {
                                 return GfPostComposer(
+                                  hideKeyboardLabel: l10n.commonHideKeyboard,
                                   controller: _replyController,
                                   focusNode: _replyFocus,
                                   targetName: _replyTargetName,
@@ -1336,7 +1339,7 @@ class _PostCard extends StatelessWidget {
     final AppLocalizations l10n = AppLocalizations.of(context);
 
     return Padding(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
@@ -1349,7 +1352,7 @@ class _PostCard extends StatelessWidget {
                 borderRadius: BorderRadius.circular(24),
                 child: GfAvatar(
                   src: resolveApiAssetUrl(post.author.avatarUrl),
-                  size: 24,
+                  size: 32,
                 ),
               ),
               const SizedBox(width: 8),
@@ -1394,12 +1397,12 @@ class _PostCard extends StatelessWidget {
                 ).caption.copyWith(color: GfTheme.colorsOf(context).iconMuted),
               ),
           ],
-          const SizedBox(height: 10),
+          const SizedBox(height: 4),
           if (post.isAuthorDeleted || post.isModeratorRemoved)
             Text(l10n.topicRemoved)
           else
             GfMarkdownView(data: post.content),
-          const SizedBox(height: 10),
+          const SizedBox(height: 4),
           LayoutBuilder(
             builder: (context, constraints) {
               final timestamp = Text(

--- a/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:core/core.dart';
 import 'package:ui_kit/ui_kit.dart';
+import '../../widgets/app_refresh_indicator.dart';
 import '../../asset_url.dart';
 
 import '../../../l10n/app_localizations.dart';
@@ -726,7 +727,7 @@ class _TopicPageState extends ConsumerState<TopicPage> {
                   threshold: 360,
                   bottomInset: 84,
                   builder: (context, scrollController) {
-                    return RefreshIndicator(
+                    return AppRefreshIndicator(
                       onRefresh: () => _load(silent: true),
                       child: CustomScrollView(
                         keyboardDismissBehavior:

--- a/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/topic/topic_page.dart
@@ -842,6 +842,8 @@ class _TopicPageState extends ConsumerState<TopicPage> {
                               builder: (context, value, _) {
                                 return GfPostComposer(
                                   hideKeyboardLabel: l10n.commonHideKeyboard,
+                                  onCollapse: _closeComposer,
+                                  collapseLabel: l10n.commonCancel,
                                   controller: _replyController,
                                   focusNode: _replyFocus,
                                   targetName: _replyTargetName,
@@ -867,11 +869,9 @@ class _TopicPageState extends ConsumerState<TopicPage> {
                                   publishLabel: l10n.commonSend,
                                   hintText: l10n.topicReplyHint,
                                   onPublish: _submitReply,
-                                  toolbar: Column(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      if (_replyCaptcha != null)
-                                        Row(
+                                  toolbar: _replyCaptcha == null
+                                      ? null
+                                      : Row(
                                           children: [
                                             InkWell(
                                               onTap: _replyCaptchaLoading
@@ -910,18 +910,6 @@ class _TopicPageState extends ConsumerState<TopicPage> {
                                             ),
                                           ],
                                         ),
-                                      Align(
-                                        alignment: Alignment.centerRight,
-                                        child: GfIconButton(
-                                          icon:
-                                              Icons.keyboard_arrow_down_rounded,
-                                          tooltip: l10n.commonCancel,
-                                          size: 44,
-                                          onPressed: _closeComposer,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
                                 );
                               },
                             ),

--- a/apps/mobile/packages/forum_app/lib/src/router.dart
+++ b/apps/mobile/packages/forum_app/lib/src/router.dart
@@ -18,6 +18,7 @@ import 'pages/content/content_page.dart';
 import 'pages/category/category_page.dart';
 import 'pages/courses/catalog_page.dart';
 import 'pages/courses/detail_page.dart';
+import 'pages/courses/my_reviews_page.dart';
 import 'pages/drafts/drafts_page.dart';
 import 'pages/home/home_page.dart';
 import 'pages/info/site_info_page.dart';
@@ -341,6 +342,10 @@ final GoRouter appRouter = GoRouter(
       builder: (_, state) =>
           SettingsPage(initialSection: state.pathParameters['section']),
     ),
+    GoRoute(
+      path: '/my-course-reviews',
+      builder: (_, _) => const MyCourseReviewsPage(),
+    ),
     GoRoute(path: '/my-content', builder: (_, _) => const ContentPage()),
     GoRoute(
       path: '/recycle-bin',
@@ -382,6 +387,9 @@ final GoRouter appRouter = GoRouter(
       path: '/courses/:courseId',
       builder: (BuildContext context, GoRouterState state) => CourseDetailPage(
         courseId: int.parse(state.pathParameters['courseId']!),
+        focusReviewId: int.tryParse(
+          state.uri.queryParameters['reviewId'] ?? '',
+        ),
         focusOfferingId: int.tryParse(
           state.uri.queryParameters['offeringId'] ?? '',
         ),

--- a/apps/mobile/packages/forum_app/lib/src/widgets/announcement_banner.dart
+++ b/apps/mobile/packages/forum_app/lib/src/widgets/announcement_banner.dart
@@ -99,46 +99,60 @@ class _AnnouncementBannerState extends ConsumerState<AnnouncementBanner> {
     final type = GfTheme.typographyOf(context);
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
         color: colors.primary.withValues(alpha: 0.05),
         border: Border(
           bottom: BorderSide(color: colors.primary.withValues(alpha: 0.15)),
         ),
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+      child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (item.title.trim().isNotEmpty)
-            Text(item.title.trim(), style: type.bodyStrong),
-          if (item.title.trim().isNotEmpty && item.html.trim().isNotEmpty)
-            const SizedBox(height: 4),
-          if (item.html.trim().isNotEmpty)
-            HtmlWidget(
-              item.html,
-              baseUrl: Uri.parse(ref.read(apiClientProvider).baseUrl),
-              textStyle: type.body,
-              customStylesBuilder: (element) =>
-                  element.localName == 'p' ? {'margin': '0 0 4px'} : null,
-              onTapUrl: _open,
+          Padding(
+            padding: const EdgeInsets.only(top: 3),
+            child: ExcludeSemantics(
+              child: GfSymbol('bell', size: 18, color: colors.primary),
             ),
-          if (items.length > 1)
-            Wrap(
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                for (var i = 0; i < items.length; i++)
-                  Semantics(
-                    selected: i == _current,
-                    child: TextButton(
-                      onPressed: () {
-                        setState(() => _current = i);
-                        _restart();
-                      },
-                      child: Text('${i + 1} / ${items.length}'),
-                    ),
+                if (item.title.trim().isNotEmpty)
+                  Text(item.title.trim(), style: type.bodyStrong),
+                if (item.title.trim().isNotEmpty && item.html.trim().isNotEmpty)
+                  const SizedBox(height: 4),
+                if (item.html.trim().isNotEmpty)
+                  HtmlWidget(
+                    item.html,
+                    baseUrl: Uri.parse(ref.read(apiClientProvider).baseUrl),
+                    textStyle: type.body,
+                    customStylesBuilder: (element) =>
+                        element.localName == 'p' ? {'margin': '0 0 4px'} : null,
+                    onTapUrl: _open,
+                  ),
+                if (items.length > 1)
+                  Wrap(
+                    children: [
+                      for (var i = 0; i < items.length; i++)
+                        Semantics(
+                          selected: i == _current,
+                          child: TextButton(
+                            onPressed: () {
+                              setState(() => _current = i);
+                              _restart();
+                            },
+                            child: Text('${i + 1} / ${items.length}'),
+                          ),
+                        ),
+                    ],
                   ),
               ],
             ),
+          ),
         ],
       ),
     );

--- a/apps/mobile/packages/forum_app/lib/src/widgets/announcement_banner.dart
+++ b/apps/mobile/packages/forum_app/lib/src/widgets/announcement_banner.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:ui_kit/ui_kit.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../providers.dart';
+
+/// Published Web announcements, with natural height for HTML and large text.
+class AnnouncementBanner extends ConsumerStatefulWidget {
+  const AnnouncementBanner({super.key, required this.announcement});
+  final AnnouncementPayload announcement;
+
+  @override
+  ConsumerState<AnnouncementBanner> createState() => _AnnouncementBannerState();
+}
+
+class _AnnouncementBannerState extends ConsumerState<AnnouncementBanner> {
+  Timer? _timer;
+  int _current = 0;
+
+  List<AnnouncementItemPayload> get _items {
+    if (!widget.announcement.enabled) return const [];
+    final items =
+        (widget.announcement.items ?? const <AnnouncementItemPayload>[])
+            .where(
+              (item) =>
+                  item.title.trim().isNotEmpty || item.html.trim().isNotEmpty,
+            )
+            .toList();
+    if (items.isEmpty && widget.announcement.html.trim().isNotEmpty) {
+      items.add(
+        AnnouncementItemPayload(
+          id: 'legacy',
+          title: '',
+          html: widget.announcement.html,
+        ),
+      );
+    }
+    return items;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _restart();
+  }
+
+  void _restart() {
+    _timer?.cancel();
+    if (_items.length > 1) {
+      _timer = Timer.periodic(const Duration(seconds: 5), (_) {
+        // Respect screen readers, reduced motion and manual selection.
+        if (!mounted ||
+            MediaQuery.accessibleNavigationOf(context) ||
+            MediaQuery.disableAnimationsOf(context)) {
+          return;
+        }
+        setState(() => _current = (_current + 1) % _items.length);
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AnnouncementBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.announcement != widget.announcement) {
+      _current = 0;
+      _restart();
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<bool> _open(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null || !{'https', 'http'}.contains(uri.scheme)) return true;
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (_) {
+      // A missing system browser must not break the feed.
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final items = _items;
+    if (items.isEmpty) return const SizedBox.shrink();
+    final item = items[_current];
+    final colors = GfTheme.colorsOf(context);
+    final type = GfTheme.typographyOf(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: colors.primary.withValues(alpha: 0.05),
+        border: Border(
+          bottom: BorderSide(color: colors.primary.withValues(alpha: 0.15)),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (item.title.trim().isNotEmpty)
+            Text(item.title.trim(), style: type.bodyStrong),
+          if (item.title.trim().isNotEmpty && item.html.trim().isNotEmpty)
+            const SizedBox(height: 4),
+          if (item.html.trim().isNotEmpty)
+            HtmlWidget(
+              item.html,
+              baseUrl: Uri.parse(ref.read(apiClientProvider).baseUrl),
+              textStyle: type.body,
+              customStylesBuilder: (element) =>
+                  element.localName == 'p' ? {'margin': '0 0 4px'} : null,
+              onTapUrl: _open,
+            ),
+          if (items.length > 1)
+            Wrap(
+              children: [
+                for (var i = 0; i < items.length; i++)
+                  Semantics(
+                    selected: i == _current,
+                    child: TextButton(
+                      onPressed: () {
+                        setState(() => _current = i);
+                        _restart();
+                      },
+                      child: Text('${i + 1} / ${items.length}'),
+                    ),
+                  ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/mobile/packages/forum_app/lib/src/widgets/app_refresh_indicator.dart
+++ b/apps/mobile/packages/forum_app/lib/src/widgets/app_refresh_indicator.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Native refresh animation with a short, viewport-independent pull gesture.
+/// [edgeOffset] keeps the indicator below overlaid navigation controls.
+class AppRefreshIndicator extends StatefulWidget {
+  const AppRefreshIndicator({
+    super.key,
+    required this.child,
+    required this.onRefresh,
+    this.edgeOffset = 0,
+  });
+  final Widget child;
+  final RefreshCallback onRefresh;
+  final double edgeOffset;
+
+  @override
+  State<AppRefreshIndicator> createState() => _AppRefreshIndicatorState();
+}
+
+class _AppRefreshIndicatorState extends State<AppRefreshIndicator> {
+  static const double _pullDistance = 72;
+  final _indicator = GlobalKey<RefreshIndicatorState>();
+  bool _tracking = false;
+  bool _requested = false;
+  double _distance = 0;
+
+  void _release() {
+    final refresh = _tracking && _distance >= _pullDistance;
+    _tracking = false;
+    _distance = 0;
+    if (!refresh || _requested) return;
+    final indicator = _indicator.currentState;
+    if (indicator == null) return;
+    _requested = true;
+    // show() coalesces with an already-armed native indicator. This retains
+    // native loading/completion semantics instead of invoking the API twice.
+    unawaited(indicator.show().whenComplete(() => _requested = false));
+  }
+
+  bool _onScroll(ScrollNotification notification) {
+    if (notification.depth != 0 ||
+        notification.metrics.axisDirection != AxisDirection.down) {
+      return false;
+    }
+    if (notification is ScrollStartNotification) {
+      _tracking =
+          notification.dragDetails != null &&
+          notification.metrics.extentBefore == 0 &&
+          !_requested;
+      _distance = 0;
+    } else if (_tracking) {
+      if (notification.metrics.extentBefore > 0) {
+        _tracking = false;
+        _distance = 0;
+      } else if (notification is ScrollEndNotification) {
+        _release();
+      } else {
+        final details = switch (notification) {
+          ScrollUpdateNotification() => notification.dragDetails,
+          OverscrollNotification() => notification.dragDetails,
+          _ => null,
+        };
+        if (details != null) {
+          // Finger travel, not the rubber-band displacement: iOS damping must
+          // not require a much longer pull than Android or a shorter viewport.
+          _distance = math.max(0, _distance + details.delta.dy);
+        } else if (notification is ScrollUpdateNotification ||
+            notification is OverscrollNotification) {
+          // iOS begins its ballistic return before emitting ScrollEnd.
+          _release();
+        }
+      }
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) => RefreshIndicator(
+    key: _indicator,
+    edgeOffset: widget.edgeOffset,
+    displacement: 32,
+    onRefresh: widget.onRefresh,
+    child: NotificationListener<ScrollNotification>(
+      onNotification: _onScroll,
+      child: widget.child,
+    ),
+  );
+}

--- a/apps/mobile/packages/forum_app/lib/src/widgets/markdown_view.dart
+++ b/apps/mobile/packages/forum_app/lib/src/widgets/markdown_view.dart
@@ -95,11 +95,15 @@ class _GfMarkdownViewState extends State<GfMarkdownView> {
       data: widget.data,
       selectable: widget.selectable,
       shrinkWrap: true,
+      markdownGenerator: MarkdownGenerator(
+        linesMargin: const EdgeInsets.symmetric(vertical: 3),
+      ),
       // Embedded in the page scroll view: never repeat its safe-area insets.
       padding: EdgeInsets.zero,
       physics: const NeverScrollableScrollPhysics(),
       config: MarkdownConfig(
         configs: <WidgetConfig>[
+          PConfig(textStyle: GfTheme.typographyOf(context).body),
           // 图片:contain + 高度约束 + 圆角边框(prose.css img)。
           ImgConfig(
             builder: (String url, Map<String, String> attributes) {

--- a/apps/mobile/packages/forum_app/test/announcement_banner_test.dart
+++ b/apps/mobile/packages/forum_app/test/announcement_banner_test.dart
@@ -1,0 +1,148 @@
+import 'package:core/core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ui_kit/ui_kit.dart';
+import 'package:forum_app/src/widgets/announcement_banner.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester,
+    AnnouncementPayload announcement,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: gfThemeData(Brightness.light),
+          home: Scaffold(
+            body: Column(
+              children: [AnnouncementBanner(announcement: announcement)],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('HTML-only announcements display their body', (tester) async {
+    await pump(
+      tester,
+      const AnnouncementPayload(
+        enabled: true,
+        html: '',
+        items: [
+          AnnouncementItemPayload(
+            id: '1',
+            title: '',
+            html: '<p>欢迎来到 <strong>YourTJ</strong></p>',
+          ),
+        ],
+      ),
+    );
+    expect(find.textContaining('欢迎来到', findRichText: true), findsWidgets);
+  });
+  testWidgets('legacy HTML announcements remain readable', (tester) async {
+    await pump(
+      tester,
+      const AnnouncementPayload(enabled: true, html: '<p>选课提醒</p>'),
+    );
+    expect(find.text('选课提醒', findRichText: true), findsWidgets);
+  });
+  testWidgets('empty items do not leave a colored empty strip', (tester) async {
+    await pump(
+      tester,
+      const AnnouncementPayload(
+        enabled: true,
+        html: '',
+        items: [AnnouncementItemPayload(id: 'empty', title: '', html: '')],
+      ),
+    );
+    expect(tester.getSize(find.byType(AnnouncementBanner)).height, 0);
+  });
+  testWidgets(
+    'rotation uses refreshed items and stops for a single replacement',
+    (tester) async {
+      await pump(
+        tester,
+        const AnnouncementPayload(
+          enabled: true,
+          html: '',
+          items: [
+            AnnouncementItemPayload(
+              id: '1',
+              title: 'First',
+              html: '<p>Body one</p>',
+            ),
+            AnnouncementItemPayload(
+              id: '2',
+              title: 'Second',
+              html: '<p>Body two</p>',
+            ),
+          ],
+        ),
+      );
+      await tester.pump(const Duration(seconds: 5));
+      expect(find.text('Second'), findsOneWidget);
+      await pump(
+        tester,
+        const AnnouncementPayload(
+          enabled: true,
+          html: '',
+          items: [
+            AnnouncementItemPayload(
+              id: '3',
+              title: 'Replacement',
+              html: '<p>Updated body</p>',
+            ),
+          ],
+        ),
+      );
+      await tester.pump(const Duration(seconds: 10));
+      expect(find.text('Replacement'), findsOneWidget);
+      expect(find.text('Second'), findsNothing);
+      expect(tester.takeException(), isNull);
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+  testWidgets(
+    'large text grows the banner and disabled announcements stay hidden',
+    (tester) async {
+      const payload = AnnouncementPayload(
+        enabled: true,
+        html:
+            '<p>A complete announcement with a link: <a href="/about">About YourTJ</a></p>',
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            theme: gfThemeData(Brightness.light),
+            home: MediaQuery(
+              data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+              child: const Scaffold(
+                body: SingleChildScrollView(
+                  child: SizedBox(
+                    width: 320,
+                    child: AnnouncementBanner(announcement: payload),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(
+        tester.getSize(find.byType(AnnouncementBanner)).height,
+        greaterThan(38),
+      );
+      expect(
+        find.textContaining('About YourTJ', findRichText: true),
+        findsWidgets,
+      );
+      expect(tester.takeException(), isNull);
+      await pump(tester, payload.copyWith(enabled: false));
+      expect(tester.getSize(find.byType(AnnouncementBanner)).height, 0);
+    },
+  );
+}

--- a/apps/mobile/packages/forum_app/test/announcement_banner_test.dart
+++ b/apps/mobile/packages/forum_app/test/announcement_banner_test.dart
@@ -25,6 +25,27 @@ void main() {
     await tester.pump();
   }
 
+  testWidgets('announcement body is indented alongside a leading bell', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const AnnouncementPayload(
+        enabled: true,
+        html: '<p>Announcement body</p>',
+      ),
+    );
+    final bell = find.byWidgetPredicate(
+      (widget) => widget is GfSymbol && widget.name == 'bell',
+    );
+    expect(bell, findsOneWidget);
+    final text = find.text('Announcement body', findRichText: true).last;
+    expect(
+      tester.getTopLeft(text).dx,
+      greaterThanOrEqualTo(tester.getTopRight(bell).dx + 10),
+    );
+  });
+
   testWidgets('HTML-only announcements display their body', (tester) async {
     await pump(
       tester,

--- a/apps/mobile/packages/forum_app/test/app_refresh_indicator_test.dart
+++ b/apps/mobile/packages/forum_app/test/app_refresh_indicator_test.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forum_app/src/widgets/app_refresh_indicator.dart';
+
+void main() {
+  for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
+    for (final empty in [false, true]) {
+      testWidgets(
+        '$platform short pull refreshes tall ${empty ? "empty" : "populated"} viewport only on release',
+        (tester) async {
+          await tester.binding.setSurfaceSize(const Size(390, 900));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+          var calls = 0;
+          final done = Completer<void>();
+          await tester.pumpWidget(
+            MaterialApp(
+              theme: ThemeData(platform: platform),
+              home: Scaffold(
+                body: AppRefreshIndicator(
+                  edgeOffset: 100,
+                  onRefresh: () {
+                    calls++;
+                    return done.future;
+                  },
+                  child: ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: [SizedBox(height: empty ? 100 : 1800)],
+                  ),
+                ),
+              ),
+            ),
+          );
+          final gesture = await tester.startGesture(const Offset(180, 250));
+          await gesture.moveBy(const Offset(0, 20));
+          await tester.pump();
+          await gesture.moveBy(const Offset(0, 85));
+          await tester.pump();
+          expect(calls, 0);
+          await gesture.up();
+          for (var frame = 0; frame < 45; frame++) {
+            await tester.pump(const Duration(milliseconds: 16));
+          }
+          expect(calls, 1);
+          expect(
+            tester.getTopLeft(find.byType(RefreshProgressIndicator)).dy,
+            greaterThanOrEqualTo(100),
+          );
+          await tester.drag(find.byType(ListView), const Offset(0, 220));
+          await tester.pump(const Duration(milliseconds: 300));
+          expect(calls, 1);
+          done.complete();
+          await tester.pumpAndSettle();
+        },
+      );
+    }
+    for (final scenario in ['small pull', 'retracted pull', 'middle of list']) {
+      testWidgets('$platform ignores $scenario', (tester) async {
+        final controller = ScrollController(
+          initialScrollOffset: scenario == 'middle of list' ? 400 : 0,
+        );
+        addTearDown(controller.dispose);
+        var calls = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(platform: platform),
+            home: Scaffold(
+              body: AppRefreshIndicator(
+                onRefresh: () async {
+                  calls++;
+                },
+                child: ListView(
+                  controller: controller,
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  children: const [SizedBox(height: 1800)],
+                ),
+              ),
+            ),
+          ),
+        );
+        final gesture = await tester.startGesture(const Offset(180, 250));
+        await gesture.moveBy(const Offset(0, 20));
+        await tester.pump();
+        await gesture.moveBy(Offset(0, scenario == 'small pull' ? 20 : 85));
+        await tester.pump();
+        if (scenario == 'retracted pull') {
+          await gesture.moveBy(const Offset(0, -80));
+          await tester.pump();
+        }
+        await gesture.up();
+        await tester.pumpAndSettle();
+        expect(calls, 0);
+      });
+    }
+  }
+}

--- a/apps/mobile/packages/forum_app/test/courses_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/courses_page_test.dart
@@ -7,6 +7,8 @@ import 'package:core/core.dart';
 import 'package:forum_app/l10n/app_localizations.dart';
 import 'package:forum_app/src/pages/courses/catalog_page.dart';
 import 'package:forum_app/src/pages/courses/detail_page.dart';
+import 'package:forum_app/src/pages/courses/course_common.dart';
+import 'package:forum_app/l10n/app_localizations_zh.dart';
 import 'package:forum_app/src/providers.dart';
 
 import 'fixtures/page_fixtures.dart';
@@ -72,6 +74,7 @@ class FakeCourseRepository extends CourseRepository {
   final Map<int, (List<CourseSummaryPayload>, bool)> listPages;
   final String summaryStatus;
   bool failBookmark;
+  Object? createError;
 
   final List<CourseRepoCall> listCalls = <CourseRepoCall>[];
   final List<CourseRepoCall> reviewCalls = <CourseRepoCall>[];
@@ -173,6 +176,7 @@ class FakeCourseRepository extends CourseRepository {
   @override
   Future<ReviewPayload> createReview(CreateCourseReviewInput input) async {
     createInputs.add(input);
+    if (createError != null) throw createError!;
     return ReviewPayload(
       id: 99,
       offeringId: input.offeringId,
@@ -641,6 +645,89 @@ void main() {
       await tester.pump(const Duration(seconds: 5));
     });
 
+    testWidgets('rating stays on one line at phone width', (tester) async {
+      final course = FakeCourseRepository(
+        _client(),
+        detailPayload: _detailPayload().copyWith(ratingAvg: 4.9),
+      );
+      await pumpDetail(tester, course);
+      tester.view.physicalSize = const Size(390, 1200);
+      await tester.pumpAndSettle();
+      final score = find.byKey(const ValueKey('course-rating-score'));
+      expect(score, findsOneWidget);
+      expect(tester.widget<Text>(score).textSpan!.toPlainText(), '4.9 / 5.0');
+      expect(tester.getSize(score).height, lessThan(60));
+      expect(tester.takeException(), isNull);
+    });
+
+    test('review transport failures have an actionable localized reason', () {
+      expect(
+        courseReviewError(
+          AppLocalizationsZh(),
+          const NetworkException(fallbackMessage: 'SocketException'),
+        ),
+        contains('检查网络'),
+      );
+      expect(
+        courseReviewError(
+          AppLocalizationsZh(),
+          const ApiException(fallbackMessage: 'internal'),
+        ),
+        contains('没有提供具体原因'),
+      );
+    });
+
+    testWidgets('own anonymous review precedes other reviews', (tester) async {
+      final reviews = _reviewPayloads();
+      reviews[2] = reviews[2].copyWith(
+        author: const ReviewAuthorPayload(kind: 'anonymous', label: '匿名同学'),
+      );
+      final course = FakeCourseRepository(
+        _client(),
+        detailPayload: _detailPayload(),
+        reviewPayloads: reviews,
+      );
+      await pumpDetail(tester, course);
+      await tester.scrollUntilVisible(
+        find.text('很不错'),
+        180,
+        scrollable: find.byType(Scrollable).first,
+      );
+      expect(
+        tester.getTopLeft(find.text('很不错')).dy,
+        lessThan(tester.getTopLeft(find.text('好课')).dy),
+      );
+    });
+
+    testWidgets('review failure explains server reason above the open sheet', (
+      tester,
+    ) async {
+      final course =
+          FakeCourseRepository(_client(), detailPayload: _detailPayload())
+            ..createError = const ApiException(
+              messageCode: 'review.duplicate',
+              fallbackMessage: 'Duplicate',
+            );
+      await pumpDetail(tester, course);
+      await tester.tap(find.text('写课评'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find
+            .descendant(
+              of: find.byType(BottomSheet),
+              matching: find.byIcon(Icons.star_border),
+            )
+            .last,
+      );
+      await tester.enterText(find.byType(TextField).last, '保留这段评价');
+      await tester.tap(find.text('发布评价'));
+      await tester.pumpAndSettle();
+      expect(find.text('你已评价过该开课实例。'), findsOneWidget);
+      expect(tester.getTopLeft(find.text('你已评价过该开课实例。')).dy, lessThan(160));
+      expect(find.text('保留这段评价'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 8));
+    });
+
     testWidgets('写课评成功前置插入列表', (tester) async {
       final FakeCourseRepository course = FakeCourseRepository(
         _client(),
@@ -681,7 +768,7 @@ void main() {
       );
       await pumpDetail(tester, course);
 
-      // 首行（id=1，helpfulCount=0）点「有用」→ 计数 1 且调用 on=true。
+      // 本人评价现在为首行（id=4，helpfulCount=2）。
       final Finder firstHelpfulChip = find.ancestor(
         of: find.text('有用').first,
         matching: find.byType(InkWell),
@@ -689,9 +776,9 @@ void main() {
       await tester.tap(find.text('有用').first);
       await tester.pumpAndSettle();
 
-      expect(course.helpfulCalls, <(int, bool)>[(1, true)]);
+      expect(course.helpfulCalls, <(int, bool)>[(4, true)]);
       expect(
-        find.descendant(of: firstHelpfulChip, matching: find.text('1')),
+        find.descendant(of: firstHelpfulChip, matching: find.text('3')),
         findsOneWidget,
       );
     });

--- a/apps/mobile/packages/forum_app/test/courses_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/courses_page_test.dart
@@ -550,6 +550,18 @@ void main() {
       final list = find.byType(ListView).first;
       await tester.drag(list, const Offset(0, -6000));
       await tester.pumpAndSettle();
+      // Lazy rows revise the scroll extent after layout, especially at larger
+      // font sizes. Settle at the real end before checking dock clearance.
+      final position = tester.widget<ListView>(list).controller!.position;
+      for (
+        var attempt = 0;
+        attempt < 4 && position.extentAfter > 0;
+        attempt++
+      ) {
+        position.jumpTo(position.maxScrollExtent);
+        await tester.pumpAndSettle();
+      }
+      expect(position.extentAfter, 0);
       final lastRow = find.text('等价');
       final dock = find
           .ancestor(of: find.text('写课评'), matching: find.byType(ColoredBox))

--- a/apps/mobile/packages/forum_app/test/courses_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/courses_page_test.dart
@@ -515,9 +515,11 @@ void main() {
       WidgetTester tester,
       FakeCourseRepository course, {
       int? focusOfferingId,
+      int? focusReviewId,
+      Size size = const Size(800, 3000),
     }) async {
       // 加高画布让整页一次构建，避免 ListView 懒加载影响断言。
-      tester.view.physicalSize = const Size(800, 3000);
+      tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
@@ -525,7 +527,11 @@ void main() {
       await tester.pumpWidget(
         _app(
           container,
-          CourseDetailPage(courseId: 42, focusOfferingId: focusOfferingId),
+          CourseDetailPage(
+            courseId: 42,
+            focusOfferingId: focusOfferingId,
+            focusReviewId: focusReviewId,
+          ),
         ),
       );
       await tester.pumpAndSettle();
@@ -675,6 +681,26 @@ void main() {
         ),
         contains('没有提供具体原因'),
       );
+    });
+
+    testWidgets('management deep link reveals the review at phone height', (
+      tester,
+    ) async {
+      final course = FakeCourseRepository(
+        _client(),
+        detailPayload: _detailPayload(),
+        reviewPayloads: [_reviewPayloads().last],
+      );
+      await pumpDetail(
+        tester,
+        course,
+        focusOfferingId: 902,
+        focusReviewId: 4,
+        size: const Size(390, 844),
+      );
+      expect(course.reviewCalls.first.offeringId, 902);
+      expect(find.text('很不错').hitTestable(), findsOneWidget);
+      expect(tester.takeException(), isNull);
     });
 
     testWidgets('own anonymous review precedes other reviews', (tester) async {

--- a/apps/mobile/packages/forum_app/test/markdown_view_test.dart
+++ b/apps/mobile/packages/forum_app/test/markdown_view_test.dart
@@ -6,6 +6,30 @@ import 'package:ui_kit/ui_kit.dart';
 import 'package:forum_app/src/widgets/markdown_view.dart';
 
 void main() {
+  testWidgets('short replies have compact block spacing and readable text', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: gfThemeData(Brightness.light),
+        home: const Scaffold(
+          body: Column(
+            children: [
+              GfMarkdownView(data: 'First paragraph\n\nSecond paragraph'),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(find.byType(GfMarkdownView)).height,
+      lessThanOrEqualTo(64),
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
+
   testWidgets('embedded markdown does not repeat device safe-area spacing', (
     tester,
   ) async {

--- a/apps/mobile/packages/forum_app/test/my_course_reviews_test.dart
+++ b/apps/mobile/packages/forum_app/test/my_course_reviews_test.dart
@@ -1,0 +1,201 @@
+import 'package:core/core.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:forum_app/l10n/app_localizations.dart';
+import 'package:forum_app/src/pages/courses/my_reviews_page.dart';
+import 'package:forum_app/src/providers.dart';
+
+class _Tokens implements TokenStorage {
+  @override
+  Future<String?> read() async => 'session';
+  @override
+  Future<void> write(String value) async {}
+  @override
+  Future<void> clear() async {}
+}
+
+ReviewPayload _review(int id, String content, {bool hidden = false}) =>
+    ReviewPayload(
+      id: id,
+      offeringId: id + 900,
+      rating: 5,
+      content: content,
+      contentHtml: '',
+      author: const ReviewAuthorPayload(kind: 'anonymous', label: '匿名同学'),
+      viewer: ReviewViewerPayload(
+        canEdit: !hidden,
+        canDelete: true,
+        isHelpful: false,
+      ),
+      helpfulCount: 0,
+      createdAt: '2026-09-01T00:00:00Z',
+      updatedAt: '2026-09-01T00:00:00Z',
+    );
+OwnCourseReviewItem _item(int id, String content, {bool hidden = false}) =>
+    OwnCourseReviewItem(
+      review: _review(id, content, hidden: hidden),
+      courseId: 42 + id,
+      courseName: '课程 $id',
+      courseCode: 'CODE$id',
+      hidden: hidden,
+      canOpenCourse: !hidden,
+    );
+
+class _Repository extends CourseRepository {
+  _Repository()
+    : super(
+        GfApiClient(
+          dio: Dio(),
+          tokenStorage: _Tokens(),
+          baseUrl: 'http://fake.local',
+        ),
+      );
+  final deletes = <int>[];
+  final cursors = <String>[];
+  bool failDelete = false;
+  bool showHidden = false;
+  @override
+  Future<OwnCourseReviewPage> ownReviews({
+    String cursor = '',
+    int pageSize = 20,
+  }) async {
+    cursors.add(cursor);
+    return OwnCourseReviewPage(
+      list: [
+        cursor.isEmpty
+            ? _item(2, '第一条匿名评价', hidden: showHidden)
+            : _item(1, '更早的评价'),
+      ],
+      nextCursor: cursor.isEmpty ? '2' : '',
+    );
+  }
+
+  @override
+  Future<ReviewPayload> updateReview(
+    int id,
+    UpdateCourseReviewInput input,
+  ) async => _review(id, input.content!);
+  @override
+  Future<bool> deleteReview(int id) async {
+    deletes.add(id);
+    if (failDelete) throw const NetworkException(fallbackMessage: 'offline');
+    return true;
+  }
+}
+
+Future<void> _pump(WidgetTester tester, _Repository repo) async {
+  final router = GoRouter(
+    routes: [
+      GoRoute(path: '/', builder: (_, _) => const MyCourseReviewsPage()),
+      GoRoute(
+        path: '/courses/:id',
+        builder: (_, state) => Scaffold(body: Text(state.uri.toString())),
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [courseRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        locale: const Locale('zh'),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets(
+    'lists own reviews across courses and opens the exact offering/review',
+    (tester) async {
+      final repo = _Repository();
+      await _pump(tester, repo);
+      expect(find.text('第一条匿名评价'), findsOneWidget);
+      await tester.tap(find.text('加载更多'));
+      await tester.pumpAndSettle();
+      expect(repo.cursors, ['', '2']);
+      expect(find.text('更早的评价'), findsOneWidget);
+      await tester.tap(find.text('查看详情').first);
+      await tester.pumpAndSettle();
+      expect(
+        find.text('/courses/44?offeringId=902&reviewId=2'),
+        findsOneWidget,
+      );
+    },
+  );
+  testWidgets('editing reuses the form and updates the management card', (
+    tester,
+  ) async {
+    final repo = _Repository();
+    await _pump(tester, repo);
+    await tester.tap(find.text('编辑'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).last, '修改后的评价');
+    await tester.tap(find.text('保存'));
+    await tester.pumpAndSettle();
+    expect(find.text('修改后的评价'), findsOneWidget);
+    await tester.pump(const Duration(seconds: 8));
+  });
+  testWidgets(
+    'delete previews the target; cancel does not delete; failure keeps it',
+    (tester) async {
+      final repo = _Repository();
+      await _pump(tester, repo);
+      await tester.tap(find.text('删除'));
+      await tester.pumpAndSettle();
+      expect(find.byType(AlertDialog), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('第一条匿名评价'),
+        ),
+        findsOneWidget,
+      );
+      await tester.tap(find.text('取消'));
+      await tester.pumpAndSettle();
+      expect(repo.deletes, isEmpty);
+      repo.failDelete = true;
+      await tester.tap(find.text('删除'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('删除'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('网络连接失败'), findsOneWidget);
+      expect(find.text('第一条匿名评价'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 8));
+      repo.failDelete = false;
+      await tester.tap(find.text('删除'));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.text('删除'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('第一条匿名评价'), findsNothing);
+      await tester.pump(const Duration(seconds: 8));
+    },
+  );
+  testWidgets(
+    'hidden reviews remain deletable without an edit or public link',
+    (tester) async {
+      await _pump(tester, _Repository()..showHidden = true);
+      expect(find.text('编辑'), findsNothing);
+      expect(find.text('查看详情'), findsNothing);
+      expect(find.text('删除'), findsOneWidget);
+      expect(find.textContaining('已被隐藏'), findsOneWidget);
+    },
+  );
+}

--- a/apps/mobile/packages/forum_app/test/publish_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/publish_page_test.dart
@@ -224,6 +224,7 @@ void main() {
           path: '/publish',
           builder: (BuildContext context, GoRouterState state) => PublishPage(
             topicId: publishTopicIdFromUri(state.uri),
+            initialContentType: contentType == 0 ? 3 : contentType,
             markdownConverter: markdownConverter,
           ),
         ),
@@ -262,6 +263,42 @@ void main() {
       pageRepository: pageRepository,
       topicRepository: topicRepository,
     );
+  }
+
+  for (final type in [2, 3]) {
+    testWidgets('dismiss keyboard preserves type $type draft', (tester) async {
+      await pumpPublishPage(tester, editing: false, contentType: type);
+      final editor = type == 3
+          ? find.byType(QuillEditor)
+          : find.byKey(const Key('publish-editor'));
+      await tester.ensureVisible(editor);
+      await tester.tap(editor);
+      await tester.pump();
+      final inputFocus = type == 3
+          ? tester.widget<QuillEditor>(editor).focusNode
+          : tester.widget<TextField>(editor).focusNode;
+      final rich = type == 3
+          ? tester.widget<QuillEditor>(editor).controller
+          : null;
+      final simple = type == 2
+          ? tester.widget<TextField>(editor).controller
+          : null;
+      if (rich != null) rich.replaceText(0, 0, 'Unsent article', null);
+      if (simple != null) simple.text = 'Unsent moment';
+      final draft = rich?.document.toPlainText() ?? simple!.text;
+      final editingFocus = inputFocus ?? FocusManager.instance.primaryFocus!;
+      expect(editingFocus.hasFocus, isTrue);
+      tester.view.viewInsets = const FakeViewPadding(bottom: 250);
+      addTearDown(tester.view.resetViewInsets);
+      await tester.pump();
+      expect(find.byTooltip('收起键盘'), findsOneWidget);
+      await tester.tap(find.byTooltip('收起键盘'));
+      await tester.pump();
+      expect(editingFocus.hasFocus, isFalse);
+      expect(rich?.document.toPlainText() ?? simple!.text, draft);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 600));
+    });
   }
 
   testWidgets(

--- a/apps/mobile/packages/forum_app/test/publish_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/publish_page_test.dart
@@ -265,6 +265,50 @@ void main() {
     );
   }
 
+  testWidgets(
+    'writing tools stay above keyboard and format the selected text',
+    (tester) async {
+      await pumpPublishPage(tester, editing: false, contentType: 3);
+      final editor = tester.widget<QuillEditor>(find.byType(QuillEditor));
+      editor.controller.replaceText(
+        0,
+        0,
+        'Selected words',
+        const TextSelection(baseOffset: 0, extentOffset: 8),
+      );
+      await tester.tap(find.byType(QuillEditor));
+      editor.controller.updateSelection(
+        const TextSelection(baseOffset: 0, extentOffset: 8),
+        ChangeSource.local,
+      );
+      tester.view.viewInsets = const FakeViewPadding(bottom: 250);
+      addTearDown(tester.view.resetViewInsets);
+      await tester.pumpAndSettle();
+      final tools = find.byKey(const Key('publish-writing-tools'));
+      final keyboardTop =
+          tester.view.physicalSize.height / tester.view.devicePixelRatio -
+          250 / tester.view.devicePixelRatio;
+      expect(tester.getBottomLeft(tools).dy, lessThanOrEqualTo(keyboardTop + 0.01));
+      await tester.tap(find.text('文字格式'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('粗体'));
+      await tester.pump();
+      expect(
+        editor.controller.getSelectionStyle().attributes.containsKey(
+          Attribute.bold.key,
+        ),
+        isTrue,
+      );
+      expect(editor.controller.document.toPlainText(), 'Selected words\n');
+      expect(tester.takeException(), isNull);
+      await tester.tap(find.byKey(const Key('publish-appbar-submit')));
+      await tester.pumpAndSettle();
+      expect(tools, findsNothing);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 600));
+    },
+  );
+
   for (final type in [2, 3]) {
     testWidgets('dismiss keyboard preserves type $type draft', (tester) async {
       await pumpPublishPage(tester, editing: false, contentType: type);

--- a/apps/mobile/packages/ui_kit/lib/src/components/business/gf_post_composer.dart
+++ b/apps/mobile/packages/ui_kit/lib/src/components/business/gf_post_composer.dart
@@ -2,12 +2,9 @@ import 'package:flutter/material.dart';
 
 import '../../theme/gf_theme.dart';
 import '../gf_button.dart';
-import '../surfaces/gf_floating_surface.dart';
 
-/// Floating reply composer mirroring web `PostComposer.vue` mobile form: a
-/// `gf-floating-surface` panel (`w-[min(42rem,100vw-1.5rem)]`) with an
-/// optional reply-target bar, the markdown editor, an image button and a
-/// publish button. Callers place it in a [Stack]/[Overlay] at bottom-4.
+/// Compact reply surface with a borderless growing editor and one action row.
+/// Optional verification content appears only when supplied by the caller.
 class GfPostComposer extends StatelessWidget {
   const GfPostComposer({
     super.key,
@@ -17,6 +14,8 @@ class GfPostComposer extends StatelessWidget {
     required this.hintText,
     this.focusNode,
     this.hideKeyboardLabel,
+    this.onCollapse,
+    this.collapseLabel,
     this.targetName,
     this.targetLabel,
     this.onCloseTarget,
@@ -35,6 +34,8 @@ class GfPostComposer extends StatelessWidget {
   final TextEditingController controller;
   final FocusNode? focusNode;
   final String? hideKeyboardLabel;
+  final VoidCallback? onCollapse;
+  final String? collapseLabel;
   final VoidCallback onPublish;
 
   /// When replying to a user, the target name and localized label shown in the
@@ -64,54 +65,125 @@ class GfPostComposer extends StatelessWidget {
     final GfColors colors = GfTheme.colorsOf(context);
     final GfRadii radii = GfTheme.radiiOf(context);
 
-    return GfFloatingSurface(
-      padding: const EdgeInsets.all(12),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          if (targetName != null)
-            Container(
-              margin: const EdgeInsets.only(bottom: 8),
-              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-              decoration: BoxDecoration(
-                color: colors.base200,
-                borderRadius: BorderRadius.circular(radii.field),
-              ),
-              child: Row(
-                children: <Widget>[
-                  Icon(
-                    Icons.reply,
-                    size: 14,
-                    color: colors.baseContent.withValues(alpha: 0.55),
-                  ),
+    return Material(
+      color: colors.base100,
+      elevation: 4,
+      shadowColor: colors.baseContent.withValues(alpha: 0.12),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(color: colors.line.withValues(alpha: 0.65)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 12, 8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            if (targetName != null)
+              Row(
+                children: [
+                  Icon(Icons.reply_rounded, size: 18, color: colors.iconMuted),
                   const SizedBox(width: 6),
                   Expanded(
                     child: Text(
                       targetLabel ?? targetName!,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: colors.baseContent.withValues(alpha: 0.75),
-                      ),
+                      style: GfTheme.typographyOf(
+                        context,
+                      ).caption.copyWith(color: colors.iconMuted),
                     ),
                   ),
                   if (onCloseTarget != null)
-                    InkWell(
-                      onTap: onCloseTarget,
-                      child: Icon(
-                        Icons.close,
-                        size: 16,
+                    IconButton(
+                      onPressed: onCloseTarget,
+                      tooltip: MaterialLocalizations.of(
+                        context,
+                      ).closeButtonTooltip,
+                      icon: Icon(
+                        Icons.close_rounded,
+                        size: 18,
                         color: colors.iconMuted,
                       ),
                     ),
                 ],
               ),
+            if (imageUrl != null && imageUrl!.isNotEmpty) ...<Widget>[
+              Align(
+                alignment: Alignment.centerLeft,
+                child: Stack(
+                  clipBehavior: Clip.none,
+                  children: <Widget>[
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(radii.field),
+                      child: Image.network(
+                        imageUrl!,
+                        width: 88,
+                        height: 72,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, _, _) => Container(
+                          width: 88,
+                          height: 72,
+                          color: colors.base300,
+                          alignment: Alignment.center,
+                          child: Icon(
+                            Icons.broken_image_outlined,
+                            color: colors.iconMuted,
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (onRemoveImage != null)
+                      Positioned(
+                        right: -10,
+                        top: -10,
+                        child: IconButton.filled(
+                          onPressed: onRemoveImage,
+                          tooltip: removeImageTooltip,
+                          icon: const Icon(Icons.close, size: 15),
+                          style: IconButton.styleFrom(
+                            minimumSize: const Size(32, 32),
+                            backgroundColor: colors.baseContent,
+                            foregroundColor: colors.base100,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+            ],
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 160),
+              child: TextField(
+                controller: controller,
+                focusNode: focusNode,
+                keyboardType: TextInputType.multiline,
+                textInputAction: TextInputAction.newline,
+                maxLines: null,
+                minLines: 2,
+                style: GfTheme.typographyOf(context).body,
+                decoration: InputDecoration(
+                  hintText: hintText,
+                  hintStyle: TextStyle(color: colors.iconMuted),
+                  border: InputBorder.none,
+                  enabledBorder: InputBorder.none,
+                  focusedBorder: InputBorder.none,
+                  disabledBorder: InputBorder.none,
+                  filled: false,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                ),
+              ),
             ),
-          if (toolbar != null || onPickImage != null) ...<Widget>[
+            if (toolbar != null)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 6),
+                child: toolbar!,
+              ),
+            const SizedBox(height: 4),
             Row(
-              children: <Widget>[
+              children: [
                 if (onPickImage != null)
                   IconButton(
                     icon: uploading
@@ -126,100 +198,50 @@ class GfPostComposer extends StatelessWidget {
                           ),
                     onPressed: uploading ? null : onPickImage,
                     tooltip: imageTooltip,
-                    visualDensity: VisualDensity.compact,
+                    constraints: const BoxConstraints(
+                      minWidth: 44,
+                      minHeight: 44,
+                    ),
                   ),
-                if (toolbar != null) Expanded(child: toolbar!),
+                IconButton(
+                  icon: Icon(
+                    Icons.keyboard_hide_rounded,
+                    size: 21,
+                    color: colors.iconMuted,
+                  ),
+                  tooltip:
+                      hideKeyboardLabel ??
+                      MaterialLocalizations.of(context).closeButtonTooltip,
+                  onPressed: () =>
+                      FocusManager.instance.primaryFocus?.unfocus(),
+                ),
+                if (onCollapse != null)
+                  IconButton(
+                    onPressed: onCollapse,
+                    tooltip:
+                        collapseLabel ??
+                        MaterialLocalizations.of(context).closeButtonTooltip,
+                    icon: Icon(
+                      Icons.keyboard_arrow_down_rounded,
+                      size: 22,
+                      color: colors.iconMuted,
+                    ),
+                  ),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: GfButton(
+                      label: publishLabel,
+                      size: GfButtonSize.medium,
+                      loading: publishing,
+                      onPressed: publishing || !canPublish ? null : onPublish,
+                    ),
+                  ),
+                ),
               ],
             ),
-            const SizedBox(height: 6),
           ],
-          if (imageUrl != null && imageUrl!.isNotEmpty) ...<Widget>[
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Stack(
-                clipBehavior: Clip.none,
-                children: <Widget>[
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(radii.field),
-                    child: Image.network(
-                      imageUrl!,
-                      width: 88,
-                      height: 72,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, _, _) => Container(
-                        width: 88,
-                        height: 72,
-                        color: colors.base300,
-                        alignment: Alignment.center,
-                        child: Icon(
-                          Icons.broken_image_outlined,
-                          color: colors.iconMuted,
-                        ),
-                      ),
-                    ),
-                  ),
-                  if (onRemoveImage != null)
-                    Positioned(
-                      right: -10,
-                      top: -10,
-                      child: IconButton.filled(
-                        onPressed: onRemoveImage,
-                        tooltip: removeImageTooltip,
-                        icon: const Icon(Icons.close, size: 15),
-                        style: IconButton.styleFrom(
-                          minimumSize: const Size(32, 32),
-                          backgroundColor: colors.baseContent,
-                          foregroundColor: colors.base100,
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-          ],
-          Container(
-            constraints: const BoxConstraints(minHeight: 76, maxHeight: 160),
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-            decoration: BoxDecoration(
-              color: colors.base100,
-              borderRadius: BorderRadius.circular(radii.field),
-              border: Border.all(color: colors.line, width: 1),
-            ),
-            child: TextField(
-              controller: controller,
-              focusNode: focusNode,
-              maxLines: null,
-              minLines: 2,
-              expands: false,
-              style: const TextStyle(fontSize: 16, height: 1.5),
-              decoration: InputDecoration(
-                hintText: hintText,
-                border: InputBorder.none,
-                isDense: true,
-              ),
-            ),
-          ),
-          const SizedBox(height: 10),
-          Row(
-            children: [
-              IconButton(
-                icon: const Icon(Icons.keyboard_hide_rounded),
-                tooltip:
-                    hideKeyboardLabel ??
-                    MaterialLocalizations.of(context).closeButtonTooltip,
-                onPressed: () => FocusManager.instance.primaryFocus?.unfocus(),
-              ),
-              const Spacer(),
-              GfButton(
-                label: publishLabel,
-                size: GfButtonSize.medium,
-                loading: publishing,
-                onPressed: publishing || !canPublish ? null : onPublish,
-              ),
-            ],
-          ),
-        ],
+        ),
       ),
     );
   }

--- a/apps/mobile/packages/ui_kit/lib/src/components/business/gf_post_composer.dart
+++ b/apps/mobile/packages/ui_kit/lib/src/components/business/gf_post_composer.dart
@@ -16,6 +16,7 @@ class GfPostComposer extends StatelessWidget {
     required this.publishLabel,
     required this.hintText,
     this.focusNode,
+    this.hideKeyboardLabel,
     this.targetName,
     this.targetLabel,
     this.onCloseTarget,
@@ -33,6 +34,7 @@ class GfPostComposer extends StatelessWidget {
 
   final TextEditingController controller;
   final FocusNode? focusNode;
+  final String? hideKeyboardLabel;
   final VoidCallback onPublish;
 
   /// When replying to a user, the target name and localized label shown in the
@@ -199,14 +201,23 @@ class GfPostComposer extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 10),
-          Align(
-            alignment: Alignment.centerRight,
-            child: GfButton(
-              label: publishLabel,
-              size: GfButtonSize.medium,
-              loading: publishing,
-              onPressed: publishing || !canPublish ? null : onPublish,
-            ),
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.keyboard_hide_rounded),
+                tooltip:
+                    hideKeyboardLabel ??
+                    MaterialLocalizations.of(context).closeButtonTooltip,
+                onPressed: () => FocusManager.instance.primaryFocus?.unfocus(),
+              ),
+              const Spacer(),
+              GfButton(
+                label: publishLabel,
+                size: GfButtonSize.medium,
+                loading: publishing,
+                onPressed: publishing || !canPublish ? null : onPublish,
+              ),
+            ],
           ),
         ],
       ),

--- a/apps/mobile/packages/ui_kit/lib/src/components/gf_topic_card.dart
+++ b/apps/mobile/packages/ui_kit/lib/src/components/gf_topic_card.dart
@@ -132,7 +132,7 @@ class _GfTopicCardState extends State<GfTopicCard> {
           hot: widget.hot,
           pinned: widget.pinned,
         ),
-        const SizedBox(height: 12),
+        const SizedBox(height: 4),
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
@@ -150,7 +150,7 @@ class _GfTopicCardState extends State<GfTopicCard> {
                           overflow: TextOverflow.ellipsis,
                           style: TextStyle(
                             color: colors.baseContent,
-                            fontSize: 16,
+                            fontSize: 17,
                             height: 1.45,
                             fontWeight: FontWeight.w600,
                           ),
@@ -171,15 +171,15 @@ class _GfTopicCardState extends State<GfTopicCard> {
                     ],
                   ),
                   if (widget.description.isNotEmpty) ...<Widget>[
-                    const SizedBox(height: 6),
+                    const SizedBox(height: 4),
                     Text(
                       widget.description,
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         color: colors.baseContent.withValues(alpha: 0.85),
-                        fontSize: 15,
-                        height: 1.6,
+                        fontSize: 17,
+                        height: 1.4,
                       ),
                     ),
                   ],
@@ -193,7 +193,7 @@ class _GfTopicCardState extends State<GfTopicCard> {
           ],
         ),
         if (images.isNotEmpty && !singleImage) ...<Widget>[
-          const SizedBox(height: 12),
+          const SizedBox(height: 4),
           LayoutBuilder(
             builder: (context, constraints) {
               if (images.length == 1) {
@@ -255,7 +255,7 @@ class _GfTopicCardState extends State<GfTopicCard> {
             },
           ),
         ],
-        const SizedBox(height: 12),
+        const SizedBox(height: 4),
         Row(
           children: <Widget>[
             _Metric(
@@ -267,27 +267,19 @@ class _GfTopicCardState extends State<GfTopicCard> {
               icon: Icons.visibility_outlined,
               value: '${widget.viewCount}',
             ),
-            const Spacer(),
-            Text(
-              widget.activityText,
-              style: TextStyle(
-                color: colors.baseContent.withValues(alpha: 0.55),
-                fontSize: 12,
-              ),
-            ),
           ],
         ),
       ],
     );
 
     return GfCard(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       onTap: widget.onTap,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           GfAvatar(src: widget.authorAvatarUrl, size: 36),
-          const SizedBox(width: 12),
+          const SizedBox(width: 10),
           Expanded(child: textContent),
         ],
       ),
@@ -331,23 +323,27 @@ class _AuthorMeta extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
                         color: colors.baseContent,
-                        fontSize: 14,
+                        fontSize: 16,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
                   const SizedBox(width: 8),
-                  Text(
-                    activityText,
-                    style: TextStyle(
-                      color: colors.baseContent.withValues(alpha: 0.55),
-                      fontSize: 12,
+                  Flexible(
+                    child: Text(
+                      activityText,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: colors.baseContent.withValues(alpha: 0.55),
+                        fontSize: 13,
+                      ),
                     ),
                   ),
                 ],
               ),
               if (categories.isNotEmpty || hot) ...<Widget>[
-                const SizedBox(height: 6),
+                const SizedBox(height: 4),
                 Wrap(
                   spacing: 6,
                   runSpacing: 4,
@@ -452,7 +448,7 @@ class _Metric extends StatelessWidget {
             value,
             style: TextStyle(
               color: colors.baseContent.withValues(alpha: 0.55),
-              fontSize: 12,
+              fontSize: 13,
             ),
           ),
         ],

--- a/apps/mobile/packages/ui_kit/lib/src/components/surfaces/gf_toast.dart
+++ b/apps/mobile/packages/ui_kit/lib/src/components/surfaces/gf_toast.dart
@@ -1,30 +1,135 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:tdesign_flutter/tdesign_flutter.dart' as td;
 
 import '../../theme/gf_theme.dart';
 
-/// Toast helper mirroring web `GlobalFlash.vue` through TDesign's transient
-/// feedback surface. Success and error states keep the YourTJ semantic colors.
-///
-/// Usage:
-/// ```dart
-/// showGfToast(context, 'Saved');
-/// ```
+final _activeToasts = Expando<OverlayEntry>();
+
+/// Shared top feedback banner, above dialogs/sheets and clear of system insets.
+/// A new message replaces the previous one; failures stay visible longer.
 void showGfToast(BuildContext context, String message, {bool error = false}) {
-  final GfColors colors = GfTheme.colorsOf(context);
-  if (error) {
-    td.TToast.showWarning(
-      message,
-      context: context,
-      maxLines: 3,
-      iconColor: colors.error,
-    );
-  } else {
-    td.TToast.showSuccess(
-      message,
-      context: context,
-      maxLines: 3,
-      iconColor: colors.success,
+  final overlay = Overlay.of(context, rootOverlay: true);
+  final previous = _activeToasts[overlay];
+  if (previous != null) {
+    previous.remove();
+    previous.dispose();
+  }
+  final themes = InheritedTheme.capture(from: context, to: overlay.context);
+  late final OverlayEntry entry;
+  void dismiss() {
+    if (_activeToasts[overlay] != entry) return;
+    _activeToasts[overlay] = null;
+    entry.remove();
+    entry.dispose();
+  }
+
+  entry = OverlayEntry(
+    builder: (_) => themes.wrap(
+      _FeedbackBanner(message: message, error: error, onDismiss: dismiss),
+    ),
+  );
+  _activeToasts[overlay] = entry;
+  overlay.insert(entry);
+}
+
+class _FeedbackBanner extends StatefulWidget {
+  const _FeedbackBanner({
+    required this.message,
+    required this.error,
+    required this.onDismiss,
+  });
+  final String message;
+  final bool error;
+  final VoidCallback onDismiss;
+
+  @override
+  State<_FeedbackBanner> createState() => _FeedbackBannerState();
+}
+
+class _FeedbackBannerState extends State<_FeedbackBanner> {
+  Timer? _timer;
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer(Duration(seconds: widget.error ? 7 : 4), widget.onDismiss);
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = GfTheme.colorsOf(context);
+    final accent = widget.error ? colors.error : colors.success;
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      child: SafeArea(
+        bottom: false,
+        minimum: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Material(
+              color: colors.base100,
+              elevation: 4,
+              shadowColor: Colors.black.withValues(alpha: .14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+                side: BorderSide(color: accent.withValues(alpha: .25)),
+              ),
+              child: Semantics(
+                liveRegion: true,
+                child: Padding(
+                  padding: const EdgeInsets.only(
+                    left: 14,
+                    top: 6,
+                    bottom: 6,
+                    right: 4,
+                  ),
+                  child: Row(
+                    children: [
+                      Icon(
+                        widget.error
+                            ? Icons.error_outline_rounded
+                            : Icons.check_circle_outline_rounded,
+                        color: accent,
+                        size: 22,
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Text(
+                          widget.message,
+                          style: GfTheme.typographyOf(
+                            context,
+                          ).body.copyWith(color: colors.baseContent),
+                        ),
+                      ),
+                      IconButton(
+                        tooltip: MaterialLocalizations.of(
+                          context,
+                        ).closeButtonTooltip,
+                        onPressed: widget.onDismiss,
+                        icon: Icon(
+                          Icons.close_rounded,
+                          size: 18,
+                          color: colors.baseContent.withValues(alpha: .55),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/apps/mobile/packages/ui_kit/lib/src/theme/gf_typography.dart
+++ b/apps/mobile/packages/ui_kit/lib/src/theme/gf_typography.dart
@@ -1,13 +1,8 @@
 import 'package:flutter/material.dart';
 
-/// Typography scale, mirroring the stable font conventions of the web
-/// design system (`apps/gooseforum/resource/src/styles/*.css`).
-///
-/// The web has no font-size tokens, but its conventions are stable:
-/// page titles 20–24/w700, list/card titles 15–16/w500-600, body 15
-/// leading-relaxed, excerpt 13, meta 12/11/10. [GfTypography] turns those
-/// conventions into one reusable scale; colors are applied by the caller
-/// (weak text uses `baseContent` with alpha, like web `base-content/55`).
+/// Mobile typography using the Web design system's hierarchy and weights.
+/// Body and secondary text are enlarged for handheld reading; tighter leading
+/// keeps feeds compact without shrinking the text or overriding system scaling.
 @immutable
 class GfTypography extends ThemeExtension<GfTypography> {
   const GfTypography({
@@ -39,20 +34,19 @@ class GfTypography extends ThemeExtension<GfTypography> {
   /// 16 / 24 / w700 — card / list titles (web `text-base font-semibold`).
   final TextStyle heading;
 
-  /// 15 / w400, line height 1.6 — body prose (web `text-[15px]
-  /// leading-relaxed`, adapted to 24 logical pixels).
+  /// 17 / w400, line height 1.4 — readable mobile prose in compact rows.
   final TextStyle body;
 
-  /// 15 / w600 — emphasized body (web `font-medium/semibold` on 15px rows).
+  /// 16 / w600 — emphasized body and author names.
   final TextStyle bodyStrong;
 
-  /// 14 / 22 — excerpts / secondary text (web `text-[13px]`).
+  /// 15 / 21 — excerpts / secondary text.
   final TextStyle small;
 
-  /// 12 — metadata (web `text-xs`).
+  /// 13 — metadata.
   final TextStyle caption;
 
-  /// 11 — compact meta / badges (web `text-[11px]`).
+  /// 12 — compact meta / badges.
   final TextStyle meta;
 
   /// 10 / w700 / tracking-wide — uppercase group labels (web
@@ -84,11 +78,11 @@ class GfTypography extends ThemeExtension<GfTypography> {
       title2: style(18, FontWeight.w700, height: 26 / 18),
       title3: style(17, FontWeight.w700, height: 1.3),
       heading: style(16, FontWeight.w700, height: 1.5),
-      body: style(15, FontWeight.w400, height: 1.6),
-      bodyStrong: style(15, FontWeight.w600, height: 1.4),
-      small: style(14, FontWeight.w400, height: 22 / 14),
-      caption: style(12, FontWeight.w400, height: 1.5),
-      meta: style(11, FontWeight.w500, height: 1.3),
+      body: style(17, FontWeight.w400, height: 1.4),
+      bodyStrong: style(16, FontWeight.w600, height: 1.4),
+      small: style(15, FontWeight.w400, height: 1.4),
+      caption: style(13, FontWeight.w400, height: 1.5),
+      meta: style(12, FontWeight.w500, height: 1.3),
       label: style(10, FontWeight.w700, height: 1.2, letterSpacing: 0.5),
     );
   }

--- a/apps/mobile/packages/ui_kit/test/components/gf_business_test.dart
+++ b/apps/mobile/packages/ui_kit/test/components/gf_business_test.dart
@@ -304,6 +304,44 @@ void main() {
   });
 
   group('GfPostComposer', () {
+    testWidgets(
+      'compact composer fits enlarged text and preserves collapse action',
+      (tester) async {
+        final controller = TextEditingController(text: 'A reply draft');
+        addTearDown(controller.dispose);
+        var collapsed = false;
+        await tester.pumpWidget(
+          gfApp(
+            MediaQuery(
+              data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+              child: SizedBox(
+                width: 320,
+                child: GfPostComposer(
+                  controller: controller,
+                  publishLabel: 'Senden',
+                  hintText: 'Reply',
+                  targetName: 'A long author name',
+                  onCloseTarget: () {},
+                  onPublish: () {},
+                  onPickImage: () {},
+                  imageTooltip: 'Image',
+                  onCollapse: () => collapsed = true,
+                  collapseLabel: 'Collapse',
+                  toolbar: const Text('Verification required'),
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(tester.takeException(), isNull);
+        expect(find.text('Verification required'), findsOneWidget);
+        await tester.tap(find.byTooltip('Collapse'));
+        expect(collapsed, isTrue);
+        expect(controller.text, 'A reply draft');
+        await tester.pumpWidget(const SizedBox.shrink());
+      },
+    );
+
     testWidgets('keyboard dismissal retains reply text', (tester) async {
       final controller = TextEditingController(text: 'Unsent reply');
       final focus = FocusNode();
@@ -332,7 +370,7 @@ void main() {
     });
 
     testWidgets(
-      'places image action above input and disables it while uploading',
+      'keeps image and keyboard actions beside send below the borderless input',
       (tester) async {
         int imageTaps = 0;
         final TextEditingController controller = TextEditingController();
@@ -362,7 +400,18 @@ void main() {
         expect(imageTaps, 0);
         final Offset imageTopLeft = tester.getTopLeft(imageButton);
         final Offset inputTopLeft = tester.getTopLeft(find.byType(TextField));
-        expect(imageTopLeft.dy, lessThan(inputTopLeft.dy));
+        expect(imageTopLeft.dy, greaterThan(inputTopLeft.dy));
+        expect(
+          tester.getCenter(imageButton).dy,
+          tester.getCenter(find.byIcon(Icons.keyboard_hide_rounded)).dy,
+        );
+        final field = tester.widget<TextField>(find.byType(TextField));
+        expect(field.decoration!.focusedBorder, InputBorder.none);
+        expect(field.decoration!.filled, isFalse);
+        expect(
+          tester.getSize(find.byType(GfPostComposer)).height,
+          lessThan(190),
+        );
       },
     );
   });

--- a/apps/mobile/packages/ui_kit/test/components/gf_business_test.dart
+++ b/apps/mobile/packages/ui_kit/test/components/gf_business_test.dart
@@ -304,6 +304,33 @@ void main() {
   });
 
   group('GfPostComposer', () {
+    testWidgets('keyboard dismissal retains reply text', (tester) async {
+      final controller = TextEditingController(text: 'Unsent reply');
+      final focus = FocusNode();
+      await tester.pumpWidget(
+        gfApp(
+          GfPostComposer(
+            controller: controller,
+            focusNode: focus,
+            onPublish: () {},
+            publishLabel: 'Send',
+            hintText: 'Reply',
+          ),
+        ),
+      );
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(focus.hasFocus, isTrue);
+      expect(find.byIcon(Icons.keyboard_hide_rounded), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.keyboard_hide_rounded));
+      await tester.pump();
+      expect(focus.hasFocus, isFalse);
+      expect(controller.text, 'Unsent reply');
+      await tester.pumpWidget(const SizedBox.shrink());
+      controller.dispose();
+      focus.dispose();
+    });
+
     testWidgets(
       'places image action above input and disables it while uploading',
       (tester) async {

--- a/apps/mobile/packages/ui_kit/test/components/gf_surfaces_test.dart
+++ b/apps/mobile/packages/ui_kit/test/components/gf_surfaces_test.dart
@@ -170,10 +170,53 @@ void main() {
   });
 
   group('GfToast', () {
-    testWidgets('renders toast helper scaffold', (tester) async {
-      // showGfToast needs a ScaffoldMessenger; smoke via building app.
-      await tester.pumpWidget(gfApp(const SizedBox()));
-      expect(find.byType(Scaffold), findsOneWidget);
+    testWidgets('top banners replace, dismiss and survive sheet closure', (
+      tester,
+    ) async {
+      late BuildContext page;
+      await tester.pumpWidget(
+        gfApp(
+          Builder(
+            builder: (context) {
+              page = context;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+      showModalBottomSheet<void>(
+        context: page,
+        builder: (context) => TextButton(
+          onPressed: () {
+            showGfToast(context, 'Saved');
+            Navigator.pop(context);
+          },
+          child: const Text('Save'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      expect(find.text('Saved'), findsOneWidget);
+      expect(tester.getTopLeft(find.text('Saved')).dy, lessThan(120));
+      showGfToast(page, 'Detailed error reason', error: true);
+      await tester.pumpAndSettle();
+      expect(find.text('Saved'), findsNothing);
+      expect(find.text('Detailed error reason'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 4));
+      expect(find.text('Detailed error reason'), findsOneWidget);
+      await tester.tap(find.byTooltip('Close'));
+      await tester.pump();
+      expect(find.text('Detailed error reason'), findsNothing);
+      showGfToast(page, 'Timed');
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 4));
+      expect(find.text('Timed'), findsNothing);
+      showGfToast(page, 'Unmount');
+      await tester.pump();
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump(const Duration(seconds: 8));
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/apps/mobile/packages/ui_kit/test/components/gf_topic_card_test.dart
+++ b/apps/mobile/packages/ui_kit/test/components/gf_topic_card_test.dart
@@ -5,6 +5,63 @@ import 'package:ui_kit/ui_kit.dart';
 import '../helpers.dart';
 
 void main() {
+  testWidgets('feed uses one timestamp and compact readable rows', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      gfApp(
+        const SizedBox(
+          width: 390,
+          child: GfTopicCard(
+            title: 'Campus',
+            description: 'A short preview',
+            authorName: 'Student',
+            authorAvatarUrl: '',
+            imageUrls: [],
+            categories: [],
+            activityText: 'now',
+            replyCount: 4,
+            viewCount: 12,
+          ),
+        ),
+      ),
+    );
+    expect(find.text('now'), findsOneWidget);
+    expect(
+      tester.widget<Text>(find.text('A short preview')).style!.fontSize,
+      greaterThanOrEqualTo(16),
+    );
+    expect(tester.getSize(find.byType(GfTopicCard)).height, lessThan(150));
+  });
+
+  testWidgets(
+    'compact feed remains readable on narrow screens with large text',
+    (tester) async {
+      await tester.pumpWidget(
+        gfApp(
+          const MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(2)),
+            child: SizedBox(
+              width: 320,
+              child: GfTopicCard(
+                title: 'A longer campus discussion title',
+                description: 'A longer preview that wraps onto several lines',
+                authorName: 'A long author name',
+                authorAvatarUrl: '',
+                imageUrls: [],
+                categories: [],
+                activityText: '2 hours ago',
+                replyCount: 10,
+                viewCount: 100,
+              ),
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isNull);
+      expect(find.text('2 hours ago'), findsOneWidget);
+    },
+  );
   for (final (name, count, ratio) in [
     ('text only', 0, 1.5),
     ('portrait single', 1, 0.75),

--- a/apps/mobile/packages/ui_kit/test/tokens_test.dart
+++ b/apps/mobile/packages/ui_kit/test/tokens_test.dart
@@ -156,11 +156,11 @@ void main() {
         expect(t.title2.fontSize, 18);
         expect(t.title3.fontSize, 17);
         expect(t.heading.fontSize, 16);
-        expect(t.body.fontSize, 15);
-        expect(t.bodyStrong.fontSize, 15);
-        expect(t.small.fontSize, 14);
-        expect(t.caption.fontSize, 12);
-        expect(t.meta.fontSize, 11);
+        expect(t.body.fontSize, 17);
+        expect(t.bodyStrong.fontSize, 16);
+        expect(t.small.fontSize, 15);
+        expect(t.caption.fontSize, 13);
+        expect(t.meta.fontSize, 12);
         expect(t.label.fontSize, 10);
       }
     });
@@ -177,9 +177,9 @@ void main() {
       expect(t.label.fontWeight, FontWeight.w700);
     });
 
-    test('body uses the mobile 15/24 reading scale', () {
+    test('body uses the compact mobile 17px reading scale', () {
       final GfTypography t = GfTypography.standard(GfColors.light.baseContent);
-      expect(t.body.height, 1.6);
+      expect(t.body.height, 1.4);
       expect(
         t.display.fontFeatures,
         contains(const FontFeature.tabularFigures()),

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -16,7 +16,8 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 ## Navigation and reading
 
 - `Current`: Home announcements render optional titles and HTML bodies, including the legacy
-  single-HTML payload. They grow with their contents and text size; empty announcements take no
+  single-HTML payload. A small bell sits in a separate leading column, with title and body aligned
+  to the same inset as Web. They grow with their contents and text size; empty announcements take no
   space. Multiple announcements rotate with numbered manual controls; assistive navigation and
   reduced motion disable automatic rotation. Refresh replaces the active announcement safely.
 - `Current`: mobile body text uses 17 logical pixels with system text scaling. Feed cards use
@@ -95,6 +96,11 @@ Web inside an authenticated in-app browser. The navigation and management bounda
   unless a semantic or provider color is explicitly set.
 
 ## Publishing
+
+- `Current`: publishing uses an unframed title and writing canvas. Article formatting tools remain
+  folded in a bottom accessory bar above the software keyboard; expanding them preserves the editor
+  selection. Image and draft actions remain in the accessory bar; the empty simple gallery is a compact
+  selection tile. Rich and simple body text use the same mobile reading scale. Preview hides the accessory bar.
 
 - `Current`: reply composers use one rounded surface with a borderless, growing two-line input.
   Image, hide-keyboard, collapse and send actions share the bottom row. The reply target is a

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -44,6 +44,10 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 - `Current`: Home, Campus and Notifications have a stable compose button; Messages has a new-chat
   button. Topic pages keep reply and floor controls in the bottom dock. Pull-to-refresh and
   reselecting the active root destination provide refresh and return-to-top without changing icons.
+  Refreshable pages accept a short pull from the top on release, including empty lists; the gesture
+  uses finger travel so tall screens and iOS rubber-band damping do not demand a longer pull.
+  Home, Campus and Notifications show the refresh indicator below their overlaid navigation.
+  Small or retracted pulls do not refresh, and an ongoing refresh cannot be started twice.
 - `Current`: the floor slider loads the selected server window on release. Earliest/latest
   shortcuts, reply links, and earlier/later pagination navigate the actual reply stream. Returning
   to the first post from a middle window reloads that window before offering refresh; stale

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-09-07
+> Last verified: 2026-09-08
 
 The Flutter app combines the forum, course catalog, scheduler and Wiki. Ordinary browsing and
 writing use native pages. Management uses the same first-party workspaces and permission checks as
@@ -14,6 +14,14 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 [0012](../decisions/0012-unified-mobile-reading-navigation.md).
 
 ## Navigation and reading
+
+- `Current`: Home announcements render optional titles and HTML bodies, including the legacy
+  single-HTML payload. They grow with their contents and text size; empty announcements take no
+  space. Multiple announcements rotate with numbered manual controls; assistive navigation and
+  reduced motion disable automatic rotation. Refresh replaces the active announcement safely.
+- `Current`: mobile body text uses 17 logical pixels with system text scaling. Feed cards use
+  compact vertical padding and one timestamp; embedded Markdown uses smaller paragraph margins
+  so short replies do not acquire a large empty footer.
 
 - `Current`: four persistent destinations — Home, Campus, Notifications and Messages — use icon-only
   navigation with accessible labels. Search is a pushed page, reachable from Home. Campus links to
@@ -87,6 +95,10 @@ Web inside an authenticated in-app browser. The navigation and management bounda
   unless a semantic or provider color is explicitly set.
 
 ## Publishing
+
+- `Current`: publishing and reply composers have a localized hide-keyboard button that preserves
+  unsent text. Dragging the publishing page or topic stream also dismisses the keyboard; opening
+  the publishing preview removes editor focus. Rich-text formatting remains available while editing.
 
 - `Current`: the type selector keeps Web's moment/question/article values. Moments and questions
   use a simple gallery plus text; articles use an inline rich editor backed by Markdown. Article

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -138,7 +138,12 @@ Web inside an authenticated in-app browser. The navigation and management bounda
   the full [Web scheduler](https://f.yourtj.de/schedule) in the external browser without transferring
   the native credential. Plans are not official enrollment results.
 - `Current`: course details retain offering-specific five-star reviews and existing review fields;
-  bookmark and write-review actions stay in a bottom dock.
+  bookmark and write-review actions stay in a bottom dock. Scores share a baseline with their
+  five-point denominator. The signed-in user’s own reviews (including anonymous reviews) appear
+  first across pagination; edit/delete controls remain on those rows.
+- `Current`: shared transient feedback appears in dismissible top banners above sheets, below
+  the system safe area. Course review failures show localized server reasons and preserve the
+  draft; success and error messages use the same surface with distinct semantic icons.
 - `Current`: Wiki search uses the existing page-grouped search contract, debounces input, ignores
   stale results and opens paragraph anchors. Search unavailability has retry feedback. Reading
   keeps directory, Wiki search and GitHub edit actions in a bottom dock; GitHub remains the content

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -96,6 +96,10 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 
 ## Publishing
 
+- `Current`: reply composers use one rounded surface with a borderless, growing two-line input.
+  Image, hide-keyboard, collapse and send actions share the bottom row. The reply target is a
+  lightweight text row; attachment previews and server-required captcha controls appear only when needed.
+
 - `Current`: publishing and reply composers have a localized hide-keyboard button that preserves
   unsent text. Dragging the publishing page or topic stream also dismisses the keyboard; opening
   the publishing preview removes editor focus. Rich-text formatting remains available while editing.

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -141,6 +141,11 @@ Web inside an authenticated in-app browser. The navigation and management bounda
   bookmark and write-review actions stay in a bottom dock. Scores share a baseline with their
   five-point denominator. The signed-in user’s own reviews (including anonymous reviews) appear
   first across pagination; edit/delete controls remain on those rows.
+- `Current`: Profile includes a private My course reviews entry for paginated management across
+  courses, including anonymous reviews. Each visible review can be edited, deleted or opened at
+  its offering and review position. Hidden reviews remain listed for deletion, with no edit or
+  public-detail action; deleted reviews are omitted. Course detail and management share the same
+  editor and a rounded delete confirmation with the target review excerpt and explicit cancel.
 - `Current`: shared transient feedback appears in dismissible top banners above sheets, below
   the system safe area. Course review failures show localized server reasons and preserve the
   draft; success and error messages use the same surface with distinct semantic icons.

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -1523,8 +1523,8 @@ ReviewListResult:
       type: string
       description: |
         Cursor for the next page, present only when more reviews exist.
-        Format is "offeringId:reviewId" of the last item of the current page
-        (course-level ordering is (offering_id DESC, id DESC)). Omit to stop paging.
+        Opaque position cursor including the ownership phase for personalized lists.
+        Pass it back unchanged. Legacy two-part cursors remain accepted. Omit to stop paging.
     total:
       type: integer
       format: int64

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -9187,3 +9187,43 @@ DirectImageUploadAbortResponse:
   oneOf:
     - $ref: '#/DirectImageUploadAbortSuccess'
     - $ref: '#/ApiFailure'
+
+OwnCourseReviewItem:
+  type: object
+  required: [review, courseId, courseName, courseCode, hidden, canOpenCourse]
+  properties:
+    review:
+      $ref: '#/ReviewPayload'
+    courseId:
+      type: integer
+      format: uint64
+    courseName:
+      type: string
+    courseCode:
+      type: string
+    hidden:
+      type: boolean
+    canOpenCourse:
+      type: boolean
+      description: False when the review, offering or course is unavailable publicly.
+  additionalProperties: false
+
+OwnCourseReviewResponse:
+  type: object
+  required: [code, result]
+  properties:
+    code:
+      type: integer
+      const: 0
+    result:
+      type: object
+      required: [list]
+      properties:
+        list:
+          type: array
+          items:
+            $ref: '#/OwnCourseReviewItem'
+        nextCursor:
+          type: string
+      additionalProperties: false
+  additionalProperties: false

--- a/packages/api-contract/coverage-matrix.md
+++ b/packages/api-contract/coverage-matrix.md
@@ -4,11 +4,11 @@
 
 路由快照来自 `TestRoutesSnapshot`（`fixtures/routes-snapshot.json`，默认配置装配，不含 OIDC `/api/oauth/*` 端点——OIDC 另有专项）。
 
-- 快照路由总数：295
-- /api JSON 路由：232，已入契约：233（100%），已知未覆盖：0
+- 快照路由总数：296
+- /api JSON 路由：233，已入契约：234（100%），已知未覆盖：0
 - 非 API 排除路由：62
 
-## 已覆盖（233）
+## 已覆盖（234）
 
 | Method | Path | operationId |
 | --- | --- | --- |
@@ -53,6 +53,7 @@
 | GET | `/api/forum/courses/:courseId/reviews` | `listCourseReviews` |
 | GET | `/api/forum/courses/:courseId/summary` | `getCourseSummary` |
 | GET | `/api/forum/get-site-statistics` | `getSiteStatistics` |
+| GET | `/api/forum/my-course-reviews` | `listOwnCourseReviews` |
 | GET | `/api/forum/notifications` | `getNotifications` |
 | GET | `/api/forum/posts/revisions` | `getPostRevisions` |
 | GET | `/api/forum/posts/window` | `getPostWindow` |

--- a/packages/api-contract/fixtures/course-reviews-owner-page-success.json
+++ b/packages/api-contract/fixtures/course-reviews-owner-page-success.json
@@ -1,0 +1,30 @@
+{
+  "result": {
+    "list": [
+      {
+        "id": 2,
+        "offeringId": 901,
+        "rating": 4,
+        "content": "匿名评价",
+        "contentHtml": "<p>匿名评价</p>\n",
+        "author": {
+          "kind": "anonymous",
+          "label": "匿名同学"
+        },
+        "viewer": {
+          "canEdit": true,
+          "canDelete": true,
+          "isHelpful": false,
+          "isDisliked": false
+        },
+        "helpfulCount": 0,
+        "createdAt": "2026-08-01T09:00:00+08:00",
+        "updatedAt": "2026-08-01T09:00:00+08:00",
+        "dislikeCount": 0
+      }
+    ],
+    "nextCursor": "901:2:1",
+    "total": 3
+  },
+  "code": 0
+}

--- a/packages/api-contract/fixtures/own-course-reviews-success.json
+++ b/packages/api-contract/fixtures/own-course-reviews-success.json
@@ -1,0 +1,36 @@
+{
+  "code": 0,
+  "result": {
+    "list": [
+      {
+        "review": {
+          "id": 2,
+          "offeringId": 901,
+          "rating": 4,
+          "content": "匿名评价",
+          "contentHtml": "<p>匿名评价</p>\n",
+          "author": {
+            "kind": "anonymous",
+            "label": "匿名同学"
+          },
+          "viewer": {
+            "canEdit": true,
+            "canDelete": true,
+            "isHelpful": false,
+            "isDisliked": false
+          },
+          "helpfulCount": 0,
+          "createdAt": "2026-08-01T09:00:00+08:00",
+          "updatedAt": "2026-08-01T09:00:00+08:00",
+          "dislikeCount": 0
+        },
+        "courseId": 42,
+        "courseName": "高等数学",
+        "courseCode": "100001",
+        "hidden": false,
+        "canOpenCourse": true
+      }
+    ],
+    "nextCursor": "2"
+  }
+}

--- a/packages/api-contract/fixtures/routes-snapshot.json
+++ b/packages/api-contract/fixtures/routes-snapshot.json
@@ -197,6 +197,10 @@
   },
   {
     "method": "GET",
+    "path": "/api/forum/my-course-reviews"
+  },
+  {
+    "method": "GET",
     "path": "/api/forum/notifications"
   },
   {

--- a/packages/api-contract/openapi.yaml
+++ b/packages/api-contract/openapi.yaml
@@ -227,6 +227,9 @@ paths:
   /api/forum/courses/{courseId}/reviews:
     get:
       $ref: ./paths/course-reviews.yaml#/listCourseReviews/get
+  /api/forum/my-course-reviews:
+    get:
+      $ref: ./paths/course-reviews.yaml#/listOwnCourseReviews/get
   /api/forum/course-reviews:
     post:
       $ref: ./paths/course-reviews.yaml#/createCourseReview/post

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -928,3 +928,58 @@ moderationCourseReviewReveal:
             examples:
               csrfRejected:
                 externalValue: ../fixtures/csrf-rejected.json
+
+listOwnCourseReviews:
+  get:
+    tags: [Forum]
+    summary: Manage the current user's course reviews across courses
+    operationId: listOwnCourseReviews
+    security:
+      - bearerAuth: []
+      - accessTokenCookie: []
+    description: |
+      Private session-scoped list, newest review ID first. Includes the caller's anonymous
+      and hidden reviews; excludes deleted reviews. No author selector is accepted.
+      Hidden reviews can be deleted but cannot be edited or opened publicly. Course metadata
+      remains available for management when the corresponding course is unavailable.
+    parameters:
+      - name: cursor
+        in: query
+        schema:
+          type: string
+          description: Opaque nextCursor from the previous page; omit for the first page.
+      - name: pageSize
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 20
+    responses:
+      '200':
+        description: Private course review page; list is empty rather than null.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/OwnCourseReviewResponse
+            examples:
+              success:
+                externalValue: ../fixtures/own-course-reviews-success.json
+      '400':
+        description: Invalid cursor or page size.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+      '401':
+        description: A valid session is required.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure
+      '500':
+        description: Could not load the user's reviews.
+        content:
+          application/json:
+            schema:
+              $ref: ../components/schemas.yaml#/ApiFailure

--- a/packages/api-contract/paths/course-reviews.yaml
+++ b/packages/api-contract/paths/course-reviews.yaml
@@ -6,7 +6,8 @@ listCourseReviews:
     operationId: listCourseReviews
     description: |
       Public read endpoint. An optional valid JWT (cookie or Bearer) only personalizes the
-      `viewer` state (canEdit/canDelete/isHelpful); anonymous callers receive the same reviews
+      `viewer` state (canEdit/canDelete/isHelpful) and places the caller's own reviews first,
+      preserving newest-first ordering within each ownership group. Anonymous callers receive the same reviews
       with viewer flags false. Review payloads never contain author identity fields
       (userId/username/avatar): anonymous and legacy reviews expose only a kind/label pair.
     parameters:
@@ -30,7 +31,8 @@ listCourseReviews:
           type: string
           description: |
             Pagination cursor returned as nextCursor in the previous response
-            (format "offeringId:reviewId"). Omit for the first page.
+            (opaque: return unchanged). Omit for the first page. Personalized cursors include
+            the ownership phase; legacy two-part cursors retain their original ordering.
       - name: pageSize
         in: query
         schema:
@@ -41,7 +43,7 @@ listCourseReviews:
           description: Page size (default 20, max 50).
     responses:
       '200':
-        description: Visible reviews ordered newest first.
+        description: Visible reviews with the authenticated caller's reviews first, newest first within each group.
         content:
           application/json:
             schema:
@@ -49,6 +51,8 @@ listCourseReviews:
             examples:
               success:
                 externalValue: ../fixtures/course-reviews-list-success.json
+              ownerFirst:
+                externalValue: ../fixtures/course-reviews-owner-page-success.json
       '400':
         description: Malformed course id or query parameters.
         content:


### PR DESCRIPTION
## Changes

Fix mobile announcements that appeared as an empty tinted strip: render HTML/legacy bodies, size to content, reset rotation when data changes, and add a leading bell with aligned indentation.

Improve reading density with 17px body text, tighter feed/reply and Markdown spacing, and a single feed timestamp. Reply and publishing composers provide explicit keyboard dismissal with draft retention, a cleaner writing surface and compact keyboard accessories.

Refreshable pages accept short pulls on release, independent of viewport height and iOS overscroll damping. Root-page indicators appear below overlaid navigation. Small/retracted pulls and mid-list scrolling do not trigger the shortcut; active refreshes remain deduplicated.

Course scores share one baseline with the denominator. Signed-in review lists prioritize the caller’s own reviews, including anonymous and older reviews beyond the first page, so edit/delete actions are immediately accessible. Ownership-aware cursors preserve pagination after cursor-row deletion; legacy two-part cursors retain their original ordering. OpenAPI, generated TypeScript, Dart documentation and fixtures are synchronized.

Profile now includes My course reviews: a session-scoped, paginated list across courses, including anonymous reviews. Owners can edit/delete with the same components used in course detail, or open the exact offering and review position. Hidden reviews remain deletable without public links or editing; deleted reviews are excluded. Delete confirmation uses a rounded surface, target excerpt, explicit cancel and destructive action. The new private API, route coverage, TypeScript and Dart mirrors, fixtures and documentation ship together.

Replace the shared toast surface with dismissible top banners above sheets. Course review failures display localized business reasons or an explicit network/unknown-reason explanation while retaining the draft. Editing uses a Save action. Success and error feedback share the same layout.

## Validation

- `flutter test --no-pub --exclude-tags golden`: forum_app 252 passed; core API/contract subset 49 passed. Previous ui_kit check: 123 passed (unchanged in this update).
- `flutter analyze --no-pub`: forum_app and core passed; prior ui_kit analysis passed (unchanged).
- Course service and course review HTTP tests passed, covering owner-first anonymous reviews, pagination, legacy/new cursor parsing, and deletion of the cursor row without losing the next review.
- Added management tests cover editing, cancellation, deletion failures, hidden reviews, pagination, unauthorized access, author-selector isolation and phone-height deep-link positioning.
- PostgreSQL `go test ./app/migration/ -run TestSchema`: passed.
- API contract `pnpm run check`, governance gates and whitespace checks passed.
- Regressions started red for announcement rendering, keyboard dismissal, reading density, refresh gestures, own-review ordering and actionable review errors.
- iOS 26.5 simulator checked on the real feed and course detail, plus reply keyboard dismissal and simple/article publishing. No test content was published.

Broader review-test selection encountered two failures in `TestAdminReviewActionHTTPContract` (topic approval and post rejection). Both reproduce with the pre-change backend files, so they are recorded as baseline failures, not a passing backend-wide suite. The focused course HTTP suite passes.

Pixel golden baselines were not regenerated. Physical-device keyboard/gesture feel remains a device verification step. Owner-first ordering across unloaded pages and the private My course reviews endpoint require deploying the backend alongside the mobile update.
