### PR TITLE
fix: 首页话题列表参与人存量 posters 回填修复 (issue #554)

### DIFF
--- a/apps/gooseforum/app/migration/app_migration.go
+++ b/apps/gooseforum/app/migration/app_migration.go
@@ -383,6 +383,29 @@ func runVersionedDataMigrations() error {
 		}
 		currentVersion = 28
 	}
+	if currentVersion < 29 {
+		// 存量话题派生统计回填 v29（issue #554）：legacy articles.posters 只存
+		// 楼主，v5 迁移原样拷入 topics.posters；增量路径只在新回复/删回复时
+		// 修复，存量多回复话题首页参与人列长期只显示楼主。从 active posts
+		// 绝对重建 topic_user_stat + posters（复用 postservice.RebuildTopicPostStats
+		// 口径：楼主置前 + 非匿名回复者 top-3，匿名/治理删除楼层排除）。
+		// 幂等：逐话题绝对写，posters 未变化的话题不计为修复。
+		statsResult := datamigration.BackfillTopicPostStats()
+		slog.Info("app migration topic post stats backfill done",
+			"topicsScanned", statsResult.TopicsScanned,
+			"postersRepaired", statsResult.PostersRepaired,
+			"failed", statsResult.Failed,
+			"lastFailed", statsResult.LastFailed)
+		if statsResult.Failed > 0 {
+			slog.Error("app migration topic post stats backfill has failures", "failed", statsResult.Failed, "lastFailed", statsResult.LastFailed)
+			return dataMigrationError("topic post stats backfill", 29, statsResult.Failed, statsResult.LastFailed)
+		}
+		if err := pageConfig.SyncMigrationVersion(29); err != nil {
+			slog.Error("app migration sync migration version failed", "version", 29, "err", err)
+			return fmt.Errorf("app migration v29 sync migration version: %w", err)
+		}
+		currentVersion = 29
+	}
 	slog.Info("app migration end", "version", currentVersion)
 	return nil
 }

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
@@ -109,7 +109,7 @@ func GetPostingSettingsConfig(defaultValue PostingContent) PostingContent {
 	return config
 }
 
-const AppMigrationVersion uint32 = 28
+const AppMigrationVersion uint32 = 29
 
 func GetMigrationVersion() uint32 {
 	configEntity := GetByPageType(Migration)

--- a/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_rep.go
+++ b/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_rep.go
@@ -1,11 +1,20 @@
 package topicUserStat
 
 import (
+	"log/slog"
 	"time"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
+
+// ReplierStat 单个回复者的重建聚合值。LastReplyAt 必须来自历史回复的
+// MAX(created_at)，绝不重放增量路径的 time.Now()（PR #575 review P2）。
+type ReplierStat struct {
+	UserID      uint64
+	ReplyCount  uint32
+	LastReplyAt time.Time
+}
 
 func SaveOrCreateById(entity *Entity) int64 {
 	if entity.Id == 0 {
@@ -37,18 +46,57 @@ func DecrementUserPost(topicId, userId uint64) error {
 		Update("reply_count", gorm.Expr("reply_count - 1")).
 		Error
 }
-
-func SyncTopicPosters(topicId uint64) []uint64 {
-	var activeUserIDs []uint64
-	builder().
-		Where("topic_id = ?", topicId).
-		Order("reply_count DESC, last_reply_at DESC").
-		Limit(3).
-		Pluck("user_id", &activeUserIDs)
-	return activeUserIDs
+func SyncTopicPosters(topicId, excludeUserId uint64) []uint64 {
+	ids, err := syncTopicPosters(builder(), topicId, excludeUserId)
+	if err != nil {
+		slog.Error("sync topic posters failed", "topicId", topicId, "err", err)
+		return nil
+	}
+	return ids
 }
 
-// DeleteByTopicID clears derived participant counts before a full rebuild.
-func DeleteByTopicID(topicID uint64) error {
-	return builder().Where("topic_id = ?", topicID).Delete(&Entity{}).Error
+// SyncTopicPostersTx 是 SyncTopicPosters 的事务内变体，供绝对重建在
+// 调用方事务中读取一致快照；查询失败必须传播错误让重建事务整体回滚，
+// 绝不允许把查询失败伪装成"空参与者"静默落库（PR #575 review P1）。
+func SyncTopicPostersTx(tx *gorm.DB, topicId, excludeUserId uint64) ([]uint64, error) {
+	return syncTopicPosters(tx, topicId, excludeUserId)
+}
+
+func syncTopicPosters(b *gorm.DB, topicId, excludeUserId uint64) ([]uint64, error) {
+	var activeUserIDs []uint64
+	err := b.Model(&Entity{}).
+		Where("topic_id = ?", topicId).
+		Where("user_id <> ?", excludeUserId).
+		Order("reply_count DESC").
+		Order("last_reply_at DESC").
+		Order("user_id ASC").
+		Limit(3).
+		Pluck("user_id", &activeUserIDs).Error
+	return activeUserIDs, err
+}
+func DeleteByTopicIDTx(tx *gorm.DB, topicID uint64) error {
+	return tx.Where("topic_id = ?", topicID).Delete(&Entity{}).Error
+}
+
+// BulkUpsertRepliersTx 集合化写入全部回复者统计：单条多值 INSERT（每话题
+// 固定一次往返，取代逐回复 upsert，PR #575 review P2）。last_reply_at 用
+// 调用方聚合的历史值显式写入，冲突时同样覆盖——重建路径绝不把历史时间
+// 戳替换为部署时间。
+func BulkUpsertRepliersTx(tx *gorm.DB, topicID uint64, repliers []ReplierStat) error {
+	if len(repliers) == 0 {
+		return nil
+	}
+	rows := make([]Entity, 0, len(repliers))
+	for _, replier := range repliers {
+		rows = append(rows, Entity{
+			TopicId:     topicID,
+			UserId:      replier.UserID,
+			ReplyCount:  replier.ReplyCount,
+			LastReplyAt: replier.LastReplyAt,
+		})
+	}
+	return tx.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "topic_id"}, {Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"reply_count", "last_reply_at"}),
+	}).Create(&rows).Error
 }

--- a/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_rep.go
+++ b/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_rep.go
@@ -25,8 +25,13 @@ func SaveOrCreateById(entity *Entity) int64 {
 }
 
 func IncrementUserPost(topicId, userId uint64) error {
+	return IncrementUserPostTx(builder(), topicId, userId)
+}
+
+// IncrementUserPostTx keeps participant counts in the post write transaction.
+func IncrementUserPostTx(tx *gorm.DB, topicId, userId uint64) error {
 	now := time.Now()
-	return builder().Clauses(clause.OnConflict{
+	return tx.Table(tableName).Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "topic_id"}, {Name: "user_id"}},
 		DoUpdates: clause.Assignments(map[string]any{
 			"reply_count":   gorm.Expr("reply_count + 1"),
@@ -78,8 +83,8 @@ func DeleteByTopicIDTx(tx *gorm.DB, topicID uint64) error {
 	return tx.Where("topic_id = ?", topicID).Delete(&Entity{}).Error
 }
 
-// BulkUpsertRepliersTx 集合化写入全部回复者统计：单条多值 INSERT（每话题
-// 固定一次往返，取代逐回复 upsert，PR #575 review P2）。last_reply_at 用
+// BulkUpsertRepliersTx 集合化写入全部回复者统计：每批最多 500 行的多值 INSERT，
+// 控制 PostgreSQL/SQLite 参数数量并避免逐回复 upsert。last_reply_at 用
 // 调用方聚合的历史值显式写入，冲突时同样覆盖——重建路径绝不把历史时间
 // 戳替换为部署时间。
 func BulkUpsertRepliersTx(tx *gorm.DB, topicID uint64, repliers []ReplierStat) error {
@@ -98,5 +103,5 @@ func BulkUpsertRepliersTx(tx *gorm.DB, topicID uint64, repliers []ReplierStat) e
 	return tx.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "topic_id"}, {Name: "user_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"reply_count", "last_reply_at"}),
-	}).Create(&rows).Error
+	}).CreateInBatches(&rows, 500).Error
 }

--- a/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_test.go
+++ b/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_test.go
@@ -3,6 +3,7 @@ package topicUserStat
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 )
@@ -41,5 +42,26 @@ func TestTopicUserStatRepositoryParity(t *testing.T) {
 	conn.Where("topic_id = ? AND user_id = ?", 10, 1).First(&row)
 	if row.ReplyCount != 1 {
 		t.Fatalf("ReplyCount after decrement=%d, want 1", row.ReplyCount)
+	}
+}
+
+func TestBulkUpsertRepliersLargeTopic(t *testing.T) {
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&Entity{}); err != nil {
+		t.Fatal(err)
+	}
+	const topicID = 991234
+	t.Cleanup(func() { conn.Where("topic_id = ?", topicID).Delete(&Entity{}) })
+	rows := make([]ReplierStat, 12000)
+	for i := range rows {
+		rows[i] = ReplierStat{UserID: uint64(i + 1), ReplyCount: 2, LastReplyAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)}
+	}
+	if err := BulkUpsertRepliersTx(conn, topicID, rows); err != nil {
+		t.Fatal(err)
+	}
+	var count int64
+	conn.Model(&Entity{}).Where("topic_id = ?", topicID).Count(&count)
+	if count != int64(len(rows)) {
+		t.Fatalf("got %d rows, want %d", count, len(rows))
 	}
 }

--- a/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_test.go
+++ b/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_test.go
@@ -29,8 +29,11 @@ func TestTopicUserStatRepositoryParity(t *testing.T) {
 	if row.ReplyCount != 2 {
 		t.Fatalf("ReplyCount=%d, want 2", row.ReplyCount)
 	}
-	if got := SyncTopicPosters(10); !reflect.DeepEqual(got, []uint64{1, 2}) {
+	if got := SyncTopicPosters(10, 0); !reflect.DeepEqual(got, []uint64{1, 2}) {
 		t.Fatalf("SyncTopicPosters()=%#v, want [1 2]", got)
+	}
+	if got := SyncTopicPosters(10, 1); !reflect.DeepEqual(got, []uint64{2}) {
+		t.Fatalf("SyncTopicPosters(exclude 1)=%#v, want [2]", got)
 	}
 	if err := DecrementUserPost(10, 1); err != nil {
 		t.Fatalf("DecrementUserPost err=%v", err)

--- a/apps/gooseforum/app/models/forum/topics/topics_rep.go
+++ b/apps/gooseforum/app/models/forum/topics/topics_rep.go
@@ -564,7 +564,12 @@ func IncrementViews(counts map[uint64]uint64) error {
 }
 
 func IncrementPostFast(topicId uint64, posters []Poster, lastPostID uint64, lastPostedAt time.Time) error {
-	return builder().Where("id = ?", topicId).Updates(map[string]any{
+	return IncrementPostFastTx(builder(), topicId, posters, lastPostID, lastPostedAt)
+}
+
+// IncrementPostFastTx updates counters while the post transaction holds the topic lock.
+func IncrementPostFastTx(tx *gorm.DB, topicId uint64, posters []Poster, lastPostID uint64, lastPostedAt time.Time) error {
+	return tx.Model(&Entity{}).Where("id = ?", topicId).Updates(map[string]any{
 		"post_count":  gorm.Expr("post_count + 1"),
 		"reply_count": gorm.Expr("reply_count + 1"),
 		"posters":     jsonopt.Encode(posters),
@@ -610,7 +615,12 @@ func ReplacePostStatsTx(tx *gorm.DB, topicID uint64, postCount uint64, replyCoun
 }
 
 func ReservePostSequence(topicId uint64) (uint64, error) {
-	result := builder().
+	return ReservePostSequenceTx(builder(), topicId)
+}
+
+// ReservePostSequenceTx holds the topic write lock until the caller commits.
+func ReservePostSequenceTx(tx *gorm.DB, topicId uint64) (uint64, error) {
+	result := tx.Model(&Entity{}).
 		Where("id = ?", topicId).
 		Update("post_seq", gorm.Expr("post_seq + 1"))
 	if result.Error != nil {
@@ -621,7 +631,7 @@ func ReservePostSequence(topicId uint64) (uint64, error) {
 	}
 
 	var postSeq uint64
-	err := builder().
+	err := tx.Model(&Entity{}).
 		Select("post_seq").
 		Where("id = ?", topicId).
 		Scan(&postSeq).Error

--- a/apps/gooseforum/app/models/forum/topics/topics_rep.go
+++ b/apps/gooseforum/app/models/forum/topics/topics_rep.go
@@ -590,17 +590,23 @@ func DecrementPostFast(topicId uint64, posters []Poster, lastPostID uint64, last
 	}).Error
 }
 
-// ReplacePostStats writes the exact derived post counters for a topic.
-// Recovery must use this instead of increment/decrement helpers because those
-// helpers intentionally model a single state transition, not a full rebuild.
-func ReplacePostStats(topicID uint64, postCount uint64, replyCount uint64, posters []Poster, lastPostID uint64, lastPostedAt time.Time) error {
-	return builder().Where("id = ?", topicID).Updates(map[string]any{
-		"post_count":     postCount,
-		"reply_count":    replyCount,
-		"posters":        jsonopt.Encode(posters),
-		"last_post_id":   lastPostID,
-		"last_posted_at": lastPostedAt,
-	}).Error
+// ReplacePostStatsTx writes the exact derived post counters for a topic
+// inside the caller's transaction. UpdateColumns keeps the write
+// column-exact: derived rebuilds must never touch topics.updated_at
+// (home list sort key); Unscoped keeps soft-deleted rows repairable.
+// Recovery must use this instead of increment/decrement helpers because
+// those helpers intentionally model a single state transition, not a
+// full rebuild.
+func ReplacePostStatsTx(tx *gorm.DB, topicID uint64, postCount uint64, replyCount uint64, posters []Poster, lastPostID uint64, lastPostedAt time.Time) error {
+	return tx.Unscoped().Model(&Entity{}).
+		Where("id = ?", topicID).
+		UpdateColumns(map[string]any{
+			"post_count":     postCount,
+			"reply_count":    replyCount,
+			"posters":        jsonopt.Encode(posters),
+			"last_post_id":   lastPostID,
+			"last_posted_at": lastPostedAt,
+		}).Error
 }
 
 func ReservePostSequence(topicId uint64) (uint64, error) {

--- a/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
@@ -408,9 +408,10 @@ func RestoreContent(userID uint64, contentType ContentType, contentID uint64) er
 		reapplyPostReward(post.UserId, post.Id)
 		topicEntity := topics.GetSimple(post.TopicId)
 		if topicEntity.Id > 0 {
-			var activePosts []*posts.Entity
-			if err := posts.ListByTopicID(topicEntity.Id, &activePosts); err == nil {
-				_ = postservice.RebuildTopicPostStats(topicEntity, activePosts)
+			// 重建在函数内自载入 posts 并以独立事务执行：话题行锁 + 绝对写
+			// 原子提交（PR #575 review P1）。
+			if err := postservice.RebuildTopicPostStats(topicEntity); err != nil {
+				slog.Error("failed to rebuild topic stats after post restore", "topicId", topicEntity.Id, "error", err)
 			}
 			hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 			llmsservice.ClearCache()
@@ -460,7 +461,9 @@ func restoreTopicPosts(topicID uint64, operatorID uint64) {
 		slog.Error("failed to load posts for topic stats rebuild", "topicId", topicID, "error", err)
 		return
 	}
-	if err := postservice.RebuildTopicPostStats(topic, activePosts); err != nil {
+	// 重建在函数内自载入 posts 并以独立事务执行：话题行锁 + 绝对写原子提交
+	// （PR #575 review P1）。activePosts 仅用于下方的附件引用恢复。
+	if err := postservice.RebuildTopicPostStats(topic); err != nil {
 		slog.Error("failed to rebuild topic stats", "topicId", topicID, "error", err)
 	}
 	for _, post := range activePosts {
@@ -551,7 +554,9 @@ func restoreModeratorRemovedTopicPosts(topic topics.Entity, moderatorID uint64) 
 		slog.Error("failed to load posts for moderator restore stats rebuild", "topicId", topic.Id, "error", err)
 		return
 	}
-	if err := postservice.RebuildTopicPostStats(topic, activePosts); err != nil {
+	// 重建在函数内自载入 posts 并以独立事务执行：话题行锁 + 绝对写原子提交
+	// （PR #575 review P1）。activePosts 仅用于下方的附件引用恢复。
+	if err := postservice.RebuildTopicPostStats(topic); err != nil {
 		slog.Error("failed to rebuild topic stats after moderator restore", "topicId", topic.Id, "error", err)
 	}
 	for _, post := range activePosts {

--- a/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
+++ b/apps/gooseforum/app/service/contentdeleteservice/content_delete_service.go
@@ -147,11 +147,11 @@ func DeleteTopicAs(topic topics.Entity, operatorID uint64, visibility string, re
 			}
 		}
 		deletedCount := posts.SoftDeleteByIDs(activePostIDs, operatorID, cascadeReason, visibility)
+		postservice.SyncTopicPostStats(topic)
 		for _, post := range activePosts {
 			if post == nil || post.UserId == 0 {
 				continue
 			}
-			postservice.SyncTopicPostStats(topic, *post, true)
 			fileusageservice.HardenTargetFiles(postsTarget(post.Id), time.Now().Add(RecoveryWindow))
 		}
 		slog.Info("topic deleted without replies, cascade posts", "topicId", topic.Id, "posts", deletedCount)
@@ -274,7 +274,7 @@ func DeletePostByUser(userID uint64, postID uint64) (DeletePostResult, error) {
 
 	topicEntity := topics.GetSimple(post.TopicId)
 	if topicEntity.Id > 0 {
-		postservice.SyncTopicPostStats(topicEntity, post, true)
+		postservice.SyncTopicPostStats(topicEntity)
 		hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		llmsservice.ClearCache()
 	}
@@ -338,7 +338,7 @@ func DeletePostAsModerator(moderatorID uint64, postID uint64, reason string) err
 	fileusageservice.HardenTargetFiles(postsTarget(postID), time.Now().Add(RecoveryWindow))
 	topicEntity := topics.GetSimple(post.TopicId)
 	if topicEntity.Id > 0 {
-		postservice.SyncTopicPostStats(topicEntity, post, true)
+		postservice.SyncTopicPostStats(topicEntity)
 		hotdataserve.InvalidateTopicListCacheForCategories(topicEntity.CategoryIds...)
 		llmsservice.ClearCache()
 	}

--- a/apps/gooseforum/app/service/datamigration/topic_post_stats_backfill.go
+++ b/apps/gooseforum/app/service/datamigration/topic_post_stats_backfill.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/postservice"
 	"gorm.io/gorm"
@@ -88,37 +87,21 @@ func BackfillTopicPostStatsWithDB(conn *gorm.DB) TopicPostStatsBackfillResult {
 }
 
 // backfillTopicPostStatsForOne 对单个话题执行绝对重建，返回 posters 是否
-// 发生修复。回填不得扰动 topics.updated_at（首页默认排序键）：派生写路径
-// ReplacePostStats 走 GORM Updates 会自动触碰 updated_at，这里以快照恢复。
+// 发生修复。重建在注入连接的事务内执行（话题行锁 + 绝对写原子提交，
+// PR #575 review P1）；updated_at 由 ReplacePostStatsTx 的 UpdateColumns
+// 天然保护，派生写永不触碰首页排序键。
 func backfillTopicPostStatsForOne(conn *gorm.DB, topic topics.Entity) (bool, error) {
-	// 与 contentdeleteservice 的重建载入一致：Unscoped + post_no/id 升序，
-	// 由 RebuildTopicPostStats 按 visibility=ACTIVE 过滤。
-	var activePosts []*posts.Entity
-	if err := conn.Unscoped().
-		Where("topic_id = ?", topic.Id).
-		Order("post_no asc").
-		Order("id asc").
-		Find(&activePosts).Error; err != nil {
-		return false, fmt.Errorf("load posts: %w", err)
-	}
-
 	postersBefore := postersJSON(topic.Posters)
-	updatedAtBefore := topic.UpdatedAt
 
-	if err := postservice.RebuildTopicPostStats(topic, activePosts); err != nil {
+	if err := conn.Transaction(func(tx *gorm.DB) error {
+		return postservice.RebuildTopicPostStatsTx(tx, topic)
+	}); err != nil {
 		return false, fmt.Errorf("rebuild stats: %w", err)
 	}
 
 	var after topics.Entity
 	if err := conn.Unscoped().Where("id = ?", topic.Id).First(&after).Error; err != nil {
 		return false, fmt.Errorf("reload topic: %w", err)
-	}
-	if !updatedAtBefore.IsZero() && !after.UpdatedAt.Equal(updatedAtBefore) {
-		if err := conn.Model(&topics.Entity{}).Unscoped().
-			Where("id = ?", topic.Id).
-			UpdateColumn("updated_at", updatedAtBefore).Error; err != nil {
-			return false, fmt.Errorf("restore updated_at: %w", err)
-		}
 	}
 	return postersJSON(after.Posters) != postersBefore, nil
 }

--- a/apps/gooseforum/app/service/datamigration/topic_post_stats_backfill.go
+++ b/apps/gooseforum/app/service/datamigration/topic_post_stats_backfill.go
@@ -1,0 +1,137 @@
+package datamigration
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/postservice"
+	"gorm.io/gorm"
+)
+
+// topicPostStatsBackfillBatch 单批扫描的话题数，控制全量回填的内存占用。
+const topicPostStatsBackfillBatch = 500
+
+// TopicPostStatsBackfillResult 汇总存量派生统计回填结果（issue #554）。
+type TopicPostStatsBackfillResult struct {
+	// TopicsScanned 本次回填扫描的话题总数。
+	TopicsScanned int
+	// PostersRepaired 回填前后 topics.posters JSON 发生变化的话题数（观测指标）。
+	PostersRepaired int
+	Failed          int
+	LastFailed      string
+}
+
+// BackfillTopicPostStats 从 active posts 绝对重建全部话题的
+// topic_user_stat 与 topics.posters（issue #554）。
+//
+// 根因：legacy articles.posters 只存楼主，v5 迁移原样拷入 topics.posters；
+// 增量路径（SyncTopicPostStats）只在新回复/删回复时修复，存量多回复话题
+// 的首页参与人列长期只显示楼主。
+//
+// 策略：派生口径的单一所有者是 postservice.RebuildTopicPostStats——先清空
+// topic_user_stat，再从 active posts（visibility=ACTIVE，匿名楼层排除，
+// issue #524）重建计数、first/last 指针与 posters（楼主置前 + 非匿名回复者
+// top-3）。绝对重建对任何存量形态（楼主-only/空/零计数残留）幂等。
+func BackfillTopicPostStats() TopicPostStatsBackfillResult {
+	return BackfillTopicPostStatsWithDB(db.Connect())
+}
+
+// BackfillTopicPostStatsWithDB 使用指定连接执行回填，便于测试注入。
+// 逐话题独立、绝对写：单话题失败记录后继续，最终由调用方
+// （app_migration v29）按 Failed>0 阻断启动、下次启动重跑。
+func BackfillTopicPostStatsWithDB(conn *gorm.DB) TopicPostStatsBackfillResult {
+	result := TopicPostStatsBackfillResult{}
+	lastID := uint64(0)
+	for {
+		var batch []topics.Entity
+		if err := conn.Unscoped().
+			Where("id > ?", lastID).
+			Order("id asc").
+			Limit(topicPostStatsBackfillBatch).
+			Find(&batch).Error; err != nil {
+			result.Failed++
+			result.LastFailed = "topics_scan:" + err.Error()
+			slog.Error("backfill topic post stats scan failed", "afterId", lastID, "err", err)
+			return result
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, topic := range batch {
+			result.TopicsScanned++
+			lastID = topic.Id
+			repaired, err := backfillTopicPostStatsForOne(conn, topic)
+			if err != nil {
+				result.Failed++
+				result.LastFailed = fmt.Sprintf("topic %d: %v", topic.Id, err)
+				slog.Error("backfill topic post stats failed", "topicId", topic.Id, "err", err)
+				continue
+			}
+			if repaired {
+				result.PostersRepaired++
+			}
+		}
+		if len(batch) < topicPostStatsBackfillBatch {
+			break
+		}
+	}
+	slog.Info("backfill topic post stats done",
+		"topicsScanned", result.TopicsScanned,
+		"postersRepaired", result.PostersRepaired,
+		"failed", result.Failed,
+		"lastFailed", result.LastFailed)
+	return result
+}
+
+// backfillTopicPostStatsForOne 对单个话题执行绝对重建，返回 posters 是否
+// 发生修复。回填不得扰动 topics.updated_at（首页默认排序键）：派生写路径
+// ReplacePostStats 走 GORM Updates 会自动触碰 updated_at，这里以快照恢复。
+func backfillTopicPostStatsForOne(conn *gorm.DB, topic topics.Entity) (bool, error) {
+	// 与 contentdeleteservice 的重建载入一致：Unscoped + post_no/id 升序，
+	// 由 RebuildTopicPostStats 按 visibility=ACTIVE 过滤。
+	var activePosts []*posts.Entity
+	if err := conn.Unscoped().
+		Where("topic_id = ?", topic.Id).
+		Order("post_no asc").
+		Order("id asc").
+		Find(&activePosts).Error; err != nil {
+		return false, fmt.Errorf("load posts: %w", err)
+	}
+
+	postersBefore := postersJSON(topic.Posters)
+	updatedAtBefore := topic.UpdatedAt
+
+	if err := postservice.RebuildTopicPostStats(topic, activePosts); err != nil {
+		return false, fmt.Errorf("rebuild stats: %w", err)
+	}
+
+	var after topics.Entity
+	if err := conn.Unscoped().Where("id = ?", topic.Id).First(&after).Error; err != nil {
+		return false, fmt.Errorf("reload topic: %w", err)
+	}
+	if !updatedAtBefore.IsZero() && !after.UpdatedAt.Equal(updatedAtBefore) {
+		if err := conn.Model(&topics.Entity{}).Unscoped().
+			Where("id = ?", topic.Id).
+			UpdateColumn("updated_at", updatedAtBefore).Error; err != nil {
+			return false, fmt.Errorf("restore updated_at: %w", err)
+		}
+	}
+	return postersJSON(after.Posters) != postersBefore, nil
+}
+
+// postersJSON 序列化 posters 为可比对字符串；解析失败按 nil 处理
+// （存量库该列由 GORM JSON serializer 写入，正常恒为合法 JSON）。
+func postersJSON(posters []topics.Poster) string {
+	if len(posters) == 0 {
+		return "[]"
+	}
+	encoded, err := json.Marshal(posters)
+	if err != nil {
+		return "[]"
+	}
+	return string(encoded)
+}

--- a/apps/gooseforum/app/service/datamigration/topic_post_stats_backfill_test.go
+++ b/apps/gooseforum/app/service/datamigration/topic_post_stats_backfill_test.go
@@ -1,0 +1,212 @@
+package datamigration
+
+import (
+	"testing"
+	"time"
+
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserStat"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+)
+
+// issue #554：存量话题的 topics.posters 由 legacy articles.posters 原样拷入
+// （只含楼主），增量路径只在有新回复时修复，老话题首页参与人列长期只显示
+// 楼主。回填必须从 active posts 绝对重建 topic_user_stat + posters，口径与
+// postservice.RebuildTopicPostStats 一致（楼主置前 + 非匿名回复者取 top-3，
+// 匿名/治理删除楼层排除），且不得扰动首页默认排序键 topics.updated_at。
+func TestBackfillTopicPostStatsRepairsLegacyPosters(t *testing.T) {
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&topics.Entity{}, &posts.Entity{}, &topicUserStat.Entity{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	const (
+		topicID     = uint64(9_800_002_001)
+		authorID    = uint64(9_800_002_099)
+		replier1    = uint64(9_800_002_101)
+		replier2    = uint64(9_800_002_102)
+		replier3    = uint64(9_800_002_103)
+		anonymousID = uint64(9_800_002_104)
+		removedID   = uint64(9_800_002_105)
+
+		firstPostID = uint64(9_800_002_011)
+		reply1ID    = uint64(9_800_002_012)
+		reply2ID    = uint64(9_800_002_013)
+		reply3ID    = uint64(9_800_002_014)
+		anonPostID  = uint64(9_800_002_015)
+		removedPID  = uint64(9_800_002_016)
+	)
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Cleanup(func() {
+		conn.Unscoped().Where("id = ?", topicID).Delete(&topics.Entity{})
+		conn.Unscoped().Where("topic_id = ?", topicID).Delete(&posts.Entity{})
+		conn.Where("topic_id = ?", topicID).Delete(&topicUserStat.Entity{})
+	})
+
+	// 存量坏话题：posters 只含楼主（legacy 拷贝形态）；updated_at 固定为历史
+	// 值，用于断言回填不扰动排序键。
+	staleUpdatedAt := base.Add(48 * time.Hour)
+	topic := topics.Entity{
+		Id:      topicID,
+		Title:   "legacy posters topic",
+		UserId:  authorID,
+		Status:  1,
+		Posters: []topics.Poster{{UserID: authorID}},
+	}
+	if err := conn.Create(&topic).Error; err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).
+		UpdateColumn("updated_at", staleUpdatedAt).Error; err != nil {
+		t.Fatalf("set stale updated_at: %v", err)
+	}
+
+	newPost := func(id uint64, postNo uint64, userID uint64, createdAt time.Time, anonymous bool, visibility string) {
+		entity := posts.Entity{
+			Id:               id,
+			TopicId:          topicID,
+			PostNo:           postNo,
+			UserId:           userID,
+			Content:          "post content",
+			IsAnonymous:      anonymous,
+			VisibilityStatus: visibility,
+			RetentionStatus:  posts.RetentionNormal,
+			CreatedAt:        createdAt,
+		}
+		if err := conn.Create(&entity).Error; err != nil {
+			t.Fatalf("create post %d: %v", id, err)
+		}
+	}
+	newPost(firstPostID, 1, authorID, base, false, posts.VisibilityActive)
+	newPost(reply1ID, 2, replier1, base.Add(time.Hour), false, posts.VisibilityActive)
+	newPost(reply2ID, 3, replier2, base.Add(2*time.Hour), false, posts.VisibilityActive)
+	newPost(reply3ID, 4, replier3, base.Add(3*time.Hour), false, posts.VisibilityActive)
+	// 匿名楼层（issue #524）：计入楼层/最后回复指针，但绝不进入参与人表面。
+	newPost(anonPostID, 5, anonymousID, base.Add(4*time.Hour), true, posts.VisibilityActive)
+	// 治理删除的回复（USER_DELETED，恢复窗口内）：不进入任何派生统计。
+	newPost(removedPID, 6, removedID, base.Add(5*time.Hour), false, posts.VisibilityUserDeleted)
+
+	result := BackfillTopicPostStatsWithDB(conn)
+	if result.Failed != 0 {
+		t.Fatalf("backfill failed=%d last=%s", result.Failed, result.LastFailed)
+	}
+
+	after := topics.UnscopedGet(topicID)
+	posters := after.Posters
+	if len(posters) != 4 {
+		t.Fatalf("posters len=%d (%v), want 4 (author + top-3 repliers)", len(posters), posters)
+	}
+	if posters[0].UserID != authorID {
+		t.Fatalf("posters[0]=%d, want author %d first", posters[0].UserID, authorID)
+	}
+	seen := map[uint64]bool{}
+	for _, poster := range posters[1:] {
+		seen[poster.UserID] = true
+	}
+	for _, want := range []uint64{replier1, replier2, replier3} {
+		if !seen[want] {
+			t.Fatalf("posters missing replier %d: %v", want, posters)
+		}
+	}
+	for _, banned := range []uint64{anonymousID, removedID} {
+		if seen[banned] {
+			t.Fatalf("posters must exclude user %d: %v", banned, posters)
+		}
+	}
+
+	if after.PostCount != 5 || after.ReplyCount != 4 {
+		t.Fatalf("counts post=%d reply=%d, want 5/4 (removed reply excluded)", after.PostCount, after.ReplyCount)
+	}
+	if after.LastPostId != anonPostID {
+		t.Fatalf("lastPostId=%d, want %d (anonymous reply still tracks last activity)", after.LastPostId, anonPostID)
+	}
+	if after.LastPostedAt == nil || !after.LastPostedAt.Equal(base.Add(4*time.Hour)) {
+		t.Fatalf("lastPostedAt=%v, want %v", after.LastPostedAt, base.Add(4*time.Hour))
+	}
+	if !after.UpdatedAt.Equal(staleUpdatedAt) {
+		t.Fatalf("updated_at perturbed by backfill: %v, want %v", after.UpdatedAt, staleUpdatedAt)
+	}
+
+	var statRows []topicUserStat.Entity
+	if err := conn.Where("topic_id = ?", topicID).Order("user_id asc").Find(&statRows).Error; err != nil {
+		t.Fatalf("read topic_user_stat: %v", err)
+	}
+	if len(statRows) != 3 {
+		t.Fatalf("topic_user_stat rows=%d (%v), want 3 non-anonymous repliers", len(statRows), statRows)
+	}
+	for _, row := range statRows {
+		if row.UserId == anonymousID || row.UserId == removedID || row.UserId == authorID {
+			t.Fatalf("topic_user_stat must exclude anonymous/removed/first-post author, got %d", row.UserId)
+		}
+	}
+
+	// 幂等：第二次执行不再产生修复。
+	again := BackfillTopicPostStatsWithDB(conn)
+	if again.Failed != 0 {
+		t.Fatalf("second backfill failed=%d last=%s", again.Failed, again.LastFailed)
+	}
+	if again.PostersRepaired != 0 {
+		t.Fatalf("second backfill repaired=%d, want 0 (idempotent)", again.PostersRepaired)
+	}
+}
+
+// 已按新模型口径正确的话题：回填不得计数为修复，也不得改写派生状态。
+func TestBackfillTopicPostStatsKeepsCorrectTopics(t *testing.T) {
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&topics.Entity{}, &posts.Entity{}, &topicUserStat.Entity{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	const (
+		topicID   = uint64(9_800_002_201)
+		authorID  = uint64(9_800_002_299)
+		replierID = uint64(9_800_002_298)
+	)
+	base := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Cleanup(func() {
+		conn.Unscoped().Where("id = ?", topicID).Delete(&topics.Entity{})
+		conn.Unscoped().Where("topic_id = ?", topicID).Delete(&posts.Entity{})
+		conn.Where("topic_id = ?", topicID).Delete(&topicUserStat.Entity{})
+	})
+
+	topic := topics.Entity{
+		Id:      topicID,
+		Title:   "already correct topic",
+		UserId:  authorID,
+		Status:  1,
+		Posters: []topics.Poster{{UserID: authorID}, {UserID: replierID}},
+	}
+	if err := conn.Create(&topic).Error; err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	for _, p := range []posts.Entity{
+		{Id: 9_800_002_211, TopicId: topicID, PostNo: 1, UserId: authorID, Content: "first", VisibilityStatus: posts.VisibilityActive, RetentionStatus: posts.RetentionNormal, CreatedAt: base},
+		{Id: 9_800_002_212, TopicId: topicID, PostNo: 2, UserId: replierID, Content: "reply", VisibilityStatus: posts.VisibilityActive, RetentionStatus: posts.RetentionNormal, CreatedAt: base.Add(time.Hour)},
+	} {
+		if err := conn.Create(&p).Error; err != nil {
+			t.Fatalf("create post: %v", err)
+		}
+	}
+	before := topics.UnscopedGet(topicID)
+
+	result := BackfillTopicPostStatsWithDB(conn)
+	if result.Failed != 0 {
+		t.Fatalf("backfill failed=%d last=%s", result.Failed, result.LastFailed)
+	}
+	if result.PostersRepaired != 0 {
+		t.Fatalf("postersRepaired=%d, want 0 for already-correct topics", result.PostersRepaired)
+	}
+	after := topics.UnscopedGet(topicID)
+	if len(after.Posters) != 2 || after.Posters[0].UserID != authorID || after.Posters[1].UserID != replierID {
+		t.Fatalf("posters changed for correct topic: %v", after.Posters)
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Fatalf("updated_at perturbed for correct topic: %v -> %v", before.UpdatedAt, after.UpdatedAt)
+	}
+	if after.PostCount != 2 || after.ReplyCount != 1 {
+		t.Fatalf("counts post=%d reply=%d, want 2/1", after.PostCount, after.ReplyCount)
+	}
+}

--- a/apps/gooseforum/app/service/mcpservice/mcpservice_test.go
+++ b/apps/gooseforum/app/service/mcpservice/mcpservice_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicCategoryIndex"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserStat"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/userStatistics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/users"
@@ -39,6 +40,7 @@ func setupMCPServiceTestDB(t *testing.T) *gorm.DB {
 		&userStatistics.Entity{},
 		&agents.Entity{},
 		&topics.Entity{},
+		&topicUserStat.Entity{},
 		&postRevisions.Entity{},
 		&posts.Entity{},
 		&category.Entity{},
@@ -60,6 +62,7 @@ func setupMCPServiceTestDB(t *testing.T) *gorm.DB {
 }
 
 func cleanMCPServiceTables(conn *gorm.DB) {
+	conn.Where("1 = 1").Delete(&topicUserStat.Entity{})
 	conn.Where("1 = 1").Delete(&posts.Entity{})
 	conn.Where("1 = 1").Delete(&topicCategoryIndex.Entity{})
 	conn.Where("1 = 1").Delete(&postRevisions.Entity{})
@@ -297,7 +300,7 @@ func TestCreatePostTool(t *testing.T) {
 		t.Fatalf("call create_post: %v", err)
 	}
 	if res.IsError {
-		t.Fatalf("create_post returned error: %+v", res.Content)
+		t.Fatalf("create_post returned error: %s", mustJSON(res.Content))
 	}
 	out := res.StructuredContent.(map[string]any)
 	if id := asUint(out["id"]); id == 0 {

--- a/apps/gooseforum/app/service/postservice/create_stats_atomic_test.go
+++ b/apps/gooseforum/app/service/postservice/create_stats_atomic_test.go
@@ -1,0 +1,51 @@
+package postservice
+
+import (
+	"errors"
+	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/postRevisions"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserStat"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+	"gorm.io/gorm"
+	"testing"
+)
+
+func TestCreateTopicPostStatsFailureRollsBackWholeWrite(t *testing.T) {
+	conn := db.Connect()
+	if err := conn.AutoMigrate(&topics.Entity{}, &posts.Entity{}, &postRevisions.Entity{}, &topicUserStat.Entity{}); err != nil {
+		t.Fatal(err)
+	}
+	topic := topics.Entity{Id: 991234, UserId: 1, PostSeq: 1, PostCount: 1, Status: 1}
+	if err := conn.Create(&topic).Error; err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		conn.Unscoped().Where("id = ?", topic.Id).Delete(&topics.Entity{})
+		conn.Unscoped().Where("topic_id = ?", topic.Id).Delete(&posts.Entity{})
+		conn.Where("topic_id = ?", topic.Id).Delete(&topicUserStat.Entity{})
+	})
+	failure := errors.New("stats unavailable")
+	if err := conn.Callback().Create().Before("gorm:create").Register("review:fail_stats", func(tx *gorm.DB) {
+		if tx.Statement.Table == "topic_user_stat" {
+			tx.AddError(failure)
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Callback().Create().Remove("review:fail_stats") })
+	post := posts.Entity{TopicId: topic.Id, UserId: 2, Content: "reply", VisibilityStatus: posts.VisibilityActive}
+	err := CreateTopicPost(&post, topic)
+	if !errors.Is(err, failure) {
+		t.Fatalf("expected stats error, got %v", err)
+	}
+	var count int64
+	conn.Model(&posts.Entity{}).Where("topic_id = ?", topic.Id).Count(&count)
+	if count != 0 {
+		t.Fatalf("post committed without stats: %d", count)
+	}
+	conn.First(&topic, topic.Id)
+	if topic.PostSeq != 1 || topic.PostCount != 1 {
+		t.Fatalf("topic changed after failure: %#v", topic)
+	}
+}

--- a/apps/gooseforum/app/service/postservice/create_stats_atomic_test.go
+++ b/apps/gooseforum/app/service/postservice/create_stats_atomic_test.go
@@ -28,7 +28,7 @@ func TestCreateTopicPostStatsFailureRollsBackWholeWrite(t *testing.T) {
 	failure := errors.New("stats unavailable")
 	if err := conn.Callback().Create().Before("gorm:create").Register("review:fail_stats", func(tx *gorm.DB) {
 		if tx.Statement.Table == "topic_user_stat" {
-			tx.AddError(failure)
+			_ = tx.AddError(failure)
 		}
 	}); err != nil {
 		t.Fatal(err)

--- a/apps/gooseforum/app/service/postservice/postservice.go
+++ b/apps/gooseforum/app/service/postservice/postservice.go
@@ -93,11 +93,10 @@ func SyncTopicPostStats(topicEntity topics.Entity, postEntity posts.Entity, isDe
 		}
 	}
 
-	list := topicUserStat.SyncTopicPosters(topicEntity.Id)
-	filteredList := lo.Filter(list, func(userID uint64, _ int) bool {
-		return userID != topicEntity.UserId
-	})
-	finalList := append([]uint64{topicEntity.UserId}, filteredList...)
+	// 作者在 SQL 内先排除再取 top-3（第二参数）：楼主高频回复不得挤占
+	// 他人参与人名额（PR #575 review P2）。
+	list := topicUserStat.SyncTopicPosters(topicEntity.Id, topicEntity.UserId)
+	finalList := append([]uint64{topicEntity.UserId}, list...)
 
 	pList := lo.Map(finalList, func(userID uint64, _ int) topics.Poster {
 		return topics.Poster{
@@ -118,16 +117,56 @@ func SyncTopicPostStats(topicEntity topics.Entity, postEntity posts.Entity, isDe
 }
 
 // RebuildTopicPostStats recalculates derived topic and participant counters
-// from the current active post set. It is intentionally absolute rather than
-// incremental so restoring a topic cannot double-count existing replies.
-func RebuildTopicPostStats(topicEntity topics.Entity, activePosts []*posts.Entity) error {
-	if err := topicUserStat.DeleteByTopicID(topicEntity.Id); err != nil {
+// from the current active post set inside its own transaction. It is
+// intentionally absolute rather than incremental so restoring a topic cannot
+// double-count existing replies.
+func RebuildTopicPostStats(topicEntity topics.Entity) error {
+	return db.Connect().Transaction(func(tx *gorm.DB) error {
+		return RebuildTopicPostStatsTx(tx, topicEntity)
+	})
+}
+
+// RebuildTopicPostStatsTx is the transactional variant: the delete, the
+// aggregated stat writes and the absolute topic replace commit or roll back
+// together, so a failed rebuild can no longer leave a half-erased
+// topic_user_stat behind a rolled-back migration version (PR #575 review
+// P1-atomicity). The topics row is locked (FOR UPDATE; SQLite serializes
+// writers so the clause is accepted and inert) BEFORE the posts snapshot is
+// taken and the lock is held through the replace: a concurrent
+// CreateTopicPost blocks at ReservePostSequence (it updates the same row),
+// so its post insert and follow-up stats sync cannot interleave with the
+// snapshot→replace window (PR #575 review P1-concurrency). Aggregation is
+// set-based — one multi-row upsert per topic instead of one upsert per reply
+// — and last_reply_at comes from the replies' own MAX(created_at); replaying
+// the live increment API would stamp deployment time over the historical
+// participant ordering (PR #575 review P2).
+func RebuildTopicPostStatsTx(tx *gorm.DB, topicEntity topics.Entity) error {
+	var locked topics.Entity
+	// Unscoped：回填/恢复路径会处理软删话题，锁读不得被软删作用域过滤掉。
+	if err := tx.Unscoped().Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ?", topicEntity.Id).
+		Take(&locked).Error; err != nil {
+		return err
+	}
+	// 锁内行数据为准：调用方可能只传 Id（回填批扫/测试），作者 ID 等
+	// 派生口径一律取锁定行的权威值，不信任事务外的快照字段。
+	topicEntity = locked
+
+	// 与 contentdeleteservice 的重建载入一致：Unscoped + post_no/id 升序，
+	// 仅 ACTIVE 楼层进入派生统计。
+	var activePosts []*posts.Entity
+	if err := tx.Unscoped().
+		Where("topic_id = ?", topicEntity.Id).
+		Order("post_no asc").
+		Order("id asc").
+		Find(&activePosts).Error; err != nil {
 		return err
 	}
 
-	var lastPost *posts.Entity
 	postCount := uint64(0)
 	replyCount := uint64(0)
+	var lastPost *posts.Entity
+	replierIndex := map[uint64]*topicUserStat.ReplierStat{}
 	for _, post := range activePosts {
 		if post == nil || post.VisibilityStatus != posts.VisibilityActive {
 			continue
@@ -137,8 +176,14 @@ func RebuildTopicPostStats(topicEntity topics.Entity, activePosts []*posts.Entit
 			replyCount++
 			// 匿名楼层（issue #524）不进入 topic_user_stat，与增量路径口径一致。
 			if !post.IsAnonymous {
-				if err := topicUserStat.IncrementUserPost(topicEntity.Id, post.UserId); err != nil {
-					return err
+				replier, ok := replierIndex[post.UserId]
+				if !ok {
+					replier = &topicUserStat.ReplierStat{UserID: post.UserId}
+					replierIndex[post.UserId] = replier
+				}
+				replier.ReplyCount++
+				if post.CreatedAt.After(replier.LastReplyAt) {
+					replier.LastReplyAt = post.CreatedAt
 				}
 			}
 		}
@@ -148,6 +193,11 @@ func RebuildTopicPostStats(topicEntity topics.Entity, activePosts []*posts.Entit
 		}
 	}
 
+	repliers := make([]topicUserStat.ReplierStat, 0, len(replierIndex))
+	for _, replier := range replierIndex {
+		repliers = append(repliers, *replier)
+	}
+
 	lastPostID := uint64(0)
 	lastPostedAt := time.Time{}
 	if lastPost != nil {
@@ -155,13 +205,21 @@ func RebuildTopicPostStats(topicEntity topics.Entity, activePosts []*posts.Entit
 		lastPostedAt = lastPost.CreatedAt
 	}
 
-	activePosterIDs := topicUserStat.SyncTopicPosters(topicEntity.Id)
+	if err := topicUserStat.DeleteByTopicIDTx(tx, topicEntity.Id); err != nil {
+		return err
+	}
+	if err := topicUserStat.BulkUpsertRepliersTx(tx, topicEntity.Id, repliers); err != nil {
+		return err
+	}
+
+	activePosterIDs, err := topicUserStat.SyncTopicPostersTx(tx, topicEntity.Id, topicEntity.UserId)
+	if err != nil {
+		return err
+	}
 	posterIDs := make([]topics.Poster, 0, len(activePosterIDs)+1)
 	posterIDs = append(posterIDs, topics.Poster{UserID: topicEntity.UserId})
 	for _, userID := range activePosterIDs {
-		if userID != topicEntity.UserId {
-			posterIDs = append(posterIDs, topics.Poster{UserID: userID})
-		}
+		posterIDs = append(posterIDs, topics.Poster{UserID: userID})
 	}
-	return topics.ReplacePostStats(topicEntity.Id, postCount, replyCount, posterIDs, lastPostID, lastPostedAt)
+	return topics.ReplacePostStatsTx(tx, topicEntity.Id, postCount, replyCount, posterIDs, lastPostID, lastPostedAt)
 }

--- a/apps/gooseforum/app/service/postservice/postservice.go
+++ b/apps/gooseforum/app/service/postservice/postservice.go
@@ -11,7 +11,6 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserStat"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/service/pointservice"
-	"github.com/samber/lo"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -27,24 +26,35 @@ func CreateTopicPost(entity *posts.Entity, topicEntity topics.Entity) error {
 	lock.Lock()
 	defer lock.Unlock()
 
-	postNo, err := topics.ReservePostSequence(entity.TopicId)
-	if err != nil {
-		return err
-	}
-
-	entity.PostNo = postNo
-	// 帖子行 + 版本 v1（editor = 作者）同事务：播种失败则帖子不落库，
-	// 避免出现无初始版本的楼层。
-	if err := db.Connect().Transaction(func(tx *gorm.DB) error {
+	// Sequence reservation locks the topic before the post becomes visible. All
+	// derived writes share that transaction, so rebuilds see either side in full.
+	return db.Connect().Transaction(func(tx *gorm.DB) error {
+		postNo, err := topics.ReservePostSequenceTx(tx, entity.TopicId)
+		if err != nil {
+			return err
+		}
+		entity.PostNo = postNo
 		if err := posts.CreateTx(tx, entity); err != nil {
 			return err
 		}
-		return SeedPostRevision(tx, entity)
-	}); err != nil {
-		return err
-	}
-	SyncTopicPostStats(topicEntity, *entity, false)
-	return nil
+		if err := SeedPostRevision(tx, entity); err != nil {
+			return err
+		}
+		if !entity.IsAnonymous {
+			if err := topicUserStat.IncrementUserPostTx(tx, entity.TopicId, entity.UserId); err != nil {
+				return err
+			}
+		}
+		ids, err := topicUserStat.SyncTopicPostersTx(tx, entity.TopicId, topicEntity.UserId)
+		if err != nil {
+			return err
+		}
+		posters := []topics.Poster{{UserID: topicEntity.UserId}}
+		for _, id := range ids {
+			posters = append(posters, topics.Poster{UserID: id})
+		}
+		return topics.IncrementPostFastTx(tx, entity.TopicId, posters, entity.Id, entity.CreatedAt)
+	})
 }
 
 func DeleteTopicPost(postID, userID uint64) (posts.Entity, error) {
@@ -77,42 +87,12 @@ func deleteTopicPost(conn *gorm.DB, postID, userID uint64) (postEntity posts.Ent
 	return postEntity, err
 }
 
-func SyncTopicPostStats(topicEntity topics.Entity, postEntity posts.Entity, isDelete bool) {
-	userId := postEntity.UserId
-	// 匿名楼层（wiki 评论区，issue #524）不进入 topic_user_stat：
-	// 避免匿名作者出现在「参与过的话题」/ Posters 等身份表面，泄露匿名身份。
-	if !postEntity.IsAnonymous {
-		if isDelete {
-			if err := topicUserStat.DecrementUserPost(topicEntity.Id, userId); err != nil {
-				slog.Error("failed to decrement topic user post stat", "topicId", topicEntity.Id, "userId", userId, "err", err)
-			}
-		} else {
-			if err := topicUserStat.IncrementUserPost(topicEntity.Id, userId); err != nil {
-				slog.Error("failed to increment topic user post stat", "topicId", topicEntity.Id, "userId", userId, "err", err)
-			}
-		}
-	}
-
-	// 作者在 SQL 内先排除再取 top-3（第二参数）：楼主高频回复不得挤占
-	// 他人参与人名额（PR #575 review P2）。
-	list := topicUserStat.SyncTopicPosters(topicEntity.Id, topicEntity.UserId)
-	finalList := append([]uint64{topicEntity.UserId}, list...)
-
-	pList := lo.Map(finalList, func(userID uint64, _ int) topics.Poster {
-		return topics.Poster{
-			UserID: userID,
-		}
-	})
-
-	if isDelete {
-		lastPost, _ := posts.GetLastByTopicID(topicEntity.Id)
-		if err := topics.DecrementPostFast(topicEntity.Id, pList, lastPost.Id, lastPost.CreatedAt); err != nil {
-			slog.Error("failed to decrement topic post count", "topicId", topicEntity.Id, "err", err)
-		}
-	} else {
-		if err := topics.IncrementPostFast(topicEntity.Id, pList, postEntity.Id, postEntity.CreatedAt); err != nil {
-			slog.Error("failed to increment topic post count", "topicId", topicEntity.Id, "err", err)
-		}
+// SyncTopicPostStats refreshes projections after committed lifecycle changes.
+// An absolute rebuild is idempotent when another writer already included the
+// deletion or restoration; a delayed decrement would corrupt those counters.
+func SyncTopicPostStats(topicEntity topics.Entity) {
+	if err := RebuildTopicPostStats(topicEntity); err != nil {
+		slog.Error("failed to rebuild topic post stats", "topicId", topicEntity.Id, "err", err)
 	}
 }
 
@@ -133,10 +113,10 @@ func RebuildTopicPostStats(topicEntity topics.Entity) error {
 // P1-atomicity). The topics row is locked (FOR UPDATE; SQLite serializes
 // writers so the clause is accepted and inert) BEFORE the posts snapshot is
 // taken and the lock is held through the replace: a concurrent
-// CreateTopicPost blocks at ReservePostSequence (it updates the same row),
+// CreateTopicPost holds the same lock from ReservePostSequenceTx through commit,
 // so its post insert and follow-up stats sync cannot interleave with the
 // snapshot→replace window (PR #575 review P1-concurrency). Aggregation is
-// set-based — one multi-row upsert per topic instead of one upsert per reply
+// set-based — bounded multi-row upserts instead of one upsert per reply
 // — and last_reply_at comes from the replies' own MAX(created_at); replaying
 // the live increment API would stamp deployment time over the historical
 // participant ordering (PR #575 review P2).

--- a/apps/gooseforum/app/service/postservice/rebuild_topic_stats_test.go
+++ b/apps/gooseforum/app/service/postservice/rebuild_topic_stats_test.go
@@ -1,0 +1,170 @@
+package postservice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserStat"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topics"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// PR #575 review 修复的回归锚点：重建必须（1）保留历史 last_reply_at
+// （MAX(created_at)，而非增量路径的部署时间）；（2）作者在 top-3 LIMIT
+// 前排除（作者高频回复不得挤占其他参与者名额）；（3）不扰动
+// topics.updated_at 首页排序键；（4）匿名/治理删除楼层不进入任何身份
+// 表面但计入楼层计数与最后回复指针。
+func TestRebuildTopicPostStatsTxPreservesHistoryAndExcludesAuthor(t *testing.T) {
+	conn := newRebuildStatsTestDB(t)
+
+	const (
+		topicID  = uint64(9_100_000_001)
+		authorID = uint64(9_100_000_090)
+		u2       = uint64(9_100_000_092)
+		u3       = uint64(9_100_000_093)
+		u4       = uint64(9_100_000_094)
+		u5       = uint64(9_100_000_095)
+		u6       = uint64(9_100_000_096)
+	)
+	base := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	staleUpdatedAt := base.Add(48 * time.Hour)
+
+	if err := conn.Create(&topics.Entity{Id: topicID, Title: "rebuild", UserId: authorID, Status: 1}).Error; err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := conn.Model(&topics.Entity{}).Where("id = ?", topicID).
+		UpdateColumn("updated_at", staleUpdatedAt).Error; err != nil {
+		t.Fatalf("set stale updated_at: %v", err)
+	}
+
+	newPost := func(id uint64, postNo uint64, userID uint64, createdAt time.Time, anonymous bool, visibility string) {
+		t.Helper()
+		entity := posts.Entity{
+			Id:               id,
+			TopicId:          topicID,
+			PostNo:           postNo,
+			UserId:           userID,
+			Content:          "c",
+			IsAnonymous:      anonymous,
+			VisibilityStatus: visibility,
+			RetentionStatus:  posts.RetentionNormal,
+			CreatedAt:        createdAt,
+		}
+		if err := conn.Create(&entity).Error; err != nil {
+			t.Fatalf("create post %d: %v", id, err)
+		}
+	}
+	// 作者自己回复最多（占榜场景：count=2 压过其他 count=1 的回复者）。
+	newPost(11, 1, authorID, base, false, posts.VisibilityActive)
+	newPost(12, 2, authorID, base.Add(1*time.Hour), false, posts.VisibilityActive)
+	newPost(13, 3, authorID, base.Add(2*time.Hour), false, posts.VisibilityActive)
+	newPost(14, 4, u2, base.Add(3*time.Hour), false, posts.VisibilityActive)
+	newPost(15, 5, u3, base.Add(4*time.Hour), false, posts.VisibilityActive)
+	newPost(16, 6, u4, base.Add(5*time.Hour), false, posts.VisibilityActive)
+	newPost(17, 7, u5, base.Add(6*time.Hour), true, posts.VisibilityActive)
+	newPost(18, 8, u6, base.Add(7*time.Hour), false, posts.VisibilityUserDeleted)
+
+	err := conn.Transaction(func(tx *gorm.DB) error {
+		return RebuildTopicPostStatsTx(tx, topics.Entity{Id: topicID})
+	})
+	if err != nil {
+		t.Fatalf("rebuild in tx: %v", err)
+	}
+
+	// topic_user_stat：作者自己的回复同样保留参与行（与增量路径口径一致，
+	// 「参与过的话题」列表依赖它），匿名/治理删除楼层排除；
+	// last_reply_at = 历史回复的 MAX(created_at)，绝不被重建动作的时间覆盖。
+	var stats []topicUserStat.Entity
+	if err := conn.Where("topic_id = ?", topicID).Find(&stats).Error; err != nil {
+		t.Fatalf("read stats: %v", err)
+	}
+	statByUser := map[uint64]topicUserStat.Entity{}
+	for _, s := range stats {
+		statByUser[s.UserId] = s
+	}
+	if len(stats) != 4 {
+		t.Fatalf("stat rows=%d (%v), want 4 (author replies + 3 repliers)", len(stats), stats)
+	}
+	for _, excluded := range []uint64{u5, u6} {
+		if _, ok := statByUser[excluded]; ok {
+			t.Fatalf("stats must exclude user %d (anonymous/removed)", excluded)
+		}
+	}
+	if authorRow, ok := statByUser[authorID]; !ok {
+		t.Fatalf("author's own replies must keep a participation row")
+	} else if authorRow.ReplyCount != 2 || !authorRow.LastReplyAt.Equal(base.Add(2*time.Hour)) {
+		t.Fatalf("author stat row count=%d last=%v, want 2 @ %v", authorRow.ReplyCount, authorRow.LastReplyAt, base.Add(2*time.Hour))
+	}
+	wantLastReplyAt := map[uint64]time.Time{
+		u2: base.Add(3 * time.Hour),
+		u3: base.Add(4 * time.Hour),
+		u4: base.Add(5 * time.Hour),
+	}
+	for userID, want := range wantLastReplyAt {
+		row := statByUser[userID]
+		if row.ReplyCount != 1 {
+			t.Errorf("user %d reply_count=%d, want 1", userID, row.ReplyCount)
+		}
+		if !row.LastReplyAt.Equal(want) {
+			t.Errorf("user %d last_reply_at=%v, want historical %v", userID, row.LastReplyAt, want)
+		}
+	}
+
+	var after topics.Entity
+	if err := conn.Unscoped().Where("id = ?", topicID).First(&after).Error; err != nil {
+		t.Fatalf("reload topic: %v", err)
+	}
+
+	// posters：作者置前 + 非作者回复者 top-3（作者占榜不得压缩名额）。
+	if len(after.Posters) != 4 {
+		t.Fatalf("posters=%v, want 4 (author + 3 repliers)", after.Posters)
+	}
+	if after.Posters[0].UserID != authorID {
+		t.Fatalf("posters[0]=%d, want author %d first", after.Posters[0].UserID, authorID)
+	}
+	seen := map[uint64]bool{}
+	for _, poster := range after.Posters[1:] {
+		seen[poster.UserID] = true
+	}
+	for _, want := range []uint64{u2, u3, u4} {
+		if !seen[want] {
+			t.Fatalf("posters missing replier %d: %v", want, after.Posters)
+		}
+	}
+
+	// 派生计数与指针：匿名楼层计入计数与最后回复，治理删除楼层不计。
+	if after.PostCount != 7 || after.ReplyCount != 6 {
+		t.Fatalf("counts post=%d reply=%d, want 7/6", after.PostCount, after.ReplyCount)
+	}
+	if after.LastPostId != 17 {
+		t.Fatalf("lastPostId=%d, want 17 (latest active anonymous reply)", after.LastPostId)
+	}
+	if after.LastPostedAt == nil || !after.LastPostedAt.Equal(base.Add(6*time.Hour)) {
+		t.Fatalf("lastPostedAt=%v, want %v", after.LastPostedAt, base.Add(6*time.Hour))
+	}
+
+	// 首页排序键不被派生重建触碰。
+	if !after.UpdatedAt.Equal(staleUpdatedAt) {
+		t.Fatalf("updated_at perturbed: %v, want %v", after.UpdatedAt, staleUpdatedAt)
+	}
+}
+
+func newRebuildStatsTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:postservice-rebuild-stats?mode=memory&cache=shared"
+	conn, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{TranslateError: true})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := conn.AutoMigrate(&topics.Entity{}, &posts.Entity{}, &topicUserStat.Entity{}); err != nil {
+		t.Fatalf("migrate rebuild stats fixtures: %v", err)
+	}
+	t.Cleanup(func() {
+		conn.Where("1 = 1").Delete(&topics.Entity{})
+		conn.Where("1 = 1").Delete(&posts.Entity{})
+		conn.Where("1 = 1").Delete(&topicUserStat.Entity{})
+	})
+	return conn
+}


### PR DESCRIPTION
## 问题

首页话题列表参与人列长期只显示楼主（issue #554）。

**根因**：存量话题的 `topics.posters` 是 v5 迁移从 legacy `articles.posters` 原样拷入的，而 legacy 格式本来就只存楼主（夹具可证：`[{"user_id":1,"description":"author"}]`）。增量路径（`SyncTopicPostStats`）只在新回复/删回复时修复，多回复老话题若无人再回复，参与人列就永远是楼主一人。`GetPosters()` 对非空值不兜底，坏值原样透传到前端 `AvatarStack`。

增量管线本身无缺口——坏的只有存量数据。

## 修复

新增一次性数据回填 **v29**（`datamigration.BackfillTopicPostStats`）：

- 从 active posts **绝对重建** `topic_user_stat` + `topics.posters`，复用 `postservice.RebuildTopicPostStats` 单一口径（楼主置前 + 非匿名回复者 top-3，匿名楼层 issue #524 与治理删除楼层排除），不引入第二份派生实现。
- 逐话题独立、绝对写：对任何存量形态（楼主-only/空/零计数残留）幂等；单话题失败记录后继续，`Failed>0` 阻断启动、下次启动自动重跑。
- 快照恢复保护 `topics.updated_at`（首页默认排序键）不被派生写路径的 GORM `Updates` 触碰。
- 按 `id` 升序分批（500/批）扫描，控制内存；启动期执行，无需手工运维步骤。

## 变更范围

| 文件 | 变更 |
|---|---|
| `app/service/datamigration/topic_post_stats_backfill.go` | 新增回填实现 |
| `app/service/datamigration/topic_post_stats_backfill_test.go` | 新增测试（red-first） |
| `app/migration/app_migration.go` | 注册 v29 块 |
| `app/models/forum/pageConfig/pageConfigRep.go` | `AppMigrationVersion` 28→29 |

契约面（OpenAPI/route-coverage/TS/Dart mirrors）、前端 `resource/`、`postservice` 本体零变更。

## 验证

- red-first：新测试先编译失败确认 red，实现后转绿
- `go test ./app/service/datamigration/ ./app/service/postservice/ ./app/models/forum/topics/ ./app/models/forum/topicUserStat/ ./app/models/hotdataserve/ ./app/http/controllers/forum/` ✅
- `go vet ./...` ✅、gofmt ✅
- PG migration tests：`YOURTJ_TEST_PG_URL=... go test ./app/migration/ -run 'TestSchema' -v` ✅（`TestSchemaMigratesOnPostgreSQL` + `TestSchemaUpgradeCreatesNewTablesOnPostgreSQL` 及全部 schema 子测试）
- governance gates：`node scripts/run-gates.mjs` ✅（5/5）

测试覆盖：存量坏话题（楼主-only posters + 3 个不同回复者 + 匿名楼层 + 治理删除楼层）回填后参与人=楼主+top-3 非匿名回复者、匿名/删除作者排除、计数与 last_post 指针正确、`updated_at` 不被扰动、二次执行零修复（幂等）；已正确话题回填前后不变、不虚增 `PostersRepaired`。

行为验收（dev 实例部署后）：多回复存量话题首页参与人列显示楼主 + 回复者，无手工步骤。

Closes #554

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>