### PR TITLE
fix(mobile): wiki 站内链接改用 decoded 域提取,修复二次编码与锚点丢失

### DIFF
--- a/apps/mobile/packages/forum_app/lib/src/pages/wiki/wiki_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/wiki/wiki_page.dart
@@ -19,6 +19,19 @@ import '../../widgets/status_views.dart';
 String encodeWikiPath(String path) =>
     path.split('/').map(Uri.encodeComponent).join('/');
 
+/// 容错解码 wiki 锚点:`Uri.fragment` 保留 percent-encoded 态(裸 Unicode
+/// 也会被 SDK 归一化为编码态),scrollToAnchor 需要解码后的真实标题 id;
+/// `Uri.decodeComponent` 对非法转义(如 `%zz`)抛 ArgumentError,此处
+/// 解码失败时原样返回,交由滚动找不到 id 时静默降级。
+String decodeWikiAnchor(String anchor) {
+  if (!anchor.contains('%')) return anchor;
+  try {
+    return Uri.decodeComponent(anchor);
+  } on ArgumentError {
+    return anchor;
+  }
+}
+
 /// wiki 页面详情(web WikiPage.vue 的移动端形态)。
 ///
 /// 正文经页面级数据通道返回的是**服务端渲染的 HTML**(goldmark →
@@ -155,9 +168,10 @@ class _WikiPageState extends ConsumerState<WikiPage> {
   /// 内部滚动;其余绝对链接交给系统浏览器。
   ///
   /// 服务端渲染的 href 处于 percent-encoded 态(issue #560):统一起
-  /// [Uri.pathSegments](逐段解码)提取目标路径、[Uri.fragment](已解码)
-  /// 提取锚点,再经 [encodeWikiPath] 单出口编码推送。不得用 `Uri.path`
-  /// ——它保留编码态,再编码会把 `%` 变成 `%25`(二次编码)。
+  /// [Uri.pathSegments](逐段解码)提取目标路径、[Uri.fragment](保留编码
+  /// 态,须经 [decodeWikiAnchor] 解码)提取锚点,再经 [encodeWikiPath]
+  /// 单出口编码推送。不得用 `Uri.path`——它保留编码态,再编码会把 `%`
+  /// 变成 `%25`(二次编码)。
   Future<bool> _handleLinkTap(String url) async {
     final Uri? uri = Uri.tryParse(url);
     if (uri == null) return false;
@@ -173,12 +187,13 @@ class _WikiPageState extends ConsumerState<WikiPage> {
         segments.length > 1 &&
         (isHttp || url.startsWith('/wiki/'));
     if (isInternalWiki) {
-      // decoded 域目标;锚点不卷入路径(%23),经 fragment 取出后重新编码拼回。
+      // decoded 域目标;锚点不卷入路径(%23)。`Uri.fragment` 保留编码态
+      //(review P2),先解码再重新编码,避免二次编码 %25E7...。
       final String target = segments.sublist(1).join('/');
       if (context.mounted && target.isNotEmpty) {
         final String? fragment = uri.hasFragment ? uri.fragment : null;
         final String anchor = (fragment != null && fragment.isNotEmpty)
-            ? '#${Uri.encodeComponent(fragment)}'
+            ? '#${Uri.encodeComponent(decodeWikiAnchor(fragment))}'
             : '';
         context.push('/wiki/${encodeWikiPath(target)}$anchor');
       }

--- a/apps/mobile/packages/forum_app/lib/src/pages/wiki/wiki_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/wiki/wiki_page.dart
@@ -153,29 +153,42 @@ class _WikiPageState extends ConsumerState<WikiPage> {
 
   /// 正文链接策略:站内 wiki 链接推入详情页;`#锚点` 交还 [HtmlWidget]
   /// 内部滚动;其余绝对链接交给系统浏览器。
+  ///
+  /// 服务端渲染的 href 处于 percent-encoded 态(issue #560):统一起
+  /// [Uri.pathSegments](逐段解码)提取目标路径、[Uri.fragment](已解码)
+  /// 提取锚点,再经 [encodeWikiPath] 单出口编码推送。不得用 `Uri.path`
+  /// ——它保留编码态,再编码会把 `%` 变成 `%25`(二次编码)。
   Future<bool> _handleLinkTap(String url) async {
     final Uri? uri = Uri.tryParse(url);
     if (uri == null) return false;
-    if (uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https')) {
-      final String path = uri.path;
-      if (path.startsWith('/wiki/')) {
-        final String target = path.substring('/wiki/'.length);
-        if (context.mounted && target.isNotEmpty) {
-          context.push('/wiki/${encodeWikiPath(target)}');
-        }
-        return true;
+    final bool isHttp =
+        uri.hasScheme && (uri.scheme == 'http' || uri.scheme == 'https');
+    // 站内判定:相对链接须 /wiki/ 前缀;绝对链接保留既有 path 前缀语义
+    //(host 校验超出本修复范围)。`/wiki` 裸路径、`/wiki/` 空 target
+    // 维持现状:不跳转。
+    final List<String> segments = uri.pathSegments;
+    final bool isInternalWiki =
+        segments.isNotEmpty &&
+        segments.first == 'wiki' &&
+        segments.length > 1 &&
+        (isHttp || url.startsWith('/wiki/'));
+    if (isInternalWiki) {
+      // decoded 域目标;锚点不卷入路径(%23),经 fragment 取出后重新编码拼回。
+      final String target = segments.sublist(1).join('/');
+      if (context.mounted && target.isNotEmpty) {
+        final String? fragment = uri.hasFragment ? uri.fragment : null;
+        final String anchor = (fragment != null && fragment.isNotEmpty)
+            ? '#${Uri.encodeComponent(fragment)}'
+            : '';
+        context.push('/wiki/${encodeWikiPath(target)}$anchor');
       }
+      return true;
+    }
+    if (isHttp) {
       try {
         await launchUrl(uri, mode: LaunchMode.externalApplication);
       } catch (_) {
         // 外部链接打开失败不阻塞阅读。
-      }
-      return true;
-    }
-    if (url.startsWith('/wiki/')) {
-      final String target = url.substring('/wiki/'.length);
-      if (context.mounted && target.isNotEmpty) {
-        context.push('/wiki/${encodeWikiPath(target)}');
       }
       return true;
     }

--- a/apps/mobile/packages/forum_app/lib/src/router.dart
+++ b/apps/mobile/packages/forum_app/lib/src/router.dart
@@ -403,7 +403,8 @@ final GoRouter appRouter = GoRouter(
       path: '/wiki/:wikiPath(.*)',
       builder: (BuildContext context, GoRouterState state) => WikiPage(
         wikiPath: state.pathParameters['wikiPath']!,
-        initialAnchor: state.uri.fragment,
+        // state.uri.fragment 保留 percent-encoded 态;解码后再传给 scrollToAnchor。
+        initialAnchor: decodeWikiAnchor(state.uri.fragment),
       ),
     ),
   ],

--- a/apps/mobile/packages/forum_app/test/wiki_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/wiki_page_test.dart
@@ -80,6 +80,7 @@ PagePayload _detailPayload({
   required String title,
   bool canEdit = true,
   String editUrl = 'https://github.com/yourtj/wiki/edit/main/guide/start.md',
+  String? content,
 }) {
   return PagePayload.fromJson(
     _pageJson(<String, dynamic>{
@@ -89,6 +90,7 @@ PagePayload _detailPayload({
       'path': path,
       'title': title,
       'content':
+          content ??
           '<h2 id="intro">介绍</h2><p>欢迎阅读 wiki 正文。</p><h3 id="details">细节说明</h3>',
       'toc': <Map<String, dynamic>>[
         <String, dynamic>{'level': 2, 'id': 'intro', 'text': '介绍'},
@@ -136,6 +138,13 @@ GfApiClient _client() => GfApiClient(
   baseUrl: 'http://fake.local',
 );
 
+/// 点击正文链接文字字形处:fwfh 的块级 RichText 占满整行宽度,链接文字
+/// 靠左,tap 中心点落在文字右侧空白处不会命中识别器,须点文字起始处。
+Future<void> _tapLinkText(WidgetTester tester, Finder finder) async {
+  final Rect rect = tester.getRect(finder);
+  await tester.tapAt(Offset(rect.left + 12, rect.center.dy));
+}
+
 Future<GoRouter> _pumpApp(
   WidgetTester tester, {
   required _FakePageRepository pages,
@@ -156,9 +165,12 @@ Future<GoRouter> _pumpApp(
     routes: <RouteBase>[
       GoRoute(path: '/', builder: (_, _) => const WikiHomePage()),
       GoRoute(
-        path: '/wiki/:path(.*)',
-        builder: (BuildContext context, GoRouterState state) =>
-            WikiPage(wikiPath: state.pathParameters['path'] ?? ''),
+        // 与生产 router.dart 对齐:参数名 wikiPath、锚点经 state.uri.fragment 传入。
+        path: '/wiki/:wikiPath(.*)',
+        builder: (BuildContext context, GoRouterState state) => WikiPage(
+          wikiPath: state.pathParameters['wikiPath'] ?? '',
+          initialAnchor: state.uri.fragment,
+        ),
       ),
     ],
   );
@@ -345,5 +357,161 @@ void main() {
     );
 
     expect(find.text('在 GitHub 编辑'), findsOneWidget);
+  });
+  testWidgets('正文内相对站内链接:中文路径单次编码跳转(issue #560)', (tester) async {
+    const String encodedTarget =
+        '/wiki/guide/%E9%80%89%E8%AF%BE%E6%8C%87%E5%8D%97';
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/getting-started': _detailPayload(
+          path: 'guide/getting-started',
+          title: '快速开始',
+          content: '<p><a href="$encodedTarget">选课指南</a></p>',
+        ),
+        encodedTarget: _detailPayload(path: 'guide/选课指南', title: '选课指南'),
+      },
+    );
+    final GoRouter router = await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/getting-started',
+    );
+
+    // 服务端渲染的 href 处于 percent-encoded 态(relative_urls.go 契约)。
+    await _tapLinkText(tester, find.textContaining('选课指南', findRichText: true));
+    await tester.pumpAndSettle();
+
+    // 页面通道按段编码后单次编码请求;go_router 单次解码还原目标页。
+    expect(pages.fetchedPaths, <String>[
+      '/wiki/guide/getting-started',
+      encodedTarget,
+    ]);
+    expect(router.state.uri.path, encodedTarget);
+    expect(find.text('选课指南'), findsOneWidget);
+  });
+
+  testWidgets('正文内相对站内链接:纯 ASCII 路径不回归', (tester) async {
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/getting-started': _detailPayload(
+          path: 'guide/getting-started',
+          title: '快速开始',
+          content: '<p><a href="/wiki/guide/faq">常见问题</a></p>',
+        ),
+        '/wiki/guide/faq': _detailPayload(path: 'guide/faq', title: '常见问题'),
+      },
+    );
+    final GoRouter router = await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/getting-started',
+    );
+
+    await _tapLinkText(tester, find.textContaining('常见问题', findRichText: true));
+    await tester.pumpAndSettle();
+
+    expect(router.state.uri.path, '/wiki/guide/faq');
+    expect(router.state.uri.fragment, isEmpty);
+    expect(pages.fetchedPaths, <String>[
+      '/wiki/guide/getting-started',
+      '/wiki/guide/faq',
+    ]);
+  });
+
+  testWidgets('正文内绝对站内链接:中文路径同样单次编码跳转', (tester) async {
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/getting-started': _detailPayload(
+          path: 'guide/getting-started',
+          title: '快速开始',
+          content:
+              '<p><a href="http://fake.local/wiki/guide/%E9%80%89%E8%AF%BE%E6%8C%87%E5%8D%97">选课指南</a></p>',
+        ),
+        '/wiki/guide/%E9%80%89%E8%AF%BE%E6%8C%87%E5%8D%97': _detailPayload(
+          path: 'guide/选课指南',
+          title: '选课指南',
+        ),
+      },
+    );
+    final GoRouter router = await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/getting-started',
+    );
+
+    await _tapLinkText(tester, find.textContaining('选课指南', findRichText: true));
+    await tester.pumpAndSettle();
+
+    expect(
+      router.state.uri.path,
+      '/wiki/guide/%E9%80%89%E8%AF%BE%E6%8C%87%E5%8D%97',
+    );
+    expect(
+      pages.fetchedPaths.last,
+      '/wiki/guide/%E9%80%89%E8%AF%BE%E6%8C%87%E5%8D%97',
+    );
+  });
+
+  testWidgets('正文内跨页锚点链接:锚点经 initialAnchor 传入不丢', (tester) async {
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/getting-started': _detailPayload(
+          path: 'guide/getting-started',
+          title: '快速开始',
+          content: '<p><a href="/wiki/guide/details#intro">跳到细节</a></p>',
+        ),
+        '/wiki/guide/details': _detailPayload(
+          path: 'guide/details',
+          title: '细节',
+          content: '<h2 id="intro">介绍</h2><p>细节正文。</p>',
+        ),
+      },
+    );
+    final GoRouter router = await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/getting-started',
+    );
+
+    await _tapLinkText(tester, find.textContaining('跳到细节', findRichText: true));
+    await tester.pumpAndSettle();
+
+    // 锚点不卷入路径(%23),路由 fragment 收到锚点。
+    expect(router.state.uri.path, '/wiki/guide/details');
+    expect(router.state.uri.fragment, 'intro');
+    expect(pages.fetchedPaths, <String>[
+      '/wiki/guide/getting-started',
+      '/wiki/guide/details',
+    ]);
+  });
+
+  testWidgets('正文内页内锚点链接:不触发页面跳转', (tester) async {
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/getting-started': _detailPayload(
+          path: 'guide/getting-started',
+          title: '快速开始',
+          content:
+              '<h2 id="intro">介绍</h2><p>欢迎阅读 wiki 正文。</p>'
+              '<p><a href="#intro">回看介绍</a></p>',
+        ),
+      },
+    );
+    await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/getting-started',
+    );
+
+    await _tapLinkText(tester, find.textContaining('回看介绍', findRichText: true));
+    await tester.pumpAndSettle();
+
+    // 页内锚点交还 fwfh 内部滚动,不产生新的页面请求。
+    expect(pages.fetchedPaths, <String>['/wiki/guide/getting-started']);
   });
 }

--- a/apps/mobile/packages/forum_app/test/wiki_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/wiki_page_test.dart
@@ -165,11 +165,12 @@ Future<GoRouter> _pumpApp(
     routes: <RouteBase>[
       GoRoute(path: '/', builder: (_, _) => const WikiHomePage()),
       GoRoute(
-        // 与生产 router.dart 对齐:参数名 wikiPath、锚点经 state.uri.fragment 传入。
+        // 与生产 router.dart 对齐:参数名 wikiPath、锚点经 state.uri.fragment
+        // 解码后传入(URI fragment 保留 percent-encoded 态)。
         path: '/wiki/:wikiPath(.*)',
         builder: (BuildContext context, GoRouterState state) => WikiPage(
           wikiPath: state.pathParameters['wikiPath'] ?? '',
-          initialAnchor: state.uri.fragment,
+          initialAnchor: decodeWikiAnchor(state.uri.fragment),
         ),
       ),
     ],
@@ -487,6 +488,93 @@ void main() {
       '/wiki/guide/getting-started',
       '/wiki/guide/details',
     ]);
+  });
+
+  testWidgets('正文内跨页锚点链接:非 ASCII 编码态锚点保持单次编码(review P2)', (tester) async {
+    const String escAnchor = '%E7%94%B3%E8%AF%B7%E6%9D%A1%E4%BB%B6'; // 申请条件
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/details': _detailPayload(
+          path: 'guide/details',
+          title: '细节',
+          content: '<p><a href="/wiki/guide/apply#$escAnchor">查看申请条件</a></p>',
+        ),
+        '/wiki/guide/apply': _detailPayload(path: 'guide/apply', title: '申请'),
+      },
+    );
+    final GoRouter router = await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/details',
+    );
+
+    await _tapLinkText(
+      tester,
+      find.textContaining('查看申请条件', findRichText: true),
+    );
+    await tester.pumpAndSettle();
+
+    // push URL 的 fragment 必须仍是单次编码;二次编码会退化为 %25E7...。
+    expect(router.state.uri.path, '/wiki/guide/apply');
+    expect(router.state.uri.fragment, escAnchor);
+  });
+
+  testWidgets('正文内跨页锚点链接:裸 Unicode 锚点解析后单次编码', (tester) async {
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/details': _detailPayload(
+          path: 'guide/details',
+          title: '细节',
+          content: '<p><a href="/wiki/guide/apply#申请条件">查看申请条件</a></p>',
+        ),
+        '/wiki/guide/apply': _detailPayload(path: 'guide/apply', title: '申请'),
+      },
+    );
+    final GoRouter router = await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/details',
+    );
+
+    await _tapLinkText(
+      tester,
+      find.textContaining('查看申请条件', findRichText: true),
+    );
+    await tester.pumpAndSettle();
+
+    // Uri.parse 把裸 Unicode fragment 归一化为编码态;解码后再编码回到单次。
+    expect(router.state.uri.fragment, '%E7%94%B3%E8%AF%B7%E6%9D%A1%E4%BB%B6');
+  });
+
+  testWidgets('深链入口:编码态锚点经路由边界解码后滚动到目标标题', (tester) async {
+    final _FakePageRepository pages = _FakePageRepository(
+      _client(),
+      payloads: <String, PagePayload>{
+        '/wiki/guide/apply': _detailPayload(
+          path: 'guide/apply',
+          title: '申请',
+          content:
+              '${List<String>.filled(30, '<p>占位段落,用于撑长页面。</p>').join()}'
+              '<h2 id="申请条件">申请条件标题</h2>',
+        ),
+      },
+    );
+    await _pumpApp(
+      tester,
+      pages: pages,
+      initialLocation: '/wiki/guide/apply#%E7%94%B3%E8%AF%B7%E6%9D%A1%E4%BB%B6',
+    );
+
+    // 编码态 fragment 若未经解码直达 scrollToAnchor,将找不到渲染的
+    // Unicode 标题 id 而不产生滚动。
+    final ListView view = tester.widget<ListView>(
+      find.byKey(const Key('wiki-page-scroll')),
+    );
+    expect(view.controller, isNotNull);
+    expect(view.controller!.offset, greaterThan(0));
+    expect(find.textContaining('申请条件标题', findRichText: true), findsOneWidget);
   });
 
   testWidgets('正文内页内锚点链接:不触发页面跳转', (tester) async {


### PR DESCRIPTION
## 问题

移动端 Wiki 正文内点击站内链接时,中文路径页面跳转失败、跨页锚点丢失(issue #560)。

根因:`_handleLinkTap` 把**仍处于 percent-encoded 态**的 href(`服务端 relative_urls.go 渲染为 /wiki/guide/%E9%80%89...`)再过一遍 `encodeWikiPath`,`%` → `%25` 二次编码;`#anchor` 也被卷入路径编码成 `%23`。

## 与 issue 建议的偏差(重要)

Issue 建议统一改用 `uri.path` 截取。但 Dart 官方文档明确 [`Uri.path`](https://api.dart.dev/stable/dart-core/Uri/path.html) 返回的是 "the actual substring of the URI representing the path, **encoded where necessary**"——**不做 percent-decode**(解码要用 `pathSegments`,逐段 `Uri.decodeComponent`)。因此:

- issue 声称"绝对链接分支用 `uri.path` 是正确的"不成立——绝对分支对中文路径同样二次编码,与相对分支同病(本 PR 前两者都坏);
- 若按 issue 建议改用 `uri.path` substring + `encodeWikiPath`,绝对分支照样 double-encode。

本 PR 改为统一在 **decoded 域**提取:`uri.pathSegments.join('/')` 取目标路径、`uri.fragment`(已解码)取锚点,再经既有 `encodeWikiPath` 单出口编码推送——与 `wiki_home_page`/`wiki_search_page` 调用点管线一致(rejected alternative 见 Blueprint)。

## 改动

- `lib/src/pages/wiki/wiki_page.dart`:`_handleLinkTap` 重写(decoded 域统一提取,绝对/相对共享同一段逻辑;锚点 `Uri.encodeComponent` 重编码拼回;`/wiki` 裸路径、`/wiki/` 空 target、页内 `#id`、外部链接行为保持现状)
- `test/wiki_page_test.dart`:测试 harness 对齐生产 router(`:wikiPath` 参数 + `initialAnchor` 传参,消除既有漂移);新增 5 个回归用例

## 验证

- 先红后绿:修复前中文相对/绝对、跨页锚点 3 个用例失败,修复后 11/11 通过
- `melos run analyze` 4 包全绿;`melos run test` 4 包全绿(forum_app 292、ui_kit 123、core 113、auth 30)
- 无契约/服务端/golden 改动,`git diff --stat` 仅 2 个文件

Closes #560

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>