### PR TITLE
feat: deploy GLM-powered Oryn maintenance in repository Actions

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -1,0 +1,35 @@
+name: Set up pinned Oryn
+description: Fetch the trusted Oryn runtime and apply this repository's operator policy.
+inputs:
+  client-id:
+    required: true
+    description: GitHub App client ID
+  private-key:
+    required: true
+    description: GitHub App private key
+runs:
+  using: composite
+  steps:
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+      id: source
+      with:
+        client-id: ${{ inputs.client-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: yzxoi
+        repositories: oryn-mini
+        permission-contents: read
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      with:
+        repository: yzxoi/oryn-mini
+        ref: e36e678fae9a4d3e173750d9ce583c9140235b10
+        token: ${{ steps.source.outputs.token }}
+        path: .oryn-runtime
+        persist-credentials: false
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+      with:
+        bun-version: 1.3.14
+    - shell: bash
+      working-directory: .oryn-runtime
+      run: |
+        cp ../.github/oryn/repositories.json config/repositories.json
+        bun install --frozen-lockfile

--- a/.github/oryn/repositories.json
+++ b/.github/oryn/repositories.json
@@ -1,0 +1,43 @@
+{
+  "repositories": [
+    {
+      "name": "YourTongji/YourTJ-Hub",
+      "enabled": true,
+      "maxItems": 20,
+      "cooldownHours": 168,
+      "allowRepair": true,
+      "allowAdopt": true,
+      "allowRebase": true,
+      "autoImplement": true,
+      "allowClusters": true,
+      "syncLabels": true,
+      "maxJobAttempts": 3,
+      "maxShepherdCycles": 6,
+      "retryMinutes": 15,
+      "scanPages": 10,
+      "allowCommands": true,
+      "allowClose": true,
+      "allowMerge": true,
+      "requiredChecks": [
+        "ci-backend",
+        "ci-frontend",
+        "ci-contract"
+      ],
+      "selection": "balanced",
+      "maxRepairAttempts": 2,
+      "validation": [
+        "node /opt/oryn-validation/validate.mjs governance",
+        "node /opt/oryn-validation/validate.mjs backend",
+        "node /opt/oryn-validation/validate.mjs postgres",
+        "node /opt/oryn-validation/validate.mjs frontend",
+        "node /opt/oryn-validation/validate.mjs contract",
+        "node /opt/oryn-validation/validate.mjs mobile"
+      ],
+      "protectedLabels": [
+        "security",
+        "do-not-bot",
+        "oryn:hold"
+      ]
+    }
+  ]
+}

--- a/.github/oryn/validate.mjs
+++ b/.github/oryn/validate.mjs
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const domains = ['governance', 'backend', 'postgres', 'frontend', 'contract', 'mobile'];
+export function selectedScopes(paths) {
+  const selected = new Set(['governance']);
+  for (const path of paths) {
+    if (/^(docs\/|README|LICENSE)|\.md$/.test(path)) continue;
+    if (path.startsWith('apps/gooseforum/')) {
+      if (path.startsWith('apps/gooseforum/resource/')) selected.add('frontend');
+      else selected.add('backend');
+      if (/^apps\/gooseforum\/app\/(models|migration)\//.test(path)) selected.add('postgres');
+      if (/^apps\/gooseforum\/app\/http\//.test(path)) selected.add('contract');
+      if (path.endsWith('go.mod') || path.endsWith('go.sum')) selected.add('postgres');
+      if (path.startsWith('apps/gooseforum/testdata/')) selected.add('frontend');
+    } else if (path.startsWith('packages/api-contract/')) {
+      for (const scope of ['contract', 'frontend', 'mobile']) selected.add(scope);
+    } else if (path.startsWith('apps/mobile/')) {
+      selected.add('mobile');
+      if (path.includes('server_message')) selected.add('frontend');
+    } else return domains;
+  }
+  return domains.filter(scope => selected.has(scope));
+}
+function run(command, args, cwd = process.cwd(), extraEnv = {}) {
+  const result = spawnSync(command, args, { cwd, env: { ...process.env, ...extraEnv }, stdio: 'inherit' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`${command} failed (${result.status ?? result.signal})`);
+}
+export function changedPaths(base) {
+  const tracked = spawnSync('git', ['diff', '--name-only', '-z', base, '--'], { encoding: 'utf8' });
+  const untracked = spawnSync('git', ['ls-files', '--others', '--exclude-standard', '-z'], { encoding: 'utf8' });
+  if (tracked.status !== 0 || untracked.status !== 0) throw new Error('Cannot establish validation scope');
+  return (tracked.stdout + untracked.stdout).split('\0').filter(Boolean);
+}
+function main() {
+  const scope = process.argv[2];
+  if (!domains.includes(scope)) throw new Error('Unknown validation scope');
+  const base = readFileSync('/opt/oryn-validation/base-sha', 'utf8').trim();
+  if (!/^[a-f0-9]{40}$/.test(base)) throw new Error('Invalid trusted base SHA');
+  if (!selectedScopes(changedPaths(base)).includes(scope)) {
+    console.log(`No ${scope} changes relative to the reviewed base.`);
+    return;
+  }
+  const root = process.cwd();
+  const backend = `${root}/apps/gooseforum`;
+  const frontend = `${backend}/resource`;
+  const contract = `${root}/packages/api-contract`;
+  const mobile = `${root}/apps/mobile`;
+  const install = cwd => {
+    if (!existsSync(`${cwd}/node_modules/.modules.yaml`)) run('pnpm', ['install', '--frozen-lockfile'], cwd);
+  };
+  if (scope === 'governance') run('node', ['scripts/run-gates.mjs']);
+  if (scope === 'backend') {
+    run('go', ['vet', './...'], backend);
+    run('go', ['test', './...'], backend);
+    run('go', ['build', '-o', `${process.env.HOME}/yourtj-hub`, '.'], backend);
+  }
+  if (scope === 'postgres') {
+    const env = { YOURTJ_TEST_PG_URL: 'host=127.0.0.1 port=5432 user=postgres password=postgres dbname=postgres sslmode=disable' };
+    run('go', ['test', './app/migration/', '-run', 'TestSchema', '-v'], backend, env);
+    run('go', ['test', './app/models/...', '-run', 'PostgreSQL$', '-v'], backend, env);
+  }
+  if (scope === 'frontend') {
+    install(frontend);
+    for (const task of ['typecheck', 'test', 'check:i18n', 'build']) run('pnpm', [task], frontend);
+  }
+  if (scope === 'contract') {
+    install(contract);
+    run('pnpm', ['check'], contract);
+  }
+  if (scope === 'mobile') {
+    // Flutter writes SDK locks/cache even for analysis; keep those writes in this ephemeral home.
+    const sdk = `${process.env.HOME}/flutter`;
+    if (!existsSync(sdk)) run('cp', ['-a', '/opt/oryn-flutter', sdk]);
+    const env = { PATH: `${sdk}/bin:${process.env.PATH}`, FLUTTER_SUPPRESS_ANALYTICS: 'true', DART_SUPPRESS_ANALYTICS: 'true' };
+    run('dart', ['pub', 'get'], mobile, env);
+    run('dart', ['run', 'melos', 'bootstrap'], mobile, env);
+    for (const task of ['analyze', 'test']) run('dart', ['run', 'melos', 'run', task], mobile, env);
+  }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/.github/workflows/ci-oryn.yml
+++ b/.github/workflows/ci-oryn.yml
@@ -1,0 +1,30 @@
+name: CI / Oryn integration
+on:
+  pull_request:
+    paths:
+      - '.github/oryn/**'
+      - '.github/actions/setup-oryn/**'
+      - '.github/workflows/*oryn*'
+      - 'scripts/test-oryn-validation.mjs'
+  push:
+    branches: [dev, main]
+    paths:
+      - '.github/oryn/**'
+      - '.github/actions/setup-oryn/**'
+      - '.github/workflows/*oryn*'
+      - 'scripts/test-oryn-validation.mjs'
+permissions:
+  contents: read
+jobs:
+  ci-oryn:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - run: node --test scripts/test-oryn-validation.mjs
+      - run: node scripts/run-gates.mjs

--- a/.github/workflows/oryn.yml
+++ b/.github/workflows/oryn.yml
@@ -1,0 +1,259 @@
+name: Oryn
+on:
+  workflow_dispatch:
+    inputs:
+      preflight:
+        description: Check App access and planning without model calls or publication
+        type: boolean
+        default: true
+      item:
+        description: Exact issue or PR number (blank means scan)
+        type: string
+      comment:
+        description: Exact maintainer command comment ID (requires item)
+        type: string
+      mode:
+        description: Review or request validated repair
+        type: choice
+        options: [review, repair]
+        default: review
+      timeout:
+        description: Task budget in seconds (10–3000; blank uses the repository default)
+        type: string
+      publish:
+        description: Publish review comments and advisory labels
+        type: boolean
+        default: false
+  schedule:
+    - cron: "23 */6 * * *"
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+permissions:
+  contents: read
+defaults:
+  run:
+    working-directory: .oryn-runtime
+concurrency:
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.ORYN_ENABLED == 'true') || (github.event_name != 'schedule' && vars.ORYN_EVENT_ENABLED == 'true')) && 'oryn-sweep' || format('oryn-disabled-{0}', github.run_id) }}
+  cancel-in-progress: false
+  queue: max
+jobs:
+  plan:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.ORYN_ENABLED == 'true') || (github.event_name != 'schedule' && vars.ORYN_EVENT_ENABLED == 'true')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      count: ${{ steps.plan.outputs.count }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-oryn
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        id: target
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+          owner: YourTongji
+          repositories: YourTJ-Hub
+          permission-contents: read
+          permission-issues: ${{ inputs.preflight == true && 'read' || 'write' }}
+          permission-pull-requests: ${{ inputs.preflight == true && 'read' || 'write' }}
+          permission-checks: read
+          permission-statuses: read
+          permission-actions: read
+      - id: plan
+        run: bun script/plan-workflow.ts
+        env:
+          ORYN_ENABLED: ${{ vars.ORYN_ENABLED }}
+          ORYN_EVENT_ENABLED: ${{ vars.ORYN_EVENT_ENABLED }}
+          ORYN_MODEL: ${{ vars.ORYN_MODEL || 'oryn/glm-5.3-flash' }}
+          ORYN_READ_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+          INPUT_REPOSITORY: YourTongji/YourTJ-Hub
+          INPUT_ITEM: ${{ inputs.item }}
+          INPUT_COMMENT: ${{ inputs.comment }}
+          INPUT_MODE: ${{ inputs.mode || 'review' }}
+          INPUT_TIMEOUT: ${{ inputs.timeout }}
+          ORYN_TASK_TIMEOUT_SECONDS: ${{ vars.ORYN_TASK_TIMEOUT_SECONDS || '1800' }}
+      - if: inputs.preflight != true && (inputs.publish == true || (github.event_name == 'schedule' && vars.ORYN_SCHEDULE_PUBLISH == 'true') || (github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && vars.ORYN_EVENT_PUBLISH == 'true'))
+        run: bun script/admit-workflow.ts
+        env:
+          ORYN_ALLOW_PUBLISH: "1"
+          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+      - if: steps.plan.outputs.count != '0'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: plan
+          path: .oryn-runtime/.artifacts/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+  run:
+    needs: plan
+    if: inputs.preflight != true && needs.plan.outputs.count != '' && needs.plan.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 65
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-oryn
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: plan
+          path: .oryn-runtime/.artifacts/plan
+      - run: |
+          mkdir -p .artifacts/result
+          cp "$JOB_FILE" .artifacts/result/job.json
+        env:
+          JOB_FILE: .artifacts/plan/${{ matrix.slug }}/jobs/${{ matrix.number }}.json
+      - id: validation
+        run: |
+          bun -e 'const j = await Bun.file(".artifacts/result/job.json").json(); console.log("repair=" + (j.mode === "repair"));' >> "$GITHUB_OUTPUT"
+      - if: steps.validation.outputs.repair == 'true'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: apps/gooseforum/go.mod
+          cache: false
+      - if: steps.validation.outputs.repair == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - if: steps.validation.outputs.repair == 'true'
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          channel: stable
+          flutter-version: 3.44.9
+          cache: false
+      - if: steps.validation.outputs.repair == 'true'
+        name: Prepare trusted validation host
+        run: |
+          sudo mkdir -p /opt/oryn-validation /opt/oryn-tools
+          sudo cp ../.github/oryn/validate.mjs /opt/oryn-validation/validate.mjs
+          bun -e 'const j = await Bun.file(".artifacts/result/job.json").json(); await Bun.write("/tmp/oryn-base-sha", j.item.baseSha);'
+          sudo cp /tmp/oryn-base-sha /opt/oryn-validation/base-sha
+          sudo npm install --prefix /opt/oryn-tools --global pnpm@11.10.0
+          echo /opt/oryn-tools/bin >> "$GITHUB_PATH"
+          flutter precache --linux
+          sudo cp -a "$FLUTTER_ROOT" /opt/oryn-flutter
+      - if: matrix.runtime
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap ripgrep
+      - if: matrix.runtime
+        run: bun run core:install
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        id: target
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+          owner: YourTongji
+          repositories: YourTJ-Hub
+          permission-contents: read
+          permission-issues: read
+          permission-pull-requests: read
+          permission-checks: read
+          permission-statuses: read
+          permission-actions: read
+      - id: execute
+        continue-on-error: true
+        run: bun script/run-workflow.ts
+        env:
+          JOB_FILE: .artifacts/plan/${{ matrix.slug }}/jobs/${{ matrix.number }}.json
+          ORYN_API_KEY: ${{ secrets.ORYN_GLM_API_KEY }}
+          ORYN_BASE_URL: ${{ vars.ORYN_BASE_URL || 'https://open.bigmodel.cn/api/coding/paas/v4' }}
+          ORYN_VARIANT: max
+          ORYN_REQUEST_TIMEOUT_SECONDS: ${{ vars.ORYN_REQUEST_TIMEOUT_SECONDS }}
+          ORYN_READ_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+      - if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: result-${{ matrix.slug }}-${{ matrix.number }}
+          path: .oryn-runtime/.artifacts/result/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+      - if: steps.execute.outcome == 'failure'
+        run: exit 1
+  publish:
+    needs: [plan, run]
+    if: always() && !cancelled() && inputs.preflight != true && needs.plan.result == 'success' && needs.plan.outputs.count != '0' && (inputs.publish == true || (github.event_name == 'schedule' && vars.ORYN_SCHEDULE_PUBLISH == 'true') || (github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && vars.ORYN_EVENT_PUBLISH == 'true'))
+    strategy:
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-oryn
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: result-${{ matrix.slug }}-${{ matrix.number }}
+          path: .oryn-runtime/.artifacts/result
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        id: target
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+          owner: YourTongji
+          repositories: YourTJ-Hub
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-checks: read
+          permission-statuses: read
+          permission-actions: read
+      - id: artifact
+        run: |
+          if test -f .artifacts/result/result.json && test ! -f .artifacts/result/failure.json; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.artifact.outputs.ready == 'true'
+        run: bun src/cli.ts publish --result .artifacts/result/result.json
+        env:
+          ORYN_ALLOW_PUBLISH: "1"
+          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_ALLOW_CLOSE: "1"
+          ORYN_ALLOW_MERGE: "1"
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+      - if: steps.artifact.outputs.ready != 'true'
+        run: bun src/cli.ts settle-failure --job .artifacts/result/job.json
+        env:
+          ORYN_ALLOW_PUBLISH: "1"
+          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ docs/               产品、架构、开发和运维文档
 - [本地开发](./docs/development/local-development.md)
 - [测试策略](./docs/development/testing.md)
 - [部署与发布](./docs/operations/deployment.md)
+- [Oryn 仓库维护机器人](./docs/operations/oryn.md)（Partial：待 App 配置与接入验证）
 
 ## 参与贡献
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -78,6 +78,7 @@ status. Do not use PR-relative "shipped this / later" labels as long-term status
 - [Deployment & release](operations/deployment.md)
 - [Mobile releases and signing](operations/mobile-releases.md)
 - [Object storage](operations/object-storage.md)
+- [Oryn repository maintenance](operations/oryn.md)
 
 ### Governance
 

--- a/docs/decisions/0015-oryn-repository-local-actions.md
+++ b/docs/decisions/0015-oryn-repository-local-actions.md
@@ -1,0 +1,55 @@
+# Run Oryn maintenance in repository-local Actions
+
+## Status
+
+Accepted
+Class: process
+
+## Context and Problem Statement
+
+YourTJ-Hub needs App-authored maintenance reports with source evidence and native Issue/PR command
+intake. The existing Oryn runtime is hosted in a separate private repository. Copying its implementation
+would create a second maintenance burden; running centrally would require event forwarding or polling.
+
+## Decision Drivers
+
+- Keep execution, logs, credentials and operator policy with the YourTongji maintainers.
+- Use native repository events without a webhook server or persisted model memory.
+- Keep App write authority separate from model execution.
+- Do not accept Bun runtime tests as validation of Go/Vue/Flutter/PostgreSQL application repairs.
+
+## Considered Options
+
+1. Repository-local Actions with a commit-pinned Oryn checkout and App installation tokens.
+2. Central Oryn Actions with cross-repository polling or event forwarding.
+3. Copy the complete Oryn implementation into this monorepo.
+
+## Decision Outcome
+
+Choose option 1. The local workflow checks out trusted policy from the default branch for native events,
+loads an immutable private Oryn revision using a source-only read token, and separates planning,
+read-only model execution and publication into jobs with independently narrowed target tokens.
+The App is installed only on the target and runtime repositories. Native events replace webhooks.
+Manual preflight exercises read access and planning without inference or publication.
+
+Use GLM 5.3 Flash with explicit max reasoning, native image input and a configured one-million-token
+context window. Enable all repository policy capabilities under existing per-item authority, freshness,
+independent review and required CI gates. Install a trusted validation entry outside the candidate
+checkout; select Go/Vue/Flutter/contract/PostgreSQL checks from changes relative to the exact job base.
+A disposable PostgreSQL service and temporary Flutter cache support isolated repair validation.
+Enable native event publication and six-hour sweeps; bounded batches and cooldown receipts cover backlog.
+A successful live App preflight and model run establish access; local checks alone do not prove deployment.
+
+## Pros and Cons of the Options
+
+- Option 1 gives YourTongji native events and direct credential ownership; it requires a local entry,
+  version maintenance and App installation on the private source repository as well as the target.
+- Option 2 centralizes updates and model secrets, but moves operational ownership away from this repo
+  and needs polling or another event transport.
+- Option 3 removes cross-repository fetch credentials, but duplicates the runtime and security fixes.
+
+## Links
+
+- [Operations guide](../operations/oryn.md)
+- [Pinned Oryn runtime](https://github.com/yzxoi/oryn-mini/tree/e36e678fae9a4d3e173750d9ce583c9140235b10)
+- [GitHub App token action](https://github.com/actions/create-github-app-token/tree/bcd2ba49218906704ab6c1aa796996da409d3eb1)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -82,3 +82,5 @@ A decision starts `Proposed`. Once implemented, its status becomes `Accepted` an
 - [0012](0012-unified-mobile-reading-navigation.md) — Unified mobile reading navigation and shared management.
 - [0013](0013-anonymous-wiki-comments.md) — Wiki 页面评论匿名发布（匿名楼层）
 - [0014](0014-mobile-release-distribution.md) — Mobile release signing, verified APK mirrors and Apple review automation.
+
+- [0015](0015-oryn-repository-local-actions.md) — Repository-local Oryn Actions with scoped GitHub App credentials.

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -1,0 +1,139 @@
+# Oryn repository maintenance
+
+> Doc type: operations guide
+>
+> Status: Active
+>
+> Owner: Platform maintainers
+>
+> Last verified: 2026-09-09
+
+Implementation status: **Current** for the configured integration. Live run results are recorded in
+Actions; a green preflight proves App access and planning, while an executed review proves model access.
+Repair publication additionally requires sandboxed application validation and an independent review.
+
+## Execution and policy
+
+[Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
+[setup action](../../.github/actions/setup-oryn/action.yml) loads
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/e36e678fae9a4d3e173750d9ce583c9140235b10)
+and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
+creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
+GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.
+
+Manual runs use the selected workflow commit. Issue/PR events load the current default branch (`dev`),
+never the contributor's PR head as executable workflow or operator policy. The model sees target source
+as evidence. The model is `glm-5.3-flash` through the official Zhipu Coding Plan endpoint, with
+`reasoning_effort=max`, thinking enabled, image input, and a configured 1,000,000-token context window.
+The context setting is not a one-million-token capacity benchmark. The default task budget is 1800
+seconds, manually overridable within 10–3000 seconds.
+
+All Oryn policy capabilities are enabled: reviews, triage, source-backed Mermaid diagrams, emoji labels,
+questions, stop/resume, repair, adoption, rebase, clusters, automatic small-bug implementation, close and
+merge. A scan selects at most 20 eligible items; later scans pick up the remaining items after cooldown
+receipts exclude completed work. Two model jobs run concurrently. Close/merge still require a current
+maintainer command and live evidence; merge additionally requires independent approval and successful
+`ci-backend`, `ci-frontend`, and `ci-contract` checks. Generated fixes remain draft PRs for human review.
+
+The trusted [validation entry](../../.github/oryn/validate.mjs) is installed outside the candidate
+checkout and mounted read-only in Oryn's credential-free bubblewrap sandbox. It compares the working
+tree with the job's exact base SHA, including staged and untracked changes. Every repair runs governance
+checks, then affected Go vet/test/build, PostgreSQL migration/model tests, Vue typecheck/test/i18n/build,
+API contract checks or Flutter analysis/tests. Unknown executable paths select all domains. Linux
+runners install Go, Node/pnpm and Flutter before repair execution; PostgreSQL uses a disposable local
+service. Flutter's writable SDK cache lives in the temporary validation home. Validation failures or
+budget exhaustion prevent patch publication; browser layout tests and other full CI suites remain
+required wherever existing repository CI selects them. Oryn cannot repair its own `.github` policy.
+
+## Register and install the App
+
+Create a GitHub App under the operator's account, for example `oryn-yourtj` if available.
+Use this repository URL as its homepage. Disable webhooks: native Actions events supply intake;
+no callback URL, OAuth user authorization, webhook receiver or client secret is needed.
+Choose installation on **Any account** because the runtime and target belong to different owners.
+This allows cross-account installation; it does not publish private repository source or require a
+Marketplace listing.
+
+Repository permissions:
+
+| Permission | App grant | Use |
+| --- | --- | --- |
+| Metadata | Read | Repository metadata and authority checks |
+| Contents | Read and write | Read source; supports the separately gated repair publisher |
+| Issues | Read and write | Issue reports, labels and operational receipts |
+| Pull requests | Read and write | PR context, reports and separately gated draft publication |
+| Actions | Read | Exact-head failure steps and bounded logs |
+| Checks | Read | CI results |
+| Commit statuses | Read | Commit status context |
+
+No organization permissions, Administration, Secrets, or Workflows write permission is needed.
+Install with **Only select repositories** in both accounts:
+
+- `YourTongji`: select only `YourTJ-Hub`.
+- `yzxoi`: select only `oryn-mini`, currently private. Each setup job requests a separate Contents-read
+  token limited to this source repository; it never uses a target token to fetch the runtime.
+
+Generate a private key. Copy the **Client ID** and store the PEM as a secret, not a file in Git or chat.
+Installation tokens are minted independently per job, narrowed to the repository and required
+permissions, and revoked at job completion. The model execution job's target token is read-only;
+its core child has no GitHub token. Tokens and private keys are never passed in artifacts or job outputs.
+The maximum task budget is 50 minutes; the target token is minted after runtime installation so its
+one-hour lifetime covers the task. The publisher receives a new token.
+
+## Repository configuration
+
+In YourTJ-Hub → Settings → Secrets and variables → Actions, add:
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Variable | `ORYN_APP_CLIENT_ID` | The App Client ID (`Iv...`), not its installation ID |
+| Secret | `ORYN_APP_PRIVATE_KEY` | Entire generated PEM private key |
+| Secret | `ORYN_GLM_API_KEY` | Zhipu Coding Plan API key; another repository's secret is not inherited |
+
+Optional overrides: `ORYN_MODEL` (default `oryn/glm-5.3-flash`), `ORYN_BASE_URL`
+(default `https://open.bigmodel.cn/api/coding/paas/v4`), `ORYN_TASK_TIMEOUT_SECONDS` (default 1800),
+`ORYN_REQUEST_TIMEOUT_SECONDS` (core adapter default 300). The workflow fixes reasoning at `max`.
+The bot login is derived from the App token action's slug output; no manual login variable is needed.
+
+Leave automation variables unset during preflight. From Actions → Oryn → Run workflow, retain
+`preflight=true` and optionally select an item number. The job validates source access, installs the
+locked runtime dependencies and plans from live target context. It does not call the model, write a
+receipt, comment, label, patch, close or merge. Inspect the `plan` artifact; any authentication/planning
+failure must be fixed before activation. This preflight verifies read access, not successful publication
+or model inference. Then run one selected item with `preflight=false`, `publish=false` to inspect a
+real model report, followed by an explicitly selected published review when ready.
+
+Automatic triggers require the workflow on the default branch. Enable only the desired variables:
+
+| Variable | `true` enables |
+| --- | --- |
+| `ORYN_EVENT_ENABLED` | Native Issue/PR/comment event execution |
+| `ORYN_EVENT_PUBLISH` | Publication for those enabled events |
+| `ORYN_ENABLED` | A scan every six hours |
+| `ORYN_SCHEDULE_PUBLISH` | Publication for scheduled scans |
+
+Manual publication defaults off; the deployment enables all four automatic execution/publication variables. `@oryn-mini review`, `@oryn-mini ask …`, `@oryn-mini stop` and
+`@oryn-mini resume` use Oryn's fixed command prefix even when the App has a different display name.
+`@oryn-mini repair`, `implement`, `assist`, `rebase`, `cluster`, `close` and `merge` are also available to authorized maintainers.
+The operator controls token grants and policy; text in issues/PRs cannot enable repair or merge.
+Disable the event/schedule execution variables to stop new automatic work; use the item's stop command
+for an active task. Preserve receipts when rotating keys or upgrading the runtime.
+
+## Maintenance and verification
+
+Update the pinned Oryn commit in the setup action through a reviewed PR; rerun a manual preflight and
+selected report after changing runtime or credentials. Review local entry changes with:
+
+```sh
+actionlint -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/oryn.yml
+node --test scripts/test-oryn-validation.mjs
+node scripts/run-gates.mjs
+git diff --check
+```
+
+The ignore covers only an older actionlint version's lack of native queued-concurrency support; do not
+suppress other errors. Local checks do not establish live App authentication or model success.
+
+References: [GitHub App registration](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app),
+[pinned token action and permission inputs](https://github.com/actions/create-github-app-token/tree/bcd2ba49218906704ab6c1aa796996da409d3eb1),
+[decision 0015](../decisions/0015-oryn-repository-local-actions.md).

--- a/scripts/test-oryn-validation.mjs
+++ b/scripts/test-oryn-validation.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { selectedScopes } from '../.github/oryn/validate.mjs';
+
+test('docs need governance, without application suites', () => {
+  assert.deepEqual(selectedScopes(['docs/operations/example.md']), ['governance']);
+});
+test('database changes require backend and PostgreSQL', () => {
+  assert.deepEqual(selectedScopes(['apps/gooseforum/app/models/forum/topic/topic.go']), ['governance', 'backend', 'postgres']);
+});
+test('HTTP changes also verify the controlled API contract', () => {
+  assert.deepEqual(selectedScopes(['apps/gooseforum/app/http/controllers/api/post.go']), ['governance', 'backend', 'contract']);
+});
+test('web and shared contract changes include their consumers', () => {
+  assert.deepEqual(selectedScopes(['packages/api-contract/openapi.yaml']), ['governance', 'frontend', 'contract', 'mobile']);
+});
+test('unknown executable surfaces fail closed by checking every application domain', () => {
+  assert.deepEqual(selectedScopes(['scripts/new-build.sh']), ['governance', 'backend', 'postgres', 'frontend', 'contract', 'mobile']);
+});
+
+test('scope includes committed PR changes, staged repair and untracked files', async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const { join } = await import('node:path');
+  const { execFileSync } = await import('node:child_process');
+  const { changedPaths } = await import('../.github/oryn/validate.mjs');
+  const directory = mkdtempSync(join(tmpdir(), 'oryn-scope-'));
+  const previous = process.cwd();
+  const git = (...args) => execFileSync('git', args, { cwd: directory, encoding: 'utf8' }).trim();
+  try {
+    git('init', '-q');
+    git('config', 'user.name', 'test');
+    git('config', 'user.email', 'test@example.invalid');
+    writeFileSync(join(directory, 'base.txt'), 'base');
+    git('add', '.');
+    git('commit', '-qm', 'base');
+    const base = git('rev-parse', 'HEAD');
+    writeFileSync(join(directory, 'committed.txt'), 'PR');
+    git('add', '.');
+    git('commit', '-qm', 'PR');
+    writeFileSync(join(directory, 'staged.txt'), 'repair');
+    git('add', '.');
+    writeFileSync(join(directory, 'untracked.txt'), 'repair');
+    process.chdir(directory);
+    assert.deepEqual(changedPaths(base).sort(), ['committed.txt', 'staged.txt', 'untracked.txt']);
+    assert.throws(() => changedPaths('0'.repeat(40)), /Cannot establish/);
+  } finally {
+    process.chdir(previous);
+    rmSync(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why
YourTJ-Hub needs repository-local, App-authored maintenance using the configured Zhipu Coding Plan key. This connects the existing Oryn Mini runtime without copying its implementation or adding persistent model memory.

## What changes
- Pin the tested GLM runtime at `e36e678fae9a4d3e173750d9ce583c9140235b10`; select GLM 5.3 Flash, max reasoning, native image input and a configured 1M context window.
- Add manual preflight, native Issue/PR/comment events and six-hour sweeps, with separate source-read, target-read and publication tokens.
- Enable triage, human-readable reports/Mermaid, emoji labels, repairs, adoption, rebase, clusters, automatic small-bug implementation and maintainer-authorized close/merge.
- Install trusted, scoped Go/Vue/Flutter/API-contract/PostgreSQL validation outside candidate checkouts. Failed validation prevents repair publication. Preserve current-source checks, independent review and required CI gates.

```mermaid
flowchart LR
  E[Repository events or scheduled scan] --> P[Trusted policy and App intake]
  P --> R[GLM and ephemeral Synergy core]
  R --> V[Isolated application validation]
  V --> W[Fresh App publication job]
  W --> G[Reports, labels and gated PR actions]
```

## Before merge
The source App installation must include private `yzxoi/oryn-mini`; the target installation must include `YourTongji/YourTJ-Hub`. Repository secrets are used only through Actions. Enabling capabilities does not authorize bulk closing or merging unrelated existing items. Live App/model verification follows deployment; local checks do not prove credential access.

## Validation
Six behavioral tests pass, including exact-base/staged/untracked scope detection and mandatory PostgreSQL selection. All five governance gates and focused actionlint checks pass (only the older linter's unsupported native `queue` key is excluded). Normal Git hooks run on push. The pinned runtime has passing CI and a successful real GLM image/tool probe and PR review.
