### PR TITLE
fix: upgrade Oryn diagnostics and model request budgets

### DIFF
--- a/.github/actions/setup-oryn/action.yml
+++ b/.github/actions/setup-oryn/action.yml
@@ -21,7 +21,7 @@ runs:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       with:
         repository: yzxoi/oryn-mini
-        ref: ac0b788d1d8db8e304c13e9c7167f45778cf0cef
+        ref: 775ff40758ffb18ae67e9fdbbf0a335fb447aeaf
         token: ${{ steps.source.outputs.token }}
         path: .oryn-runtime
         persist-credentials: false

--- a/docs/decisions/0020-oryn-failure-diagnostics.md
+++ b/docs/decisions/0020-oryn-failure-diagnostics.md
@@ -1,0 +1,43 @@
+# Preserve Oryn failure evidence and budget long model requests
+
+## Status
+
+Accepted
+Class: process
+
+## Context and Problem Statement
+
+Long max-reasoning reviews can hit a fixed request wall limit before exhausting the task budget.
+Generic execution failure receipts hide the Core/Provider error needed to distinguish model errors,
+cancellation and report-format failures.
+
+## Decision Drivers
+
+- Let healthy reasoning streams use the bounded task budget.
+- Preserve useful failure evidence without retaining model histories or credentials.
+- Keep task cancellation, source freshness and publication checks effective.
+
+## Considered Options
+
+1. Upgrade the pinned Oryn runtime to task-bounded calls and redacted failure artifacts.
+2. Keep the short fixed request timeout and generic failure receipt.
+3. Retain complete model session logs for troubleshooting.
+
+## Decision Outcome
+
+Choose option 1. Requests default to the remaining task budget, retaining first-byte and idle bounds.
+An explicit repository variable may impose a shorter request wall limit. Operators remove the legacy
+300-second override to adopt the default. The worker preserves selected Core/Provider errors and
+budget/progress metadata before cleanup; CLI and workflow failure settlement retain that diagnostic.
+Format failures include the attempt and output size. Raw model content and provider bodies are excluded.
+
+## Pros and Cons of the Options
+
+- Option 1 supports long reasoning and useful diagnostics while preserving total cost/time bounds.
+- Option 2 is simpler but repeatedly interrupts useful work and conceals the reason.
+- Option 3 captures more evidence but needlessly retains sensitive and reusable session content.
+
+## Links
+
+- [Operations guide](../operations/oryn.md)
+- [Oryn implementation and fault fixtures](https://github.com/yzxoi/oryn-mini/pull/12)

--- a/docs/operations/oryn.md
+++ b/docs/operations/oryn.md
@@ -16,7 +16,7 @@ Repair publication additionally requires sandboxed application validation and an
 
 [Oryn workflow](../../.github/workflows/oryn.yml) runs on this repository's Actions runners. The trusted
 [setup action](../../.github/actions/setup-oryn/action.yml) loads
-[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/ac0b788d1d8db8e304c13e9c7167f45778cf0cef)
+[Oryn Mini at an immutable commit](https://github.com/yzxoi/oryn-mini/tree/775ff40758ffb18ae67e9fdbbf0a335fb447aeaf)
 and applies [this repository's policy](../../.github/oryn/repositories.json). Oryn's public Synergy core
 creates a fresh temporary home per invocation; no server, database or reusable model history is deployed.
 GitHub comments contain bounded queue receipts; Actions artifacts expire after seven days.
@@ -103,7 +103,7 @@ In YourTJ-Hub → Settings → Secrets and variables → Actions, add:
 
 Optional overrides: `ORYN_MODEL` (default `oryn/glm-5.3-flash`), `ORYN_BASE_URL`
 (default `https://open.bigmodel.cn/api/coding/paas/v4`), `ORYN_TASK_TIMEOUT_SECONDS` (default 1800),
-`ORYN_REQUEST_TIMEOUT_SECONDS` (core adapter default 300). The workflow fixes reasoning at `max`.
+`ORYN_REQUEST_TIMEOUT_SECONDS` (optional 1–3000 seconds; defaults to the remaining task budget). The workflow fixes reasoning at `max`.
 The bot login is derived from the App token action's slug output; no manual login variable is needed.
 
 Leave automation variables unset during preflight. From Actions → Oryn → Run workflow, retain
@@ -146,6 +146,18 @@ The deployed App passed [live preflight](https://github.com/YourTongji/YourTJ-Hu
 A [real GLM review and publication](https://github.com/YourTongji/YourTJ-Hub/actions/runs/34368176030)
 completed with 20 tool calls and explicit max reasoning, producing a Chinese source review, Mermaid
 and four advisory labels on issue #594. This review did not execute repair validation.
+
+## Failure diagnostics and request budgets
+
+A model request may use the remaining task budget. First-byte and idle limits remain at most 120 and
+60 seconds; the total task deadline and authorized cancellation still apply. Remove an existing
+`ORYN_REQUEST_TIMEOUT_SECONDS=300` override to use this default, or set a shorter explicit wall limit.
+
+Failed executions retain a bounded, redacted `diagnostic` in `failure.json` and an `oryn_failure` log
+event. These include the failure stage, elapsed time, budgets, Core status, available provider errors
+and progress counts. Report format failures include the correction attempt and output size. No raw
+prompts, reasoning, provider bodies or headers are retained. A bare abort without further Core evidence
+remains an unknown cause. See [the diagnostics decision](../decisions/0020-oryn-failure-diagnostics.md).
 
 ## Maintenance and verification
 


### PR DESCRIPTION
Upgrade Oryn to preserve redacted Core/Provider failures through Actions artifacts and let long model calls use the remaining task budget. First-byte/idle limits, task cancellation and publication gates remain enforced. The operations guide documents removing the old 300-second override and reading the new diagnostic.

Runtime implementation: https://github.com/yzxoi/oryn-mini/pull/12

Validation: actionlint on both Oryn workflows, six validation-selection tests, all five repository governance gates, normal pre-commit and pre-push hooks (Go vet, incremental lint, frontend typecheck). Upstream real Core fault fixtures cover provider errors, JSON correction exhaustion, keepalive timeouts, total budget and explicit cancellation.