### PR TITLE
fix(forum): keep security allowlists non-nil so /login renders with empty domain allowlist (issue #643)

### DIFF
--- a/apps/gooseforum/app/http/controllers/forum/payload_test.go
+++ b/apps/gooseforum/app/http/controllers/forum/payload_test.go
@@ -2,7 +2,11 @@ package forum
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 func TestIsSafeRedirect(t *testing.T) {
@@ -162,5 +166,35 @@ func TestTopicPermissionsCanPost(t *testing.T) {
 				t.Errorf("canPost = %v, want %v", canPost, tt.wantCanPost)
 			}
 		})
+	}
+}
+
+// TestLoginPagePayloadAllowedDomainsNeverNull 断言 /login 页面 payload 的
+// props.allowedDomains 恒为非 null JSON 数组（issue #643）：默认空白名单
+// 曾被序列化为 null，登录页前端 setup 解引用直接 TypeError 白屏，且违反
+// OpenAPI SecurityAndRegistration 的 required string[] 契约。
+func TestLoginPagePayloadAllowedDomainsNeverNull(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/login", Login)
+
+	req := httptest.NewRequest(http.MethodGet, "/login", nil)
+	req.Header.Set("X-Goose-Page", "true")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Props struct {
+			AllowedDomains []string `json:"allowedDomains"`
+		} `json:"props"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode page payload: %v", err)
+	}
+	if payload.Props.AllowedDomains == nil {
+		t.Fatalf("props.allowedDomains = null, want non-null array (issue #643); body=%s", recorder.Body.String())
 	}
 }

--- a/apps/gooseforum/app/models/defaultconfig/defaultconfig.go
+++ b/apps/gooseforum/app/models/defaultconfig/defaultconfig.go
@@ -119,10 +119,13 @@ func GetDefaultHttpNotifyConfig() pageConfig.HttpNotifyConfig {
 
 func GetDefaultSecuritySettingsConfig() pageConfig.SecurityAndRegistration {
 	config := mustPageConfigDefaults().Security
-	config.AllowedDomains = append([]string(nil), config.AllowedDomains...)
-	config.ReservedUsernames = append([]string(nil), config.ReservedUsernames...)
-	config.BannedUsernames = append([]string(nil), config.BannedUsernames...)
-	config.SensitiveWords = append([]string(nil), config.SensitiveWords...)
+	// 列表字段拷贝并保证非 nil（issue #643）：append([]string(nil),...) 在
+	// 默认空列表时退化为 nil，JSON 序列化产出 null，违反 SecurityAndRegistration
+	// 的 required string[] 契约并使登录页前端 setup 解引用白屏。
+	config.AllowedDomains = append([]string{}, config.AllowedDomains...)
+	config.ReservedUsernames = append([]string{}, config.ReservedUsernames...)
+	config.BannedUsernames = append([]string{}, config.BannedUsernames...)
+	config.SensitiveWords = append([]string{}, config.SensitiveWords...)
 	return config
 }
 

--- a/apps/gooseforum/app/models/defaultconfig/defaultconfig_test.go
+++ b/apps/gooseforum/app/models/defaultconfig/defaultconfig_test.go
@@ -68,6 +68,20 @@ func TestPageConfigDefaultGettersReturnCopies(t *testing.T) {
 	}
 }
 
+func TestDefaultSecuritySettingsConfigListsAreNeverNil(t *testing.T) {
+	config := GetDefaultSecuritySettingsConfig()
+	for name, list := range map[string][]string{
+		"allowedDomains":    config.AllowedDomains,
+		"reservedUsernames": config.ReservedUsernames,
+		"bannedUsernames":   config.BannedUsernames,
+		"sensitiveWords":    config.SensitiveWords,
+	} {
+		if list == nil {
+			t.Errorf("default %s = nil, want non-nil empty slice (issue #643)", name)
+		}
+	}
+}
+
 func TestNormalizeStoredScheduleSettings(t *testing.T) {
 	rows := func(pairs ...[3]string) []pageConfig.ScheduleSectionTime {
 		times := make([]pageConfig.ScheduleSectionTime, 0, len(pairs))

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfigRep.go
@@ -54,6 +54,7 @@ func GetConfigByPageType[T any](pageType string, defaultValue T) T {
 
 // GetSecuritySettingsConfig 读取安全配置并兼容旧配置缺少每日注册上限字段。
 func GetSecuritySettingsConfig(defaultValue SecurityAndRegistration) SecurityAndRegistration {
+	normalizeSecurityLists(&defaultValue)
 	entity := GetByPageType(SecuritySettings)
 	if entity.Id == 0 {
 		return defaultValue
@@ -71,7 +72,28 @@ func GetSecuritySettingsConfig(defaultValue SecurityAndRegistration) SecurityAnd
 		config.MaxDailySignups = defaultValue.MaxDailySignups
 	}
 	config.MaxDailySignups = max(config.MaxDailySignups, -1)
+	// 列表字段保证非 nil（issue #643）：存量行缺键/显式 null 解码为 nil，
+	// JSON 序列化会产出 null，违反 required string[] 契约并使登录页白屏。
+	normalizeSecurityLists(&config)
 	return config
+}
+
+// normalizeSecurityLists 就地保证安全配置四个列表字段非 nil（issue #643）。
+// 默认值与存量行两条读取路径统一收口，保证 JSON 序列化不产出 null，
+// /login payload 与管理端回显始终满足 OpenAPI required string[] 契约。
+func normalizeSecurityLists(config *SecurityAndRegistration) {
+	if config.AllowedDomains == nil {
+		config.AllowedDomains = []string{}
+	}
+	if config.ReservedUsernames == nil {
+		config.ReservedUsernames = []string{}
+	}
+	if config.BannedUsernames == nil {
+		config.BannedUsernames = []string{}
+	}
+	if config.SensitiveWords == nil {
+		config.SensitiveWords = []string{}
+	}
 }
 
 // GetPostingSettingsConfig 读取发布内容设置（issue #369，上游 c47cff94）。

--- a/apps/gooseforum/app/models/forum/pageConfig/pageConfig_test.go
+++ b/apps/gooseforum/app/models/forum/pageConfig/pageConfig_test.go
@@ -199,3 +199,75 @@ func TestSecretStorageShapesOmitCiphertextFromDomainJSON(t *testing.T) {
 		}
 	})
 }
+
+// TestGetSecuritySettingsConfigListFieldsAreNeverNil 验证读取路径保证四个列表
+// 字段非 nil（issue #643）：存量配置行缺键/显式 null、无行回退默认值，都不应
+// 让 JSON 序列化产出 null，否则 /login payload 违反 OpenAPI required string[]
+// 契约并使登录页前端 setup 解引用崩溃。
+func TestGetSecuritySettingsConfigListFieldsAreNeverNil(t *testing.T) {
+	conn := dbconnect.Connect()
+	if err := conn.AutoMigrate(&Entity{}); err != nil {
+		t.Fatalf("migrate page config: %v", err)
+	}
+	conn.Where("page_type = ?", SecuritySettings).Delete(&Entity{})
+	entity := Entity{PageType: SecuritySettings, Config: `{}`}
+	if err := conn.Create(&entity).Error; err != nil {
+		t.Fatalf("create security config: %v", err)
+	}
+	t.Cleanup(func() { conn.Where("page_type = ?", SecuritySettings).Delete(&Entity{}) })
+
+	defaults := SecurityAndRegistration{EnableSignup: true, MaxDailySignups: -1}
+	assertNoNilLists := func(t *testing.T, config SecurityAndRegistration) {
+		t.Helper()
+		lists := map[string][]string{
+			"allowedDomains":    config.AllowedDomains,
+			"reservedUsernames": config.ReservedUsernames,
+			"bannedUsernames":   config.BannedUsernames,
+			"sensitiveWords":    config.SensitiveWords,
+		}
+		for name, list := range lists {
+			if list == nil {
+				t.Errorf("%s = nil, want non-nil empty slice", name)
+			}
+		}
+		b, err := json.Marshal(config)
+		if err != nil {
+			t.Fatalf("marshal config: %v", err)
+		}
+		if strings.Contains(string(b), "null") {
+			t.Errorf("config JSON contains null list field: %s", b)
+		}
+	}
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "list keys missing", raw: `{"enableSignup":true}`},
+		{name: "explicit null list", raw: `{"enableSignup":true,"allowedDomains":null,"reservedUsernames":null,"bannedUsernames":null,"sensitiveWords":null}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := conn.Model(&entity).Update("config", tt.raw).Error; err != nil {
+				t.Fatalf("update security config: %v", err)
+			}
+			assertNoNilLists(t, GetSecuritySettingsConfig(defaults))
+		})
+	}
+
+	t.Run("populated list preserved", func(t *testing.T) {
+		if err := conn.Model(&entity).Update("config", `{"allowedDomains":["tongji.edu.cn"]}`).Error; err != nil {
+			t.Fatalf("update security config: %v", err)
+		}
+		config := GetSecuritySettingsConfig(defaults)
+		if len(config.AllowedDomains) != 1 || config.AllowedDomains[0] != "tongji.edu.cn" {
+			t.Fatalf("allowedDomains = %#v, want [tongji.edu.cn]", config.AllowedDomains)
+		}
+		assertNoNilLists(t, config)
+	})
+
+	t.Run("no stored row falls back to non-nil default", func(t *testing.T) {
+		conn.Where("page_type = ?", SecuritySettings).Delete(&Entity{})
+		assertNoNilLists(t, GetSecuritySettingsConfig(defaults))
+	})
+}

--- a/apps/gooseforum/resource/src/site/pages/LoginPage.vue
+++ b/apps/gooseforum/resource/src/site/pages/LoginPage.vue
@@ -21,8 +21,11 @@ type Mode = 'login' | 'register' | 'forgot'
 const { t, locale } = useI18n()
 const { isDark } = useSiteTheme()
 const mode = ref<Mode>(page.props.initialMode || 'login')
-const selectedEmailDomain = ref(page.props.allowedDomains[0] || '')
-const emailDomainOptions = page.props.allowedDomains.map((domain) => ({ value: domain, label: `@${domain}` }))
+// issue #643：空白名单时后端（存量配置行缺键）会把 allowedDomains 序列化为
+// null，setup 直接解引用曾导致整页白屏；归一化为数组后再使用。
+const allowedDomains = computed(() => page.props.allowedDomains ?? [])
+const selectedEmailDomain = ref(allowedDomains.value[0] || '')
+const emailDomainOptions = allowedDomains.value.map((domain) => ({ value: domain, label: `@${domain}` }))
 const langMenuOpen = ref(false)
 let langCloseTimer: number | undefined
 const twoFactorPending = ref(false)
@@ -174,7 +177,7 @@ async function handleRegister() {
     error.value = t('auth.validation.registerRequired')
     return
   }
-  const email = page.props.allowedDomains.length ? `${registerForm.email}@${selectedEmailDomain.value}` : registerForm.email
+  const email = allowedDomains.value.length ? `${registerForm.email}@${selectedEmailDomain.value}` : registerForm.email
   if (registerForm.password !== registerForm.confirmPassword) {
     error.value = t('auth.validation.passwordMismatch')
     return
@@ -404,13 +407,13 @@ function onToggleTheme() {
             </label>
             <div>
               <label for="register-email" class="sr-only">{{ t('auth.email') }}</label>
-              <span v-if="page.props.allowedDomains.length > 0" class="gf-input flex overflow-hidden !p-0 focus-within:border-primary focus-within:ring-4 focus-within:ring-primary/20">
+              <span v-if="allowedDomains.length > 0" class="gf-input flex overflow-hidden !p-0 focus-within:border-primary focus-within:ring-4 focus-within:ring-primary/20">
                 <span class="relative min-w-0 flex-1">
                   <Mail class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-base-content/55" />
                   <input id="register-email" v-model.trim="registerForm.email" type="text" inputmode="email" class="h-full w-full bg-transparent pl-10 pr-2 text-base outline-none sm:text-sm" :placeholder="t('auth.emailPrefix')" />
                 </span>
-                <span v-if="page.props.allowedDomains.length === 1" class="flex shrink-0 items-center border-l border-line bg-base-200/70 px-3 text-sm font-medium text-base-content/70">
-                  @{{ page.props.allowedDomains[0] }}
+                <span v-if="allowedDomains.length === 1" class="flex shrink-0 items-center border-l border-line bg-base-200/70 px-3 text-sm font-medium text-base-content/70">
+                  @{{ allowedDomains[0] }}
                 </span>
                 <SiteSelect
                   v-else

--- a/apps/gooseforum/resource/test/login-allowed-domains.test.ts
+++ b/apps/gooseforum/resource/test/login-allowed-domains.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+// issue #643 回归：注册邮箱域名白名单为空（shipped default）时，后端存量
+// 配置行缺键会把 allowedDomains 序列化为 null；LoginPage setup 曾直接解引用
+// 导致整页白屏。修复后页面必须容错挂载，注册表单退化为自由邮箱输入。
+import { describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { i18n } from '../src/runtime/i18n'
+import type { LayoutPayload, LoginPageProps } from '@gooseforum/client'
+
+vi.mock('../src/runtime/api', () => ({
+  getCaptcha: vi.fn(async () => ({ captchaId: 'captcha-id', captchaImg: 'data:image/png;base64,x' })),
+  login: vi.fn(async () => ({})),
+  register: vi.fn(async () => ''),
+  forgotPassword: vi.fn(async () => ''),
+  verifyTotp: vi.fn(async () => undefined),
+}))
+vi.mock('../src/runtime/flash-message', () => ({
+  queueFlashMessage: vi.fn(),
+}))
+vi.mock('../src/runtime/site-theme', async () => {
+  const { ref } = await import('vue')
+  return {
+    useSiteTheme: () => ({ isDark: ref(false) }),
+    setThemePreference: vi.fn(),
+  }
+})
+
+import LoginPage from '../src/site/pages/LoginPage.vue'
+
+const layout: LayoutPayload = {
+  site: {
+    name: 'yourtj',
+    description: '',
+    logo: '',
+    favicon: '',
+    brandType: 'text',
+    brandText: 'yourtj',
+    brandImage: '',
+  },
+  viewer: {
+    id: 0,
+    username: '',
+    email: '',
+    avatarUrl: '',
+    isAuthenticated: false,
+    canAccessAdmin: false,
+    isModerator: false,
+    requiresEmailVerification: false,
+    adminPermissions: [],
+  },
+  sidebar: { categories: [], activeKey: '' },
+  footer: { links: [], primary: [] },
+  unread: { notifications: false, messages: false },
+  posting: { maxTitleLength: 100 },
+  theme: { enabled: false, current: 'gf-light', themeColor: '' },
+  insightFlareEnabled: false,
+}
+
+function buildProps(allowedDomains: unknown): LoginPageProps {
+  return {
+    initialMode: 'register',
+    redirectUrl: '/',
+    githubUrl: '/api/auth/github',
+    googleUrl: '/api/auth/google',
+    googleReady: true,
+    termsOfServiceEnabled: false,
+    privacyPolicyEnabled: false,
+    allowedDomains: allowedDomains as LoginPageProps['allowedDomains'],
+    oauthNotice: false,
+  }
+}
+
+describe('LoginPage allowedDomains null 容错（issue #643）', () => {
+  test('allowedDomains=null：注册页正常挂载，退化为自由邮箱输入', () => {
+    const wrapper = mount(LoginPage, {
+      props: { layout, props: buildProps(null) },
+      global: { plugins: [i18n] },
+    })
+    expect(wrapper.find('form').exists()).toBe(true)
+    // 自由邮箱分支：type=email 输入框；不再渲染域名后缀/域名下拉
+    expect(wrapper.find('input[type="email"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('@')
+    wrapper.unmount()
+  })
+
+  test('allowedDomains 为单域名数组：仍渲染域名后缀（不回归）', () => {
+    const wrapper = mount(LoginPage, {
+      props: { layout, props: buildProps(['tongji.edu.cn']) },
+      global: { plugins: [i18n] },
+    })
+    expect(wrapper.find('input[type="email"]').exists()).toBe(false)
+    expect(wrapper.text()).toContain('@tongji.edu.cn')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #643. With the registration email-domain allowlist empty (the shipped default), the backend serialized `allowedDomains` as JSON `null` in the `/login` page payload, and `LoginPage.vue` dereferenced it unguarded in `setup()`, throwing `TypeError: Cannot read properties of null (reading '0')` before any tab could mount — a blank login/register/forgot page on every stock deployment.

## Root cause

- `GetDefaultSecuritySettingsConfig` copied the four list fields with `append([]string(nil), ...)`, which degrades an empty default (`"allowedDomains": []` in `security.json`) to `nil`.
- `GetSecuritySettingsConfig` decoded stored rows as-is, so rows saved before the fields existed (or with explicit `null`) also decoded to `nil`.
- `buildLoginPageProps` passed the raw slice through; a `nil` slice marshals as `null`, violating the required `string[]` in the OpenAPI `SecurityAndRegistration` schema and the TS mirrors.

## Changes

**Backend** (normalization at the owner read path, covering all three sources):
- `pageConfig.GetSecuritySettingsConfig` now runs `normalizeSecurityLists` on both the default-value path and the stored-row path, guaranteeing non-nil `allowedDomains` / `reservedUsernames` / `bannedUsernames` / `sensitiveWords`.
- `defaultconfig.GetDefaultSecuritySettingsConfig` copies with `append([]string{}, ...)` so empty defaults stay `[]` instead of `nil`.

**Frontend** (defense in depth against any future null source):
- `LoginPage.vue` normalizes `page.props.allowedDomains ?? []` through a computed and routes all six references (setup, `handleRegister`, and the three template branches) through it.

## Tests

- `TestGetSecuritySettingsConfigListFieldsAreNeverNil` — Go read-path regression covering missing keys, explicit null, populated preservation, and no-row fallback.
- `TestDefaultSecuritySettingsConfigListsAreNeverNil` — default getter never returns nil lists.
- `TestLoginPagePayloadAllowedDomainsNeverNull` — `/login` payload assertion (reproduced the exact `"allowedDomains":null` body from the issue before the fix).
- `test/login-allowed-domains.test.ts` — Vue mount test with `allowedDomains: null` asserting the page renders and degrades to a free-form email input, plus a populated-array non-regression case.

All four new tests failed red before the fix and pass after.

## Verification

- `go vet ./...` + `go test ./...` (apps/gooseforum) — pass
- `golangci-lint run --new-from-rev=origin/dev` — 0 issues
- `pnpm typecheck` + `pnpm test` (827 tests) + `pnpm build` (resource) — pass
- `node scripts/run-gates.mjs` — all 5 governance gates OK

No contract, migration, or schema changes: the wire payload now matches the already-declared required `string[]` shape.