### PR TITLE
fix: keep Oryn repairs current across metadata updates

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: 3cbdccc7d7b05e6027e8965ed89f19f4e807c081
+        ref: b87c472ef3bccf1d9683efc19c43de78046a4be9
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/docs/decisions/0016-oryn-semantic-freshness.md
+++ b/docs/decisions/0016-oryn-semantic-freshness.md
@@ -1,0 +1,49 @@
+# Distinguish Oryn source changes from repository administration
+
+## Status
+
+Accepted
+Class: process
+
+## Context and Problem Statement
+
+Assigning issue #594 during implementation changed its GitHub timestamp. Oryn rejected the pending
+decision report despite unchanged source and discussion, then showed a generic publication failure.
+Normal issue administration must not discard otherwise current maintenance evidence.
+
+## Decision Drivers
+
+- Preserve exact source, discussion and maintainer authority checks before publication.
+- Allow unrelated assignment, project and bot-receipt updates during work.
+- Make pending decisions and actual validation status visible.
+
+## Considered Options
+
+1. Upgrade the pinned Oryn runtime to compare source fields and context snapshots separately.
+2. Require maintainers to avoid all issue administration during model execution.
+3. Disable publication freshness checks.
+
+## Decision Outcome
+
+Choose option 1. The runtime compares item identity, title/body, source SHAs, labels and eligibility,
+then verifies the captured discussion/review/check snapshot and live command authority. A result without
+a context snapshot cannot publish across timestamp drift. Changes to requirements, code or evidence
+remain blocking. Assignee/project updates no longer cause false source-change failures.
+
+Decision-needed repairs publish their question and actual validation status without exporting a patch.
+Publication failures identify source-field or context categories without copying source content or raw
+errors into receipts. Existing repository policy, model credentials and CI/approval requirements remain
+in force. The Actions-only runtime and ephemeral model-session architecture follow decision 0015.
+
+## Pros and Cons of the Options
+
+- Option 1 separates relevant evidence from metadata, but requires maintaining the runtime pin.
+- Option 2 needs no code change but blocks ordinary collaboration and does not fix bot timestamp writes.
+- Option 3 avoids false rejections but permits stale results or withdrawn authority to publish.
+
+## Links
+
+- [Operations guide](../operations/oryn.md)
+- [Repository-local runtime decision](0015-oryn-repository-local-actions.md)
+- [Runtime fix](https://github.com/yzxoi/oryn-mini/pull/9)
+- [Observed publication failure](https://github.com/YourTongji/YourTJ-Hub/actions/runs/34426777441)

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-09-09
+> Last verified: 2026-09-10
 
 Implementation status: **Current** for the configured integration. Live run results are recorded in
 Actions; a green preflight proves App access and planning, while an executed review proves model access.
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/3cbdccc7d7b05e6027e8965ed89f19f4e807c081)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/b87c472ef3bccf1d9683efc19c43de78046a4be9)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.
@@ -120,6 +120,13 @@ Manual publication defaults off; the deployment enables all four automatic execu
 `@oryn-mini fix`, `implement issue`, `rebase`, `cluster #N #M`, `autoclose` and `automerge` are also available to authorized maintainers.
 Slash aliases such as `/review`, `/autofix`, `/rebase`, `/autoclose` and `/automerge` are supported.
 Bot-authored comments skip planning and do not occupy the sweep queue; human commands retain runtime parsing and authority checks.
+Publication compares source fields and the captured discussion/review/check context separately.
+Assignee, project and bot-receipt timestamp updates do not interrupt an otherwise unchanged task;
+changed requirements, code, discussion, labels and command authority still block stale publication.
+A decision-needed repair shows the concrete question and whether host validation ran, and publishes
+no patch. Source/context publication failures identify the changed category in the status receipt.
+See [the freshness decision](../decisions/0016-oryn-semantic-freshness.md).
+
 The operator controls token grants and policy; text in issues/PRs cannot enable repair or merge.
 Disable the event/schedule execution variables to stop new automatic work; use the item's stop command
 for an active task. Preserve receipts when rotating keys or upgrading the runtime.


### PR DESCRIPTION
Issue #594’s pending decision report failed to publish after an assignee update changed GitHub’s general timestamp. Upgrade the pinned Oryn runtime to compare actual source fields and captured discussion/review/check context separately. Requirement, code, label and authority changes remain blocking.

Decision receipts now show the pending question and actual validation status. Source/context publication failures identify the changed category. Model settings and repository capability switches are unchanged.

Validation: Oryn regression tests first reproduced the failure; 72 tests pass locally with one Linux-only skip, and source CI covers Linux sandbox/core smokes. Target governance gates and actionlint pass. Normal pre-push Go vet, incremental lint and frontend typecheck pass. Revalidated and recovered #594’s original decision report against unchanged live source/context without rerunning the model.

See runtime fix yzxoi/oryn-mini#9 and decision 0016.