### PR TITLE
fix: qualify PostgreSQL traffic stat upserts

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.26"
-      - name: Test (PostgreSQL migration + course PG-gated)
+      - name: Test (PostgreSQL migration + PG-gated models)
         working-directory: apps/gooseforum
         env:
           YOURTJ_TEST_PG_URL: "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable"
@@ -174,3 +174,4 @@ jobs:
         run: |
           go test ./app/migration/ -run 'TestSchema' -v
           go test ./app/models/forum/course/ -run 'PostgreSQL$' -v
+          go test ./app/models/forum/dailyStats/ -run 'PostgreSQL$' -v

--- a/apps/gooseforum/app/models/forum/dailyStats/dailyStats_pg_test.go
+++ b/apps/gooseforum/app/models/forum/dailyStats/dailyStats_pg_test.go
@@ -10,7 +10,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-func TestIncrementPostgreSQLExistingRow(t *testing.T) {
+func TestIncrementExistingRowPostgreSQL(t *testing.T) {
 	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
 	if dsn == "" {
 		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL daily stats test")
@@ -34,12 +34,14 @@ func TestIncrementPostgreSQLExistingRow(t *testing.T) {
 	})
 
 	for _, key := range []StatType{StatTypeRegCount, StatTypeTopicCount, StatTypeReplyCount} {
-		if err := db.Table(tableName).Clauses(clause.OnConflict{DoNothing: true}).Create(map[string]any{
-			"stat_date":  dayString,
-			"stat_key":   string(key),
-			"stat_value": int64(0),
-		}).Error; err != nil {
-			t.Fatalf("preinitialize %s: %v", key, err)
+		if key != StatTypeReplyCount {
+			if err := db.Table(tableName).Clauses(clause.OnConflict{DoNothing: true}).Create(map[string]any{
+				"stat_date":  dayString,
+				"stat_key":   string(key),
+				"stat_value": int64(0),
+			}).Error; err != nil {
+				t.Fatalf("preinitialize %s: %v", key, err)
+			}
 		}
 		if err := increment(db.Table(tableName), day, key, 1); err != nil {
 			t.Fatalf("first increment(%s): %v", key, err)

--- a/apps/gooseforum/app/models/forum/dailyStats/dailyStats_pg_test.go
+++ b/apps/gooseforum/app/models/forum/dailyStats/dailyStats_pg_test.go
@@ -1,0 +1,59 @@
+package dailyStats
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func TestIncrementPostgreSQLExistingRow(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL daily stats test")
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	if err := db.AutoMigrate(&Entity{}); err != nil {
+		t.Fatalf("AutoMigrate daily stats on postgres: %v", err)
+	}
+
+	day := time.Date(2099, 1, 3, 0, 0, 0, 0, time.UTC)
+	dayString := day.Format("2006-01-02")
+	if err := db.Where("stat_date = ?", dayString).Delete(&Entity{}).Error; err != nil {
+		t.Fatalf("clean daily stats before test: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Where("stat_date = ?", dayString).Delete(&Entity{}).Error
+	})
+
+	for _, key := range []StatType{StatTypeRegCount, StatTypeTopicCount, StatTypeReplyCount} {
+		if err := db.Table(tableName).Clauses(clause.OnConflict{DoNothing: true}).Create(map[string]any{
+			"stat_date":  dayString,
+			"stat_key":   string(key),
+			"stat_value": int64(0),
+		}).Error; err != nil {
+			t.Fatalf("preinitialize %s: %v", key, err)
+		}
+		if err := increment(db.Table(tableName), day, key, 1); err != nil {
+			t.Fatalf("first increment(%s): %v", key, err)
+		}
+		if err := increment(db.Table(tableName), day, key, 1); err != nil {
+			t.Fatalf("second increment(%s): %v", key, err)
+		}
+
+		var got Entity
+		if err := db.Where("stat_date = ? AND stat_key = ?", dayString, key).First(&got).Error; err != nil {
+			t.Fatalf("load %s: %v", key, err)
+		}
+		if got.StatValue != 2 {
+			t.Fatalf("%s stat_value = %d, want 2", key, got.StatValue)
+		}
+	}
+}

--- a/apps/gooseforum/app/models/forum/dailyStats/dailyStats_rep.go
+++ b/apps/gooseforum/app/models/forum/dailyStats/dailyStats_rep.go
@@ -18,12 +18,16 @@ const (
 
 // Increment 增加统计值 (Upsert)
 func Increment(date time.Time, key StatType, delta int64) error {
+	return increment(builder(), date, key, delta)
+}
+
+func increment(db *gorm.DB, date time.Time, key StatType, delta int64) error {
 	dateStr := date.Format("2006-01-02")
 
-	return builder().Clauses(clause.OnConflict{
+	return db.Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "stat_date"}, {Name: "stat_key"}},
 		DoUpdates: clause.Assignments(map[string]any{
-			"stat_value": gorm.Expr("stat_value + ?", delta),
+			"stat_value": gorm.Expr(tableName+".stat_value + ?", delta),
 		}),
 	}).Create(map[string]any{
 		"stat_date":  dateStr,

--- a/apps/gooseforum/app/service/datamigration/topic_count_naming.go
+++ b/apps/gooseforum/app/service/datamigration/topic_count_naming.go
@@ -76,7 +76,7 @@ func migrateDailyStatsTopicCount(conn *gorm.DB, result *TopicCountNamingResult) 
 		if err := conn.Table("daily_stats").Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "stat_date"}, {Name: "stat_key"}},
 			DoUpdates: clause.Assignments(map[string]any{
-				"stat_value": gorm.Expr("stat_value + ?", row.StatValue),
+				"stat_value": gorm.Expr("daily_stats.stat_value + ?", row.StatValue),
 			}),
 		}).Create(map[string]any{
 			"stat_date":  row.StatDate,


### PR DESCRIPTION
## Summary / 摘要

修复 PostgreSQL 部署下管理后台「流量概览」不累计注册、主题和回复统计的问题。根因是 `daily_stats` 的 `ON CONFLICT DO UPDATE` 中使用了未限定表名的 `stat_value`，在 PostgreSQL 上会触发列引用歧义并导致异步统计事件最终被丢弃。

Closes #543

## Behavior change / 行为变更

- 将 `dailyStats.Increment` 的冲突更新表达式从裸 `stat_value + ?` 改为 `daily_stats.stat_value + ?`，确保 PostgreSQL 能在已有统计行上正确原子累加。
- 同步修正 `topic_count` 历史命名迁移中的同类 PostgreSQL upsert 表达式，避免迁移命中已有目标行时出现相同错误。
- 新增真实 PostgreSQL 回归测试，覆盖 `reg_count`、`topic_count`、`reply_count` 三种统计在预初始化行上的连续累加。
- API schema、前端数据结构和管理后台展示逻辑均不变。

## Verification / 验证

已实际执行并通过：

- [x] `git diff --check`
- [x] `node scripts/run-gates.mjs`
- [x] `cd apps/gooseforum && go vet ./...`
- [x] `cd apps/gooseforum && golangci-lint run --new-from-rev=origin/dev`（0 issues）
- [x] `cd apps/gooseforum/resource && pnpm typecheck`
- [x] 真实 PostgreSQL 下 `TestIncrementPostgreSQLExistingRow`
- [x] `TestAdminTrafficOverviewHTTPContract`
- [x] PostgreSQL `TestSchema*` 迁移测试
- [x] 完整 `go test ./...`
- [x] 构建单一二进制并在 VPS 上启动 PostgreSQL + Meilisearch + 应用服务，健康检查正常
- [x] 端到端实际注册 1 个用户、发布 1 个主题、创建 1 条回复后，管理接口返回当日 `regCount=1`、`topicCount=1`、`replyCount=1`

首次 push 时本地 hook 的 PATH 未包含已安装的 `golangci-lint` / `pnpm`；补齐环境后已将 pre-push 三项检查逐项手动执行并全部通过，再完成 push。

## Docs & contract impact / 文档与契约影响

- 无 OpenAPI / generated client 变更。
- 无用户可见接口或前端行为变更。
- 本次属于内部 PostgreSQL 兼容性 bug 修复；回归测试与现有代码说明足以覆盖本次变更，无需修改产品文档中心。

## Known gaps / 已知缺口

- 本修复恢复部署后新事件的准确增量统计，但此前因异步事件失败而已经丢失的历史统计不会自动重放。
- 本 PR 不猜测或伪造历史数据。若后续需要回填，应按可验证来源单独制定运维方案：注册数可按 `users.created_at` 重建；回复数可按持久化帖子语义重建；主题发布数需谨慎处理草稿后发布/重新发布与 `created_at` 不等价的问题。
