### PR TITLE
fix: restore mobile 1.0.2 TestFlight release recovery

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -13,6 +13,14 @@ on:
         description: "仅失败恢复时填写已有 mobile-vX.Y.Z 标签；留空正常发布"
         required: false
         type: string
+      recover_ios:
+        description: "仅恢复已有 iOS 构建的分发（必须填写 tag；不重打包、不发布 Android）"
+        type: boolean
+        default: false
+      testflight_only:
+        description: "仅提交 TestFlight，保留 App Store 当前审核队列"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -41,11 +49,13 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           BUMP: ${{ inputs.bump }}
           RESUME_TAG: ${{ inputs.tag }}
+          RECOVER_IOS: ${{ inputs.recover_ios }}
+          TESTFLIGHT_ONLY: ${{ inputs.testflight_only }}
         run: python3 scripts/mobile-release/prepare_mobile.py
 
   android:
     needs: prepare
-    if: needs.prepare.outputs.tag != ''
+    if: needs.prepare.outputs.tag != '' && !inputs.recover_ios
     runs-on: ubuntu-latest
     environment: mobile-release
     permissions:
@@ -129,23 +139,39 @@ jobs:
       IOS_TEAM_ID: "4HJTS3G3T2"
       ASC_TELEMETRY_DISABLED: "1"
       ASC_TIMEOUT: 90s
+      IOS_PUBLISH_TARGET: ${{ inputs.testflight_only && 'testflight' || 'both' }}
+      IOS_EXISTING_BUILD_ONLY: ${{ inputs.recover_ios }}
+      IOS_STORE_PATH: ${{ github.workspace }}/apps/mobile/store
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.prepare.outputs.sha }}
+      # Recover old immutable builds using reviewed publisher fixes from this main run.
+      # Store metadata remains from the original release source above.
+      - name: Checkout release tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: .release-tools
+          sparse-checkout: |
+            scripts/mobile-release
+            .github/workflows
       - uses: subosito/flutter-action@v2
+        if: ${{ !inputs.recover_ios }}
         with:
           flutter-version: "3.44.9"
           channel: stable
           cache: true
       - name: Bootstrap
+        if: ${{ !inputs.recover_ios }}
         working-directory: apps/mobile
         run: dart pub get
       - name: Install verified ASC CLI
         run: |
-          python3 scripts/mobile-release/install_asc.py "$RUNNER_TEMP/asc"
+          python3 .release-tools/scripts/mobile-release/install_asc.py "$RUNNER_TEMP/asc"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
       - name: Install private iOS signing inputs
+        if: ${{ !inputs.recover_ios }}
         env:
           IOS_DISTRIBUTION_P12_BASE64: ${{ secrets.IOS_DISTRIBUTION_P12_BASE64 }}
           IOS_PROFILE_BASE64: ${{ secrets.IOS_PROFILE_BASE64 }}
@@ -163,11 +189,29 @@ jobs:
           with open(os.environ['GITHUB_ENV'], 'a') as output:
               output.write(f'IOS_P12_PATH={root / "distribution.p12"}\nIOS_PROFILE_PATH={root / "profile.mobileprovision"}\nASC_PRIVATE_KEY_PATH={root / "AuthKey.p8"}\n')
           PY
+      - name: Install only ASC authentication for recovery
+        if: inputs.recover_ios
+        env:
+          ASC_PRIVATE_KEY_BASE64: ${{ secrets.ASC_PRIVATE_KEY_BASE64 }}
+        run: |
+          python3 - <<'PY'
+          import os, base64
+          from pathlib import Path
+          os.umask(0o077)
+          root = Path(os.environ['RUNNER_TEMP']) / 'yourtj-ios-secrets'
+          root.mkdir()
+          key = root / 'AuthKey.p8'
+          key.write_bytes(base64.b64decode(os.environ['ASC_PRIVATE_KEY_BASE64'], validate=True))
+          with open(os.environ['GITHUB_ENV'], 'a') as output:
+              output.write(f'ASC_PRIVATE_KEY_PATH={key}\n')
+          PY
+      - name: Validate release tools
+        run: python3 -m unittest discover -s .release-tools/scripts/mobile-release -p 'test_*.py'
       - name: Build App Store IPA
+        if: ${{ !inputs.recover_ios }}
         env:
           IOS_P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
         run: |
-          python3 -m unittest discover -s scripts/mobile-release -p 'test_*.py'
           python3 scripts/mobile-release/build_ios.py
       - name: Authenticate App Store Connect
         env:
@@ -178,9 +222,9 @@ jobs:
         env:
           IOS_REVIEW_JSON: ${{ secrets.IOS_REVIEW_JSON }}
           IOS_IPA_PATH: apps/mobile/build/release/ios/forum_app.ipa
-        run: python3 scripts/mobile-release/publish_ios.py
+        run: python3 .release-tools/scripts/mobile-release/publish_ios.py
       - name: Preserve signed IPA and symbols for recovery
-        if: always()
+        if: always() && !inputs.recover_ios
         uses: actions/upload-artifact@v4
         with:
           name: ios-${{ needs.prepare.outputs.version }}-${{ needs.prepare.outputs.number }}

--- a/docs/decisions/0014-mobile-release-distribution.md
+++ b/docs/decisions/0014-mobile-release-distribution.md
@@ -37,6 +37,10 @@ same-name files. Only GitHub's HTTPS API supplies update metadata; public mirror
 bytes. The client checks the digest before Android verifies package/version/signing identity and
 opens the system installer. iOS uses a checksum-pinned ASC CLI to upload once and submit the same
 build to TestFlight and App Store review. Server `vX.Y.Z` releases retain their independent flow.
+An explicit iOS-only recovery uses corrected publisher tools from the reviewed main dispatch,
+tagged store metadata and Apple's existing exact version/build, without rebuilding or uploading.
+TestFlight-only submission is opt-in and leaves pending App Store reviews unchanged; the default
+combined submission reports an outstanding App Store version as a blocker.
 
 Release preparation may run from dev with the repository-level `RELEASE_TOKEN`. This deliberately
 trusts maintainers who can merge workflow or release-script changes into dev with that credential's

--- a/docs/operations/mobile-releases.md
+++ b/docs/operations/mobile-releases.md
@@ -39,6 +39,8 @@ system installer remain independent gates; a completed upload does not mean dist
 gh workflow run release-mobile.yml --ref main -f bump=patch
 # Resume the exact failed version; bump is ignored when tag is supplied:
 gh workflow run release-mobile.yml --ref main -f bump=patch -f tag=mobile-v1.0.1
+# Resume only an already uploaded iOS build; keep the existing App Store review queue:
+gh workflow run release-mobile.yml --ref main -f tag=mobile-v1.0.2 -f recover_ios=true -f testflight_only=true
 ```
 
 Recovery still checks that the tag's source is reachable from main, but does not require newer dev
@@ -48,9 +50,11 @@ never move or rewrite a release tag. An uncertain API response after reserving a
 resolved by inspecting that tag and using recovery, rather than selecting another bump.
 
 Update public store metadata/screenshots under `apps/mobile/store/` through normal product PRs.
-A pending Apple version can block creation of the next App Store version. TestFlight can succeed
-while that App Store step requires recovery; the job reports failure rather than claiming both
-channels completed. Apple agreements, review decisions and the system installer are not bypassed.
+A pending Apple version can block creation of the next App Store version. The default combined
+submission reports the blocking version/state and fails, even if TestFlight succeeded. Select
+`testflight_only=true` to explicitly omit App Store submission; the job summary identifies that
+omission and preserves the existing review queue. It never withdraws another version automatically.
+Apple agreements, review decisions and the system installer are not bypassed.
 
 Server tags remain `vX.Y.Z`. **Release / main** opens/reuses the `dev` → `main` PR when the trees
 differ and stops. After that PR passes checks and merges, rerun to tag the approved main commit,
@@ -187,10 +191,13 @@ alone does not implement Sign in with Apple or enable Firebase push configuratio
   first confirm no uploader is active. Never delete a processing upload or existing build. Invalid
   processing fails immediately.
 - **Publisher repair after a tag exists:** the tag and retained signed artifacts remain immutable.
-  A workflow rerun checks out the original tagged source, so it does not pick up a later publisher
-  fix. Use the corrected publisher locally against the original run's verified signed artifacts
-  and the original version/build/tag, or publish a new reviewed source with a new version/build.
-  Never move the old tag merely to change the publisher script.
+  With `recover_ios=true` and an existing tag, the workflow skips Android and all iOS build/signing
+  steps. It uses publisher tools from the dispatch's reviewed main commit, store metadata from the
+  original tagged source, and the exact recorded version/build already uploaded to Apple. A missing
+  build fails before any upload; only ASC credentials are installed. Leave `testflight_only=false`
+  to resume both submission channels, or set it to true to preserve a pending App Store version.
+  A normal rebuild still uses tagged source and can produce different signed ZIP bytes. Use retained
+  artifacts for Android recovery; never move a tag or overwrite an existing APK to repair tooling.
 - **Apple validation/rejection:** correct the reported store fields or app behavior. A binary change
   needs a new version/build release; metadata-only corrections can resume against the existing build.
   Already waiting/in-review/approved submissions using the same build are preserved.

--- a/scripts/mobile-release/prepare_mobile.py
+++ b/scripts/mobile-release/prepare_mobile.py
@@ -63,6 +63,10 @@ def tag_identity(tag):
 def main():
     bump = os.environ.get('BUMP', 'patch')
     resume = os.environ.get('RESUME_TAG', '').strip()
+    recover_ios = os.environ.get('RECOVER_IOS') == 'true'
+    testflight_only = os.environ.get('TESTFLIGHT_ONLY') == 'true'
+    if recover_ios and not resume:
+        raise ValueError('iOS recovery requires an existing release tag')
     if bump not in {'patch', 'minor', 'major'} or (resume and not TAG.fullmatch(resume)):
         raise ValueError('Invalid release input')
     if os.environ['GITHUB_REF'] not in {'refs/heads/main', 'refs/heads/dev'}:
@@ -77,6 +81,8 @@ def main():
         # this preparation run exits before the serialized main run acquires the group.
         args = ['gh', 'workflow', 'run', 'release-mobile.yml', '--ref', 'main', '-f', f'bump={bump}']
         if resume: args.extend(['-f', f'tag={resume}'])
+        if recover_ios: args.extend(['-f', 'recover_ios=true'])
+        if testflight_only: args.extend(['-f', 'testflight_only=true'])
         read(*args)
         print('Mobile release dispatched on main; follow its Release / mobile run.')
         return

--- a/scripts/mobile-release/publish_ios.py
+++ b/scripts/mobile-release/publish_ios.py
@@ -79,8 +79,13 @@ def main():
     os.environ.setdefault("ASC_TIMEOUT", "90s")
     version = os.environ["MOBILE_VERSION"]
     number = os.environ["MOBILE_BUILD_NUMBER"]
-    ipa = os.environ["IOS_IPA_PATH"]
+    target = os.environ.get("IOS_PUBLISH_TARGET", "both")
+    if target not in {"both", "testflight"}:
+        raise ValueError("Invalid iOS publish target; choose both or testflight")
     if find_build(version, number) is None:
+        if os.environ.get("IOS_EXISTING_BUILD_ONLY") == "true":
+            raise ValueError("iOS recovery requires an existing uploaded build with the exact version/build number")
+        ipa = os.environ["IOS_IPA_PATH"]
         uploads = asc("builds", "uploads", "list", "--app", APP_ID,
                       "--cf-bundle-short-version", version, "--cf-bundle-version", number, "--paginate")["data"]
         matching = [u for u in uploads if u["attributes"].get("cfBundleShortVersionString") == version
@@ -105,10 +110,24 @@ def main():
             "--test-notes", "Test course search and reviews, scheduler, Wiki, community and account features.",
             "--locale", "en-US", "--submit", "--confirm")
     print(f"TestFlight build: {build_id}", flush=True)
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as output:
+            output.write(f"TestFlight: {version} ({number}), build `{build_id}`.\n\n")
+    if target == "testflight":
+        message = "App Store submission skipped by request; the existing review queue is unchanged."
+        print(message)
+        if summary:
+            with open(summary, "a") as output:
+                output.write(message + "\n")
+        return
 
-    versions = asc("versions", "list", "--app", APP_ID, "--version", version, "--include", "build")["data"]
-    if versions:
-        current = versions[0]
+    versions = asc("versions", "list", "--app", APP_ID, "--platform", "IOS", "--include", "build", "--paginate")["data"]
+    matching = [v for v in versions if v["attributes"]["versionString"] == version]
+    if len(matching) > 1:
+        raise ValueError("Ambiguous App Store version identity")
+    if matching:
+        current = matching[0]
         state = current["attributes"].get("appStoreState")
         attached = current.get("relationships", {}).get("build", {}).get("data") or {}
         if state in ACCEPTED_STATES:
@@ -118,6 +137,16 @@ def main():
             return
         version_id = current["id"]
     else:
+        released = {"READY_FOR_SALE", "READY_FOR_DISTRIBUTION", "REPLACED_WITH_NEW_VERSION",
+                    "REMOVED_FROM_SALE", "DEVELOPER_REMOVED_FROM_SALE"}
+        for other in versions:
+            attributes = other["attributes"]
+            state = attributes.get("appStoreState")
+            if state not in released:
+                raise ValueError(
+                    f"App Store {attributes['versionString']} is {state}; it blocks creation of {version}. "
+                    "Preserve its review queue using testflight-only recovery, or resolve the existing version in ASC."
+                )
         created = resource(asc("versions", "create", "--app", APP_ID, "--version", version,
                                "--platform", "IOS", "--release-type", "AFTER_APPROVAL",
                                "--copyright", "2026 YourTJ Open Source"))
@@ -127,7 +156,8 @@ def main():
                      asc("localizations", "list", "--version", version_id, "--paginate")["data"]}
     fields = {"description": "description", "keywords": "keywords", "marketingUrl": "marketing-url",
               "supportUrl": "support-url", "whatsNew": "whats-new"}
-    for folder in sorted((ROOT / "apps/mobile/store").iterdir()):
+    store = Path(os.environ.get("IOS_STORE_PATH", str(ROOT / "apps/mobile/store")))
+    for folder in sorted(store.iterdir()):
         if not folder.is_dir() or not (folder / "metadata.json").exists():
             continue
         locale = folder.name

--- a/scripts/mobile-release/test_prepare_mobile.py
+++ b/scripts/mobile-release/test_prepare_mobile.py
@@ -33,6 +33,26 @@ class MobileVersionTest(unittest.TestCase):
                 parse_annotation('mobile-v1.2.3', json.dumps(data))
 
 class MobilePreparationTest(unittest.TestCase):
+    def test_ios_recovery_requires_tag_before_any_release_work(self):
+        import os
+        from unittest.mock import patch
+        import prepare_mobile as mobile
+        with patch.dict(os.environ, RECOVER_IOS='true', RESUME_TAG='', GITHUB_REF='refs/heads/main'), patch.object(mobile.subprocess, 'run') as run:
+            with self.assertRaisesRegex(ValueError, 'recovery.*tag'):
+                mobile.main()
+            run.assert_not_called()
+
+    def test_dev_forwards_recovery_and_testflight_target_to_main(self):
+        import os
+        from unittest.mock import patch
+        import prepare_mobile as mobile
+        with patch.dict(os.environ, RECOVER_IOS='true', TESTFLIGHT_ONLY='true', BUMP='patch', RESUME_TAG='mobile-v1.0.2', GITHUB_REF='refs/heads/dev'), patch.object(mobile.subprocess, 'run'), patch.object(mobile, 'tag_identity'), patch.object(mobile, 'read') as read:
+            mobile.main()
+        args = read.call_args.args
+        self.assertIn('recover_ios=true', args)
+        self.assertIn('testflight_only=true', args)
+        self.assertIn('tag=mobile-v1.0.2', args)
+
     def test_resume_keeps_tag_build_and_skips_new_release_pr(self):
         import os
         from pathlib import Path

--- a/scripts/mobile-release/test_publish_ios.py
+++ b/scripts/mobile-release/test_publish_ios.py
@@ -7,8 +7,10 @@ import publish_ios as publisher
 
 class IosResumeTest(unittest.TestCase):
     def setUp(self):
-        self.env = patch.dict(os.environ, MOBILE_VERSION='1.0.1', MOBILE_BUILD_NUMBER='2', IOS_IPA_PATH='/unused.ipa')
+        self.env = patch.dict(os.environ, MOBILE_VERSION='1.0.1', MOBILE_BUILD_NUMBER='2', IOS_IPA_PATH='/unused.ipa', IOS_PUBLISH_TARGET='both', IOS_EXISTING_BUILD_ONLY='false')
         self.env.start()
+        os.environ.pop('IOS_STORE_PATH', None)
+        os.environ.pop('GITHUB_STEP_SUMMARY', None)
         self.addCleanup(self.env.stop)
 
     def test_already_submitted_build_does_not_upload_or_resubmit(self):
@@ -20,12 +22,54 @@ class IosResumeTest(unittest.TestCase):
             if args[:3] == ('builds', 'beta-app-review-submission', 'view'):
                 return {'data': {'attributes': {'betaReviewState': 'WAITING_FOR_REVIEW'}}}
             if args[:2] == ('versions', 'list'):
-                return {'data': [{'id': 'version', 'attributes': {'appStoreState': 'WAITING_FOR_REVIEW'}, 'relationships': {'build': {'data': {'id': 'build'}}}}]}
+                return {'data': [{'id': 'version', 'attributes': {'versionString': '1.0.1', 'appStoreState': 'WAITING_FOR_REVIEW'}, 'relationships': {'build': {'data': {'id': 'build'}}}}]}
             if args[:2] == ('builds', 'update'): return {}
             self.fail(f'Unexpected mutation: {args[:2]}')
         with patch.object(publisher, 'asc', side_effect=asc):
             publisher.main()
         self.assertFalse(any('upload' in call or 'submit' in call for call in calls))
+
+    def test_testflight_recovery_preserves_app_store_review_queue(self):
+        calls = []
+        def asc(*args, **kwargs):
+            calls.append(args)
+            if args[:2] == ('builds', 'list'):
+                return {'data': [{'id': 'build', 'attributes': {'processingState': 'VALID'}}]}
+            if args[:3] == ('builds', 'beta-app-review-submission', 'view'):
+                return {'data': {'attributes': {'betaReviewState': 'APPROVED'}}}
+            if args[:2] == ('builds', 'update'): return {}
+            self.fail(f'Unexpected App Store or upload mutation: {args[:2]}')
+        with patch.dict(os.environ, IOS_PUBLISH_TARGET='testflight', IOS_EXISTING_BUILD_ONLY='true'), patch.object(publisher, 'asc', side_effect=asc):
+            publisher.main()
+        self.assertFalse(any(call[0] == 'versions' for call in calls))
+
+    def test_recovery_missing_build_does_not_upload(self):
+        with patch.dict(os.environ, IOS_EXISTING_BUILD_ONLY='true'), patch.object(publisher, 'find_build', return_value=None), patch.object(publisher, 'wait_for_build', side_effect=AssertionError('Unexpected upload polling')), patch.object(publisher, 'asc') as asc:
+            with self.assertRaisesRegex(ValueError, 'existing.*build'):
+                publisher.main()
+            asc.assert_not_called()
+
+    def test_pending_other_app_store_version_reports_actionable_blocker(self):
+        calls = []
+        def asc(*args, **kwargs):
+            calls.append(args)
+            if args[:2] == ('builds', 'list'):
+                return {'data': [{'id': 'build', 'attributes': {'processingState': 'VALID'}}]}
+            if args[:3] == ('builds', 'beta-app-review-submission', 'view'):
+                return {'data': {'attributes': {'betaReviewState': 'APPROVED'}}}
+            if args[:2] == ('versions', 'list'):
+                self.assertIn('--paginate', args)
+                return {'data': [{'id': 'old-version', 'attributes': {'versionString': '1.0.0', 'appStoreState': 'WAITING_FOR_REVIEW'}}]}
+            if args[:2] == ('builds', 'update'): return {}
+            self.fail(f'Unexpected mutation while old version is pending: {args[:2]}')
+        with patch.object(publisher, 'asc', side_effect=asc), self.assertRaisesRegex(ValueError, '1.0.0.*WAITING_FOR_REVIEW'):
+            publisher.main()
+
+    def test_invalid_publish_target_fails_before_network_calls(self):
+        with patch.dict(os.environ, IOS_PUBLISH_TARGET='unknown'), patch.object(publisher, 'wait_for_build', side_effect=AssertionError('Unexpected upload polling')), patch.object(publisher, 'asc') as asc:
+            with self.assertRaisesRegex(ValueError, 'publish target'):
+                publisher.main()
+            asc.assert_not_called()
 
     def test_incomplete_upload_reservation_requires_recovery_not_duplicate_upload(self):
         def asc(*args, **kwargs):


### PR DESCRIPTION
Backport the release-tooling fix from #623 to main so the already uploaded mobile-v1.0.2 / iOS build 3 can finish TestFlight distribution while App Store 1.0.0 remains waiting for review.

Adds explicit iOS-only recovery and TestFlight-only submission, refuses recovery uploads for absent builds, reports pending App Store versions clearly, and uses main publisher tools with the original tagged metadata. APKs, tags and existing Apple review submissions remain unchanged. This backport contains only release scripts, workflow and their documentation.

Validation: 37 main-branch release tests passed under recovery environment flags; actionlint, whitespace and all five governance gates passed. Normal pre-push hooks passed. Maintainer explicitly authorized admin bypass merge and release recovery; App Store review cancellation is not authorized and is not performed.
