### PR TITLE
fix: review large PRs with paged Oryn evidence

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: b6366a121e1eaa89f3d5ce95872ef25c7df00aa2
+        ref: 34d7d1ac7b74b62b8d924fc9d70202b19e68a398
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: 34d7d1ac7b74b62b8d924fc9d70202b19e68a398
+        ref: ac0b788d1d8db8e304c13e9c7167f45778cf0cef
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ docs/               产品、架构、开发和运维文档
 - [本地开发](./docs/development/local-development.md)
 - [测试策略](./docs/development/testing.md)
 - [部署与发布](./docs/operations/deployment.md)
-- [Oryn 仓库维护机器人](./docs/operations/oryn.md)（Partial：待 App 配置与接入验证）
+- [Oryn 仓库维护机器人](./docs/operations/oryn.md)（Current：已接入 GitHub App 与仓库 Actions）
 
 ## 参与贡献
 

--- a/docs/decisions/0018-oryn-paged-diff-evidence.md
+++ b/docs/decisions/0018-oryn-paged-diff-evidence.md
@@ -1,0 +1,50 @@
+# Read large Oryn PR diffs on demand
+
+## Status
+
+Accepted
+Class: process
+
+## Context and Problem Statement
+
+PR #611 failed before inference when its roughly 183 KB diff exceeded Oryn's 150 KB inline-evidence
+limit. Increasing the configured model context window cannot remove a host-side rejection. Maintainers
+need large PRs to enter review with explicit coverage rather than fail solely because of diff size.
+
+## Decision Drivers
+
+- Preserve complete change inventory and access to relevant source evidence.
+- Keep model context bounded per read without silently truncating review coverage.
+- Retain the Actions-only runtime and current execution/publication permissions.
+
+## Considered Options
+
+1. Upgrade Oryn to paged inventories and on-demand per-file diff reads.
+2. Increase the hardcoded inline diff limit.
+3. Truncate large diffs before inference.
+
+## Decision Outcome
+
+Choose option 1. The setup action pins Oryn's tested paged-evidence implementation. The host provides
+statistics and a complete file inventory, then Core reads bounded diff pages through its existing read
+tool. Renames, deletions, binary notices and long lines remain explicit. Independent repair review uses
+the same mechanism for the cumulative patch. Evidence lives outside the candidate checkout in temporary
+task storage; Core allows reading it but denies external writes, and task cleanup removes it.
+
+The 150 KB PR input rejection is removed. Time and model-step budgets still apply; incomplete review
+coverage must be disclosed as needs_human. The separate repair-publication patch limit, validation,
+source/command freshness and live close/merge gates remain. No provider, key, App grant or workflow
+trigger change is required.
+
+## Pros and Cons of the Options
+
+- Option 1 spends context on relevant evidence and reuses Core's public read capability, at the cost of
+  more file reads on large reviews.
+- Option 2 is smaller but shifts the failure threshold and continues to inline unrelated evidence.
+- Option 3 avoids the exception while concealing missing review evidence.
+
+## Links
+
+- [Operations guide](../operations/oryn.md)
+- [Oryn implementation](https://github.com/yzxoi/oryn-mini/pull/11)
+- [Observed failure](https://github.com/YourTongji/YourTJ-Hub/actions/runs/34435400271)

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/b6366a121e1eaa89f3d5ce95872ef25c7df00aa2)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/34d7d1ac7b74b62b8d924fc9d70202b19e68a398)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.
@@ -27,6 +27,14 @@ as evidence. The model is `glm-5.3-flash` through the official Zhipu Coding Plan
 `reasoning_effort=max`, thinking enabled, image input, and a configured 1,000,000-token context window.
 The context setting is not a one-million-token capacity benchmark. The default task budget is 1800
 seconds, manually overridable within 10–3000 seconds.
+
+PR review receives change statistics and a complete paged file inventory. Core reads per-file diffs on
+demand from task-owned temporary storage outside the candidate checkout, with at most 24,000 bytes and
+120 lines per page. This removes the former 150 KB PR input rejection without opening a shell or adding
+persistent state. Renames, deletion, binary notices and long-line continuations remain explicit.
+Independent repair review uses the cumulative staged change inventory. Incomplete coverage is reported
+as needs_human; deadlines and the separate repair-output limit still apply. See
+[the diff evidence decision](../decisions/0018-oryn-paged-diff-evidence.md).
 
 All Oryn policy capabilities are enabled: reviews, triage, source-backed Mermaid diagrams, emoji labels,
 questions, stop/resume, repair, adoption, rebase, clusters, automatic small-bug implementation, close and

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/34d7d1ac7b74b62b8d924fc9d70202b19e68a398)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/ac0b788d1d8db8e304c13e9c7167f45778cf0cef)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.


### PR DESCRIPTION
Oryn rejected PR #611 before inference because its diff exceeded the 150 KB inline-input cap. Pin the runtime to the paged-evidence implementation: reviews receive change statistics and a complete file inventory, then read per-file diffs on demand through Core. Independent repair review uses the same mechanism for the cumulative patch. Temporary evidence is outside both the candidate checkout and validation home, with model writes denied.

A sampled #611 revision (da810e5) produces 68 files, 79 diff pages and 6 inventory pages from a 185,572-byte diff; its diff introduction is 1,355 bytes. Deadlines, coverage disclosure, source/authority guards and repair-publication output limits remain in force.

Validation: source regression suite and real Core read/write-boundary smoke passed locally; the full source Linux CI passed. Target actionlint, six Oryn validation tests, five governance gates and normal pre-push Go vet/lint/frontend typecheck passed. This PR also updates the operations decision and the stale README integration status. Deployment is merged; live review verification is running through the repository workflow.