### PR TITLE
fix(forum): align Unicode posting length limits

### DIFF
--- a/apps/gooseforum/app/http/controllers/api/topicController.go
+++ b/apps/gooseforum/app/http/controllers/api/topicController.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	db "github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/connect/dbconnect"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/eventbus"
@@ -164,7 +165,8 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 		return component.FailResponseCode(component.MessageRequestInvalidParams, nil)
 	}
 
-	if len(req.Params.Title) < postingConfig.TextControl.MinTitleLength {
+	titleLength := utf8.RuneCountInString(req.Params.Title)
+	if titleLength < postingConfig.TextControl.MinTitleLength {
 		minLength := postingConfig.TextControl.MinTitleLength
 		return component.FailResponseCode(
 			component.MessageTopicTitleTooShort,
@@ -173,7 +175,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 
 	}
 
-	if len(req.Params.Title) > postingConfig.TextControl.MaxTitleLength {
+	if titleLength > postingConfig.TextControl.MaxTitleLength {
 		maxLength := postingConfig.TextControl.MaxTitleLength
 		return component.FailResponseCode(
 			component.MessageTopicTitleTooLong,
@@ -182,7 +184,8 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 
 	}
 
-	if len(req.Params.Content) < postingConfig.TextControl.MinPostLength {
+	contentLength := utf8.RuneCountInString(req.Params.Content)
+	if contentLength < postingConfig.TextControl.MinPostLength {
 		minLength := postingConfig.TextControl.MinPostLength
 		return component.FailResponseCode(
 			component.MessageTopicContentTooShort,
@@ -191,7 +194,7 @@ func writeTopic(req component.BetterRequest[WriteTopicReq], agent bool) componen
 
 	}
 
-	if len(req.Params.Content) > postingConfig.TextControl.MaxPostLength {
+	if contentLength > postingConfig.TextControl.MaxPostLength {
 		maxLength := postingConfig.TextControl.MaxPostLength
 		return component.FailResponseCode(
 			component.MessageTopicContentTooLong,
@@ -508,7 +511,8 @@ func createPost(req component.BetterRequest[CreatePostReq], agent bool) componen
 	}
 
 	content := strings.TrimSpace(req.Params.Content)
-	if len(content) < postingConfig.TextControl.MinPostLength {
+	contentLength := utf8.RuneCountInString(content)
+	if contentLength < postingConfig.TextControl.MinPostLength {
 		minLength := postingConfig.TextControl.MinPostLength
 		return component.FailResponseCode(
 			component.MessageCommentContentTooShort,
@@ -517,7 +521,7 @@ func createPost(req component.BetterRequest[CreatePostReq], agent bool) componen
 
 	}
 
-	if len(content) > postingConfig.TextControl.MaxPostLength {
+	if contentLength > postingConfig.TextControl.MaxPostLength {
 		maxLength := postingConfig.TextControl.MaxPostLength
 		return component.FailResponseCode(
 			component.MessageCommentContentTooLong,
@@ -671,7 +675,8 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 	}
 
 	content := strings.TrimSpace(req.Params.Content)
-	if len(content) < postingConfig.TextControl.MinPostLength {
+	contentLength := utf8.RuneCountInString(content)
+	if contentLength < postingConfig.TextControl.MinPostLength {
 		minLength := postingConfig.TextControl.MinPostLength
 		return component.FailResponseCode(
 			component.MessageCommentContentTooShort,
@@ -680,7 +685,7 @@ func UpdatePost(req component.BetterRequest[UpdatePostReq]) component.Response {
 
 	}
 
-	if len(content) > postingConfig.TextControl.MaxPostLength {
+	if contentLength > postingConfig.TextControl.MaxPostLength {
 		maxLength := postingConfig.TextControl.MaxPostLength
 		return component.FailResponseCode(
 			component.MessageCommentContentTooLong,

--- a/apps/gooseforum/app/http/controllers/forum/payload.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload.go
@@ -142,8 +142,13 @@ type LayoutPayload struct {
 	Sidebar             SidebarPayload      `json:"sidebar"`
 	Footer              FooterPayload       `json:"footer"`
 	Unread              UnreadStatusPayload `json:"unread"`
+	Posting             PostingPayload      `json:"posting"`
 	Theme               ThemePayload        `json:"theme"`
 	InsightFlareEnabled bool                `json:"insightFlareEnabled"`
+}
+
+type PostingPayload struct {
+	MaxTitleLength int `json:"maxTitleLength"`
 }
 
 type ThemePayload struct {
@@ -739,7 +744,10 @@ func buildLayout(c *gin.Context, activeKey string) LayoutPayload {
 			Primary: footerPrimary,
 		},
 		Unread: unread,
-		Theme:  buildThemePayload(c),
+		Posting: PostingPayload{
+			MaxTitleLength: hotdataserve.GetPostingSettingsConfigCache().TextControl.MaxTitleLength,
+		},
+		Theme: buildThemePayload(c),
 	}
 }
 

--- a/apps/gooseforum/app/http/routes/contract_forum_post_interactions_test.go
+++ b/apps/gooseforum/app/http/routes/contract_forum_post_interactions_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/markdown2html"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/api"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/controllers/forum"
-	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/bundles/markdown2html"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/http/middleware"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/defaultconfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/contentDeleteEvent"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pageConfig"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/postRevisions"
@@ -232,6 +233,31 @@ func TestCreatePostHTTPContract(t *testing.T) {
 		}
 	})
 
+	t.Run("unicode comment limit counts code points", func(t *testing.T) {
+		conn, router := setupForumInteractionContractTest(t)
+		posting := defaultconfig.GetDefaultPostingSettingsConfig()
+		posting.TextControl.MinPostLength = 1
+		posting.TextControl.MaxPostLength = 4
+		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
+		hotdataserve.ClearPostingSettingsConfigCache()
+
+		user := createHTTPContractUser(t, conn, contractTestID())
+		base := contractTestID()
+		topicID, firstPostID := base, base+1
+		createContractPublishedTopic(t, conn, topicID, firstPostID, user.Id)
+		token := contractSessionToken(t, user)
+		body := fmt.Sprintf(`{"topicId":%d,"content":"汉😀ab"}`, topicID)
+		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/create", body, token)); response.Code != 0 {
+			t.Fatalf("four-rune comment response = %#v, want success", response)
+		}
+
+		body = fmt.Sprintf(`{"topicId":%d,"content":"汉汉汉汉汉"}`, topicID)
+		response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/create", body, token))
+		if response.MessageCode != "comment.content.tooLong" || response.Params["maxLength"] != float64(4) {
+			t.Fatalf("too-long comment response = %#v, want comment.content.tooLong maxLength=4", response)
+		}
+	})
+
 	t.Run("missing session returns 401", func(t *testing.T) {
 		_, router := setupForumInteractionContractTest(t)
 		assertInteractionUnauthenticated(t, router, "/api/forum/posts/create", `{}`, "auth-required.json")
@@ -312,6 +338,32 @@ func TestUpdatePostHTTPContract(t *testing.T) {
 		}
 		if _, err := time.Parse(time.RFC3339, updated.LastEditedAt); err != nil {
 			t.Fatalf("lastEditedAt = %q, want RFC3339: %v", updated.LastEditedAt, err)
+		}
+	})
+
+	t.Run("unicode updated comment limit counts code points", func(t *testing.T) {
+		conn, router := setupForumInteractionContractTest(t)
+		posting := defaultconfig.GetDefaultPostingSettingsConfig()
+		posting.TextControl.MinPostLength = 1
+		posting.TextControl.MaxPostLength = 4
+		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
+		hotdataserve.ClearPostingSettingsConfigCache()
+
+		user := createHTTPContractUser(t, conn, contractTestID())
+		base := contractTestID()
+		topicID, firstPostID, replyID := base, base+1, base+2
+		createContractPublishedTopic(t, conn, topicID, firstPostID, user.Id)
+		createContractReplyPost(t, conn, replyID, topicID, user.Id)
+		token := contractSessionToken(t, user)
+		body := fmt.Sprintf(`{"postId":%d,"content":"😀汉ab"}`, replyID)
+		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/update", body, token)); response.Code != 0 {
+			t.Fatalf("four-rune updated comment response = %#v, want success", response)
+		}
+
+		body = fmt.Sprintf(`{"postId":%d,"content":"😀😀😀😀😀"}`, replyID)
+		response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/update", body, token))
+		if response.MessageCode != "comment.content.tooLong" || response.Params["maxLength"] != float64(4) {
+			t.Fatalf("too-long updated comment response = %#v, want comment.content.tooLong maxLength=4", response)
 		}
 	})
 

--- a/apps/gooseforum/app/http/routes/contract_forum_post_interactions_test.go
+++ b/apps/gooseforum/app/http/routes/contract_forum_post_interactions_test.go
@@ -236,7 +236,7 @@ func TestCreatePostHTTPContract(t *testing.T) {
 	t.Run("unicode comment limit counts code points", func(t *testing.T) {
 		conn, router := setupForumInteractionContractTest(t)
 		posting := defaultconfig.GetDefaultPostingSettingsConfig()
-		posting.TextControl.MinPostLength = 1
+		posting.TextControl.MinPostLength = 3
 		posting.TextControl.MaxPostLength = 4
 		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
 		hotdataserve.ClearPostingSettingsConfigCache()
@@ -249,6 +249,12 @@ func TestCreatePostHTTPContract(t *testing.T) {
 		body := fmt.Sprintf(`{"topicId":%d,"content":"汉😀ab"}`, topicID)
 		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/create", body, token)); response.Code != 0 {
 			t.Fatalf("four-rune comment response = %#v, want success", response)
+		}
+
+		shortBody := fmt.Sprintf(`{"topicId":%d,"content":"汉😀"}`, topicID)
+		shortResponse := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/create", shortBody, token))
+		if shortResponse.MessageCode != "comment.content.tooShort" || shortResponse.Params["minLength"] != float64(3) {
+			t.Fatalf("short Unicode reply response = %#v", shortResponse)
 		}
 
 		body = fmt.Sprintf(`{"topicId":%d,"content":"汉汉汉汉汉"}`, topicID)
@@ -344,7 +350,7 @@ func TestUpdatePostHTTPContract(t *testing.T) {
 	t.Run("unicode updated comment limit counts code points", func(t *testing.T) {
 		conn, router := setupForumInteractionContractTest(t)
 		posting := defaultconfig.GetDefaultPostingSettingsConfig()
-		posting.TextControl.MinPostLength = 1
+		posting.TextControl.MinPostLength = 3
 		posting.TextControl.MaxPostLength = 4
 		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
 		hotdataserve.ClearPostingSettingsConfigCache()
@@ -358,6 +364,12 @@ func TestUpdatePostHTTPContract(t *testing.T) {
 		body := fmt.Sprintf(`{"postId":%d,"content":"😀汉ab"}`, replyID)
 		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/update", body, token)); response.Code != 0 {
 			t.Fatalf("four-rune updated comment response = %#v, want success", response)
+		}
+
+		shortBody := fmt.Sprintf(`{"postId":%d,"content":"汉😀"}`, replyID)
+		shortResponse := decodeContractEnvelope(t, serveJSON(router, "/api/forum/posts/update", shortBody, token))
+		if shortResponse.MessageCode != "comment.content.tooShort" || shortResponse.Params["minLength"] != float64(3) {
+			t.Fatalf("short Unicode reply response = %#v", shortResponse)
 		}
 
 		body = fmt.Sprintf(`{"postId":%d,"content":"😀😀😀😀😀"}`, replyID)

--- a/apps/gooseforum/app/http/routes/contract_http_test.go
+++ b/apps/gooseforum/app/http/routes/contract_http_test.go
@@ -446,6 +446,65 @@ func TestWriteTopicHTTPContract(t *testing.T) {
 		}
 	})
 
+	t.Run("unicode title limit counts code points", func(t *testing.T) {
+		conn, router := setupHTTPContractTest(t)
+		posting := defaultconfig.GetDefaultPostingSettingsConfig()
+		posting.TextControl.MinTitleLength = 1
+		posting.TextControl.MaxTitleLength = 4
+		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
+		hotdataserve.ClearPostingSettingsConfigCache()
+
+		user := createHTTPContractUser(t, conn, contractTestID())
+		categoryID := contractTestID()
+		if err := conn.Create(&category.Entity{Id: categoryID, Name: "Unicode", Slug: fmt.Sprintf("unicode-%d", categoryID)}).Error; err != nil {
+			t.Fatalf("create unicode category: %v", err)
+		}
+		token := contractSessionToken(t, user)
+		for _, title := range []string{"aaaa", "汉汉汉汉", "😀😀😀😀", "a汉😀b"} {
+			body := fmt.Sprintf(`{"title":%q,"content":"Unicode title contract content.","categoryId":[%d],"topicStatus":1}`, title, categoryID)
+			recorder := serveJSON(router, "/api/forum/topics/write", body, token)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("title %q status = %d, want 200: %s", title, recorder.Code, recorder.Body.String())
+			}
+			if response := decodeContractEnvelope(t, recorder); response.MessageCode == "topic.title.tooLong" || response.MessageCode == "topic.title.tooShort" {
+				t.Fatalf("title %q response = %#v, must pass title length validation", title, response)
+			}
+		}
+
+		body := fmt.Sprintf(`{"title":"汉汉汉汉汉","content":"Unicode title contract content.","categoryId":[%d],"topicStatus":1}`, categoryID)
+		recorder := serveJSON(router, "/api/forum/topics/write", body, token)
+		response := decodeContractEnvelope(t, recorder)
+		if response.MessageCode != "topic.title.tooLong" || response.Params["maxLength"] != float64(4) {
+			t.Fatalf("too-long title response = %#v, want topic.title.tooLong maxLength=4", response)
+		}
+	})
+
+	t.Run("unicode topic content limit counts code points", func(t *testing.T) {
+		conn, router := setupHTTPContractTest(t)
+		posting := defaultconfig.GetDefaultPostingSettingsConfig()
+		posting.TextControl.MinPostLength = 1
+		posting.TextControl.MaxPostLength = 4
+		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
+		hotdataserve.ClearPostingSettingsConfigCache()
+
+		user := createHTTPContractUser(t, conn, contractTestID())
+		categoryID := contractTestID()
+		if err := conn.Create(&category.Entity{Id: categoryID, Name: "Unicode Content", Slug: fmt.Sprintf("unicode-content-%d", categoryID)}).Error; err != nil {
+			t.Fatalf("create unicode content category: %v", err)
+		}
+		token := contractSessionToken(t, user)
+		body := fmt.Sprintf(`{"title":"Valid title","content":"汉😀ab","categoryId":[%d],"topicStatus":1}`, categoryID)
+		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/topics/write", body, token)); response.MessageCode == "topic.content.tooLong" || response.MessageCode == "topic.content.tooShort" {
+			t.Fatalf("four-rune content response = %#v, must pass content length validation", response)
+		}
+
+		body = fmt.Sprintf(`{"title":"Valid title","content":"汉汉汉汉汉","categoryId":[%d],"topicStatus":1}`, categoryID)
+		response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/topics/write", body, token))
+		if response.MessageCode != "topic.content.tooLong" || response.Params["maxLength"] != float64(4) {
+			t.Fatalf("too-long content response = %#v, want topic.content.tooLong maxLength=4", response)
+		}
+	})
+
 	t.Run("missing session returns 401", func(t *testing.T) {
 		_, router := setupHTTPContractTest(t)
 		recorder := serveJSON(router, "/api/forum/topics/write", `{}`, "")

--- a/apps/gooseforum/app/http/routes/contract_http_test.go
+++ b/apps/gooseforum/app/http/routes/contract_http_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/pointsRecord"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/postRevisions"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/posts"
+	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/taskQueue"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicCategoryIndex"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserAction"
 	"github.com/YourTongji/YourTJ-Hub/apps/gooseforum/app/models/forum/topicUserStat"
@@ -79,6 +80,7 @@ func setupHTTPContractTest(t *testing.T) (*gorm.DB, *gin.Engine) {
 		&userSessions.Entity{},
 		&topics.Entity{},
 		&postRevisions.Entity{},
+		&taskQueue.Entity{},
 		&posts.Entity{},
 		&category.Entity{},
 		&topicCategoryIndex.Entity{},
@@ -449,7 +451,7 @@ func TestWriteTopicHTTPContract(t *testing.T) {
 	t.Run("unicode title limit counts code points", func(t *testing.T) {
 		conn, router := setupHTTPContractTest(t)
 		posting := defaultconfig.GetDefaultPostingSettingsConfig()
-		posting.TextControl.MinTitleLength = 1
+		posting.TextControl.MinTitleLength = 3
 		posting.TextControl.MaxTitleLength = 4
 		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
 		hotdataserve.ClearPostingSettingsConfigCache()
@@ -466,9 +468,17 @@ func TestWriteTopicHTTPContract(t *testing.T) {
 			if recorder.Code != http.StatusOK {
 				t.Fatalf("title %q status = %d, want 200: %s", title, recorder.Code, recorder.Body.String())
 			}
-			if response := decodeContractEnvelope(t, recorder); response.MessageCode == "topic.title.tooLong" || response.MessageCode == "topic.title.tooShort" {
+			if response := decodeContractEnvelope(t, recorder); response.Code != 0 {
 				t.Fatalf("title %q response = %#v, must pass title length validation", title, response)
 			}
+		}
+
+		// Keep length boundary requests independent from the five-write rate limit.
+		ratelimit.Default().ResetAll()
+		shortBody := fmt.Sprintf(`{"title":"汉😀","content":"Unicode title contract content.","categoryId":[%d],"topicStatus":1}`, categoryID)
+		shortResponse := decodeContractEnvelope(t, serveJSON(router, "/api/forum/topics/write", shortBody, token))
+		if shortResponse.MessageCode != "topic.title.tooShort" || shortResponse.Params["minLength"] != float64(3) {
+			t.Fatalf("short Unicode title response = %#v", shortResponse)
 		}
 
 		body := fmt.Sprintf(`{"title":"汉汉汉汉汉","content":"Unicode title contract content.","categoryId":[%d],"topicStatus":1}`, categoryID)
@@ -482,7 +492,7 @@ func TestWriteTopicHTTPContract(t *testing.T) {
 	t.Run("unicode topic content limit counts code points", func(t *testing.T) {
 		conn, router := setupHTTPContractTest(t)
 		posting := defaultconfig.GetDefaultPostingSettingsConfig()
-		posting.TextControl.MinPostLength = 1
+		posting.TextControl.MinPostLength = 3
 		posting.TextControl.MaxPostLength = 4
 		persistHTTPContractConfig(t, conn, pageConfig.PostingSettings, posting)
 		hotdataserve.ClearPostingSettingsConfigCache()
@@ -494,8 +504,14 @@ func TestWriteTopicHTTPContract(t *testing.T) {
 		}
 		token := contractSessionToken(t, user)
 		body := fmt.Sprintf(`{"title":"Valid title","content":"汉😀ab","categoryId":[%d],"topicStatus":1}`, categoryID)
-		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/topics/write", body, token)); response.MessageCode == "topic.content.tooLong" || response.MessageCode == "topic.content.tooShort" {
+		if response := decodeContractEnvelope(t, serveJSON(router, "/api/forum/topics/write", body, token)); response.Code != 0 {
 			t.Fatalf("four-rune content response = %#v, must pass content length validation", response)
+		}
+
+		shortBody := fmt.Sprintf(`{"title":"Valid title","content":"汉😀","categoryId":[%d],"topicStatus":1}`, categoryID)
+		shortResponse := decodeContractEnvelope(t, serveJSON(router, "/api/forum/topics/write", shortBody, token))
+		if shortResponse.MessageCode != "topic.content.tooShort" || shortResponse.Params["minLength"] != float64(3) {
+			t.Fatalf("short Unicode body response = %#v", shortResponse)
 		}
 
 		body = fmt.Sprintf(`{"title":"Valid title","content":"汉汉汉汉汉","categoryId":[%d],"topicStatus":1}`, categoryID)

--- a/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
+++ b/apps/gooseforum/resource/packages/client/src/contracts/payload.ts
@@ -66,8 +66,13 @@ export interface LayoutPayload {
   sidebar: SidebarPayload
   footer: FooterPayload
   unread: UnreadStatusPayload
+  posting: PostingPayload
   theme: ThemePayload
   insightFlareEnabled: boolean
+}
+
+export interface PostingPayload {
+  maxTitleLength: number
 }
 
 export interface ThemePayload {

--- a/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
+++ b/apps/gooseforum/resource/packages/client/src/gen/openapi.ts
@@ -6215,7 +6215,9 @@ export interface components {
              * @description Existing topic ID when updating; omit or send 0 when creating.
              */
             topicId?: number;
+            /** @description Markdown content; configurable minimum and maximum lengths count Unicode code points. */
             content: string;
+            /** @description Title; configurable minimum and maximum lengths count Unicode code points. */
             title: string;
             categoryId: number[];
             /**
@@ -6307,7 +6309,7 @@ export interface components {
              * @description Target topic; unknown or not-viewable ids fail with `topic.notFound` (HTTP 200).
              */
             topicId: number;
-            /** @description Markdown reply content. The server trims whitespace and enforces configurable length bounds (`comment.content.tooShort` / `comment.content.tooLong`, params minLength/maxLength). */
+            /** @description Markdown reply content. The server trims whitespace and enforces configurable length bounds in Unicode code points (`comment.content.tooShort` / `comment.content.tooLong`, params minLength/maxLength). */
             content: string;
             /**
              * Format: uint64
@@ -6346,7 +6348,7 @@ export interface components {
              * @description Post owned by the caller; someone else's post fails with `topic.operationDenied` (HTTP 200).
              */
             postId: number;
-            /** @description Replacement markdown content; trimmed and length-checked like posts/create. */
+            /** @description Replacement markdown content; trimmed and length-checked in Unicode code points like posts/create. */
             content: string;
         };
         UpdatePostResult: {

--- a/apps/gooseforum/resource/src/runtime/api.ts
+++ b/apps/gooseforum/resource/src/runtime/api.ts
@@ -656,13 +656,18 @@ export interface SubmitTopicInput {
 }
 
 export async function submitTopic(topic: SubmitTopicInput): Promise<number> {
-  const response = await fetch('/api/forum/topics/write', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(topic),
-  })
+  let response: Response
+  try {
+    response = await fetch('/api/forum/topics/write', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(topic),
+    })
+  } catch {
+    throw new Error(t('api.topicSaveFailed'))
+  }
   if (response.status === 429) {
     return readApiResponse<number>(response, t('api.topicSaveFailed'))
   }

--- a/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
+++ b/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
@@ -277,7 +277,8 @@ async function handleSubmit() {
   let finalTitle = title.value.trim()
   if (quickPublishType.value === 2 && !finalTitle) {
     const cleanContent = content.value.replace(/[#*`~>[\]()\n]/g, ' ').trim()
-    finalTitle = cleanContent.slice(0, 30) || (uploadedImages.value.length > 0 ? t('publish.modal.imageOnlyTitle') : t('publish.contentTypesAction.thought'))
+    const fallbackTitle = cleanContent || (uploadedImages.value.length > 0 ? t('publish.modal.imageOnlyTitle') : t('publish.contentTypesAction.thought'))
+    finalTitle = Array.from(fallbackTitle).slice(0, titleMaxLength.value).join('')
   }
 
   let finalContent = content.value.trim()

--- a/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
+++ b/apps/gooseforum/resource/src/site/components/QuickPublishModal.vue
@@ -78,7 +78,9 @@ const selectedCategory = computed(() => {
   return categories.value.find((c) => c.id === categoryIds.value[0]) || null
 })
 
-const titleMaxLength = computed(() => (quickPublishType.value === 2 ? 30 : 120))
+const configuredTitleMaxLength = computed(() => Math.max(0, props.layout.posting.maxTitleLength))
+const titleMaxLength = computed(() => (quickPublishType.value === 2 ? Math.min(30, configuredTitleMaxLength.value) : configuredTitleMaxLength.value))
+const titleLength = computed(() => Array.from(title.value).length)
 
 const typeMeta = computed(() => {
   const isEdit = isEditing.value
@@ -166,6 +168,14 @@ function handleTitleEnter() {
 
 function clearSensitiveHighlight() {
   sensitiveWords.value = []
+}
+
+function handleTitleInput() {
+  clearSensitiveHighlight()
+  const runes = Array.from(title.value)
+  if (runes.length > titleMaxLength.value) {
+    title.value = runes.slice(0, titleMaxLength.value).join('')
+  }
 }
 
 function imageAlt(filename: string) {
@@ -487,14 +497,13 @@ async function handleSubmit() {
                 class="w-full text-base sm:text-lg font-bold placeholder:text-base-content/35 border-none bg-transparent outline-none focus:outline-none focus:ring-0 px-0 text-base-content transition"
                 :class="{ 'gf-sensitive-field': containsSensitiveText(title, sensitiveWords) }"
                 :placeholder="quickPublishType === 2 ? t('publish.modal.thoughtTitlePlaceholder') : typeMeta.placeholder"
-                :maxlength="titleMaxLength"
-                @input="clearSensitiveHighlight"
+                @input="handleTitleInput"
                 @focus="titleFocused = true"
                 @blur="titleFocused = false"
                 @keydown.enter.prevent="handleTitleEnter"
               />
               <span class="shrink-0 text-xs font-mono text-base-content/40 select-none">
-                {{ title.length }}/{{ titleMaxLength }}
+                {{ titleLength }}/{{ titleMaxLength }}
               </span>
             </div>
           </div>

--- a/apps/gooseforum/resource/test/login-oauth-notice.test.ts
+++ b/apps/gooseforum/resource/test/login-oauth-notice.test.ts
@@ -51,6 +51,7 @@ const layout: LayoutPayload = {
   sidebar: { categories: [], activeKey: '' },
   footer: { links: [], primary: [] },
   unread: { notifications: false, messages: false },
+  posting: { maxTitleLength: 100 },
   theme: { enabled: false, current: 'gf-light', themeColor: '' },
   insightFlareEnabled: false,
 }

--- a/apps/gooseforum/resource/test/quick-publish-modal.test.ts
+++ b/apps/gooseforum/resource/test/quick-publish-modal.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { loadQuickPublishModal, useEverOpenedQuickPublish } from '../src/site/composables/useQuickPublish'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+import * as api from '../src/runtime/api'
 import { flushPromises, mount } from '@vue/test-utils'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import Draggable from 'vuedraggable'
@@ -377,4 +378,36 @@ describe('QuickPublish 懒加载与首开锁存', () => {
     await new Promise((resolve) => setTimeout(resolve, 300))
     expect(everOpened.value).toBe(true)
   })
+})
+
+test.each([
+  { limit: 4, body: '汉😀abc', expected: '汉😀ab' },
+  { limit: 30, body: 'a'.repeat(29) + '😀tail', expected: 'a'.repeat(29) + '😀' },
+  { limit: 4, body: '', expected: '' },
+])('automatic moment title respects code points and server limit: $limit / $body', async ({ limit, body, expected }) => {
+  i18n.global.locale.value = 'zh'
+  const { openQuickPublish, closeQuickPublish } = useQuickPublish()
+  openQuickPublish(2)
+  const submit = vi.spyOn(api, 'submitTopic').mockRejectedValue(new Error('stop after capture'))
+  const wrapper = mount(QuickPublishModal, {
+    props: { layout: { ...mockLayout, posting: { maxTitleLength: limit } } },
+    global: { plugins: [i18n, router] },
+    attachTo: document.body,
+  })
+  try {
+    await flushPromises()
+    const vm = wrapper.vm as any
+    vm.categoryIds = [101]
+    vm.content = body
+    vm.editor = { syncValue: () => body }
+    if (!body) vm.uploadedImages = [{ id: 'image', url: '/file/img/test.png', uploading: false }]
+    await vm.handleSubmit()
+    const expectedTitle = body ? expected : Array.from(i18n.global.t('publish.modal.imageOnlyTitle')).slice(0, limit).join('')
+    expect(submit).toHaveBeenCalledWith(expect.objectContaining({ title: expectedTitle }))
+  } finally {
+    closeQuickPublish()
+    await flushPromises()
+    wrapper.unmount()
+    submit.mockRestore()
+  }
 })

--- a/apps/gooseforum/resource/test/quick-publish-modal.test.ts
+++ b/apps/gooseforum/resource/test/quick-publish-modal.test.ts
@@ -26,6 +26,7 @@ const mockLayout: LayoutPayload = {
   },
   footer: { links: [], primary: [] },
   unread: { notifications: 0, messages: 0 },
+  posting: { maxTitleLength: 100 },
   theme: { enabled: true, current: 'gf-light', themeColor: '#3b82f6' },
   insightFlareEnabled: false,
 }
@@ -51,6 +52,46 @@ describe('QuickPublishModal 组件', () => {
     expect(categoryTexts.some((t) => t?.includes('学术讨论'))).toBe(true)
 
     // 关闭弹层
+    closeQuickPublish()
+    await flushPromises()
+    wrapper.unmount()
+  })
+
+  test('标题长度使用服务端配置并按 Unicode code point 计数', async () => {
+    i18n.global.locale.value = 'zh'
+    const { openQuickPublish, closeQuickPublish } = useQuickPublish()
+    openQuickPublish(1)
+
+    const wrapper = mount(QuickPublishModal, {
+      props: { layout: mockLayout },
+      global: { plugins: [i18n, router] },
+      attachTo: document.body,
+    })
+    await flushPromises()
+
+    const dialog = document.body.querySelector('[role="dialog"]')
+    const input = dialog?.querySelector('input[type="text"]') as HTMLInputElement | null
+    expect(input).not.toBeNull()
+    expect(input?.hasAttribute('maxlength')).toBe(false)
+
+    input!.value = 'a'.repeat(100)
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+    expect(input!.value).toBe('a'.repeat(100))
+
+    const mixed = `${'汉'.repeat(99)}😀`
+    input!.value = mixed
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+    expect(input!.value).toBe(mixed)
+    expect(dialog?.textContent).toContain('100/100')
+
+    input!.value = `${mixed}A`
+    input!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+    expect(input!.value).toBe(mixed)
+    expect(dialog?.textContent).toContain('100/100')
+
     closeQuickPublish()
     await flushPromises()
     wrapper.unmount()

--- a/apps/gooseforum/resource/test/settings-can-set-password.test.ts
+++ b/apps/gooseforum/resource/test/settings-can-set-password.test.ts
@@ -92,6 +92,7 @@ const layout: LayoutPayload = {
   sidebar: { categories: [], activeKey: 'settings' },
   footer: { links: [], primary: [] },
   unread: { notifications: false, messages: false },
+  posting: { maxTitleLength: 100 },
   theme: { enabled: false, current: 'gf-light', themeColor: '' },
   insightFlareEnabled: false,
 }

--- a/apps/gooseforum/resource/test/write-gate-403.test.ts
+++ b/apps/gooseforum/resource/test/write-gate-403.test.ts
@@ -46,6 +46,14 @@ describe('CheckWritableAccount 403 envelope parsing (issue #404/#415)', () => {
     })
   })
 
+  test('submitTopic maps fetch rejection to the localized save failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('NetworkError when attempting to fetch resource.')))
+
+    await expect(
+      submitTopic({ topicId: 0, title: 't', content: 'c', categoryId: [1], topicStatus: 0 }),
+    ).rejects.toThrow('api.topicSaveFailed')
+  })
+
   test('followUser surfaces permission.emailRequired instead of a generic HTTP 403', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(emailRequired403, 403))
     vi.stubGlobal('fetch', fetchMock)

--- a/apps/mobile/packages/core/lib/src/gen/layout.dart
+++ b/apps/mobile/packages/core/lib/src/gen/layout.dart
@@ -13,10 +13,21 @@ abstract class LayoutPayload with _$LayoutPayload {
     required FooterPayload footer,
     required UnreadStatusPayload unread,
     required ThemePayload theme,
+    PostingPayload? posting,
   }) = _LayoutPayload;
 
   factory LayoutPayload.fromJson(Map<String, dynamic> json) =>
       _$LayoutPayloadFromJson(json);
+}
+
+/// Public posting limits, measured in Unicode code points. Nullable on layout
+/// for responses from servers that predate the posting payload.
+@freezed
+abstract class PostingPayload with _$PostingPayload {
+  const factory PostingPayload({required int maxTitleLength}) = _PostingPayload;
+
+  factory PostingPayload.fromJson(Map<String, dynamic> json) =>
+      _$PostingPayloadFromJson(json);
 }
 
 @freezed

--- a/apps/mobile/packages/core/lib/src/gen/layout.freezed.dart
+++ b/apps/mobile/packages/core/lib/src/gen/layout.freezed.dart
@@ -28,6 +28,7 @@ mixin _$LayoutPayload {
   FooterPayload get footer => throw _privateConstructorUsedError;
   UnreadStatusPayload get unread => throw _privateConstructorUsedError;
   ThemePayload get theme => throw _privateConstructorUsedError;
+  PostingPayload? get posting => throw _privateConstructorUsedError;
 
   /// Serializes this LayoutPayload to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -54,6 +55,7 @@ abstract class $LayoutPayloadCopyWith<$Res> {
     FooterPayload footer,
     UnreadStatusPayload unread,
     ThemePayload theme,
+    PostingPayload? posting,
   });
 
   $SitePayloadCopyWith<$Res> get site;
@@ -62,6 +64,7 @@ abstract class $LayoutPayloadCopyWith<$Res> {
   $FooterPayloadCopyWith<$Res> get footer;
   $UnreadStatusPayloadCopyWith<$Res> get unread;
   $ThemePayloadCopyWith<$Res> get theme;
+  $PostingPayloadCopyWith<$Res>? get posting;
 }
 
 /// @nodoc
@@ -86,6 +89,7 @@ class _$LayoutPayloadCopyWithImpl<$Res, $Val extends LayoutPayload>
     Object? footer = null,
     Object? unread = null,
     Object? theme = null,
+    Object? posting = freezed,
   }) {
     return _then(
       _value.copyWith(
@@ -117,6 +121,10 @@ class _$LayoutPayloadCopyWithImpl<$Res, $Val extends LayoutPayload>
                 ? _value.theme
                 : theme // ignore: cast_nullable_to_non_nullable
                       as ThemePayload,
+            posting: freezed == posting
+                ? _value.posting
+                : posting // ignore: cast_nullable_to_non_nullable
+                      as PostingPayload?,
           )
           as $Val,
     );
@@ -181,6 +189,20 @@ class _$LayoutPayloadCopyWithImpl<$Res, $Val extends LayoutPayload>
       return _then(_value.copyWith(theme: value) as $Val);
     });
   }
+
+  /// Create a copy of LayoutPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $PostingPayloadCopyWith<$Res>? get posting {
+    if (_value.posting == null) {
+      return null;
+    }
+
+    return $PostingPayloadCopyWith<$Res>(_value.posting!, (value) {
+      return _then(_value.copyWith(posting: value) as $Val);
+    });
+  }
 }
 
 /// @nodoc
@@ -200,6 +222,7 @@ abstract class _$$LayoutPayloadImplCopyWith<$Res>
     FooterPayload footer,
     UnreadStatusPayload unread,
     ThemePayload theme,
+    PostingPayload? posting,
   });
 
   @override
@@ -214,6 +237,8 @@ abstract class _$$LayoutPayloadImplCopyWith<$Res>
   $UnreadStatusPayloadCopyWith<$Res> get unread;
   @override
   $ThemePayloadCopyWith<$Res> get theme;
+  @override
+  $PostingPayloadCopyWith<$Res>? get posting;
 }
 
 /// @nodoc
@@ -237,6 +262,7 @@ class __$$LayoutPayloadImplCopyWithImpl<$Res>
     Object? footer = null,
     Object? unread = null,
     Object? theme = null,
+    Object? posting = freezed,
   }) {
     return _then(
       _$LayoutPayloadImpl(
@@ -268,6 +294,10 @@ class __$$LayoutPayloadImplCopyWithImpl<$Res>
             ? _value.theme
             : theme // ignore: cast_nullable_to_non_nullable
                   as ThemePayload,
+        posting: freezed == posting
+            ? _value.posting
+            : posting // ignore: cast_nullable_to_non_nullable
+                  as PostingPayload?,
       ),
     );
   }
@@ -284,6 +314,7 @@ class _$LayoutPayloadImpl implements _LayoutPayload {
     required this.footer,
     required this.unread,
     required this.theme,
+    this.posting,
   }) : _header = header;
 
   factory _$LayoutPayloadImpl.fromJson(Map<String, dynamic> json) =>
@@ -311,10 +342,12 @@ class _$LayoutPayloadImpl implements _LayoutPayload {
   final UnreadStatusPayload unread;
   @override
   final ThemePayload theme;
+  @override
+  final PostingPayload? posting;
 
   @override
   String toString() {
-    return 'LayoutPayload(site: $site, viewer: $viewer, header: $header, sidebar: $sidebar, footer: $footer, unread: $unread, theme: $theme)';
+    return 'LayoutPayload(site: $site, viewer: $viewer, header: $header, sidebar: $sidebar, footer: $footer, unread: $unread, theme: $theme, posting: $posting)';
   }
 
   @override
@@ -328,7 +361,8 @@ class _$LayoutPayloadImpl implements _LayoutPayload {
             (identical(other.sidebar, sidebar) || other.sidebar == sidebar) &&
             (identical(other.footer, footer) || other.footer == footer) &&
             (identical(other.unread, unread) || other.unread == unread) &&
-            (identical(other.theme, theme) || other.theme == theme));
+            (identical(other.theme, theme) || other.theme == theme) &&
+            (identical(other.posting, posting) || other.posting == posting));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
@@ -342,6 +376,7 @@ class _$LayoutPayloadImpl implements _LayoutPayload {
     footer,
     unread,
     theme,
+    posting,
   );
 
   /// Create a copy of LayoutPayload
@@ -367,6 +402,7 @@ abstract class _LayoutPayload implements LayoutPayload {
     required final FooterPayload footer,
     required final UnreadStatusPayload unread,
     required final ThemePayload theme,
+    final PostingPayload? posting,
   }) = _$LayoutPayloadImpl;
 
   factory _LayoutPayload.fromJson(Map<String, dynamic> json) =
@@ -386,12 +422,170 @@ abstract class _LayoutPayload implements LayoutPayload {
   UnreadStatusPayload get unread;
   @override
   ThemePayload get theme;
+  @override
+  PostingPayload? get posting;
 
   /// Create a copy of LayoutPayload
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$LayoutPayloadImplCopyWith<_$LayoutPayloadImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+PostingPayload _$PostingPayloadFromJson(Map<String, dynamic> json) {
+  return _PostingPayload.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PostingPayload {
+  int get maxTitleLength => throw _privateConstructorUsedError;
+
+  /// Serializes this PostingPayload to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of PostingPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $PostingPayloadCopyWith<PostingPayload> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PostingPayloadCopyWith<$Res> {
+  factory $PostingPayloadCopyWith(
+    PostingPayload value,
+    $Res Function(PostingPayload) then,
+  ) = _$PostingPayloadCopyWithImpl<$Res, PostingPayload>;
+  @useResult
+  $Res call({int maxTitleLength});
+}
+
+/// @nodoc
+class _$PostingPayloadCopyWithImpl<$Res, $Val extends PostingPayload>
+    implements $PostingPayloadCopyWith<$Res> {
+  _$PostingPayloadCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of PostingPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? maxTitleLength = null}) {
+    return _then(
+      _value.copyWith(
+            maxTitleLength: null == maxTitleLength
+                ? _value.maxTitleLength
+                : maxTitleLength // ignore: cast_nullable_to_non_nullable
+                      as int,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$PostingPayloadImplCopyWith<$Res>
+    implements $PostingPayloadCopyWith<$Res> {
+  factory _$$PostingPayloadImplCopyWith(
+    _$PostingPayloadImpl value,
+    $Res Function(_$PostingPayloadImpl) then,
+  ) = __$$PostingPayloadImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int maxTitleLength});
+}
+
+/// @nodoc
+class __$$PostingPayloadImplCopyWithImpl<$Res>
+    extends _$PostingPayloadCopyWithImpl<$Res, _$PostingPayloadImpl>
+    implements _$$PostingPayloadImplCopyWith<$Res> {
+  __$$PostingPayloadImplCopyWithImpl(
+    _$PostingPayloadImpl _value,
+    $Res Function(_$PostingPayloadImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of PostingPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({Object? maxTitleLength = null}) {
+    return _then(
+      _$PostingPayloadImpl(
+        maxTitleLength: null == maxTitleLength
+            ? _value.maxTitleLength
+            : maxTitleLength // ignore: cast_nullable_to_non_nullable
+                  as int,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PostingPayloadImpl implements _PostingPayload {
+  const _$PostingPayloadImpl({required this.maxTitleLength});
+
+  factory _$PostingPayloadImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PostingPayloadImplFromJson(json);
+
+  @override
+  final int maxTitleLength;
+
+  @override
+  String toString() {
+    return 'PostingPayload(maxTitleLength: $maxTitleLength)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PostingPayloadImpl &&
+            (identical(other.maxTitleLength, maxTitleLength) ||
+                other.maxTitleLength == maxTitleLength));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, maxTitleLength);
+
+  /// Create a copy of PostingPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PostingPayloadImplCopyWith<_$PostingPayloadImpl> get copyWith =>
+      __$$PostingPayloadImplCopyWithImpl<_$PostingPayloadImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PostingPayloadImplToJson(this);
+  }
+}
+
+abstract class _PostingPayload implements PostingPayload {
+  const factory _PostingPayload({required final int maxTitleLength}) =
+      _$PostingPayloadImpl;
+
+  factory _PostingPayload.fromJson(Map<String, dynamic> json) =
+      _$PostingPayloadImpl.fromJson;
+
+  @override
+  int get maxTitleLength;
+
+  /// Create a copy of PostingPayload
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$PostingPayloadImplCopyWith<_$PostingPayloadImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/apps/mobile/packages/core/lib/src/gen/layout.g.dart
+++ b/apps/mobile/packages/core/lib/src/gen/layout.g.dart
@@ -19,6 +19,9 @@ _$LayoutPayloadImpl _$$LayoutPayloadImplFromJson(Map<String, dynamic> json) =>
         json['unread'] as Map<String, dynamic>,
       ),
       theme: ThemePayload.fromJson(json['theme'] as Map<String, dynamic>),
+      posting: json['posting'] == null
+          ? null
+          : PostingPayload.fromJson(json['posting'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$$LayoutPayloadImplToJson(_$LayoutPayloadImpl instance) =>
@@ -30,7 +33,17 @@ Map<String, dynamic> _$$LayoutPayloadImplToJson(_$LayoutPayloadImpl instance) =>
       'footer': instance.footer,
       'unread': instance.unread,
       'theme': instance.theme,
+      'posting': instance.posting,
     };
+
+_$PostingPayloadImpl _$$PostingPayloadImplFromJson(Map<String, dynamic> json) =>
+    _$PostingPayloadImpl(
+      maxTitleLength: (json['maxTitleLength'] as num).toInt(),
+    );
+
+Map<String, dynamic> _$$PostingPayloadImplToJson(
+  _$PostingPayloadImpl instance,
+) => <String, dynamic>{'maxTitleLength': instance.maxTitleLength};
 
 _$SitePayloadImpl _$$SitePayloadImplFromJson(Map<String, dynamic> json) =>
     _$SitePayloadImpl(

--- a/apps/mobile/packages/core/test/layout_posting_payload_test.dart
+++ b/apps/mobile/packages/core/test/layout_posting_payload_test.dart
@@ -1,0 +1,41 @@
+import 'package:core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> layoutJson() => {
+  'site': {
+    'name': '',
+    'description': '',
+    'logo': '',
+    'favicon': '',
+    'brandType': '',
+    'brandText': '',
+    'brandImage': '',
+  },
+  'viewer': {
+    'id': 0,
+    'username': '',
+    'email': '',
+    'avatarUrl': '',
+    'isAuthenticated': false,
+    'canAccessAdmin': false,
+    'isModerator': false,
+    'requiresEmailVerification': false,
+  },
+  'sidebar': {'categories': [], 'activeKey': ''},
+  'footer': {'links': [], 'primary': []},
+  'unread': {'notifications': false, 'messages': false},
+  'theme': {'enabled': false, 'current': 'gf-light', 'themeColor': ''},
+};
+
+void main() {
+  test('layout preserves server posting limit', () {
+    final input = layoutJson()..['posting'] = {'maxTitleLength': 42};
+    final payload = LayoutPayload.fromJson(input);
+    expect(payload.posting?.maxTitleLength, 42);
+    expect(payload.posting?.toJson(), {'maxTitleLength': 42});
+  });
+
+  test('older layout without posting limits remains readable', () {
+    expect(LayoutPayload.fromJson(layoutJson()).posting, isNull);
+  });
+}

--- a/docs/product/current-state.md
+++ b/docs/product/current-state.md
@@ -87,6 +87,15 @@ errors discard stale candidates, caret operations stay within the editable root,
 position and accessible option references follow the current session. Code and links suppress
 suggestions; insertion preserves plain `@username` Markdown with a trailing space.
 
+### Posting length limits
+
+`Current`: Forum topic titles, topic bodies and reply creation/editing enforce configured
+minimum and maximum lengths in Unicode code points. A basic Chinese character or a single-code-point
+emoji counts as one; combining sequences and joined emoji may contain multiple code points.
+The Web quick publisher reads the title maximum from the server layout payload. Moment titles
+retain the shorter 30-code-point cap within that configured maximum, including automatic titles.
+Network failures during topic submission use localized save-failure copy.
+
 ## Correctness first
 
 Before expanding features, close these baselines (avoid building on a wrong foundation):

--- a/packages/api-contract/components/schemas.yaml
+++ b/packages/api-contract/components/schemas.yaml
@@ -360,9 +360,11 @@ WriteTopicRequest:
     content:
       type: string
       minLength: 1
+      description: Markdown content; configurable minimum and maximum lengths count Unicode code points.
     title:
       type: string
       minLength: 1
+      description: Title; configurable minimum and maximum lengths count Unicode code points.
     categoryId:
       type: array
       minItems: 1
@@ -2470,7 +2472,7 @@ CreatePostRequest:
     content:
       type: string
       minLength: 1
-      description: Markdown reply content. The server trims whitespace and enforces configurable length bounds (`comment.content.tooShort` / `comment.content.tooLong`, params minLength/maxLength).
+      description: Markdown reply content. The server trims whitespace and enforces configurable length bounds in Unicode code points (`comment.content.tooShort` / `comment.content.tooLong`, params minLength/maxLength).
     replyToPostId:
       type: integer
       format: uint64
@@ -2541,7 +2543,7 @@ UpdatePostRequest:
     content:
       type: string
       minLength: 1
-      description: Replacement markdown content; trimmed and length-checked like posts/create.
+      description: Replacement markdown content; trimmed and length-checked in Unicode code points like posts/create.
   additionalProperties: false
 
 UpdatePostResult:


### PR DESCRIPTION
## 变更说明

修复 #592：论坛标题、主题正文、评论创建与编辑统一按 Unicode code point（Go rune）校验可配置长度。Layout 下发标题上限，Web 快捷发布使用该配置；中文及单码点 emoji 不再按 UTF-8 字节数或 UTF-16 单元误判。

瞬间的手动标题与自动标题均遵守配置内的 30 码点上限，自动截取不会切断 emoji；纯图片的默认标题也使用相同上限。fetch 网络失败显示现有本地化保存失败文案。

同步 OpenAPI 长度语义、生成 TypeScript、Flutter layout payload 镜像和当前产品说明。移动端兼容旧服务端未下发 posting 的响应。

## 验证

- 新增自动标题回归先确认失败：较小服务端上限被绕过、emoji 在 UTF-16 截断点损坏；修复后通过。
- 加强后端成功断言，补齐任务表测试夹具；标题/正文/评论创建与编辑覆盖 Unicode 最小/最大边界。
- `go test ./app/http/routes ./app/http/controllers/forum -count=1`：通过。
- `pnpm exec vitest run test/quick-publish-modal.test.ts test/write-gate-403.test.ts`：18 项通过。
- `flutter test --no-pub test/layout_posting_payload_test.dart test/publish_payload_test.dart`：5 项通过。
- `pnpm build`：通过（含 typecheck）。
- OpenAPI lint、bundle、1099 个响应 fixtures、299 条路由覆盖检查、TS 生成校验：通过；lint 保留已有 14 个 warning。
- `node scripts/run-gates.mjs`、`git diff --check`：通过。
- 推送执行 go vet、增量 golangci-lint 和前端 typecheck hooks。

不修改配置默认值、数据库 schema 或依赖。组合字符和 ZWJ emoji 仍按多个 code point 计算，前后端保持一致。

Closes #592
