### PR TITLE
fix(forum): seed-demo/mock-topics 灌入的话题设为已发布 (issue #645)

### DIFF
--- a/apps/gooseforum/app/console/cmd/mockTopics.go
+++ b/apps/gooseforum/app/console/cmd/mockTopics.go
@@ -36,9 +36,10 @@ func runMockTopics(cmd *cobra.Command, args []string) {
 		req := component.BetterRequest[api.WriteTopicReq]{
 			UserId: user.Id,
 			Params: api.WriteTopicReq{
-				Title:      fmt.Sprintf("测试文章 %03d - %s", i, time.Now().Format("15:04:05")),
-				Content:    fmt.Sprintf("这是第 %d 篇自动生成的测试文章内容。\n\n生成时间: %s\n作者: %s", i, time.Now().Format(time.RFC3339), user.Username),
-				CategoryId: []uint64{1}, // Default to first category
+				Title:       fmt.Sprintf("测试文章 %03d - %s", i, time.Now().Format("15:04:05")),
+				Content:     fmt.Sprintf("这是第 %d 篇自动生成的测试文章内容。\n\n生成时间: %s\n作者: %s", i, time.Now().Format(time.RFC3339), user.Username),
+				CategoryId:  []uint64{1}, // Default to first category
+				TopicStatus: 1,           // 已发布：mock 数据应进入公开列表（issue #645）
 			},
 		}
 

--- a/apps/gooseforum/app/console/cmd/seedDemo.go
+++ b/apps/gooseforum/app/console/cmd/seedDemo.go
@@ -76,29 +76,13 @@ func runSeedDemo(cmd *cobra.Command, args []string) {
 		})
 
 	// 3. Topics
-	topicTitles := []string{
-		"【水帖】今天也在为期末周头秃，大家有什么摸鱼妙招？",
-		"Vue 3 组合式 API 的组件设计心得分享",
-	}
-	contents := []string{
-		"## 开个楼\n\n期末周要来了，图书馆座位比春运还难抢 (｡•́︿•̀｡)。\n\n大家来说说自己的 **摸鱼** 或者 *高效复习* 的小妙招吧：\n\n- 番茄钟 25+5\n- 把手机锁进柜子\n- 组队学习互相监督\n\n> 附：学校图书馆 10 楼靠窗的位置风景很好，适合背书。\n\n```text\n早睡早起，拒绝熬夜复习\n```\n",
-		"最近在用 **组合式 API** 重构老项目，分享几个体会：\n\n1. 按**关注点**组织代码，而不是按选项块\n2. `computed` 依赖追踪比 watch 好用的多\n3. 抽 composable 时注意命名：`useXxx`\n\n代码示例：\n\n```ts\nconst { loading, data, refresh } = useTopicList()\n```\n\n欢迎交流～",
-	}
-
-	for i, title := range topicTitles {
-		resp := api.WriteTopic(component.BetterRequest[api.WriteTopicReq]{
-			UserId: userIds[i%len(userIds)],
-			Params: api.WriteTopicReq{
-				Title:      title,
-				Content:    contents[i],
-				CategoryId: []uint64{1},
-			},
-		})
+	for _, req := range buildSeedTopicRequests(userIds) {
+		resp := api.WriteTopic(req)
 		if resp.Data.Code != component.SUCCESS {
-			fmt.Printf("Failed to create topic %q: %s\n", title, resp.Data.MessageCode)
+			fmt.Printf("Failed to create topic %q: %s\n", req.Params.Title, resp.Data.MessageCode)
 			return
 		}
-		fmt.Printf("Created topic: %s\n", title)
+		fmt.Printf("Created topic: %s\n", req.Params.Title)
 	}
 
 	// 4. Nested replies on topic 1: OP gets 5 direct children (to test expand),
@@ -158,4 +142,32 @@ func runSeedDemo(cmd *cobra.Command, args []string) {
 	fmt.Println("Created topic2 reply")
 
 	fmt.Println("Seed demo data completed.")
+}
+
+// buildSeedTopicRequests 构造本地预览的种子话题写请求。TopicStatus 必须为 1
+// （已发布）：首页列表以 FilterStatus=true 过滤 status!=1 的话题，零值 0 会让
+// seed 数据灌入后不可见（issue #645）。
+func buildSeedTopicRequests(userIds []uint64) []component.BetterRequest[api.WriteTopicReq] {
+	topicTitles := []string{
+		"【水帖】今天也在为期末周头秃，大家有什么摸鱼妙招？",
+		"Vue 3 组合式 API 的组件设计心得分享",
+	}
+	contents := []string{
+		"## 开个楼\n\n期末周要来了，图书馆座位比春运还难抢 (｡•́︿•̀｡)。\n\n大家来说说自己的 **摸鱼** 或者 *高效复习* 的小妙招吧：\n\n- 番茄钟 25+5\n- 把手机锁进柜子\n- 组队学习互相监督\n\n> 附：学校图书馆 10 楼靠窗的位置风景很好，适合背书。\n\n```text\n早睡早起，拒绝熬夜复习\n```\n",
+		"最近在用 **组合式 API** 重构老项目，分享几个体会：\n\n1. 按**关注点**组织代码，而不是按选项块\n2. `computed` 依赖追踪比 watch 好用的多\n3. 抽 composable 时注意命名：`useXxx`\n\n代码示例：\n\n```ts\nconst { loading, data, refresh } = useTopicList()\n```\n\n欢迎交流～",
+	}
+
+	reqs := make([]component.BetterRequest[api.WriteTopicReq], 0, len(topicTitles))
+	for i, title := range topicTitles {
+		reqs = append(reqs, component.BetterRequest[api.WriteTopicReq]{
+			UserId: userIds[i%len(userIds)],
+			Params: api.WriteTopicReq{
+				Title:       title,
+				Content:     contents[i],
+				CategoryId:  []uint64{1},
+				TopicStatus: 1,
+			},
+		})
+	}
+	return reqs
 }

--- a/apps/gooseforum/app/console/cmd/seedDemo_test.go
+++ b/apps/gooseforum/app/console/cmd/seedDemo_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "testing"
+
+// TestBuildSeedTopicRequestsPublishTopics 回归 issue #645：seed 话题必须以
+// TopicStatus=1（已发布）写入，否则首页 FilterStatus=true 会过滤掉 status=0
+// 的种子话题，本地预览看不到任何内容。
+func TestBuildSeedTopicRequestsPublishTopics(t *testing.T) {
+	userIds := []uint64{10, 20, 30}
+
+	reqs := buildSeedTopicRequests(userIds)
+	if len(reqs) != 2 {
+		t.Fatalf("buildSeedTopicRequests() returned %d requests, want 2", len(reqs))
+	}
+
+	for i, req := range reqs {
+		if req.Params.TopicStatus != 1 {
+			t.Errorf("topic %d TopicStatus = %d, want 1 (published)", i, req.Params.TopicStatus)
+		}
+		if req.UserId == 0 {
+			t.Errorf("topic %d UserId = 0, want a demo user id", i)
+		}
+		if len(req.Params.CategoryId) != 1 || req.Params.CategoryId[0] != 1 {
+			t.Errorf("topic %d CategoryId = %v, want [1]", i, req.Params.CategoryId)
+		}
+	}
+}


### PR DESCRIPTION
## 问题

本地执行 `go run . seed-demo`（或 `mock-topics`）后，首页 `/` 看不到任何话题，但数据库里已有对应数据。

根因：`seedDemo.go` 和 `mockTopics.go` 创建话题时未设置 `TopicStatus`，零值 `0` 进入 `WriteTopic` → `topic.Status = 0`（未发布）。首页列表 `topics.Page` 使用 `FilterStatus: true`，过滤掉 `status != 1` 的话题。

Closes #645

## 改动

- `seedDemo.go`：把种子话题构造抽成 `buildSeedTopicRequests`，显式设置 `TopicStatus: 1`。
- `mockTopics.go`：同样设置 `TopicStatus: 1`（同根因）。
- 新增 `seedDemo_test.go`：回归断言 seed 话题请求均为已发布状态。

## 验证

- `go vet ./app/console/...` 通过
- `go test ./app/console/...` 全部通过
- `go build ./...` 通过