### PR TITLE
fix(web): 用户卡片关注状态跨界面同步、回源刷新与缓存重验 (issue #593)

### DIFF
--- a/apps/gooseforum/resource/src/runtime/follow-state.ts
+++ b/apps/gooseforum/resource/src/runtime/follow-state.ts
@@ -1,0 +1,44 @@
+// 会话内「我是否关注了某用户」的单一事实源（issue #593）。
+// UserCard 的挂载级缓存与 UserPage 的本地 ref 各自为政，一处关注/取关后
+// 另一处继续展示旧态；这里集中登记最近一次已知状态，并在变更时广播
+// goose:follow-changed（沿用 goose:page / goose:unread 的 window 事件约定），
+// 各展示面订阅纠正。注意：这里只是会话内缓存，SSR 载荷与 /api/user-card
+// 仍是权威来源，登记值随时可被回源结果覆盖。
+
+export interface FollowChangeDetail {
+  userId: number
+  isFollowing: boolean
+}
+
+export const FOLLOW_CHANGE_EVENT = 'goose:follow-changed'
+
+const known = new Map<number, boolean>()
+
+export function getKnownFollowState(userId: number): boolean | undefined {
+  return known.get(userId)
+}
+
+export function recordFollowState(userId: number, isFollowing: boolean) {
+  known.set(userId, isFollowing)
+}
+
+// 关注/取关成功后调用：登记新状态并广播，供 UserCard/UserPage 等即时同步。
+export function broadcastFollowChange(userId: number, isFollowing: boolean) {
+  recordFollowState(userId, isFollowing)
+  window.dispatchEvent(
+    new CustomEvent<FollowChangeDetail>(FOLLOW_CHANGE_EVENT, {
+      detail: { userId, isFollowing },
+    }),
+  )
+}
+
+export function onFollowChange(handler: (detail: FollowChangeDetail) => void): () => void {
+  const listener = (event: Event) => handler((event as CustomEvent<FollowChangeDetail>).detail)
+  window.addEventListener(FOLLOW_CHANGE_EVENT, listener)
+  return () => window.removeEventListener(FOLLOW_CHANGE_EVENT, listener)
+}
+
+// 仅供测试：清空会话内登记状态。
+export function resetFollowState() {
+  known.clear()
+}

--- a/apps/gooseforum/resource/src/runtime/follow-state.ts
+++ b/apps/gooseforum/resource/src/runtime/follow-state.ts
@@ -13,9 +13,18 @@ export interface FollowChangeDetail {
 export const FOLLOW_CHANGE_EVENT = 'goose:follow-changed'
 
 const known = new Map<number, boolean>()
+// 每用户变更代次：广播一次递增一次。回源请求落地时对比代次，
+// 可识别「请求发出后、响应落地前发生了同 tab 关注变更」，避免旧快照回退新状态。
+const changeSeq = new Map<number, number>()
+let lastSeq = 0
 
 export function getKnownFollowState(userId: number): boolean | undefined {
   return known.get(userId)
+}
+
+// 读取用户当前的变更代次（请求发出前快照用）。
+export function getFollowChangeSeq(userId: number): number {
+  return changeSeq.get(userId) ?? 0
 }
 
 export function recordFollowState(userId: number, isFollowing: boolean) {
@@ -25,6 +34,7 @@ export function recordFollowState(userId: number, isFollowing: boolean) {
 // 关注/取关成功后调用：登记新状态并广播，供 UserCard/UserPage 等即时同步。
 export function broadcastFollowChange(userId: number, isFollowing: boolean) {
   recordFollowState(userId, isFollowing)
+  changeSeq.set(userId, ++lastSeq)
   window.dispatchEvent(
     new CustomEvent<FollowChangeDetail>(FOLLOW_CHANGE_EVENT, {
       detail: { userId, isFollowing },
@@ -41,4 +51,6 @@ export function onFollowChange(handler: (detail: FollowChangeDetail) => void): (
 // 仅供测试：清空会话内登记状态。
 export function resetFollowState() {
   known.clear()
+  changeSeq.clear()
+  lastSeq = 0
 }

--- a/apps/gooseforum/resource/src/site/components/UserCard.vue
+++ b/apps/gooseforum/resource/src/site/components/UserCard.vue
@@ -11,6 +11,8 @@ import {
   UserX,
 } from '@lucide/vue'
 import { getUserCard, followUser } from '@/runtime/api'
+// 关注状态单一事实源：卡片缓存的可变状态必须经它登记/广播，跨 surface 才能一致（issue #593）
+import { broadcastFollowChange, getKnownFollowState, onFollowChange, recordFollowState } from '@/runtime/follow-state'
 import { formatDate, formatNumber, timeAgo } from '@/runtime/format'
 import type { UserCardShowDetail } from '@/runtime/user-card-events'
 import type { UserCardPayload } from '@gooseforum/client'
@@ -28,6 +30,10 @@ const position = ref({ left: 0, top: 0 })
 const cardEl = ref<HTMLElement | null>(null)
 const activeBadgeCode = ref('')
 const cache = new Map<number, UserCardPayload>()
+const cacheFetchedAt = new Map<number, number>()
+// 缓存命中后超过该时长触发后台重验（stale-while-revalidate）：
+// 卡片组件与应用同生命周期，缓存一旦永不失效，跨 surface 的关注变更永远不可见
+const CACHE_REVALIDATE_TTL_MS = 60_000
 let requestToken = 0
 let preferredSide: 'top' | 'bottom' | null = null
 
@@ -47,6 +53,7 @@ const coverStyle = computed(() => {
 })
 const isFollowing = ref(false)
 const followLoading = ref(false)
+const followError = ref('')
 const externalLinks = computed(() => {
   const links: Array<{ key: string; label: string; url: string; icon?: SimpleIcon }> = []
   const primaryUrl = normalizeWebsiteURL(card.value?.website || '')
@@ -111,6 +118,29 @@ function placeCard(target: HTMLElement) {
   }
 }
 
+function storeInCache(userId: number, payload: UserCardPayload) {
+  cache.set(userId, payload)
+  cacheFetchedAt.set(userId, Date.now())
+  recordFollowState(userId, payload.isFollowing)
+}
+
+// stale-while-revalidate：立即展示缓存，后台向 /api/user-card 回源。
+// 命中缓存不再意味着「本会话内永远正确」——用户主页取关、其他标签页变更都要靠这里收敛。
+async function revalidateCard(userId: number, token: number) {
+  try {
+    const result = await getUserCard(userId)
+    storeInCache(userId, result)
+    // 仅当仍在展示同一用户时才刷新 UI；token 过期说明已切换到别的卡片，只更新缓存
+    if (token !== requestToken) return
+    if (card.value?.userId === userId) {
+      card.value = result
+      isFollowing.value = result.isFollowing
+    }
+  } catch {
+    // 重验失败保留缓存展示，下次打开再试
+  }
+}
+
 async function show(event: Event) {
   const detail = (event as CustomEvent<UserCardShowDetail>).detail
   if (!detail?.user?.id || !detail.target) return
@@ -118,14 +148,19 @@ async function show(event: Event) {
   fallbackUser.value = detail.user
   visible.value = true
   error.value = ''
-  isFollowing.value = Boolean(detail.user.isFollowing)
+  followError.value = ''
+  isFollowing.value = getKnownFollowState(detail.user.id) ?? Boolean(detail.user.isFollowing)
   requestAnimationFrame(() => placeCard(detail.target))
 
   const cached = cache.get(detail.user.id)
   if (cached) {
     card.value = cached
-    isFollowing.value = cached.isFollowing
+    isFollowing.value = getKnownFollowState(detail.user.id) ?? cached.isFollowing
     loading.value = false
+    const fetchedAt = cacheFetchedAt.get(detail.user.id) || 0
+    if (Date.now() - fetchedAt >= CACHE_REVALIDATE_TTL_MS) {
+      void revalidateCard(detail.user.id, ++requestToken)
+    }
     return
   }
 
@@ -134,8 +169,8 @@ async function show(event: Event) {
   card.value = null
   try {
     const result = await getUserCard(detail.user.id)
+    storeInCache(detail.user.id, result)
     if (token !== requestToken) return
-    cache.set(detail.user.id, result)
     card.value = result
     isFollowing.value = result.isFollowing
     requestAnimationFrame(() => placeCard(detail.target))
@@ -151,12 +186,23 @@ async function toggleFollow() {
   const userCard = card.value
   if (!userCard || userCard.isSelf || followLoading.value) return
   followLoading.value = true
+  followError.value = ''
   try {
     await followUser(userCard.userId, isFollowing.value)
-    isFollowing.value = !isFollowing.value
-    userCard.isFollowing = isFollowing.value
-  } catch {
-    // 关注失败保持原状态，静默处理（API 错误已由后端提示）
+    const target = !isFollowing.value
+    isFollowing.value = target
+    userCard.isFollowing = target
+    broadcastFollowChange(userCard.userId, target)
+    // 回源拿权威结果：本地翻转只是乐观更新，isFollowing 与粉丝数以 /api/user-card 为准
+    const fresh = await getUserCard(userCard.userId)
+    storeInCache(userCard.userId, fresh)
+    if (card.value?.userId === userCard.userId) {
+      card.value = fresh
+      isFollowing.value = fresh.isFollowing
+    }
+  } catch (e) {
+    // 关注失败保持原状态，内联提示（对齐 UserPage 的 followError 模式）
+    followError.value = e instanceof Error ? e.message : t('api.followFailed')
   } finally {
     followLoading.value = false
   }
@@ -173,6 +219,8 @@ function onKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') hideNow()
 }
 
+let offFollowChange: (() => void) | undefined
+
 onMounted(() => {
   window.addEventListener('goose:user-card-show', show)
   document.addEventListener('pointerdown', onDocumentPointerDown)
@@ -180,6 +228,12 @@ onMounted(() => {
   window.addEventListener('scroll', hideNow, { passive: true })
   window.addEventListener('resize', hideNow)
   window.addEventListener('goose:page', hideNow)
+  // 用户主页等处关注/取关后，同步纠正打开中的卡片与缓存条目
+  offFollowChange = onFollowChange(({ userId, isFollowing: following }) => {
+    const cached = cache.get(userId)
+    if (cached) cached.isFollowing = following
+    if (card.value?.userId === userId) isFollowing.value = following
+  })
 })
 
 onBeforeUnmount(() => {
@@ -189,6 +243,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('scroll', hideNow)
   window.removeEventListener('resize', hideNow)
   window.removeEventListener('goose:page', hideNow)
+  offFollowChange?.()
 })
 
 </script>
@@ -395,6 +450,8 @@ onBeforeUnmount(() => {
             </a>
           </div>
         </div>
+        <!-- 关注失败内联提示（issue #593）：失败保持原状态并给出可操作文案，不再静默吞错 -->
+        <p v-if="followError" role="alert" class="mt-2 text-xs text-error">{{ followError }}</p>
           </div>
         </Transition>
       </div>

--- a/apps/gooseforum/resource/src/site/components/UserCard.vue
+++ b/apps/gooseforum/resource/src/site/components/UserCard.vue
@@ -12,7 +12,7 @@ import {
 } from '@lucide/vue'
 import { getUserCard, followUser } from '@/runtime/api'
 // 关注状态单一事实源：卡片缓存的可变状态必须经它登记/广播，跨 surface 才能一致（issue #593）
-import { broadcastFollowChange, getKnownFollowState, onFollowChange, recordFollowState } from '@/runtime/follow-state'
+import { broadcastFollowChange, getFollowChangeSeq, getKnownFollowState, onFollowChange, recordFollowState } from '@/runtime/follow-state'
 import { formatDate, formatNumber, timeAgo } from '@/runtime/format'
 import type { UserCardShowDetail } from '@/runtime/user-card-events'
 import type { UserCardPayload } from '@gooseforum/client'
@@ -124,12 +124,23 @@ function storeInCache(userId: number, payload: UserCardPayload) {
   recordFollowState(userId, payload.isFollowing)
 }
 
+// 回源落地（PR #600 review 2）：若请求飞行期间发生了同 tab 关注变更广播，
+// 响应里的 isFollowing 是变更前的旧快照，关注状态以广播为准，其余字段照常采纳。
+function adoptFreshCard(userId: number, fresh: UserCardPayload, seqAtRequest: number) {
+  if (getFollowChangeSeq(userId) !== seqAtRequest) {
+    const known = getKnownFollowState(userId)
+    if (known !== undefined) fresh.isFollowing = known
+  }
+  storeInCache(userId, fresh)
+}
+
 // stale-while-revalidate：立即展示缓存，后台向 /api/user-card 回源。
 // 命中缓存不再意味着「本会话内永远正确」——用户主页取关、其他标签页变更都要靠这里收敛。
 async function revalidateCard(userId: number, token: number) {
+  const seqAtRequest = getFollowChangeSeq(userId)
   try {
     const result = await getUserCard(userId)
-    storeInCache(userId, result)
+    adoptFreshCard(userId, result, seqAtRequest)
     // 仅当仍在展示同一用户时才刷新 UI；token 过期说明已切换到别的卡片，只更新缓存
     if (token !== requestToken) return
     if (card.value?.userId === userId) {
@@ -167,9 +178,10 @@ async function show(event: Event) {
   const token = ++requestToken
   loading.value = true
   card.value = null
+  const seqAtRequest = getFollowChangeSeq(detail.user.id)
   try {
     const result = await getUserCard(detail.user.id)
-    storeInCache(detail.user.id, result)
+    adoptFreshCard(detail.user.id, result, seqAtRequest)
     if (token !== requestToken) return
     card.value = result
     isFollowing.value = result.isFollowing
@@ -189,23 +201,31 @@ async function toggleFollow() {
   followError.value = ''
   try {
     await followUser(userCard.userId, isFollowing.value)
-    const target = !isFollowing.value
-    isFollowing.value = target
-    userCard.isFollowing = target
-    broadcastFollowChange(userCard.userId, target)
-    // 回源拿权威结果：本地翻转只是乐观更新，isFollowing 与粉丝数以 /api/user-card 为准
+  } catch (e) {
+    // 只有关注操作本身的失败才算「关注失败」，保持原状态并内联提示
+    followError.value = e instanceof Error ? e.message : t('api.followFailed')
+    followLoading.value = false
+    return
+  }
+  // 以下不再有「关注失败」：POST 已成功，翻转与广播是本地的即时反馈
+  const target = !isFollowing.value
+  isFollowing.value = target
+  userCard.isFollowing = target
+  broadcastFollowChange(userCard.userId, target)
+  // 回源拿权威结果与粉丝数；失败只代表资料未刷新，不算关注失败（PR #600 review 1），
+  // 计数等字段由 SWR/TTL 下次重验兜底。loading 保持到回源结束，避免飞行期间再次点击发出反向 action
+  const seqAtRequest = getFollowChangeSeq(userCard.userId)
+  try {
     const fresh = await getUserCard(userCard.userId)
-    storeInCache(userCard.userId, fresh)
+    adoptFreshCard(userCard.userId, fresh, seqAtRequest)
     if (card.value?.userId === userCard.userId) {
       card.value = fresh
       isFollowing.value = fresh.isFollowing
     }
-  } catch (e) {
-    // 关注失败保持原状态，内联提示（对齐 UserPage 的 followError 模式）
-    followError.value = e instanceof Error ? e.message : t('api.followFailed')
-  } finally {
-    followLoading.value = false
+  } catch {
+    // 回源失败保留乐观状态，静默等待下次重验
   }
+  followLoading.value = false
 }
 
 function onDocumentPointerDown(event: PointerEvent) {

--- a/apps/gooseforum/resource/src/site/pages/UserPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/UserPage.vue
@@ -18,6 +18,8 @@ import {
   UserPlus,
 } from '@lucide/vue'
 import { followUser } from '@/runtime/api'
+// 与 UserCard 共享关注状态事实源：本页关注/取关要广播出去，卡片上的变更也要同步回来（issue #593）
+import { broadcastFollowChange, onFollowChange } from '@/runtime/follow-state'
 import { formatDate, formatDateTime, formatNumber, timeAgo } from '@/runtime/format'
 import { fetchPage } from '@/runtime/router'
 import { topicDescription } from '@/runtime/topic-description'
@@ -134,6 +136,7 @@ async function toggleFollow() {
   try {
     await followUser(page.props.user.userId, isFollowing.value)
     isFollowing.value = !isFollowing.value
+    broadcastFollowChange(page.props.user.userId, isFollowing.value)
   } catch (error) {
     followError.value = error instanceof Error ? error.message : t('api.followFailed')
   } finally {
@@ -233,7 +236,15 @@ function observeSentinel() {
   observer.observe(loadMoreSentinel.value)
 }
 
-onMounted(observeSentinel)
+let offFollowChange: (() => void) | undefined
+
+onMounted(() => {
+  observeSentinel()
+  // 用户卡片上的关注/取关广播回来时，同步本页按钮状态
+  offFollowChange = onFollowChange(({ userId, isFollowing: following }) => {
+    if (userId === page.props.user.userId) isFollowing.value = following
+  })
+})
 onActivated(() => {
   void nextTick(observeSentinel)
 })
@@ -242,6 +253,7 @@ onDeactivated(() => {
 })
 onBeforeUnmount(() => {
   observer?.disconnect()
+  offFollowChange?.()
 })
 
 function safeProfileUrl(value?: string) {

--- a/apps/gooseforum/resource/test/user-card-follow-state.test.ts
+++ b/apps/gooseforum/resource/test/user-card-follow-state.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { i18n } from '../src/runtime/i18n'
+
+const { getUserCardMock, followUserMock } = vi.hoisted(() => ({
+  getUserCardMock: vi.fn(),
+  followUserMock: vi.fn(),
+}))
+
+vi.mock('@/runtime/api', () => ({
+  getUserCard: getUserCardMock,
+  followUser: followUserMock,
+}))
+
+import UserCard from '../src/site/components/UserCard.vue'
+import { broadcastFollowChange, getKnownFollowState, resetFollowState } from '../src/runtime/follow-state'
+import type { UserCardPayload } from '@gooseforum/client'
+
+const t = (key: string) => i18n.global.t(key)
+
+function makeCard(overrides: Partial<UserCardPayload> = {}): UserCardPayload {
+  return {
+    userId: 42,
+    username: 'alice',
+    nickname: 'Alice',
+    avatarUrl: '/static/pic/default-avatar.webp',
+    profileCoverUrl: '',
+    bio: '',
+    signature: '',
+    websiteName: '',
+    website: '',
+    prestige: 0,
+    externalInformation: {},
+    isAdmin: false,
+    topicCount: 1,
+    replyCount: 2,
+    likeReceivedCount: 3,
+    likeGivenCount: 0,
+    followerCount: 10,
+    followingCount: 0,
+    collectionCount: 0,
+    isOnline: false,
+    isFollowing: false,
+    isSelf: false,
+    badges: [],
+    wornBadge: null,
+    lastActiveTime: '2026-09-09T00:00:00Z',
+    createdAt: '2026-01-01T00:00:00Z',
+    isAccountClosed: false,
+    ...overrides,
+  }
+}
+
+function showCard(userId = 42) {
+  const target = document.createElement('a')
+  document.body.appendChild(target)
+  window.dispatchEvent(
+    new CustomEvent('goose:user-card-show', {
+      detail: { user: { id: userId, username: 'alice', avatarUrl: '' }, target },
+    }),
+  )
+}
+
+function followButton(): HTMLButtonElement | null {
+  const buttons = Array.from(document.body.querySelectorAll('button'))
+  return buttons.find((b) => [t('userCard.follow'), t('userCard.following')].includes(b.textContent?.trim() || '')) ?? null
+}
+
+function followerStatValue(): string {
+  const cells = Array.from(document.body.querySelectorAll('.grid.grid-cols-4 > div'))
+  const cell = cells.find((c) => c.textContent?.includes(t('userCard.stats.followers')))
+  return cell?.querySelector('div')?.textContent?.trim() ?? ''
+}
+
+async function flushAll() {
+  await flushPromises()
+  await flushPromises()
+}
+
+let wrapper: ReturnType<typeof mount> | undefined
+
+async function mountCard() {
+  wrapper = mount(UserCard, { global: { plugins: [i18n] } })
+  await flushPromises()
+}
+
+describe('UserCard 关注状态（issue #593）', () => {
+  beforeEach(() => {
+    resetFollowState()
+    getUserCardMock.mockReset()
+    followUserMock.mockReset()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+    document.body.innerHTML = ''
+    vi.useRealTimers()
+  })
+
+  test('toggle 成功后回源刷新：按钮态以服务端为准，粉丝数更新并写回缓存', async () => {
+    getUserCardMock.mockResolvedValueOnce(makeCard())
+    getUserCardMock.mockResolvedValueOnce(makeCard({ isFollowing: true, followerCount: 11 }))
+    followUserMock.mockResolvedValueOnce(true)
+    await mountCard()
+    showCard()
+    await flushAll()
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.follow'))
+
+    followButton()!.click()
+    await flushAll()
+
+    expect(followUserMock).toHaveBeenCalledWith(42, false)
+    expect(getUserCardMock).toHaveBeenCalledTimes(2)
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+    expect(getKnownFollowState(42)).toBe(true)
+
+    // TTL 内重开命中缓存（且共享状态已纠正），不重复拉取
+    window.dispatchEvent(new CustomEvent('goose:page'))
+    showCard()
+    await flushAll()
+    expect(getUserCardMock).toHaveBeenCalledTimes(2)
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+  })
+
+  test('toggle 失败：内联展示错误且状态不变，不再静默吞错', async () => {
+    getUserCardMock.mockResolvedValueOnce(makeCard())
+    followUserMock.mockRejectedValueOnce(new Error('关注操作失败'))
+    await mountCard()
+    showCard()
+    await flushAll()
+
+    followButton()!.click()
+    await flushAll()
+
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.follow'))
+    expect(getUserCardMock).toHaveBeenCalledTimes(1)
+    const alert = document.body.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('关注操作失败')
+  })
+
+  test('goose:follow-changed 广播即时纠正已打开卡片与缓存（跨 surface 同步）', async () => {
+    getUserCardMock.mockResolvedValueOnce(makeCard())
+    await mountCard()
+    showCard()
+    await flushAll()
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.follow'))
+
+    broadcastFollowChange(42, true)
+    await flushAll()
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+
+    // 缓存条目已同步：TTL 内重开不再拉取
+    window.dispatchEvent(new CustomEvent('goose:page'))
+    showCard()
+    await flushAll()
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+    expect(getUserCardMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('缓存命中后超过 TTL 触发 stale-while-revalidate，旧态被服务端纠正', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    getUserCardMock.mockResolvedValueOnce(makeCard({ isFollowing: false, followerCount: 10 }))
+    await mountCard()
+    showCard()
+    await flushAll()
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.follow'))
+    expect(getUserCardMock).toHaveBeenCalledTimes(1)
+
+    window.dispatchEvent(new CustomEvent('goose:page'))
+    vi.setSystemTime(Date.now() + 61_000)
+    getUserCardMock.mockResolvedValueOnce(makeCard({ isFollowing: true, followerCount: 11 }))
+    showCard()
+    await flushAll()
+
+    expect(getUserCardMock).toHaveBeenCalledTimes(2)
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+    expect(followerStatValue()).toBe('11')
+  })
+})

--- a/apps/gooseforum/resource/test/user-card-follow-state.test.ts
+++ b/apps/gooseforum/resource/test/user-card-follow-state.test.ts
@@ -178,4 +178,49 @@ describe('UserCard 关注状态（issue #593）', () => {
     expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
     expect(followerStatValue()).toBe('11')
   })
+
+  test('toggle 成功但回源失败：不算关注失败，保持已关注（PR #600 review 1）', async () => {
+    getUserCardMock.mockResolvedValueOnce(makeCard({ isFollowing: false }))
+    followUserMock.mockResolvedValueOnce(true)
+    getUserCardMock.mockRejectedValueOnce(new Error('network down'))
+    await mountCard()
+    showCard()
+    await flushAll()
+
+    followButton()!.click()
+    await flushAll()
+
+    expect(followUserMock).toHaveBeenCalledTimes(1)
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+    expect(document.body.querySelector('[role="alert"]')).toBeNull()
+  })
+
+  test('回源飞行期间收到同 tab 广播：旧快照不回退关注状态（PR #600 review 2）', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    getUserCardMock.mockResolvedValueOnce(makeCard({ isFollowing: false, followerCount: 10 }))
+    await mountCard()
+    showCard()
+    await flushAll()
+
+    // TTL 过期触发 SWR，并让重验请求挂起
+    window.dispatchEvent(new CustomEvent('goose:page'))
+    vi.setSystemTime(Date.now() + 61_000)
+    let resolveRefresh!: (v: UserCardPayload) => void
+    getUserCardMock.mockImplementationOnce(() => new Promise<UserCardPayload>((r) => { resolveRefresh = r }))
+    showCard()
+    await flushAll()
+    expect(getUserCardMock).toHaveBeenCalledTimes(2)
+
+    // 飞行期间其他 surface 关注了该用户
+    broadcastFollowChange(42, true)
+    await flushAll()
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+
+    // 旧快照（广播前的服务端状态）落地，不得覆盖较新的广播状态
+    resolveRefresh(makeCard({ isFollowing: false, followerCount: 11 }))
+    await flushAll()
+
+    expect(getKnownFollowState(42)).toBe(true)
+    expect(followButton()?.textContent?.trim()).toBe(t('userCard.following'))
+  })
 })


### PR DESCRIPTION
## 根因分析（对 issue #593 描述的修正）

issue 的「疑似根因 1」在当前 dev 上已不成立：`toggleFollow` 通过 `userCard.isFollowing = ...` 变异的是与缓存同一引用的对象（`card.value` 在 cache 命中/拉取两个分支都与缓存条目同引用），组件内重开卡片状态是正确的。经核实（issue 创建于 2026-09-09，晚于关注按钮上线的 90bcd418），真正剩余的缺陷是：

1. **卡片缓存永不失效、无跨 surface 同步**：`show()` 命中缓存直接返回、从不 revalidate；UserCard 的挂载级 `cache` 与 UserPage 的本地 `isFollowing` ref 是两份独立状态，在用户主页关注/取关后，用户卡片继续展示旧态。
2. **乐观翻转无权威回源**：`follow-user` 契约只返回 `true`，前端翻转后从不向服务端验证；失败被静默吞掉（UserPage 有 `followError` 内联提示，UserCard 没有）。
3. **followerCount 过期**：toggle 后卡片缓存的粉丝数不刷新。

## 修复（仅前端，不动契约）

- 新增 `src/runtime/follow-state.ts`：会话级关注状态单一事实源（登记 + `goose:follow-changed` window 事件广播，沿用 `goose:page`/`goose:unread` 既有约定）。
- **UserCard**：
  - `toggleFollow()` 成功后回源 `GET /api/user-card`，以权威结果更新 `isFollowing` 与 `followerCount` 并替换缓存；失败不再静默，按钮下内联展示错误（`role="alert"`）。
  - `show()` 缓存命中超过 60s 触发 **stale-while-revalidate**：立即展示缓存，后台重验纠正（requestToken 守卫防止错刷到别的用户）。
  - 订阅 `goose:follow-changed`，其他 surface 的关注/取关即时纠正打开中的卡片与缓存条目。
- **UserPage**：toggle 成功后广播；订阅广播反向同步本页按钮。

## 测试（红先行）

新增 `test/user-card-follow-state.test.ts`（4 用例，先在旧实现上确认行为级红，再转绿）：
- toggle 成功回源：按钮态以服务端为准、粉丝数更新、缓存写回
- toggle 失败：内联错误展示、状态不变
- `goose:follow-changed` 广播即时纠正已打开卡片与缓存
- 缓存命中超 TTL 触发 SWR，旧态被服务端纠正

## 验证

- `pnpm typecheck` ✅
- `pnpm test`：744 用例中 743 通过；唯一失败 `post-view-mode-integration.test.ts` 为全量并发时本机资源性超时（在干净 dev 上单跑通过、全量并发同样复现），与本次改动无关，单跑本用例 ✅
- `pnpm build` ✅（exit 0）
- `node scripts/run-gates.mjs`：`verify-manifest` hash 不匹配在干净 dev 检出上同样出现（Windows 换行符 vs seed hash 的本地既有状态），与本次改动无关

Fixes #593