### PR TITLE
fix: isolate Oryn batch failures and publish each item promptly

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: e36e678fae9a4d3e173750d9ce583c9140235b10
+        ref: 3cbdccc7d7b05e6027e8965ed89f19f4e807c081
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/.github/workflows/oryn-item.yml
+++ b/.github/workflows/oryn-item.yml
@@ -1,0 +1,179 @@
+name: Oryn item
+on:
+  workflow_call:
+    inputs:
+      slug:
+        type: string
+        required: true
+      number:
+        type: number
+        required: true
+      runtime:
+        type: boolean
+        required: true
+      source-ref:
+        type: string
+        required: true
+      publish:
+        type: boolean
+        required: true
+    secrets:
+      ORYN_APP_PRIVATE_KEY:
+        required: true
+      ORYN_GLM_API_KEY:
+        required: true
+permissions:
+  contents: read
+defaults:
+  run:
+    working-directory: .oryn-runtime
+jobs:
+  run:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 65
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports: [5432:5432]
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ inputs.source-ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-oryn
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: plan
+          path: .oryn-runtime/.artifacts/plan
+      - run: |
+          mkdir -p .artifacts/result
+          cp "$JOB_FILE" .artifacts/result/job.json
+        env:
+          JOB_FILE: .artifacts/plan/${{ inputs.slug }}/jobs/${{ inputs.number }}.json
+      - id: validation
+        run: |
+          bun -e 'const j = await Bun.file(".artifacts/result/job.json").json(); console.log("repair=" + (j.mode === "repair"));' >> "$GITHUB_OUTPUT"
+      - if: steps.validation.outputs.repair == 'true'
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: apps/gooseforum/go.mod
+          cache: false
+      - if: steps.validation.outputs.repair == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+      - if: steps.validation.outputs.repair == 'true'
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
+        with:
+          channel: stable
+          flutter-version: 3.44.9
+          cache: false
+      - if: steps.validation.outputs.repair == 'true'
+        name: Prepare trusted validation host
+        run: |
+          sudo mkdir -p /opt/oryn-validation /opt/oryn-tools
+          sudo cp ../.github/oryn/validate.mjs /opt/oryn-validation/validate.mjs
+          bun -e 'const j = await Bun.file(".artifacts/result/job.json").json(); await Bun.write("/tmp/oryn-base-sha", j.item.baseSha);'
+          sudo cp /tmp/oryn-base-sha /opt/oryn-validation/base-sha
+          sudo npm install --prefix /opt/oryn-tools --global pnpm@11.10.0
+          echo /opt/oryn-tools/bin >> "$GITHUB_PATH"
+          flutter precache --linux
+          sudo cp -a "$FLUTTER_ROOT" /opt/oryn-flutter
+      - if: inputs.runtime
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap ripgrep
+      - if: inputs.runtime
+        run: bun run core:install
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        id: target
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+          owner: YourTongji
+          repositories: YourTJ-Hub
+          permission-contents: read
+          permission-issues: read
+          permission-pull-requests: read
+          permission-checks: read
+          permission-statuses: read
+          permission-actions: read
+      - id: execute
+        continue-on-error: true
+        run: bun script/run-workflow.ts
+        env:
+          JOB_FILE: .artifacts/plan/${{ inputs.slug }}/jobs/${{ inputs.number }}.json
+          ORYN_API_KEY: ${{ secrets.ORYN_GLM_API_KEY }}
+          ORYN_BASE_URL: ${{ vars.ORYN_BASE_URL || 'https://open.bigmodel.cn/api/coding/paas/v4' }}
+          ORYN_VARIANT: max
+          ORYN_REQUEST_TIMEOUT_SECONDS: ${{ vars.ORYN_REQUEST_TIMEOUT_SECONDS }}
+          ORYN_READ_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+      - if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: result-${{ inputs.slug }}-${{ inputs.number }}
+          path: .oryn-runtime/.artifacts/result/
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+      - if: steps.execute.outcome == 'failure'
+        run: exit 1
+  publish:
+    needs: run
+    if: always() && !cancelled() && inputs.publish
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          ref: ${{ inputs.source-ref }}
+          persist-credentials: false
+      - uses: ./.github/actions/setup-oryn
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: result-${{ inputs.slug }}-${{ inputs.number }}
+          path: .oryn-runtime/.artifacts/result
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        id: target
+        with:
+          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+          owner: YourTongji
+          repositories: YourTJ-Hub
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-checks: read
+          permission-statuses: read
+          permission-actions: read
+      - id: artifact
+        run: |
+          if test -f .artifacts/result/result.json && test ! -f .artifacts/result/failure.json; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.artifact.outputs.ready == 'true'
+        run: bun src/cli.ts publish --result .artifacts/result/result.json
+        env:
+          ORYN_ALLOW_PUBLISH: "1"
+          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_ALLOW_CLOSE: "1"
+          ORYN_ALLOW_MERGE: "1"
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+      - if: steps.artifact.outputs.ready != 'true'
+        run: bun src/cli.ts settle-failure --job .artifacts/result/job.json
+        env:
+          ORYN_ALLOW_PUBLISH: "1"
+          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
+          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]

--- a/.github/workflows/oryn.yml
+++ b/.github/workflows/oryn.yml
@@ -47,13 +47,17 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     outputs:
-      matrix: ${{ steps.plan.outputs.matrix }}
-      count: ${{ steps.plan.outputs.count }}
+      source-ref: ${{ steps.revision.outputs.ref }}
+      matrix: ${{ steps.admit.outputs.matrix || steps.plan.outputs.matrix }}
+      count: ${{ (steps.admit.outputs.count || steps.plan.outputs.count) }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
           persist-credentials: false
+      - id: revision
+        working-directory: .
+        run: echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-oryn
         with:
           client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
@@ -86,12 +90,13 @@ jobs:
           INPUT_TIMEOUT: ${{ inputs.timeout }}
           ORYN_TASK_TIMEOUT_SECONDS: ${{ vars.ORYN_TASK_TIMEOUT_SECONDS || '1800' }}
       - if: inputs.preflight != true && (inputs.publish == true || (github.event_name == 'schedule' && vars.ORYN_SCHEDULE_PUBLISH == 'true') || (github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && vars.ORYN_EVENT_PUBLISH == 'true'))
+        id: admit
         run: bun script/admit-workflow.ts
         env:
           ORYN_ALLOW_PUBLISH: "1"
           ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
           ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
-      - if: steps.plan.outputs.count != '0'
+      - if: (steps.admit.outputs.count || steps.plan.outputs.count) != '0'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: plan
@@ -99,161 +104,20 @@ jobs:
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
-  run:
+  process:
     needs: plan
     if: inputs.preflight != true && needs.plan.outputs.count != '' && needs.plan.outputs.count != '0'
     strategy:
       fail-fast: false
       max-parallel: 2
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 65
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports: [5432:5432]
-        options: >-
-          --health-cmd "pg_isready -U postgres"
-          --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
-          persist-credentials: false
-      - uses: ./.github/actions/setup-oryn
-        with:
-          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: plan
-          path: .oryn-runtime/.artifacts/plan
-      - run: |
-          mkdir -p .artifacts/result
-          cp "$JOB_FILE" .artifacts/result/job.json
-        env:
-          JOB_FILE: .artifacts/plan/${{ matrix.slug }}/jobs/${{ matrix.number }}.json
-      - id: validation
-        run: |
-          bun -e 'const j = await Bun.file(".artifacts/result/job.json").json(); console.log("repair=" + (j.mode === "repair"));' >> "$GITHUB_OUTPUT"
-      - if: steps.validation.outputs.repair == 'true'
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
-        with:
-          go-version-file: apps/gooseforum/go.mod
-          cache: false
-      - if: steps.validation.outputs.repair == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: 24
-      - if: steps.validation.outputs.repair == 'true'
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
-        with:
-          channel: stable
-          flutter-version: 3.44.9
-          cache: false
-      - if: steps.validation.outputs.repair == 'true'
-        name: Prepare trusted validation host
-        run: |
-          sudo mkdir -p /opt/oryn-validation /opt/oryn-tools
-          sudo cp ../.github/oryn/validate.mjs /opt/oryn-validation/validate.mjs
-          bun -e 'const j = await Bun.file(".artifacts/result/job.json").json(); await Bun.write("/tmp/oryn-base-sha", j.item.baseSha);'
-          sudo cp /tmp/oryn-base-sha /opt/oryn-validation/base-sha
-          sudo npm install --prefix /opt/oryn-tools --global pnpm@11.10.0
-          echo /opt/oryn-tools/bin >> "$GITHUB_PATH"
-          flutter precache --linux
-          sudo cp -a "$FLUTTER_ROOT" /opt/oryn-flutter
-      - if: matrix.runtime
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap ripgrep
-      - if: matrix.runtime
-        run: bun run core:install
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        id: target
-        with:
-          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
-          owner: YourTongji
-          repositories: YourTJ-Hub
-          permission-contents: read
-          permission-issues: read
-          permission-pull-requests: read
-          permission-checks: read
-          permission-statuses: read
-          permission-actions: read
-      - id: execute
-        continue-on-error: true
-        run: bun script/run-workflow.ts
-        env:
-          JOB_FILE: .artifacts/plan/${{ matrix.slug }}/jobs/${{ matrix.number }}.json
-          ORYN_API_KEY: ${{ secrets.ORYN_GLM_API_KEY }}
-          ORYN_BASE_URL: ${{ vars.ORYN_BASE_URL || 'https://open.bigmodel.cn/api/coding/paas/v4' }}
-          ORYN_VARIANT: max
-          ORYN_REQUEST_TIMEOUT_SECONDS: ${{ vars.ORYN_REQUEST_TIMEOUT_SECONDS }}
-          ORYN_READ_TOKEN: ${{ steps.target.outputs.token }}
-          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
-      - if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: result-${{ matrix.slug }}-${{ matrix.number }}
-          path: .oryn-runtime/.artifacts/result/
-          include-hidden-files: true
-          if-no-files-found: error
-          retention-days: 7
-      - if: steps.execute.outcome == 'failure'
-        run: exit 1
-  publish:
-    needs: [plan, run]
-    if: always() && !cancelled() && inputs.preflight != true && needs.plan.result == 'success' && needs.plan.outputs.count != '0' && (inputs.publish == true || (github.event_name == 'schedule' && vars.ORYN_SCHEDULE_PUBLISH == 'true') || (github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && vars.ORYN_EVENT_PUBLISH == 'true'))
-    strategy:
-      max-parallel: 1
-      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.repository.default_branch }}
-          persist-credentials: false
-      - uses: ./.github/actions/setup-oryn
-        with:
-          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          name: result-${{ matrix.slug }}-${{ matrix.number }}
-          path: .oryn-runtime/.artifacts/result
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
-        id: target
-        with:
-          client-id: ${{ vars.ORYN_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
-          owner: YourTongji
-          repositories: YourTJ-Hub
-          permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
-          permission-checks: read
-          permission-statuses: read
-          permission-actions: read
-      - id: artifact
-        run: |
-          if test -f .artifacts/result/result.json && test ! -f .artifacts/result/failure.json; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-          fi
-      - if: steps.artifact.outputs.ready == 'true'
-        run: bun src/cli.ts publish --result .artifacts/result/result.json
-        env:
-          ORYN_ALLOW_PUBLISH: "1"
-          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
-          ORYN_ALLOW_CLOSE: "1"
-          ORYN_ALLOW_MERGE: "1"
-          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
-      - if: steps.artifact.outputs.ready != 'true'
-        run: bun src/cli.ts settle-failure --job .artifacts/result/job.json
-        env:
-          ORYN_ALLOW_PUBLISH: "1"
-          ORYN_WRITE_TOKEN: ${{ steps.target.outputs.token }}
-          ORYN_BOT_LOGIN: ${{ steps.target.outputs.app-slug }}[bot]
+    uses: ./.github/workflows/oryn-item.yml
+    with:
+      slug: ${{ matrix.slug }}
+      number: ${{ matrix.number }}
+      runtime: ${{ matrix.runtime }}
+      source-ref: ${{ needs.plan.outputs.source-ref }}
+      publish: ${{ inputs.publish == true || (github.event_name == 'schedule' && vars.ORYN_SCHEDULE_PUBLISH == 'true') || (github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' && vars.ORYN_EVENT_PUBLISH == 'true') }}
+    secrets:
+      ORYN_APP_PRIVATE_KEY: ${{ secrets.ORYN_APP_PRIVATE_KEY }}
+      ORYN_GLM_API_KEY: ${{ secrets.ORYN_GLM_API_KEY }}

--- a/docs/decisions/0015-oryn-repository-local-actions.md
+++ b/docs/decisions/0015-oryn-repository-local-actions.md
@@ -29,6 +29,10 @@ would create a second maintenance burden; running centrally would require event 
 Choose option 1. The local workflow checks out trusted policy from the default branch for native events,
 loads an immutable private Oryn revision using a source-only read token, and separates planning,
 read-only model execution and publication into jobs with independently narrowed target tokens.
+A reusable per-item workflow publishes each result as soon as its execution completes; a slow item
+does not hold every other report behind a batch-wide barrier. The planner records one trusted
+workflow commit for all children. Admission dispatches only successfully reserved jobs, defers stale
+sources independently and releases reservations on abort. Source freshness remains mandatory.
 The App is installed only on the target and runtime repositories. Native events replace webhooks.
 Manual preflight exercises read access and planning without inference or publication.
 
@@ -52,5 +56,5 @@ A successful live App preflight and model run establish access; local checks alo
 ## Links
 
 - [Operations guide](../operations/oryn.md)
-- [Pinned Oryn runtime](https://github.com/yzxoi/oryn-mini/tree/e36e678fae9a4d3e173750d9ce583c9140235b10)
+- [Pinned Oryn runtime](https://github.com/yzxoi/oryn-mini/tree/3cbdccc7d7b05e6027e8965ed89f19f4e807c081)
 - [GitHub App token action](https://github.com/actions/create-github-app-token/tree/bcd2ba49218906704ab6c1aa796996da409d3eb1)

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/e36e678fae9a4d3e173750d9ce583c9140235b10)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/3cbdccc7d7b05e6027e8965ed89f19f4e807c081)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.
@@ -31,7 +31,10 @@ seconds, manually overridable within 10–3000 seconds.
 All Oryn policy capabilities are enabled: reviews, triage, source-backed Mermaid diagrams, emoji labels,
 questions, stop/resume, repair, adoption, rebase, clusters, automatic small-bug implementation, close and
 merge. A scan selects at most 20 eligible items; later scans pick up the remaining items after cooldown
-receipts exclude completed work. Two model jobs run concurrently. Close/merge still require a current
+receipts exclude completed work. Two item workflows run concurrently. Each item publishes immediately after its own execution,
+without waiting for other items in the batch; [the item workflow](../../.github/workflows/oryn-item.yml)
+keeps model and publisher credentials in separate jobs. All jobs use the trusted workflow commit
+recorded by the planner. Stale admissions are deferred individually, and aborted reservations are released. Close/merge still require a current
 maintainer command and live evidence; merge additionally requires independent approval and successful
 `ci-backend`, `ci-frontend`, and `ci-contract` checks. Generated fixes remain draft PRs for human review.
 


### PR DESCRIPTION
A default-branch update during the live backlog scan exposed two orchestration problems: a stale reservation aborted the entire batch and left earlier items leased, and completed reports waited behind every other item before publication.

Pin the fixed Oryn runtime, consume its successfully admitted matrix, and run each item through a reusable execution/publication workflow. Up to two item workflows run concurrently; each publishes immediately after its own execution, with separate App tokens and one trusted workflow commit recorded by the planner. Source freshness, command authority, repair validation, approval and CI gates remain mandatory.

The source fix defers stale admissions individually and releases reservations on fatal admission/artifact errors or post-write freshness failure. Prior failed/cancelled run receipts were released while automatic intake was paused; activation and fresh scans resume after this deployment.

Validation: six target validation-scope tests, five governance gates and focused actionlint pass. Normal push hooks run. The runtime has 69 passing local tests (one Linux-only case skipped), including HTTP reproduction of the stranded-receipt race; Linux CI covers the sandbox/provider suite. The earlier live GLM issue review and label publication succeeded; the later PR report was correctly blocked when its head advanced during review.
