### PR TITLE
fix: bust InsightFlare script cache

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/render_i18n_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/render_i18n_test.go
@@ -39,7 +39,7 @@ func TestAppTemplateInsightFlareRendering(t *testing.T) {
 			if err := reg.render(&buf, "home.gohtml", templateData{Payload: payload, Lang: "en"}); err != nil {
 				t.Fatalf("render home template: %v", err)
 			}
-			got := strings.Contains(buf.String(), "https://ana.yourtj.de/script.js?siteId=")
+			got := strings.Contains(buf.String(), "https://ana.yourtj.de/script.js?siteId=09521282-d1ce-4a88-add6-99c039014def&v=1")
 			if got != tc.want {
 				t.Fatalf("InsightFlare script rendered with enabled=%t, want %t", tc.enabled, tc.want)
 			}

--- a/apps/gooseforum/resource/templates/layout/app.gohtml
+++ b/apps/gooseforum/resource/templates/layout/app.gohtml
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/static/pic/icons/apple-touch-icon.png">
     {{if .Payload.Layout.Site.Favicon}}<link rel="icon" href="{{ResourceAsset .Payload.Layout.Site.Favicon}}">{{end}}
     {{if .Payload.Layout.Site.ExternalLinks}}{{SafeHTML .Payload.Layout.Site.ExternalLinks}}{{end}}
-    {{if .Payload.Layout.InsightFlareEnabled}}<script defer src="https://ana.yourtj.de/script.js?siteId=09521282-d1ce-4a88-add6-99c039014def"></script>{{end}}
+    {{if .Payload.Layout.InsightFlareEnabled}}<script defer src="https://ana.yourtj.de/script.js?siteId=09521282-d1ce-4a88-add6-99c039014def&v=1"></script>{{end}}
     {{ResourceEntry `src/site/main.ts`}}
     {{if .Payload.Layout.Theme.Href}}<link id="goose-site-theme-link" rel="stylesheet" href="{{.Payload.Layout.Theme.Href}}">{{end}}
 </head>

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -116,8 +116,10 @@ Cloudflare 或 InsightFlare 管理面完成，不要把 Wrangler 本地认证文
 ```bash
 curl -fsSL https://ana.yourtj.de/healthz
 curl -fsSL -o /dev/null -w '%{http_code}\n' \
-  'https://ana.yourtj.de/script.js?siteId=09521282-d1ce-4a88-add6-99c039014def'
+  'https://ana.yourtj.de/script.js?siteId=09521282-d1ce-4a88-add6-99c039014def&v=1'
 ```
+
+脚本 URL 的 `v` 参数用于在观测脚本缓存策略变更后强制浏览器重新获取动态脚本；如果脚本缓存契约再次发生不兼容变化，应递增该版本号。
 
 ### 旧 VitePress wiki 内容迁移（GitHub 唯一真实源）
 


### PR DESCRIPTION
## 变更摘要

- 为 InsightFlare 统计脚本 URL 增加 `v=1` 版本参数。
- 让已经缓存旧版动态脚本的浏览器强制重新请求，避免继续复用可能绑定其他客户端 IP 的旧采集 Token。
- 更新部署文档中的验证地址，并说明后续缓存契约变化时需要递增版本号。
- 收紧模板渲染测试，验证脚本 URL 包含固定站点与缓存版本参数。

## 背景

InsightFlare 的 `script.js` 响应包含绑定客户端 IP 的采集 Token。线上 Wrangler tail 已观察到 `collect_token_ip_mismatch` 告警，Hub 侧需要先让存量浏览器脱离旧 URL 的浏览器缓存。

该 PR 只处理 Hub 侧的客户端缓存迁移，不包含 Cloudflare Cache Rule 或 InsightFlare Worker 源码修改。生产环境仍需将 `ana.yourtj.de/script.js` 配置为绕过 CDN 缓存，并清理已有 CDN 缓存。

## 验证结果

- `go test ./app/http/controllers/forum`：通过
- `git diff --check`：通过
- `go test ./...`：统计相关测试通过；全量测试受到本机 Meilisearch 未配置 Authorization 的既有环境问题影响，多个 Wiki/搜索测试返回 401，与本次改动无关。
