### PR TITLE
fix(forum): qualify reply count upsert on postgres

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -167,11 +167,13 @@ jobs:
         working-directory: apps/gooseforum
         env:
           YOURTJ_TEST_PG_URL: "host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable"
-        # PostgreSQL$ 覆盖 course 包内所有 PG 门控用例（stats 并发、学期列表）。
-        # 刻意不逐个显式列举：本 PR 修的正是 pg-only 缺陷（SQLite 宽松通过，只有
-        # PostgreSQL 报错），一旦列举就会漏接线，回归护栏形同虚设。同名模式的新
-        # 用例会自动纳入。
+        # PostgreSQL$ 覆盖已接线包内所有 PG 门控用例（course stats 并发/学期列表、
+        # dailyStats 增量、topicUserStat upsert 歧义）。刻意不逐个显式列举用例：
+        # 本类缺陷 pg-only（SQLite 宽松通过，只有 PostgreSQL 报错），一旦漏接线，
+        # 回归护栏形同虚设。包内同名模式的新用例会自动纳入；但新出现 PG 门控的
+        # 包必须在此显式接线（PR #589 的 topicUserStat 一度漏接）。
         run: |
           go test ./app/migration/ -run 'TestSchema' -v
           go test ./app/models/forum/course/ -run 'PostgreSQL$' -v
           go test ./app/models/forum/dailyStats/ -run 'PostgreSQL$' -v
+          go test ./app/models/forum/topicUserStat/ -run 'PostgreSQL$' -v

--- a/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_pg_test.go
+++ b/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_pg_test.go
@@ -1,0 +1,48 @@
+package topicUserStat
+
+import (
+	"os"
+	"testing"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func TestIncrementUserPostExistingRowPostgreSQL(t *testing.T) {
+	dsn := os.Getenv("YOURTJ_TEST_PG_URL")
+	if dsn == "" {
+		t.Skip("YOURTJ_TEST_PG_URL not set; skipping PostgreSQL topic user stat test")
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("connect postgres: %v", err)
+	}
+	if err := db.AutoMigrate(&Entity{}); err != nil {
+		t.Fatalf("AutoMigrate topic user stat on postgres: %v", err)
+	}
+
+	const topicID uint64 = 99588001
+	const userID uint64 = 99588002
+	if err := db.Where("topic_id = ? AND user_id = ?", topicID, userID).Delete(&Entity{}).Error; err != nil {
+		t.Fatalf("clean topic user stat before test: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Where("topic_id = ? AND user_id = ?", topicID, userID).Delete(&Entity{}).Error
+	})
+
+	if err := IncrementUserPostTx(db, topicID, userID); err != nil {
+		t.Fatalf("first increment: %v", err)
+	}
+	if err := IncrementUserPostTx(db, topicID, userID); err != nil {
+		t.Fatalf("second increment: %v", err)
+	}
+
+	var got Entity
+	if err := db.Where("topic_id = ? AND user_id = ?", topicID, userID).First(&got).Error; err != nil {
+		t.Fatalf("load topic user stat: %v", err)
+	}
+	if got.ReplyCount != 2 {
+		t.Fatalf("reply_count = %d, want 2", got.ReplyCount)
+	}
+}

--- a/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_rep.go
+++ b/apps/gooseforum/app/models/forum/topicUserStat/topicUserStat_rep.go
@@ -34,7 +34,8 @@ func IncrementUserPostTx(tx *gorm.DB, topicId, userId uint64) error {
 	return tx.Table(tableName).Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "topic_id"}, {Name: "user_id"}},
 		DoUpdates: clause.Assignments(map[string]any{
-			"reply_count":   gorm.Expr("reply_count + 1"),
+			// Qualify the target row: PostgreSQL also exposes EXCLUDED.reply_count here.
+			"reply_count":   gorm.Expr("? + 1", clause.Column{Table: tableName, Name: "reply_count"}),
 			"last_reply_at": now,
 		}),
 	}).Create(map[string]any{


### PR DESCRIPTION
## 背景

修复 #588：PostgreSQL 下创建非匿名评论时，`topic_user_stat` 的 UPSERT 在 `ON CONFLICT DO UPDATE` 中裸引用 `reply_count`，会被 PostgreSQL 判定为目标表列与 `EXCLUDED.reply_count` 之间存在歧义，返回 `SQLSTATE 42702`，并使评论创建事务整体回滚。

## 改动

- 在 `IncrementUserPostTx` 中将累加表达式明确限定为目标表 `topic_user_stat.reply_count`，保持原有“已有累计值 + 1”的语义不变。
- 增加 PostgreSQL 专项回归测试，覆盖连续两次同 `(topic_id, user_id)` 增量并断言 `reply_count == 2`。
- 不改动事务结构、统计口径、HTTP 契约或数据库 schema。

## 验证

已执行并通过：

- PostgreSQL 红测：修复前 `TestIncrementUserPostExistingRowPostgreSQL` 稳定复现 `SQLSTATE 42702`。
- PostgreSQL 绿测：修复后同一测试通过。
- `go test ./app/models/forum/topicUserStat -count=1 -v`
- `go test ./app/service/postservice -count=1`
- `go vet ./app/models/forum/topicUserStat`
- `YOURTJ_TEST_PG_URL=... go test ./app/migration/ -run 'TestSchema' -count=1 -v`
- `node scripts/run-gates.mjs`
- `git diff --check`
- pre-push hook：`go vet ./...`、增量 `golangci-lint`（0 issues）、前端 `typecheck` 全部通过。

## 文档 / 契约影响

- 无 OpenAPI / HTTP 契约变化。
- 无数据库 schema / migration 变化。
- 代码内补充 PostgreSQL UPSERT 限定列的原因注释，避免后续退化为裸列引用。

## 已知限制

无新增已知限制。本 PR 仅修复 #588 的 PostgreSQL 方言兼容问题，不扩展参与者统计行为。

Closes #588
