### PR TITLE
fix: prevent Oryn reports from filling its event queue

### DIFF
--- a/.github/workflows/oryn.yml
+++ b/.github/workflows/oryn.yml
@@ -38,12 +38,12 @@ defaults:
   run:
     working-directory: .oryn-runtime
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.ORYN_ENABLED == 'true') || (github.event_name != 'schedule' && vars.ORYN_EVENT_ENABLED == 'true')) && 'oryn-sweep' || format('oryn-disabled-{0}', github.run_id) }}
+  group: ${{ (github.event_name != 'issue_comment' || github.event.comment.user.type != 'Bot') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.ORYN_ENABLED == 'true') || (github.event_name != 'schedule' && vars.ORYN_EVENT_ENABLED == 'true')) && 'oryn-sweep' || format('oryn-disabled-{0}', github.run_id) }}
   cancel-in-progress: false
   queue: max
 jobs:
   plan:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.ORYN_ENABLED == 'true') || (github.event_name != 'schedule' && vars.ORYN_EVENT_ENABLED == 'true')
+    if: (github.event_name != 'issue_comment' || github.event.comment.user.type != 'Bot') && (github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && vars.ORYN_ENABLED == 'true') || (github.event_name != 'schedule' && vars.ORYN_EVENT_ENABLED == 'true'))
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     outputs:

--- a/docs/decisions/0015-oryn-repository-local-actions.md
+++ b/docs/decisions/0015-oryn-repository-local-actions.md
@@ -38,6 +38,7 @@ independent review and required CI gates. Install a trusted validation entry out
 checkout; select Go/Vue/Flutter/contract/PostgreSQL checks from changes relative to the exact job base.
 A disposable PostgreSQL service and temporary Flutter cache support isolated repair validation.
 Enable native event publication and six-hour sweeps; bounded batches and cooldown receipts cover backlog.
+Bot comments skip intake and use a separate concurrency group so Oryn reports cannot occupy the work queue.
 A successful live App preflight and model run establish access; local checks alone do not prove deployment.
 
 ## Pros and Cons of the Options

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -114,10 +114,17 @@ Automatic triggers require the workflow on the default branch. Enable only the d
 
 Manual publication defaults off; the deployment enables all four automatic execution/publication variables. `@oryn-mini review`, `@oryn-mini ask …`, `@oryn-mini stop` and
 `@oryn-mini resume` use Oryn's fixed command prefix even when the App has a different display name.
-`@oryn-mini repair`, `implement`, `assist`, `rebase`, `cluster`, `close` and `merge` are also available to authorized maintainers.
+`@oryn-mini fix`, `implement issue`, `rebase`, `cluster #N #M`, `autoclose` and `automerge` are also available to authorized maintainers.
+Slash aliases such as `/review`, `/autofix`, `/rebase`, `/autoclose` and `/automerge` are supported.
+Bot-authored comments skip planning and do not occupy the sweep queue; human commands retain runtime parsing and authority checks.
 The operator controls token grants and policy; text in issues/PRs cannot enable repair or merge.
 Disable the event/schedule execution variables to stop new automatic work; use the item's stop command
 for an active task. Preserve receipts when rotating keys or upgrading the runtime.
+
+The deployed App passed [live preflight](https://github.com/YourTongji/YourTJ-Hub/actions/runs/34367999977).
+A [real GLM review and publication](https://github.com/YourTongji/YourTJ-Hub/actions/runs/34368176030)
+completed with 20 tool calls and explicit max reasoning, producing a Chinese source review, Mermaid
+and four advisory labels on issue #594. This review did not execute repair validation.
 
 ## Maintenance and verification
 


### PR DESCRIPTION
Oryn publishes progress receipts and reports as issue comments. With native events enabled, those bot comments would enter the same sweep queue and install the private runtime before being discarded. Skip bot comments before planning and give ignored runs independent concurrency groups so they cannot delay maintainer commands or backlog scans.

Correct the documented command aliases and record the successful YourTJ-Hub App preflight and real GLM report/label publication. Focused actionlint and all five governance gates pass; normal push hooks run. Bot filtering will be verified against actual scan receipts after activation.
