### PR TITLE
fix: release main in one run after PR CI

### DIFF
--- a/.github/workflows/ci-mobile.yml
+++ b/.github/workflows/ci-mobile.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/ci-mobile.yml"
       - ".github/workflows/release-mobile.yml"
       - ".github/workflows/release-to-main.yml"
+      - ".github/workflows/deploy-main.yml"
       - "scripts/mobile-release/**"
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - ".github/workflows/ci-mobile.yml"
       - ".github/workflows/release-mobile.yml"
       - ".github/workflows/release-to-main.yml"
+      - ".github/workflows/deploy-main.yml"
       - "scripts/mobile-release/**"
 
 concurrency:

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -1,15 +1,28 @@
 name: Deploy / main
 
 on:
-  # 生产部署唯一入口: release-to-main 显式触发, 不监听 push
-  # (防止直接 push main 导致意外/双重复部署)
+  # release-to-main dispatches the published server tag; manual recovery also
+  # selects a server tag. Merging main alone does not deploy production.
   workflow_dispatch:
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a server release tag on main
+        run: |
+          if [[ ! "$GITHUB_REF" =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Select a server vX.Y.Z tag to deploy production"
+            exit 1
+          fi
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
       - uses: ./.github/actions/build-binary
 
   build-image:

--- a/.github/workflows/release-to-main.yml
+++ b/.github/workflows/release-to-main.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Server version increment (requires dev changes merged into main by PR)"
+        description: "Server version increment (waits for PR CI, merges and releases automatically)"
         required: true
         type: choice
         options: [patch, minor, major]
@@ -22,13 +22,14 @@ jobs:
   prepare:
     if: github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 65
     outputs:
       tag: ${{ steps.release.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Require dev to reach main through a reviewed PR
+      - name: Wait for PR CI, merge dev into main and tag the release
         id: release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -74,9 +75,9 @@ jobs:
       - name: 触发生产部署(deploy-main)
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
-          # push 事件对 GITHUB_TOKEN / fine-grained PAT 可能不触发 workflow,
-          # 但 workflow_dispatch 是明确例外, 直接显式触发 deploy-main
-          sleep 5
-          gh workflow run deploy-main.yml --ref main
-          echo "已触发 deploy-main workflow 部署生产"
+          # Dispatch the published tag so every deployment job uses the same
+          # commit as the release binaries, even if main advances meanwhile.
+          gh workflow run deploy-main.yml --ref "$RELEASE_TAG"
+          echo "已触发 deploy-main workflow 部署 $RELEASE_TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,9 @@ docs/        Docs center (product/architecture/development/operations)
 
 - `dev` is the main development line: create `feat/<topic>` / `fix/<topic>` / `docs/<topic>` from
   `origin/dev`, open PRs against `dev`; CI builds and auto-deploys `dev` to the test instance.
-- `main` is the production site: merges to `main` go through PR + CI and auto-deploy to the prod
-  instance. Never develop directly on `main` or `dev`.
+- `main` is the production site: changes reach it through PR + CI. `Release / main` merges the
+  release PR, publishes a server tag and dispatches production deployment on that tag (see
+  `docs/operations/deployment.md`). Never develop directly on `main` or `dev`.
 - The dev instance syncs a consistent snapshot of the main database on each deploy (see
   `docs/operations/deployment.md`), so DB migrations are rehearsed on dev before reaching main.
 - Stage only files this task owns; leave unrelated dirty/untracked files alone.

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -6,14 +6,16 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-08-06
+> Last verified: 2026-09-10
 
 ## Branches
 
 - `dev` is the main development line: create `feat/<topic>` / `fix/<topic>` / `docs/<topic>` from
   `origin/dev`, open PRs against `dev`. CI builds and auto-deploys `dev` to the test instance.
-- `main` is the production site: merges to `main` go through PR + CI and auto-deploy to the prod
-  instance. Never develop directly on `main` or `dev`.
+- `main` is the production site: changes reach it through PR + CI. The server release workflow
+  merges the release PR after CI, publishes a tag and dispatches production deployment on that tag;
+  see the [release runbook](../operations/deployment.md). Never develop directly
+  on `main` or `dev`.
 - The dev instance syncs a consistent snapshot of the main database on each deploy (see
   `docs/operations/deployment.md`), so DB migrations are rehearsed on dev before reaching main.
 - Prefer worktrees (`git worktree add`) for parallel tasks; do not mix branches in one checkout.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -6,7 +6,7 @@
 >
 > Owner: Platform maintainers
 >
-> Last verified: 2026-09-06
+> Last verified: 2026-09-10
 
 ## Deployment shape
 
@@ -222,18 +222,43 @@ webhook_secret = ""         # 兼容旧配置的明文密钥；推荐改用管�
      `IMAGE_KEEP_N` tags of the instance prefix including the current one, plus the `prev`
      rollback tag).
      The dev workflow sets `IMAGE_KEEP_N=3` because dev deploys frequently.
-- `main` is the production site; merges to `main` trigger `.github/workflows/deploy-main.yml`:
+- `main` is the production site. `Release / main` explicitly dispatches
+  `.github/workflows/deploy-main.yml` on the published server tag; merging main alone does not deploy:
   1. Build single binary and push GHCR image `main-<sha>` on GitHub Actions.
   2. SSH: `backup-db.sh main` (pre-deploy consistent snapshot, keep 7).
   3. SSH: `deploy.sh main main-<sha> 5234` → pull image, compose up, health check,
      auto-rollback to previous image tag on failure; same post-deploy image pruning as dev
      (`IMAGE_KEEP_N=5`, keeps more rollback candidates for production).
-- **Release gate**: `.github/workflows/release-to-main.yml` (manual `workflow_dispatch`) opens or
-  reuses a `dev` → `main` PR when the trees differ, then stops for normal review and CI. After merge,
-  rerun it to increment the exact server `vX.Y.Z` tags, tag the reviewed main commit, publish server
-  binaries and dispatch deployment. It never directly pushes to main. The existing `RELEASE_TOKEN`
-  creates the PR/tag through GitHub APIs. Mobile tags use a separate namespace and workflow; see
-  [mobile releases](mobile-releases.md).
+- **Release gate — Current**: run `.github/workflows/release-to-main.yml` (`Release / main`)
+  once on `dev` or `main` and select `patch`, `minor` or `major`. It captures the dev/main commits,
+  opens or reuses a `dev` → `main` PR when their trees differ, waits for PR CI, merges with a merge
+  commit, tags that exact commit as `vX.Y.Z`, publishes server binaries and dispatches deployment.
+  The dev branch is retained. Content already promoted to main can be released without another PR;
+  an existing server tag on that commit prevents a second version reservation.
+  - The script requires successful PR runs of `ci-backend.yml`, `ci-frontend.yml`, `ci-contract.yml`
+    and `ci-govulncheck.yml`, and waits for every other reported `ci-*.yml` workflow. It waits for
+    entire workflows, including backend race/PG jobs. Missing core workflows remain pending;
+    failure, cancellation or a skipped whole workflow stops release. Dev push checks, checks for
+    another head, and runs older than the PR or main base commit do not satisfy this gate.
+  - CI is checked explicitly even without repository required-check settings. The merge uses the
+    captured head SHA and respects GitHub merge requirements, including required reviews when
+    configured; it does not use an admin bypass. A draft/closed PR, conflict or changed dev/main
+    snapshot stops release. CI and merge requirements have a 60-minute wait limit. Resolve the
+    reported problem, then start a new run for the intended snapshot.
+  - Tagging uses the returned merge SHA and verifies its parents against the captured main/dev
+    commits. Deployment runs on the published tag, so its binary, image, scripts and rendered
+    config all come from the released source even when main advances. Production deployments are
+    serialized; the deploy workflow rejects branch refs, mobile tags and tags outside main history.
+  - If publishing fails after tagging, rerun the failed publish job so it reuses the prepared tag.
+    For deployment recovery or rollback, dispatch the deploy workflow on the desired existing
+    server tag: `gh workflow run deploy-main.yml --ref vX.Y.Z` (replace with the actual tag).
+    Selecting `main` directly is rejected. Production environment deployment policies must permit
+    server tags if branch/tag restrictions are configured.
+  - `RELEASE_TOKEN` creates and merges PRs and creates tags through GitHub APIs; it needs repository
+    Contents and Pull requests write permissions plus Actions read permission for CI polling
+    (classic PATs need equivalent repository/workflow access). The workflow's `GITHUB_TOKEN`
+    publishes assets and dispatches deployment using its existing Contents/Actions write permissions.
+  Mobile tags use a separate namespace and workflow; see [mobile releases](mobile-releases.md).
 - Why dev syncs main's db: migrations (`app/migration` AutoMigrate + versioned data migrations) run at
   startup, so each dev deploy rehearses the exact migration the next main deploy will run.
 - Config is rendered in CI from `deploy/config.toml.tmpl` + `deploy/instances/<env>.json`
@@ -272,7 +297,7 @@ Deploy/apply/drift workflows 的 job 声明对应 `environment:`，自动获得�
 | `GH_CLIENT_ID` / `GH_CLIENT_SECRET` | production only | GitHub OAuth（dev 因 DB siteUrl 无环境隔离保持空，渲染 allow-empty） |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | both（可选） | Google OAuth；为空时登录入口保持关闭 |
 | `AI_API_KEY` | both（可空） | `[ai_summary].api_key`（AI 总结默认关闭） |
-| `RELEASE_TOKEN` | repo-level | release-to-main 创建 dev→main PR 和发布 tag 用 PAT |
+| `RELEASE_TOKEN` | repo-level | release-to-main 创建/合并 dev→main PR、读取 CI 和发布 tag 用 PAT |
 
 > 命名注意：GitHub 保留 `GITHUB_` 前缀 secret 名，故 GitHub OAuth 凭据用 `GH_CLIENT_ID/SECRET`。
 

--- a/scripts/mobile-release/README.md
+++ b/scripts/mobile-release/README.md
@@ -9,14 +9,17 @@ owns versioning, GitHub environment secrets, signing backup/rotation and recover
 - `publish_android.py [--verify-only]` validates split APKs and publishes immutable-name assets.
 - `prepare_mobile.py` prepares the production PR and reserves patch/minor/major version tags,
   or resumes an existing tag without consuming a build number.
-- `prepare_server.py` opens the production PR or tags already reviewed main source; mobile tags
-  never influence server version increments.
+- `prepare_server.py` opens or reuses the production PR, waits for CI and merge requirements,
+  merges the captured dev snapshot and tags the resulting main commit in one run. It also accepts
+  already promoted main content; mobile tags never influence server version increments. The
+  [server release runbook](../../docs/operations/deployment.md) owns CI gates,
+  timeout/recovery, token permissions and deployment identity.
 
 Run release-script regressions without signing credentials or external mutations:
 
 ```bash
 python3 -m unittest discover -s scripts/mobile-release -p 'test_*.py'
-actionlint .github/workflows/release-mobile.yml .github/workflows/release-to-main.yml .github/workflows/ci-mobile.yml
+actionlint .github/workflows/release-mobile.yml .github/workflows/release-to-main.yml .github/workflows/deploy-main.yml .github/workflows/ci-mobile.yml
 ```
 
 The publish commands mutate external services. `--verify-only` on the Android publisher writes local

--- a/scripts/mobile-release/prepare_server.py
+++ b/scripts/mobile-release/prepare_server.py
@@ -1,11 +1,23 @@
 #!/usr/bin/env python3
-"""Open the dev → main PR when needed; tag only reviewed main content."""
+"""Promote dev through PR CI and merge, then tag that exact production commit."""
 import json
 import os
 from pathlib import Path
 import re
 import subprocess
 import tempfile
+import time
+
+
+REPOSITORY = "YourTongji/YourTJ-Hub"
+# These workflows run for every PR. Never interpret missing checks as success,
+# even when the repository has no required status checks configured.
+REQUIRED_WORKFLOWS = {
+    ".github/workflows/ci-backend.yml",
+    ".github/workflows/ci-frontend.yml",
+    ".github/workflows/ci-contract.yml",
+    ".github/workflows/ci-govulncheck.yml",
+}
 
 
 def next_version(tags, bump):
@@ -23,35 +35,125 @@ def read(*args):
     return subprocess.check_output(args, text=True).strip()
 
 
+def api(path, *args):
+    return json.loads(read("gh", "api", f"repos/{REPOSITORY}/{path}", *args))
+
+
+def ci_ready(pr, source_sha, since):
+    pages = api(f"actions/runs?event=pull_request&branch=dev&head_sha={source_sha}&per_page=100",
+                "--paginate", "--slurp")
+    latest = {}
+    for page in pages:
+        for run in page["workflow_runs"]:
+            path = run["path"]
+            if (not path.startswith(".github/workflows/ci-")
+                    or run["event"] != "pull_request"
+                    or run["head_sha"] != source_sha
+                    or run["head_branch"] != "dev"
+                    or run["head_repository"]["full_name"] != REPOSITORY
+                    or run["created_at"] < since):
+                continue
+            # GitHub can return an empty association for same-repository PRs.
+            # In that case branch, SHA and PR/base freshness still constrain the run.
+            if run["pull_requests"] and not any(
+                    item["number"] == pr["number"] for item in run["pull_requests"]):
+                continue
+            if path not in latest or run["id"] > latest[path]["id"]:
+                latest[path] = run
+    for run in latest.values():
+        if run["status"] == "completed" and run["conclusion"] != "success":
+            raise RuntimeError(f"Release CI {run['conclusion']}: {run['html_url']}")
+    missing = REQUIRED_WORKFLOWS - latest.keys()
+    pending = [path for path, run in latest.items() if run["status"] != "completed"]
+    if missing or pending:
+        print("Waiting for PR CI: " + ", ".join(sorted(missing | set(pending))), flush=True)
+        return False
+    # Wait for whole workflows, including dependent race/PG jobs, not just their
+    # first green job. Path-filtered CI participates whenever it has a run.
+    return True
+
+
+def validate_pr(pr, source_sha, base_sha):
+    if (pr["head"]["ref"] != "dev" or pr["base"]["ref"] != "main"
+            or pr["head"]["repo"]["full_name"] != REPOSITORY
+            or pr["base"]["repo"]["full_name"] != REPOSITORY):
+        raise RuntimeError("Release PR must promote this repository's dev to main")
+    if pr["head"]["sha"] != source_sha or pr["base"]["sha"] != base_sha:
+        raise RuntimeError("dev or main changed during release; start a new release for the new snapshot")
+    if pr["state"] != "open" and not pr["merged"]:
+        raise RuntimeError("Release PR was closed without merging")
+    if pr["draft"]:
+        raise RuntimeError("Release PR is a draft; mark it ready before releasing")
+    if not pr["merged"] and pr["mergeable_state"] == "dirty":
+        raise RuntimeError("Release PR has merge conflicts")
+
+
+def wait_for_merge(number, source_sha, base_sha, timeout=3600):
+    deadline = time.monotonic() + timeout
+    base_date = api(f"commits/{base_sha}")["commit"]["committer"]["date"]
+    while time.monotonic() < deadline:
+        pr = api(f"pulls/{number}")
+        validate_pr(pr, source_sha, base_sha)
+        # Do not reuse dev push checks or PR checks older than this PR/base.
+        if ci_ready(pr, source_sha, max(pr["created_at"], base_date)):
+            # Re-read after CI polling so changes during the API calls cannot
+            # silently select a different head. The merge API also locks the SHA.
+            pr = api(f"pulls/{number}")
+            validate_pr(pr, source_sha, base_sha)
+            if pr["merged"]:
+                return pr["merge_commit_sha"]
+            if pr["mergeable"] and pr["mergeable_state"] == "clean":
+                merged = api(f"pulls/{number}/merge", "--method", "PUT",
+                             "-f", f"sha={source_sha}", "-f", "merge_method=merge")
+                if not merged.get("merged"):
+                    raise RuntimeError(f"PR merge refused: {merged.get('message')}")
+                return merged["sha"]
+            print(f"Waiting for PR #{number} merge requirements: {pr['mergeable_state']}", flush=True)
+        time.sleep(15)
+    raise TimeoutError(f"Timed out waiting for PR #{number} CI/merge requirements; no release tag created")
+
+
 def ensure_promoted():
+    source_sha = read("git", "rev-parse", "origin/dev")
+    base_sha = read("git", "rev-parse", "origin/main")
+    if (os.environ.get("GITHUB_REF") == "refs/heads/dev"
+            and os.environ["GITHUB_SHA"] != source_sha):
+        raise RuntimeError("dev changed since this workflow was dispatched; start a new release")
     # Content equivalence accepts squash/rebase merges without requiring matching ancestry.
-    comparison = subprocess.run(["git", "diff", "--quiet", "origin/main", "origin/dev"]).returncode
+    comparison = subprocess.run(["git", "diff", "--quiet", base_sha, source_sha]).returncode
     if comparison not in (0, 1):
         raise RuntimeError("Could not compare main and dev")
     if comparison == 1:
-        prs = json.loads(read("gh", "pr", "list", "--base", "main", "--head", "dev", "--state", "open", "--json", "url"))
+        prs = json.loads(read("gh", "pr", "list", "--base", "main", "--head", "dev", "--state", "open", "--json", "number,url"))
         if prs:
-            print("Merge the existing release PR, then rerun: " + prs[0]["url"])
+            number = prs[0]["number"]
+            print("Continuing release PR: " + prs[0]["url"], flush=True)
         else:
             with tempfile.TemporaryDirectory() as folder:
                 body = Path(folder) / "body.md"
-                body.write_text("Promote the tested dev snapshot to production. Merge through the required PR checks, then rerun the requested release workflow to tag and publish its release artifacts. Mobile releases use their separate mobile-vX.Y.Z tags.\n")
-                print(read("gh", "pr", "create", "--base", "main", "--head", "dev", "--title", "chore: promote dev to main", "--body-file", str(body)))
-        return False
-    return True
+                body.write_text(f"Promote dev snapshot `{source_sha}` to production. The server release workflow waits for PR CI, merges this PR, then tags, publishes and deploys that commit in the same run. Branch protection still applies. Mobile releases use their separate mobile-vX.Y.Z tags.\n")
+                url = read("gh", "pr", "create", "--base", "main", "--head", "dev", "--title", "chore: promote dev to main", "--body-file", str(body))
+                print(url, flush=True)
+                number = int(url.rstrip("/").rsplit("/", 1)[1])
+        sha = wait_for_merge(number, source_sha, base_sha)
+        subprocess.run(["git", "fetch", "origin", "main"], check=True)
+        # A concurrent main update can race the merge API (which locks only the
+        # head). Never publish a merge containing a base we did not validate.
+        if read("git", "show", "-s", "--format=%P", sha).split() != [base_sha, source_sha]:
+            raise RuntimeError("Merged PR has unexpected parents; refusing to publish")
+        return sha
+    return base_sha
 
 
 def main():
     subprocess.run(["git", "fetch", "origin", "dev", "main", "--tags"], check=True)
-    if not ensure_promoted():
-        return
+    sha = ensure_promoted()
     tag = next_version(read("git", "tag", "--list").splitlines(), os.environ["BUMP"])
     # Ref creation through the API avoids putting a PAT in Git remote URLs.
-    sha = read("git", "rev-parse", "origin/main")
     existing_tags = read("git", "tag", "--points-at", sha).splitlines()
     if any(re.fullmatch(r"v\d+\.\d+\.\d+", item) for item in existing_tags):
         raise ValueError("This main commit already has a server release tag; resume its failed run instead")
-    read("gh", "api", "--method", "POST", "repos/YourTongji/YourTJ-Hub/git/refs",
+    read("gh", "api", "--method", "POST", f"repos/{REPOSITORY}/git/refs",
          "-f", f"ref=refs/tags/{tag}", "-f", f"sha={sha}")
     with open(os.environ["GITHUB_OUTPUT"], "a") as output:
         output.write(f"tag={tag}\n")

--- a/scripts/mobile-release/test_prepare_server.py
+++ b/scripts/mobile-release/test_prepare_server.py
@@ -1,4 +1,13 @@
 import unittest
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+import subprocess
+from tempfile import TemporaryDirectory
+import textwrap
+from unittest.mock import patch
+import prepare_server as server
 from prepare_server import next_version
 
 
@@ -8,3 +17,313 @@ class ServerVersionTest(unittest.TestCase):
         self.assertEqual(next_version([], 'minor'), 'v0.1.0')
         self.assertEqual(next_version(['v1.9.0'], 'major'), 'v2.0.0')
         with self.assertRaises(ValueError): next_version([], 'invalid')
+
+
+class ServerPromotionTest(unittest.TestCase):
+    def setUp(self):
+        environment = patch.dict(os.environ, GITHUB_REF='', GITHUB_SHA='')
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    def test_existing_pr_continues_to_merge_in_the_same_run(self):
+        def read(*args):
+            if args == ('git', 'rev-parse', 'origin/dev'):
+                return 'dev-sha'
+            if args == ('git', 'rev-parse', 'origin/main'):
+                return 'main-sha'
+            if args[:3] == ('gh', 'pr', 'list'):
+                return json.dumps([{'number': 607, 'url': 'https://github.com/YourTongji/YourTJ-Hub/pull/607'}])
+            if args == ('git', 'show', '-s', '--format=%P', 'merged-sha'):
+                return 'main-sha dev-sha'
+            self.fail(f'Unexpected command: {args}')
+
+        with patch.object(server.subprocess, 'run') as run, \
+             patch.object(server, 'read', side_effect=read), \
+             patch.object(server, 'wait_for_merge', create=True, return_value='merged-sha') as merge:
+            run.return_value.returncode = 1
+            self.assertEqual(server.ensure_promoted(), 'merged-sha')
+        merge.assert_called_once_with(607, 'dev-sha', 'main-sha')
+
+    def test_new_pr_is_created_and_merged_without_a_second_dispatch(self):
+        def read(*args):
+            if args[:2] == ('git', 'rev-parse'):
+                return 'dev-sha' if args[2] == 'origin/dev' else 'main-sha'
+            if args[:3] == ('gh', 'pr', 'list'):
+                return '[]'
+            if args[:3] == ('gh', 'pr', 'create'):
+                body = Path(args[-1]).read_text()
+                self.assertIn('dev-sha', body)
+                return 'https://github.com/YourTongji/YourTJ-Hub/pull/608'
+            if args[:2] == ('git', 'show'):
+                return 'main-sha dev-sha'
+            self.fail(f'Unexpected command: {args}')
+
+        with patch.object(server.subprocess, 'run') as run, \
+             patch.object(server, 'read', side_effect=read), \
+             patch.object(server, 'wait_for_merge', return_value='merged-sha') as merge:
+            run.return_value.returncode = 1
+            self.assertEqual(server.ensure_promoted(), 'merged-sha')
+        merge.assert_called_once_with(608, 'dev-sha', 'main-sha')
+
+    def test_equal_trees_release_the_captured_main_commit(self):
+        with patch.object(server.subprocess, 'run') as run, \
+             patch.object(server, 'read', side_effect=['dev-sha', 'main-sha']), \
+             patch.object(server, 'wait_for_merge') as merge:
+            run.return_value.returncode = 0
+            self.assertEqual(server.ensure_promoted(), 'main-sha')
+        merge.assert_not_called()
+
+    def test_failed_diff_does_not_promote(self):
+        with patch.object(server.subprocess, 'run') as run, \
+             patch.object(server, 'read', side_effect=['dev-sha', 'main-sha']), \
+             self.assertRaisesRegex(RuntimeError, 'compare'):
+            run.return_value.returncode = 128
+            server.ensure_promoted()
+
+    def test_dev_dispatch_does_not_include_later_commits(self):
+        with patch.dict(os.environ, GITHUB_REF='refs/heads/dev', GITHUB_SHA='original-sha'), \
+             patch.object(server, 'read', side_effect=['new-dev-sha', 'main-sha']), \
+             patch.object(server.subprocess, 'run') as run, \
+             self.assertRaisesRegex(RuntimeError, 'dispatched'):
+            server.ensure_promoted()
+        run.assert_not_called()
+
+    def test_main_racing_merge_is_not_published(self):
+        with patch.object(server.subprocess, 'run') as run, \
+             patch.object(server, 'read', side_effect=[
+                 'dev-sha', 'main-sha', '[{"number":607,"url":"pr-url"}]', 'new-main dev-sha']), \
+             patch.object(server, 'wait_for_merge', return_value='merged-sha'), \
+             self.assertRaisesRegex(RuntimeError, 'unexpected parents'):
+            run.return_value.returncode = 1
+            server.ensure_promoted()
+
+
+def release_pr():
+    return {
+        'number': 607, 'state': 'open', 'merged': False, 'draft': False,
+        'mergeable': True, 'mergeable_state': 'clean', 'merge_commit_sha': 'merged-sha',
+        'created_at': '2026-09-10T01:00:00Z',
+        'head': {'ref': 'dev', 'sha': 'dev-sha', 'repo': {'full_name': server.REPOSITORY}},
+        'base': {'ref': 'main', 'sha': 'main-sha', 'repo': {'full_name': server.REPOSITORY}},
+    }
+
+
+def ci_run(path, **updates):
+    run = {
+        'id': 100, 'path': path, 'event': 'pull_request', 'head_branch': 'dev',
+        'head_sha': 'dev-sha', 'head_repository': {'full_name': server.REPOSITORY},
+        'created_at': '2026-09-10T01:01:00Z', 'pull_requests': [],
+        'status': 'completed', 'conclusion': 'success', 'html_url': f'https://github.com/run/{path}',
+    }
+    run.update(updates)
+    return run
+
+
+class ServerCITest(unittest.TestCase):
+    def setUp(self):
+        self.runs = [ci_run(path) for path in sorted(server.REQUIRED_WORKFLOWS)]
+
+    def ready(self, runs):
+        # Split across pages to guard against silently missing checks after page 1.
+        with patch.object(server, 'api', return_value=[{'workflow_runs': runs[:2]}, {'workflow_runs': runs[2:]}]):
+            return server.ci_ready(release_pr(), 'dev-sha', '2026-09-10T01:00:00Z')
+
+    def test_all_core_workflows_are_required_even_without_branch_protection(self):
+        self.assertTrue(self.ready(self.runs))
+        self.assertFalse(self.ready([]))
+        self.assertFalse(self.ready(self.runs[:-1]))
+
+    def test_pending_workflow_waits_for_its_dependent_jobs(self):
+        self.runs[0].update(status='in_progress', conclusion=None)
+        self.assertFalse(self.ready(self.runs))
+
+    def test_optional_workflow_also_blocks_while_running_or_failed(self):
+        optional = ci_run('.github/workflows/ci-mobile.yml', status='queued', conclusion=None)
+        self.assertFalse(self.ready(self.runs + [optional]))
+        for conclusion in ['failure', 'cancelled', 'timed_out', 'skipped', 'action_required', None]:
+            with self.subTest(conclusion=conclusion), self.assertRaisesRegex(RuntimeError, 'Release CI'):
+                self.ready(self.runs + [dict(optional, status='completed', conclusion=conclusion)])
+
+    def test_latest_workflow_run_wins_over_earlier_success_or_failure(self):
+        path = self.runs[0]['path']
+        for ordering in [False, True]:
+            runs = self.runs + [ci_run(path, id=101, status='in_progress', conclusion=None)]
+            self.assertFalse(self.ready(list(reversed(runs)) if ordering else runs))
+        self.assertTrue(self.ready(self.runs + [ci_run(path, id=99, conclusion='failure')]))
+
+    def test_other_events_heads_prs_and_stale_runs_do_not_satisfy_ci(self):
+        for override in [
+                {'event': 'push'}, {'head_sha': 'old-dev'}, {'head_branch': 'other'},
+                {'head_repository': {'full_name': 'someone/fork'}},
+                {'created_at': '2026-09-10T00:59:59Z'}, {'pull_requests': [{'number': 999}]}]:
+            with self.subTest(override=override):
+                runs = deepcopy(self.runs)
+                runs[0].update(override)
+                self.assertFalse(self.ready(runs))
+        self.runs[0]['pull_requests'] = [{'number': 607}]
+        self.assertTrue(self.ready(self.runs))
+
+    def test_non_ci_automation_does_not_block_release(self):
+        self.assertTrue(self.ready(self.runs + [ci_run('.github/workflows/release-to-main.yml', status='in_progress')]))
+
+
+class ServerMergeTest(unittest.TestCase):
+    def setUp(self):
+        self.pr = release_pr()
+        self.pr_reads = []
+        self.merges = []
+        self.merge_response = {'merged': True, 'sha': 'merged-sha'}
+        self.api_mock = patch.object(server, 'api', side_effect=self.api).start()
+        self.sleep = patch.object(server.time, 'sleep').start()
+        self.clock = patch.object(server.time, 'monotonic', side_effect=range(100)).start()
+        self.addCleanup(patch.stopall)
+
+    def api(self, path, *args):
+        if path == 'commits/main-sha':
+            return {'commit': {'committer': {'date': '2026-09-10T00:00:00Z'}}}
+        if path == 'pulls/607':
+            return self.pr_reads.pop(0) if self.pr_reads else self.pr
+        if path == 'pulls/607/merge':
+            self.merges.append(args)
+            return self.merge_response
+        self.fail(f'Unexpected API call: {path}, {args}')
+
+    def test_wait_then_merge_uses_locked_head_and_preserves_dev_branch(self):
+        with patch.object(server, 'ci_ready', side_effect=[False, True]):
+            self.assertEqual(server.wait_for_merge(607, 'dev-sha', 'main-sha'), 'merged-sha')
+        self.sleep.assert_called_once_with(15)
+        self.assertEqual(self.merges, [('--method', 'PUT', '-f', 'sha=dev-sha', '-f', 'merge_method=merge')])
+
+    def test_failed_ci_never_merges(self):
+        with patch.object(server, 'ci_ready', side_effect=RuntimeError('Release CI failure')), \
+             self.assertRaisesRegex(RuntimeError, 'CI failure'):
+            server.wait_for_merge(607, 'dev-sha', 'main-sha')
+        self.assertEqual(self.merges, [])
+
+    def test_closed_draft_conflicting_or_changed_pr_never_merges(self):
+        variants = [
+            dict(self.pr, state='closed'), dict(self.pr, draft=True),
+            dict(self.pr, mergeable_state='dirty'),
+            dict(self.pr, head=dict(self.pr['head'], sha='new-dev')),
+            dict(self.pr, base=dict(self.pr['base'], sha='new-main')),
+            dict(self.pr, head=dict(self.pr['head'], repo={'full_name': 'someone/fork'})),
+        ]
+        for pr in variants:
+            with self.subTest(pr=pr), patch.object(server, 'ci_ready') as ready, self.assertRaises(RuntimeError):
+                self.pr = pr
+                server.wait_for_merge(607, 'dev-sha', 'main-sha')
+            ready.assert_not_called()
+        self.assertEqual(self.merges, [])
+
+    def test_source_change_during_ci_read_is_caught_before_merge(self):
+        self.pr_reads = [self.pr, dict(self.pr, head=dict(self.pr['head'], sha='new-dev'))]
+        with patch.object(server, 'ci_ready', return_value=True), self.assertRaisesRegex(RuntimeError, 'changed'):
+            server.wait_for_merge(607, 'dev-sha', 'main-sha')
+        self.assertEqual(self.merges, [])
+
+    def test_review_requirements_wait_and_timeout_without_bypass(self):
+        self.pr['mergeable_state'] = 'blocked'
+        with patch.object(server, 'ci_ready', return_value=True), self.assertRaises(TimeoutError):
+            server.wait_for_merge(607, 'dev-sha', 'main-sha', timeout=3)
+        self.assertEqual(self.merges, [])
+
+    def test_missing_ci_times_out_without_merge(self):
+        with patch.object(server, 'ci_ready', return_value=False), self.assertRaises(TimeoutError):
+            server.wait_for_merge(607, 'dev-sha', 'main-sha', timeout=3)
+        self.assertEqual(self.merges, [])
+
+    def test_external_merge_still_waits_for_ci(self):
+        self.pr.update(merged=True, state='closed')
+        with patch.object(server, 'ci_ready', side_effect=[False, True]):
+            self.assertEqual(server.wait_for_merge(607, 'dev-sha', 'main-sha'), 'merged-sha')
+        self.assertEqual(self.merges, [])
+        self.sleep.assert_called_once()
+
+    def test_merge_refusal_or_api_error_does_not_return_a_release_commit(self):
+        self.merge_response = {'merged': False, 'message': 'Head changed'}
+        with patch.object(server, 'ci_ready', return_value=True), self.assertRaisesRegex(RuntimeError, 'Head changed'):
+            server.wait_for_merge(607, 'dev-sha', 'main-sha')
+        with patch.object(server, 'api', side_effect=subprocess.CalledProcessError(1, 'gh')), \
+             self.assertRaises(subprocess.CalledProcessError):
+            server.wait_for_merge(607, 'dev-sha', 'main-sha')
+
+
+class ServerTagTest(unittest.TestCase):
+    def test_tag_uses_merge_result_instead_of_moving_main(self):
+        calls = []
+        def read(*args):
+            calls.append(args)
+            if args == ('git', 'tag', '--list'):
+                return 'v1.2.3\nmobile-v99.0.0'
+            if args == ('git', 'tag', '--points-at', 'merged-sha'):
+                return ''
+            if args[:2] == ('gh', 'api'):
+                return '{}'
+            self.fail(f'Unexpected command: {args}')
+        with TemporaryDirectory() as folder:
+            output = Path(folder) / 'output'
+            with patch.dict(os.environ, BUMP='minor', GITHUB_OUTPUT=str(output)), \
+                 patch.object(server.subprocess, 'run'), \
+                 patch.object(server, 'ensure_promoted', return_value='merged-sha'), \
+                 patch.object(server, 'read', side_effect=read):
+                server.main()
+            self.assertEqual(output.read_text(), 'tag=v1.3.0\n')
+        self.assertIn('sha=merged-sha', calls[-1])
+        self.assertIn('ref=refs/tags/v1.3.0', calls[-1])
+
+    def test_duplicate_tag_does_not_reserve_another_version(self):
+        with patch.dict(os.environ, BUMP='patch'), patch.object(server.subprocess, 'run'), \
+             patch.object(server, 'ensure_promoted', return_value='merged-sha'), \
+             patch.object(server, 'read', side_effect=['v1.2.3', 'v1.2.3']) as read, \
+             self.assertRaisesRegex(ValueError, 'already has'):
+            server.main()
+        self.assertEqual(read.call_count, 2)
+
+    def test_promotion_failure_never_creates_a_tag(self):
+        with patch.object(server.subprocess, 'run'), \
+             patch.object(server, 'ensure_promoted', side_effect=RuntimeError('CI failed')), \
+             patch.object(server, 'read') as read, self.assertRaises(RuntimeError):
+            server.main()
+        read.assert_not_called()
+
+
+def workflow_shell(filename, step_name):
+    lines = (Path(__file__).resolve().parents[2] / '.github/workflows' / filename).read_text().splitlines()
+    start = lines.index(f'      - name: {step_name}')
+    start = lines.index('        run: |', start) + 1
+    end = start
+    while end < len(lines) and (not lines[end].strip() or lines[end].startswith('          ')):
+        end += 1
+    return textwrap.dedent('\n'.join(lines[start:end]))
+
+
+class ServerDeploymentTest(unittest.TestCase):
+    def test_dispatch_deploys_published_tag_even_when_main_moves(self):
+        shell = workflow_shell('release-to-main.yml', '触发生产部署(deploy-main)')
+        with TemporaryDirectory() as folder:
+            stub = Path(folder) / 'gh'
+            stub.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$CALL_LOG"\n')
+            stub.chmod(0o755)
+            log = Path(folder) / 'log'
+            env = dict(os.environ, PATH=folder + os.pathsep + os.environ['PATH'],
+                       CALL_LOG=str(log), RELEASE_TAG='v1.2.4', GITHUB_REF='refs/heads/dev')
+            subprocess.run(['bash', '-e', '-c', shell], env=env, check=True, capture_output=True)
+            self.assertEqual(log.read_text().splitlines(), ['workflow', 'run', 'deploy-main.yml', '--ref', 'v1.2.4'])
+
+    def test_deploy_rejects_branches_mobile_tags_and_non_main_commits(self):
+        shell = workflow_shell('deploy-main.yml', 'Require a server release tag on main')
+        with TemporaryDirectory() as folder:
+            stub = Path(folder) / 'git'
+            stub.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$CALL_LOG"\nexit "$GIT_RESULT"\n')
+            stub.chmod(0o755)
+            log = Path(folder) / 'log'
+            for ref, git_result, succeeds in [
+                    ('refs/tags/v1.2.3', '0', True), ('refs/heads/main', '0', False),
+                    ('refs/tags/mobile-v1.2.3', '0', False), ('refs/tags/v1.2.3-beta', '0', False),
+                    ('refs/tags/v1.2.3', '1', False)]:
+                with self.subTest(ref=ref, git_result=git_result):
+                    env = dict(os.environ, PATH=folder + os.pathsep + os.environ['PATH'], CALL_LOG=str(log),
+                               GITHUB_REF=ref, GITHUB_SHA='published-sha', GIT_RESULT=git_result)
+                    result = subprocess.run(['bash', '-e', '-c', shell], env=env, capture_output=True)
+                    self.assertEqual(result.returncode == 0, succeeds)
+            self.assertEqual(log.read_text().splitlines(), ['merge-base', '--is-ancestor', 'published-sha', 'origin/main'])


### PR DESCRIPTION
Release / main currently succeeds after opening a production PR and requires another manual run after merge. This change waits for PR CI, merges the captured dev commit, then tags, publishes and dispatches deployment in the same run.

- Require all four core PR CI workflows and wait for other reported CI workflows, including dependent backend jobs. Fail on failed CI, conflicts, draft/closed PRs, changed source/base commits or timeout; preserve GitHub merge requirements.
- Verify the merge parents and deploy the published server tag so binaries, images and deployment configuration use the same commit. Serialize production deployments and require a server tag in main history for deployment/recovery.
- Update release documentation and include deploy-workflow changes in the release regression trigger. No application, API contract or database changes.

Validation:
- Reproduced the old stop-after-PR behavior with a failing regression before implementing the fix.
- `GITHUB_REF=refs/heads/dev GITHUB_SHA=ci-commit python3 -m unittest discover -s scripts/mobile-release -p 'test_*.py'`: 56 tests passed.
- `actionlint .github/workflows/release-to-main.yml .github/workflows/deploy-main.yml .github/workflows/ci-mobile.yml`: passed.
- `node scripts/run-gates.mjs` and `git diff --check`: passed.
- Pre-push hooks: `go vet ./...`, incremental golangci-lint and `pnpm typecheck` passed.
- Read-only verification against the real CI records for PR #607 passed. No production merge, release or deployment was executed during validation.

Operational requirements: RELEASE_TOKEN needs Contents/Pull requests write and Actions read access. Repository protection settings are unchanged; the release script explicitly enforces its CI gate. Configured production environment policies must permit server tags.
