### PR TITLE
fix(quick-publish): require categories for short posts

### DIFF
--- a/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
+++ b/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
@@ -67,11 +67,13 @@ const errorMessage = ref('')
 const sensitiveWords = ref<string[]>([])
 const validationAttempted = ref(false)
 const titleInput = ref<HTMLInputElement | null>(null)
+const categoryPickerTrigger = ref<HTMLButtonElement | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
 const editor = ref<InstanceType<typeof VditorOfficial> | null>(null)
 const uploadedImages = ref<UploadedImageItem[]>([])
 
 const categories = computed(() => props.layout?.sidebar?.categories || [])
+const categoryMissing = computed(() => validationAttempted.value && categoryIds.value.length === 0)
 
 const selectedCategory = computed(() => {
   if (categoryIds.value.length === 0) return null
@@ -132,9 +134,6 @@ watch(
         content.value = ''
         categoryIds.value = []
         uploadedImages.value = []
-        if (categories.value.length > 0) {
-          categoryIds.value = [categories.value[0].id]
-        }
       }
 
       void nextTick(() => {
@@ -276,7 +275,14 @@ async function handleSubmit() {
     finalContent = t('publish.modal.imageOnlyContent')
   }
 
-  if (!finalTitle || !finalContent || categoryIds.value.length === 0) {
+  if (categoryIds.value.length === 0) {
+    errorMessage.value = t('publish.validation.categoryRequired')
+    categoryPickerOpen.value = true
+    void nextTick(() => categoryPickerTrigger.value?.focus())
+    return
+  }
+
+  if (!finalTitle || !finalContent) {
     errorMessage.value = t('publish.validation.requiredFields')
     return
   }
@@ -370,7 +376,7 @@ async function handleSubmit() {
           </DialogClose>
         </div>
 
-        <!-- 弹层主体：参考用户截图（首行快捷传图 -> 填写标题 -> 添加正文铺满 -> 底部工具栏与添加分区） -->
+        <!-- 弹层主体：首行快捷传图 -> 选择分类 -> 填写标题 -> 添加正文铺满 -> 底部工具栏 -->
         <div class="flex-1 min-h-0 flex flex-col px-4 sm:px-6 py-2.5 sm:py-3 gap-2.5 sm:gap-3 overflow-hidden sm:overflow-y-auto">
           <!-- 首行入口：快捷传图与已上传图片预览横向滑动流（支持滑动预览与拖拽重排，移动端比例适度放大） -->
           <div class="gf-image-scroll-track shrink-0 flex items-center gap-3 overflow-x-auto pb-2 pt-0.5">
@@ -477,57 +483,18 @@ async function handleSubmit() {
             />
           </div>
 
-          <!-- 第二行：标题输入与字数计数器（如 0/30） -->
-          <div class="shrink-0 pt-0.5">
-            <div class="relative flex items-center justify-between gap-3">
-              <input
-                ref="titleInput"
-                v-model="title"
-                type="text"
-                class="w-full text-base sm:text-lg font-bold placeholder:text-base-content/35 border-none bg-transparent outline-none focus:outline-none focus:ring-0 px-0 text-base-content transition"
-                :class="{ 'gf-sensitive-field': containsSensitiveText(title, sensitiveWords) }"
-                :placeholder="quickPublishType === 2 ? t('publish.modal.thoughtTitlePlaceholder') : typeMeta.placeholder"
-                :maxlength="titleMaxLength"
-                @input="clearSensitiveHighlight"
-                @focus="titleFocused = true"
-                @blur="titleFocused = false"
-                @keydown.enter.prevent="handleTitleEnter"
-              />
-              <span class="shrink-0 text-xs font-mono text-base-content/40 select-none">
-                {{ title.length }}/{{ titleMaxLength }}
-              </span>
-            </div>
-          </div>
-
-          <!-- 极轻细微过渡线：聚焦时柔和过渡到主色调 -->
-          <div
-            class="shrink-0 h-px w-full transition-all duration-300"
-            :class="titleFocused ? 'bg-primary/50 ring-1 ring-primary/20' : 'bg-line/40'"
-          />
-
-          <!-- 第三行：正文编辑器（弹性填满剩余空间，工具栏移到底部大拇指触控区，隐去传图按钮） -->
-          <div class="gf-modal-editor relative flex-1 min-h-0 flex flex-col">
-            <VditorOfficial
-              ref="editor"
-              v-model="content"
-              :simple="true"
-              :hide-upload="true"
-              :sensitive-words="sensitiveWords"
-              :placeholder="t('publish.modal.contentPlaceholder')"
-              @input="clearSensitiveHighlight"
-              @upload="uploadImageFiles"
-              @error="handleEditorError"
-            />
-          </div>
-
-          <!-- 第四行：参考截图放置在正文/工具栏下方的“+ 添加分区及话题”药丸胶囊 -->
-          <div class="shrink-0 flex items-center gap-2 pt-0.5">
+          <!-- 第二行：分类选择器，先于标题明确发布归属 -->
+          <div class="shrink-0 flex flex-col items-start gap-1 pt-0.5">
             <PopoverRoot v-model:open="categoryPickerOpen">
               <PopoverTrigger as-child>
                 <button
+                  ref="categoryPickerTrigger"
                   type="button"
                   class="group inline-flex items-center gap-1.5 sm:gap-2 rounded-full border border-line/80 bg-base-200/50 hover:bg-base-200/80 hover:border-primary/40 px-3 py-1.5 text-xs font-medium text-base-content/85 transition-all duration-150 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 cursor-pointer"
+                  :class="{ 'border-error bg-error/5 text-error focus-visible:ring-error/40': categoryMissing }"
                   :aria-label="t('publish.modal.addCategoryAndTopic')"
+                  :aria-invalid="categoryMissing"
+                  :aria-describedby="categoryMissing ? 'quick-publish-category-hint' : undefined"
                 >
                   <Plus v-if="!selectedCategory" class="h-3.5 w-3.5 opacity-60 group-hover:opacity-100 transition-opacity" />
                   <span
@@ -572,6 +539,57 @@ async function handleSubmit() {
                 </PopoverContent>
               </PopoverPortal>
             </PopoverRoot>
+            <p
+              v-if="categoryMissing"
+              id="quick-publish-category-hint"
+              role="alert"
+              class="px-1 text-xs font-medium text-error animate-in fade-in-0 slide-in-from-top-1 duration-150"
+            >
+              {{ t('publish.validation.categoryRequired') }}
+            </p>
+          </div>
+
+          <!-- 第三行：标题输入与字数计数器（如 0/30） -->
+          <div class="shrink-0 pt-0.5">
+            <div class="relative flex items-center justify-between gap-3">
+              <input
+                ref="titleInput"
+                v-model="title"
+                type="text"
+                class="w-full text-base sm:text-lg font-bold placeholder:text-base-content/35 border-none bg-transparent outline-none focus:outline-none focus:ring-0 px-0 text-base-content transition"
+                :class="{ 'gf-sensitive-field': containsSensitiveText(title, sensitiveWords) }"
+                :placeholder="quickPublishType === 2 ? t('publish.modal.thoughtTitlePlaceholder') : typeMeta.placeholder"
+                :maxlength="titleMaxLength"
+                @input="clearSensitiveHighlight"
+                @focus="titleFocused = true"
+                @blur="titleFocused = false"
+                @keydown.enter.prevent="handleTitleEnter"
+              />
+              <span class="shrink-0 text-xs font-mono text-base-content/40 select-none">
+                {{ title.length }}/{{ titleMaxLength }}
+              </span>
+            </div>
+          </div>
+
+          <!-- 极轻细微过渡线：聚焦时柔和过渡到主色调 -->
+          <div
+            class="shrink-0 h-px w-full transition-all duration-300"
+            :class="titleFocused ? 'bg-primary/50 ring-1 ring-primary/20' : 'bg-line/40'"
+          />
+
+          <!-- 第四行：正文编辑器（弹性填满剩余空间，工具栏移到底部大拇指触控区，隐去传图按钮） -->
+          <div class="gf-modal-editor relative flex-1 min-h-0 flex flex-col">
+            <VditorOfficial
+              ref="editor"
+              v-model="content"
+              :simple="true"
+              :hide-upload="true"
+              :sensitive-words="sensitiveWords"
+              :placeholder="t('publish.modal.contentPlaceholder')"
+              @input="clearSensitiveHighlight"
+              @upload="uploadImageFiles"
+              @error="handleEditorError"
+            />
           </div>
 
           <!-- 验证码卡片（触发风控时展示） -->
@@ -599,7 +617,7 @@ async function handleSubmit() {
           </div>
 
           <!-- 错误状态反馈 -->
-          <p v-if="errorMessage" class="shrink-0 text-xs text-error font-medium px-1 animate-in fade-in-0 slide-in-from-top-1 duration-150">
+          <p v-if="errorMessage && !categoryMissing" class="shrink-0 text-xs text-error font-medium px-1 animate-in fade-in-0 slide-in-from-top-1 duration-150">
             {{ errorMessage }}
           </p>
         </div>

--- a/apps/gooseforum/resource/test/quick-publish-modal.test.ts
+++ b/apps/gooseforum/resource/test/quick-publish-modal.test.ts
@@ -45,12 +45,58 @@ describe('QuickPublishModal 组件', () => {
     const dialog = document.body.querySelector('[role="dialog"]')
     expect(dialog).not.toBeNull()
 
-    // 检查分类标签
+    // 打开分类选择器后检查分类选项
+    const categoryTrigger = document.body.querySelector(
+      `button[aria-label="${i18n.global.t('publish.modal.addCategoryAndTopic')}"]`,
+    ) as HTMLButtonElement | null
+    expect(categoryTrigger).not.toBeNull()
+    categoryTrigger?.click()
+    await flushPromises()
     const categoryButtons = document.body.querySelectorAll('button')
     const categoryTexts = Array.from(categoryButtons).map((b) => b.textContent)
     expect(categoryTexts.some((t) => t?.includes('学术讨论'))).toBe(true)
 
     // 关闭弹层
+    closeQuickPublish()
+    await flushPromises()
+    wrapper.unmount()
+  })
+
+  test('新建短文不默认分类，未选分类提交时提示并定位分类选择器', async () => {
+    i18n.global.locale.value = 'zh'
+    const { openQuickPublish, closeQuickPublish } = useQuickPublish()
+    openQuickPublish(2) // 瞬间类型
+
+    const wrapper = mount(QuickPublishModal, {
+      props: { layout: mockLayout },
+      global: { plugins: [i18n, router] },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    const vm = wrapper.vm as any
+    const dialog = document.body.querySelector('[role="dialog"]')
+    const categoryTrigger = dialog?.querySelector(
+      `button[aria-label="${i18n.global.t('publish.modal.addCategoryAndTopic')}"]`,
+    ) as HTMLButtonElement | null
+    const titleInput = dialog?.querySelector('input[type="text"]') as HTMLInputElement | null
+
+    expect(vm.categoryIds).toEqual([])
+    expect(categoryTrigger).not.toBeNull()
+    expect(titleInput).not.toBeNull()
+    expect(categoryTrigger!.compareDocumentPosition(titleInput!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    vm.title = '测试标题'
+    vm.content = '测试正文'
+    await vm.handleSubmit()
+    await flushPromises()
+
+    expect(vm.categoryMissing).toBe(true)
+    expect(vm.errorMessage).toBe(i18n.global.t('publish.validation.categoryRequired'))
+    expect(categoryTrigger?.getAttribute('aria-invalid')).toBe('true')
+    expect(categoryTrigger?.className).toContain('border-error')
+    expect(document.activeElement).toBe(categoryTrigger)
+
     closeQuickPublish()
     await flushPromises()
     wrapper.unmount()


### PR DESCRIPTION
## Summary / 摘要
修复 Issue #595：调整“瞬间/提问”短文发布时的分类选择流程，降低漏选分类的概率并提供明确反馈。

## Behavior change / 行为变更
- 将分类选择器移动到标题输入框上方。
- 新建“瞬间/提问”时分类默认为空，不再自动选择第一个分类。
- 未选择分类直接提交时，展示定向提示，自动展开并聚焦分类选择器，同时高亮错误状态。

## Verification / 验证
- [x] `git diff --check`
- [x] `pnpm exec vitest run test/quick-publish-modal.test.ts`（10/10）
- [x] `pnpm test`（682 个测试通过）
- [x] `pnpm test:browser`（44 个测试通过）
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `mise exec go@1.26.8 -- go vet ./...`
- [x] 使用 mise 管理的 Go 1.26.8 重建 golangci-lint，并通过 `golangci-lint run --new-from-rev=origin/dev`（0 issues）

## Docs & contract impact / 文档与契约影响
本次仅修改已有前端交互和回归测试，不涉及 API、OpenAPI 契约、数据结构或部署行为；复用了已有多语言校验文案，无需更新文档中心。

## Known gaps / 已知缺口
`pnpm build` 仍输出依赖侧的 Rolldown `@vueuse/core` PURE annotation 和大 chunk 警告，但构建成功；本 PR 未扩大范围处理。

Closes #595