### PR TITLE
fix: retain Oryn reviews across CI and discussion updates

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: 1ac66592ee6878f960d693cd82892f221472595e
+        ref: b6366a121e1eaa89f3d5ce95872ef25c7df00aa2
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: b87c472ef3bccf1d9683efc19c43de78046a4be9
+        ref: 1ac66592ee6878f960d693cd82892f221472595e
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/docs/decisions/0017-oryn-task-interruption.md
+++ b/docs/decisions/0017-oryn-task-interruption.md
@@ -1,0 +1,49 @@
+# Keep Oryn work across normal collaboration updates
+
+## Status
+
+Accepted
+Class: process
+
+## Context and Problem Statement
+
+PR #609 completed model review but CI completion and a review bot's status update invalidated its
+context digest before publication. This discarded useful review without any source change. Maintainers
+require interruption only for explicit stop commands, changes to the original command or its authority,
+and changes to the reviewed title/body or code.
+
+## Decision Drivers
+
+- Allow ordinary comments, CI progress, review updates and label/project administration during work.
+- Preserve source and command authority checks.
+- Keep live merge readiness separate from source review validity.
+
+## Considered Options
+
+1. Upgrade Oryn to separate task interruption from live operation gates.
+2. Rerun the model after every context-digest change.
+3. Trust captured CI and approval state for merges.
+
+## Decision Outcome
+
+Choose option 1. This supersedes decision 0016's context-digest and active-label locking. Active polling
+and publication check title/body, exact source SHAs, the original command, current author permission and
+authorized stop commands. Context is a review snapshot, not a publication lock. New comments, CI/review
+updates and label/project changes do not discard results. Protected labels continue to filter new work.
+
+Repository eligibility and branch permissions remain publication prerequisites. Merge separately checks
+current CI, mergeability and independent approval, and publishes a waiting report when they are unmet.
+Closure retains source evidence and linked-PR checks. There is no change to model/provider settings,
+credentials, capability opt-ins or the Actions-only ephemeral runtime.
+
+## Pros and Cons of the Options
+
+- Option 1 preserves completed source work while checking the actual write's current requirements.
+- Option 2 is simpler but makes normal parallel CI and review activity waste model runs.
+- Option 3 avoids waiting but permits merging after failed CI or withdrawn approval.
+
+## Links
+
+- [Operations guide](../operations/oryn.md)
+- [Previous freshness decision](0016-oryn-semantic-freshness.md)
+- [Observed failure](https://github.com/YourTongji/YourTJ-Hub/actions/runs/34431404905)

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/1ac66592ee6878f960d693cd82892f221472595e)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/b6366a121e1eaa89f3d5ce95872ef25c7df00aa2)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/b87c472ef3bccf1d9683efc19c43de78046a4be9)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/1ac66592ee6878f960d693cd82892f221472595e)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.
@@ -120,12 +120,15 @@ Manual publication defaults off; the deployment enables all four automatic execu
 `@oryn-mini fix`, `implement issue`, `rebase`, `cluster #N #M`, `autoclose` and `automerge` are also available to authorized maintainers.
 Slash aliases such as `/review`, `/autofix`, `/rebase`, `/autoclose` and `/automerge` are supported.
 Bot-authored comments skip planning and do not occupy the sweep queue; human commands retain runtime parsing and authority checks.
-Publication compares source fields and the captured discussion/review/check context separately.
-Assignee, project and bot-receipt timestamp updates do not interrupt an otherwise unchanged task;
-changed requirements, code, discussion, labels and command authority still block stale publication.
-A decision-needed repair shows the concrete question and whether host validation ran, and publishes
-no patch. Source/context publication failures identify the changed category in the status receipt.
-See [the freshness decision](../decisions/0016-oryn-semantic-freshness.md).
+Admitted work is interrupted by explicit authorized stop commands, edits to its original command,
+revoked author permission, changes to Issue/PR title or body, and new head/base commits. Ordinary
+comments, CI/review status, labels, assignees and project updates do not discard completed work.
+Protected labels filter new admissions; use `@oryn-mini stop` to interrupt a running task.
+Publication still requires live source/command checks, repository access and an open/unlocked target.
+Merge separately verifies current checks, mergeability and independent approval; unmet conditions
+publish a waiting report rather than fail the review. Reports identify discussion and CI as the
+snapshot used for that run. A decision-needed repair shows its question and actual validation status.
+See [the task interruption decision](../decisions/0017-oryn-task-interruption.md).
 
 The operator controls token grants and policy; text in issues/PRs cannot enable repair or merge.
 Disable the event/schedule execution variables to stop new automatic work; use the item's stop command


### PR DESCRIPTION
PR #609 completed review but failed publication when CI finished and a review bot updated its status. Upgrade Oryn so only source/title/body changes, original-command changes, revoked authority and authorized stop commands interrupt admitted work. Ordinary discussion, CI/review updates and labels no longer invalidate the result.

Merge still independently checks current CI, mergeability and approval and publishes a waiting report when blocked. Protected labels filter admission; repository and branch-write prerequisites remain. Update the operations guide and decision 0017.

Validation: source regressions reproduced the context/label failures and author-permission fallback before the fixes. Oryn has 75 passing local tests with one Linux-only skip; CI owns Linux sandbox/core smoke checks. Target governance and actionlint pass. Normal pre-push Go vet, incremental lint and frontend typecheck pass.

Runtime: yzxoi/oryn-mini#10. This change does not change model credentials or deploy application code.