### PR TITLE
fix(feed): preserve pending interactions across refresh, view and account changes

### DIFF
--- a/apps/gooseforum/resource/src/site/components/TopicCardActions.vue
+++ b/apps/gooseforum/resource/src/site/components/TopicCardActions.vue
@@ -45,6 +45,7 @@ const commentUrl = computed(() => {
       :disabled="state.actingLike"
       :aria-pressed="state.liked === true"
       :title="t('topic.like')"
+      :aria-label="`${t('topic.like')} ${formatNumber(state.likeCount)}`"
       @click="interaction.toggle(false)"
     >
       <Heart class="h-4 w-4" :class="state.liked ? 'fill-current' : ''" />

--- a/apps/gooseforum/resource/src/site/components/TopicCardActions.vue
+++ b/apps/gooseforum/resource/src/site/components/TopicCardActions.vue
@@ -1,98 +1,28 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Bookmark, Eye, Heart, MessageSquare } from '@lucide/vue'
 import { formatNumber } from '@/runtime/format'
-import { bookmarkTopic, likeTopic } from '@/runtime/api'
 import type { TopicPayload } from '@gooseforum/client'
+import { createTopicCardInteraction, type TopicCardInteraction } from '@/site/utils/topic-card-interactions'
 
-// 卡片级快捷互动（issue #380）：初始态来自列表 payload 的观察者字段；
-// liked/bookmarked 缺席（访客或状态不可用）时点击引导登录，不假设 false。
-// 点赞乐观更新 ±1，失败回滚；语义与详情页 PostStream 一致（action 1/2 幂等切换）。
-const props = defineProps<{ topic: TopicPayload }>()
-
-const emit = defineEmits<{
-  interacted: [patch: { liked?: boolean; bookmarked?: boolean; likeCount?: number }]
-}>()
-
+const props = defineProps<{ topic: TopicPayload; interaction?: TopicCardInteraction }>()
 const { t } = useI18n()
-
-const liked = ref(props.topic.liked)
-const bookmarked = ref(props.topic.bookmarked)
-const likeCount = ref(props.topic.likeCount)
-const actingLike = ref(false)
-const actingBookmark = ref(false)
-
-// 就地刷新（排序切换/静默重载）按 topic.id 复用实例：非操作中跟随服务端 payload，
-// 避免卡片状态过期；操作进行中跳过，完成后由下一次刷新收敛（对齐移动端 override 语义）。
-watch(
-  () => props.topic,
-  (next) => {
-    if (actingLike.value || actingBookmark.value) return
-    liked.value = next.liked
-    bookmarked.value = next.bookmarked
-    likeCount.value = next.likeCount
-  },
-)
-
-// topic.url 当前不带 query；容错拼接，未来带 query 时不会产生 "??reply=1"。
-const commentUrl = computed(() =>
-  props.topic.url.includes('?')
-    ? `${props.topic.url}&reply=1`
-    : `${props.topic.url}?reply=1`,
-)
-
-function jumpToLogin() {
-  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
-  window.location.href = `/login?redirect=${encodeURIComponent(current)}`
-}
-
-async function toggleLike() {
-  if (actingLike.value) return
-  if (liked.value === undefined) {
-    jumpToLogin()
-    return
-  }
-  const previousLiked = liked.value
-  const previousCount = likeCount.value
-  const nextLiked = !previousLiked
-  actingLike.value = true
-  liked.value = nextLiked
-  likeCount.value = Math.max(0, previousCount + (nextLiked ? 1 : -1))
-  try {
-    await likeTopic(props.topic.id, nextLiked ? 1 : 2)
-    emit('interacted', { liked: nextLiked, likeCount: likeCount.value })
-  } catch {
-    liked.value = previousLiked
-    likeCount.value = previousCount
-  } finally {
-    actingLike.value = false
-  }
-}
-
-async function toggleBookmark() {
-  if (actingBookmark.value) return
-  if (bookmarked.value === undefined) {
-    jumpToLogin()
-    return
-  }
-  const previousBookmarked = bookmarked.value
-  const nextBookmarked = !previousBookmarked
-  actingBookmark.value = true
-  bookmarked.value = nextBookmarked
-  try {
-    await bookmarkTopic(props.topic.id, nextBookmarked ? 1 : 2)
-    emit('interacted', { bookmarked: nextBookmarked })
-  } catch {
-    bookmarked.value = previousBookmarked
-  } finally {
-    actingBookmark.value = false
-  }
-}
+// Standalone cards own their state; feed cards receive the list's longer-lived owner.
+const local = props.interaction ? undefined : createTopicCardInteraction(props.topic, t)
+const interaction = computed(() => props.interaction ?? local!)
+const state = computed(() => interaction.value.state)
+watch(() => [props.topic, props.topic.liked, props.topic.bookmarked, props.topic.likeCount], () => local?.sync(props.topic))
+onBeforeUnmount(() => local?.dispose())
+const commentUrl = computed(() => {
+  const url = new URL(props.topic.url, window.location.href)
+  url.searchParams.set('reply', '1')
+  return `${url.pathname}${url.search}${url.hash}`
+})
 </script>
 
 <template>
-  <div class="flex items-center gap-0.5 text-xs text-base-content/55">
+  <div class="flex flex-wrap items-center gap-0.5 text-xs text-base-content/55">
     <a
       :href="commentUrl"
       class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-base-200 hover:text-base-content"
@@ -111,25 +41,26 @@ async function toggleBookmark() {
     <button
       type="button"
       class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-base-200 hover:text-base-content disabled:cursor-default disabled:opacity-60"
-      :class="liked ? 'text-error' : ''"
-      :disabled="actingLike"
-      :aria-pressed="liked === true"
+      :class="state.liked ? 'text-error' : ''"
+      :disabled="state.actingLike"
+      :aria-pressed="state.liked === true"
       :title="t('topic.like')"
-      @click="toggleLike"
+      @click="interaction.toggle(false)"
     >
-      <Heart class="h-4 w-4" :class="liked ? 'fill-current' : ''" />
-      <span class="tabular-nums">{{ likeCount }}</span>
+      <Heart class="h-4 w-4" :class="state.liked ? 'fill-current' : ''" />
+      <span class="tabular-nums">{{ formatNumber(state.likeCount) }}</span>
     </button>
     <button
       type="button"
       class="inline-flex h-7 items-center gap-1.5 rounded-md px-2 transition-colors hover:bg-base-200 hover:text-base-content disabled:cursor-default disabled:opacity-60"
-      :class="bookmarked ? 'text-primary' : ''"
-      :disabled="actingBookmark"
-      :aria-pressed="bookmarked === true"
-      :title="bookmarked ? t('topic.bookmarked') : t('topic.bookmark')"
-      @click="toggleBookmark"
+      :class="state.bookmarked ? 'text-primary' : ''"
+      :disabled="state.actingBookmark"
+      :aria-pressed="state.bookmarked === true"
+      :title="state.bookmarked ? t('topic.bookmarked') : t('topic.bookmark')"
+      @click="interaction.toggle(true)"
     >
-      <Bookmark class="h-4 w-4" :class="bookmarked ? 'fill-current' : ''" />
+      <Bookmark class="h-4 w-4" :class="state.bookmarked ? 'fill-current' : ''" />
     </button>
+    <p v-if="state.error" role="alert" class="w-full px-2 pt-1 text-error">{{ state.error }}</p>
   </div>
 </template>

--- a/apps/gooseforum/resource/src/site/components/TopicList.vue
+++ b/apps/gooseforum/resource/src/site/components/TopicList.vue
@@ -1,18 +1,21 @@
 <script setup lang="ts">
-import { useSlots } from 'vue'
+import { onBeforeUnmount, shallowReactive, useSlots, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { TopicPayload } from '@gooseforum/client'
+import { createTopicCardInteraction, type TopicCardInteraction } from '@/site/utils/topic-card-interactions'
 import TopicCardActions from '@/site/components/TopicCardActions.vue'
 import TopicFeedPreview from '@/site/components/TopicFeedPreview.vue'
 import TopicRow from '@/site/components/TopicRow.vue'
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   topics: TopicPayload[]
+  viewerId?: number
   home?: boolean
   showCategories?: boolean
   showHot?: boolean
   showPinned?: boolean
   feedMode?: 'table' | 'card'
 }>(), {
+  viewerId: 0,
   home: false,
   showCategories: true,
   showHot: true,
@@ -23,13 +26,30 @@ withDefaults(defineProps<{
 const { t } = useI18n()
 const slots = useSlots()
 
-// 成功互动回写共享 topic 对象：card↔table 切换或重挂载时新实例读到的即最新状态。
-function applyInteraction(
-  topic: TopicPayload,
-  patch: { liked?: boolean; bookmarked?: boolean; likeCount?: number },
-) {
-  Object.assign(topic, patch)
+const interactions = shallowReactive(new Map<number, TopicCardInteraction>())
+function clearInteractions() {
+  for (const interaction of interactions.values()) interaction.dispose()
+  interactions.clear()
 }
+watch(() => props.viewerId, clearInteractions, { flush: 'sync' })
+watch(() => props.topics.map(topic => [topic, topic.liked, topic.bookmarked, topic.likeCount]), () => {
+  const ids = new Set(props.topics.map(topic => topic.id))
+  for (const [id, interaction] of interactions) {
+    if (!ids.has(id)) { interaction.dispose(); interactions.delete(id) }
+  }
+  for (const topic of props.topics) {
+    const interaction = interactions.get(topic.id)
+    if (interaction) interaction.sync(topic)
+    else interactions.set(topic.id, createTopicCardInteraction(topic, t))
+  }
+}, { immediate: true })
+// Recreate owners even when a viewer switch retains the same topic array.
+watch(() => props.viewerId, () => {
+  for (const topic of props.topics) {
+    if (!interactions.has(topic.id)) interactions.set(topic.id, createTopicCardInteraction(topic, t))
+  }
+})
+onBeforeUnmount(clearInteractions)
 </script>
 
 <template>
@@ -73,7 +93,7 @@ function applyInteraction(
         :key="topic.id"
         class="gf-card group relative overflow-hidden [&_a.gf-topic-chip]:pointer-events-auto [&_a.gf-topic-chip]:relative [&_a.gf-topic-chip]:z-10"
       >
-        <TopicFeedPreview :topic="topic" compact :show-stats="false" class="pointer-events-none" />
+        <TopicFeedPreview :topic="topic" :show-categories="showCategories" :show-hot="showHot" :show-pinned="showPinned" compact :show-stats="false" class="pointer-events-none" />
         <!-- stretched-link：整卡可点，互动按钮浮于遮罩之上，避免嵌套交互元素 -->
         <a
           :href="topic.url"
@@ -83,7 +103,7 @@ function applyInteraction(
         <TopicCardActions
           :topic="topic"
           class="relative px-3.5 pb-3"
-          @interacted="(patch) => applyInteraction(topic, patch)"
+          :interaction="interactions.get(topic.id)"
         />
       </div>
     </div>

--- a/apps/gooseforum/resource/src/site/pages/HomePage.vue
+++ b/apps/gooseforum/resource/src/site/pages/HomePage.vue
@@ -616,7 +616,7 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <TopicList :topics="topics" home :show-pinned="showPinnedLabels" :feed-mode="feedMode">
+        <TopicList :topics="topics" :viewer-id="page.layout.viewer.id" home :show-pinned="showPinnedLabels" :feed-mode="feedMode">
           <template #empty>
             <EmptyState v-if="!hasTopics" :icon="UsersRound" :title="t('topicList.emptyTitle')" :description="t('topicList.emptyDescription')" />
           </template>

--- a/apps/gooseforum/resource/src/site/utils/topic-card-interactions.ts
+++ b/apps/gooseforum/resource/src/site/utils/topic-card-interactions.ts
@@ -1,0 +1,72 @@
+import { reactive } from 'vue'
+import type { TopicPayload } from '@gooseforum/client'
+import { bookmarkTopic, likeTopic } from '@/runtime/api'
+
+// Owned by the list, so recycling a card never releases its pending action.
+// Each field follows fresh payloads independently; a viewer change invalidates
+// the owner before any response can write into the next viewer's list.
+export function createTopicCardInteraction(initial: TopicPayload, t: (key: string) => string) {
+  let source = initial
+  let active = true
+  let generation = 0
+  const state = reactive({
+    liked: initial.liked,
+    bookmarked: initial.bookmarked,
+    likeCount: initial.likeCount,
+    actingLike: false,
+    actingBookmark: false,
+    error: '',
+  })
+
+  function sync(next: TopicPayload) {
+    if (next.id !== source.id || (next.liked === undefined && source.liked !== undefined)) {
+      generation++
+      state.actingLike = false
+      state.actingBookmark = false
+      state.error = ''
+    }
+    source = next
+    if (!state.actingLike) {
+      state.liked = next.liked
+      state.likeCount = next.likeCount
+    }
+    if (!state.actingBookmark) state.bookmarked = next.bookmarked
+  }
+
+  async function toggle(bookmark: boolean) {
+    const busy = bookmark ? 'actingBookmark' : 'actingLike'
+    const field = bookmark ? 'bookmarked' : 'liked'
+    if (!active || state[busy]) return
+    if (state[field] === undefined) {
+      const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
+      window.location.href = `/login?redirect=${encodeURIComponent(current)}`
+      return
+    }
+    const requestGeneration = generation
+    const target = !state[field]
+    state[busy] = true
+    state[field] = target
+    state.error = ''
+    if (!bookmark) state.likeCount = Math.max(0, state.likeCount + (target ? 1 : -1))
+    try {
+      const success = await (bookmark ? bookmarkTopic : likeTopic)(source.id, target ? 1 : 2)
+      if (!active || requestGeneration !== generation) return
+      if (!success) throw new Error(t(bookmark ? 'api.bookmarkFailed' : 'api.likeFailed'))
+      source[field] = target
+      if (!bookmark) source.likeCount = state.likeCount
+    } catch (error) {
+      if (!active || requestGeneration !== generation) return
+      // source is the latest authoritative payload, including a refresh that
+      // completed while this action was pending. Never roll back the other field.
+      state[field] = source[field]
+      if (!bookmark) state.likeCount = source.likeCount
+      state.error = error instanceof Error ? error.message : t(bookmark ? 'api.bookmarkFailed' : 'api.likeFailed')
+    } finally {
+      if (active && requestGeneration === generation) state[busy] = false
+    }
+  }
+
+  return { state, sync, toggle, dispose: () => { active = false } }
+}
+
+export type TopicCardInteraction = ReturnType<typeof createTopicCardInteraction>

--- a/apps/gooseforum/resource/test/fixtures/browser/topic-card.html
+++ b/apps/gooseforum/resource/test/fixtures/browser/topic-card.html
@@ -1,0 +1,1 @@
+<!doctype html><html><head><meta name="viewport" content="width=device-width, initial-scale=1" /></head><body><div id="app"></div><script type="module" src="./topic-card.ts"></script></body></html>

--- a/apps/gooseforum/resource/test/fixtures/browser/topic-card.ts
+++ b/apps/gooseforum/resource/test/fixtures/browser/topic-card.ts
@@ -1,0 +1,15 @@
+import { createApp, h } from 'vue'
+import TopicList from '../../../src/site/components/TopicList.vue'
+import { i18n, setLocale } from '../../../src/runtime/i18n'
+import '../../../src/styles/resource.css'
+import type { TopicPayload } from '@gooseforum/client'
+await setLocale('zh')
+const topic: TopicPayload = {
+  id: 42, title: '卡片互动', description: '卡片阅读与快捷互动', url: '/p/42',
+  author: { id: 1, username: 'alice', avatarUrl: '' }, participants: [],
+  categories: [{ id: 9, name: '学习', url: '/c/9', color: '#10b981' }],
+  replyCount: 7, viewCount: 100, likeCount: 5, pinWeight: 0, processStatus: 0,
+  activityText: '刚刚', lastUpdateTime: '2026-09-11T00:00:00Z', contentType: 3,
+  liked: false, bookmarked: false,
+}
+createApp({ render: () => h(TopicList, { topics: [topic], viewerId: 1, feedMode: 'card' }) }).use(i18n).mount('#app')

--- a/apps/gooseforum/resource/test/topic-card-quick-interactions.test.ts
+++ b/apps/gooseforum/resource/test/topic-card-quick-interactions.test.ts
@@ -79,6 +79,63 @@ describe('TopicCardActions 卡片快捷互动（issue #380）', () => {
     vi.resetAllMocks()
   })
 
+  it('pending action survives card/table remount and prevents duplicates', async () => {
+    let complete!: (value: boolean) => void
+    vi.mocked(likeTopic).mockReturnValue(new Promise(resolve => { complete = resolve }))
+    const topic = baseTopic()
+    wrapper = mount(TopicList, {
+      props: { topics: [topic], feedMode: 'card', viewerId: 1 },
+      global: { plugins: [i18n], stubs: { TopicFeedPreview: true, TopicRow: true } },
+    })
+    await wrapper.find('button[title="点赞"]').trigger('click')
+    await wrapper.setProps({ feedMode: 'table' })
+    await wrapper.setProps({ feedMode: 'card' })
+    expect(wrapper.find('button[title="点赞"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('button[title="点赞"]').text()).toBe('6')
+    complete(true)
+    await flushPromises()
+    expect(topic.liked).toBe(true)
+    expect(wrapper.find('button[title="点赞"]').text()).toBe('6')
+  })
+
+  it('refresh updates unrelated fields and failed action uses the refreshed count', async () => {
+    let reject!: (reason: Error) => void
+    vi.mocked(likeTopic).mockReturnValue(new Promise((_, fail) => { reject = fail }))
+    const view = mountActions(baseTopic())
+    await view.find('button[title="点赞"]').trigger('click')
+    await view.setProps({ topic: baseTopic({ bookmarked: true, likeCount: 10 }) })
+    expect(view.findAll('button')[1].attributes('aria-pressed')).toBe('true')
+    reject(new Error('network failed'))
+    await flushPromises()
+    expect(view.find('button[title="点赞"]').text()).toBe('10')
+    expect(view.find('[role="alert"]').text()).toContain('network failed')
+  })
+
+  it('old viewer completion cannot mutate the new viewer topic', async () => {
+    let complete!: (value: boolean) => void
+    vi.mocked(likeTopic).mockReturnValue(new Promise(resolve => { complete = resolve }))
+    wrapper = mount(TopicList, {
+      props: { topics: [baseTopic()], feedMode: 'card', viewerId: 1 },
+      global: { plugins: [i18n], stubs: { TopicFeedPreview: true } },
+    })
+    await wrapper.find('button[title="点赞"]').trigger('click')
+    const next = baseTopic({ liked: false, likeCount: 20 })
+    await wrapper.setProps({ topics: [next], viewerId: 2 })
+    complete(true)
+    await flushPromises()
+    expect(wrapper.find('button[title="点赞"]').text()).toBe('20')
+    expect(next.liked).toBe(false)
+  })
+
+  it('false API result rolls back and exposes a failure', async () => {
+    vi.mocked(likeTopic).mockResolvedValue(false)
+    const view = mountActions(baseTopic())
+    await view.find('button[title="点赞"]').trigger('click')
+    await flushPromises()
+    expect(view.find('button[title="点赞"]').text()).toBe('5')
+    expect(view.find('[role="alert"]').exists()).toBe(true)
+  })
+
   it('渲染点赞计数、回复计数与评论入口', () => {
     const view = mountActions(baseTopic())
     const likeButton = view.find('button[title="点赞"]')

--- a/apps/gooseforum/resource/test/topic-card.browser.mjs
+++ b/apps/gooseforum/resource/test/topic-card.browser.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { after, before, test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+import { createServer } from 'vite'
+let server, browser, origin
+before(async () => {
+  server = await createServer({ root: fileURLToPath(new URL('../', import.meta.url)), server: { host: '127.0.0.1', port: 0, open: false } })
+  await server.listen()
+  origin = `http://127.0.0.1:${server.httpServer.address().port}`
+  browser = await chromium.launch()
+})
+after(async () => { await browser?.close(); await server?.close() })
+for (const fontSize of [16, 32]) {
+  test(`card links and actions remain reachable at 320px with ${fontSize}px root text`, async () => {
+    const page = await browser.newPage({ viewport: { width: 320, height: 900 } })
+    try {
+      await page.route('**/api/forum/topics/like', route => route.fulfill({ json: { code: 0, result: true } }))
+      await page.goto(`${origin}/assets/test/fixtures/browser/topic-card.html`)
+      await page.locator('button[title="点赞"]').waitFor()
+      await page.evaluate(size => { document.documentElement.style.fontSize = `${size}px` }, fontSize)
+      const like = page.getByRole('button', { name: /^点赞/ })
+      await like.click({ timeout: 3000 })
+      assert.equal(await like.getAttribute('aria-pressed'), 'true')
+      assert.equal(await like.textContent(), '6')
+      assert.ok(await page.locator('a.gf-topic-chip').evaluate(el => {
+        const r = el.getBoundingClientRect()
+        return el.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2))
+      }), 'category link must sit above the stretched card link')
+      const comment = page.locator('a[href="/p/42?reply=1"]')
+      await comment.click({ trial: true })
+      await page.locator('a.gf-topic-chip').click({ trial: true })
+      assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth), 'card must not overflow the viewport')
+    } finally { await page.close() }
+  })
+}

--- a/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
@@ -247,8 +247,9 @@ class _HomePageState extends ConsumerState<HomePage> {
               topicId: topic.id,
               action: target ? 1 : 2,
             );
-      if (!mounted || epoch != ref.read(offlineCacheEpochProvider))
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider)) {
         return false;
+      }
       if (!success) {
         _rollbackInteraction(topic.id, bookmark, snapshot);
         showGfToast(

--- a/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/home/home_page.dart
@@ -27,13 +27,11 @@ class HomePage extends ConsumerStatefulWidget {
   ConsumerState<HomePage> createState() => _HomePageState();
 }
 
-/// 单条互动 override：null 字段表示该动作不触碰对应状态；epoch 用于在合并时
-/// 丢弃跨离线缓存会话（登出/换号）残留的乐观状态。
+/// Per-action overrides keep a failed like independent of a concurrent bookmark.
 typedef _InteractionOverride = ({
   int revision,
   int epoch,
-  bool? liked,
-  bool? bookmarked,
+  bool value,
   int? likeCount,
 });
 
@@ -45,32 +43,32 @@ class _HomePageState extends ConsumerState<HomePage> {
   int _loadSequence = 0;
   int _interactionRevision = 0;
   final _pendingInteractions = <(int, bool)>{};
-  final _interactionOverrides = <int, _InteractionOverride>{};
+  final _interactionOverrides = <(int, bool), _InteractionOverride>{};
 
-  // Only writes completed after a read started override that response. A later
-  // refresh (including returning from topic detail) remains authoritative.
+  // Pending writes and writes completed after a read started override that
+  // response. A refresh started after completion remains authoritative.
   List<TopicPayload> _mergeInteractions(
     List<TopicPayload> incoming,
     int readRevision,
   ) => [for (final topic in incoming) _mergeInteraction(topic, readRevision)];
 
   TopicPayload _mergeInteraction(TopicPayload topic, int readRevision) {
-    final update = _interactionOverrides[topic.id];
-    if (update == null) return topic;
-    // 跨会话的乐观 override 不折叠到新会话数据上。
-    if (update.epoch != ref.read(offlineCacheEpochProvider)) {
-      _interactionOverrides.remove(topic.id);
-      return topic;
+    var result = topic;
+    for (final bookmark in [false, true]) {
+      final key = (topic.id, bookmark);
+      final update = _interactionOverrides[key];
+      if (update == null) continue;
+      if (update.epoch != ref.read(offlineCacheEpochProvider) ||
+          (!_pendingInteractions.contains(key) &&
+              update.revision <= readRevision)) {
+        _interactionOverrides.remove(key);
+        continue;
+      }
+      result = bookmark
+          ? result.copyWith(bookmarked: update.value)
+          : result.copyWith(liked: update.value, likeCount: update.likeCount!);
     }
-    if (update.revision <= readRevision) {
-      _interactionOverrides.remove(topic.id);
-      return topic;
-    }
-    return topic.copyWith(
-      liked: update.liked ?? topic.liked,
-      bookmarked: update.bookmarked ?? topic.bookmarked,
-      likeCount: update.likeCount ?? topic.likeCount,
-    );
+    return result;
   }
 
   final List<TopicPayload> _topics = <TopicPayload>[];
@@ -215,30 +213,27 @@ class _HomePageState extends ConsumerState<HomePage> {
     final index = _topics.indexWhere((t) => t.id == topic.id);
     final current = index >= 0 ? _topics[index] : topic;
     // 乐观更新先于请求落盘：图标与点赞计数立即切换并记录 override（并发刷新
-    // 据此折叠）；失败或过期会话按字段回滚快照，避免与服务端权威刷新双计。
+    // 据此折叠）；失败按字段回滚，过期会话丢弃结果，避免跨会话污染。
     final snapshot = (
       liked: current.liked,
       bookmarked: current.bookmarked,
       likeCount: current.likeCount,
-      override: _interactionOverrides[topic.id],
+      override: _interactionOverrides[key],
     );
     final optimistic = (
       revision: ++_interactionRevision,
       epoch: epoch,
-      liked: bookmark ? snapshot.override?.liked : target,
-      bookmarked: bookmark ? target : snapshot.override?.bookmarked,
+      value: target,
       likeCount: bookmark
-          ? snapshot.override?.likeCount
+          ? null
           : math.max(0, snapshot.likeCount + (target ? 1 : -1)),
     );
     setState(() {
-      _interactionOverrides[topic.id] = optimistic;
+      _interactionOverrides[key] = optimistic;
       if (index >= 0) {
-        _topics[index] = _topics[index].copyWith(
-          liked: optimistic.liked ?? _topics[index].liked,
-          bookmarked: optimistic.bookmarked ?? _topics[index].bookmarked,
-          likeCount: optimistic.likeCount ?? _topics[index].likeCount,
-        );
+        _topics[index] = bookmark
+            ? current.copyWith(bookmarked: target)
+            : current.copyWith(liked: target, likeCount: optimistic.likeCount!);
       }
     });
     try {
@@ -252,16 +247,29 @@ class _HomePageState extends ConsumerState<HomePage> {
               topicId: topic.id,
               action: target ? 1 : 2,
             );
-      if (!success ||
-          !mounted ||
-          epoch != ref.read(offlineCacheEpochProvider)) {
+      if (!mounted || epoch != ref.read(offlineCacheEpochProvider))
+        return false;
+      if (!success) {
         _rollbackInteraction(topic.id, bookmark, snapshot);
+        showGfToast(
+          context,
+          AppLocalizations.of(context).commonLoadFailed,
+          error: true,
+        );
         return false;
       }
+      // A read begun before completion must still retain this action, even if
+      // it began after the optimistic update. A subsequent refresh is authoritative.
+      _interactionOverrides[key] = (
+        revision: ++_interactionRevision,
+        epoch: epoch,
+        value: optimistic.value,
+        likeCount: optimistic.likeCount,
+      );
       return true;
     } catch (error) {
-      _rollbackInteraction(topic.id, bookmark, snapshot);
       if (mounted && epoch == ref.read(offlineCacheEpochProvider)) {
+        _rollbackInteraction(topic.id, bookmark, snapshot);
         showGfToast(
           context,
           resolveErrorMessage(AppLocalizations.of(context), error),
@@ -270,12 +278,12 @@ class _HomePageState extends ConsumerState<HomePage> {
       }
       return false;
     } finally {
-      _pendingInteractions.remove(key);
+      if (mounted && epoch == ref.read(offlineCacheEpochProvider)) {
+        _pendingInteractions.remove(key);
+      }
     }
   }
 
-  /// 回滚乐观更新：只还原本次动作触碰的字段（不覆盖并发落定的另一类互动）。
-  /// 跨会话同样撤销本地翻转，避免旧会话的乐观状态悬挂到新会话列表上。
   void _rollbackInteraction(
     int topicId,
     bool bookmark,
@@ -289,20 +297,20 @@ class _HomePageState extends ConsumerState<HomePage> {
   ) {
     if (!mounted) return;
     setState(() {
+      final key = (topicId, bookmark);
       if (snapshot.override == null) {
-        _interactionOverrides.remove(topicId);
+        _interactionOverrides.remove(key);
       } else {
-        _interactionOverrides[topicId] = snapshot.override!;
+        _interactionOverrides[key] = snapshot.override!;
       }
       final index = _topics.indexWhere((t) => t.id == topicId);
       if (index >= 0) {
-        _topics[index] = _topics[index].copyWith(
-          liked: bookmark ? _topics[index].liked : snapshot.liked,
-          bookmarked: bookmark
-              ? snapshot.bookmarked
-              : _topics[index].bookmarked,
-          likeCount: bookmark ? _topics[index].likeCount : snapshot.likeCount,
-        );
+        _topics[index] = bookmark
+            ? _topics[index].copyWith(bookmarked: snapshot.bookmarked)
+            : _topics[index].copyWith(
+                liked: snapshot.liked,
+                likeCount: snapshot.likeCount,
+              );
       }
     });
   }
@@ -315,6 +323,11 @@ class _HomePageState extends ConsumerState<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<int>(offlineCacheEpochProvider, (_, _) {
+      _pendingInteractions.clear();
+      _interactionOverrides.clear();
+      _load();
+    });
     final AppLocalizations l10n = AppLocalizations.of(context);
     return RootSurface(
       title: 'YourTJ',

--- a/apps/mobile/packages/forum_app/test/home_topic_actions_test.dart
+++ b/apps/mobile/packages/forum_app/test/home_topic_actions_test.dart
@@ -9,6 +9,7 @@ import 'package:forum_app/src/pages/home/home_page.dart';
 import 'package:forum_app/src/providers.dart';
 import 'package:forum_app/src/widgets/app_refresh_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:ui_kit/ui_kit.dart';
 import 'fixtures/page_fixtures.dart';
 
 class _Tokens implements TokenStorage {
@@ -26,6 +27,7 @@ GfApiClient _client() =>
 class _Pages extends PageRepository {
   _Pages() : super(_client());
   bool liked = true;
+  int likeCount = 5;
   bool bookmarked = true;
   bool known = true;
   Completer<PagePayload>? pending;
@@ -39,6 +41,7 @@ class _Pages extends PageRepository {
           ...first,
           'id': 100 + i,
           'title': 'Topic $i',
+          'likeCount': likeCount,
           if (known) 'liked': liked,
           if (known) 'bookmarked': bookmarked,
         },
@@ -184,6 +187,81 @@ void main() {
     topics.pending!.complete(true);
     await tester.pumpAndSettle();
     expect(find.byIcon(Icons.favorite), findsOneWidget);
+  });
+
+  testWidgets('refresh while like is pending preserves its icon and count', (
+    tester,
+  ) async {
+    final pages = _Pages()..liked = false;
+    final topics = _Topics(pages)..pending = Completer<bool>();
+    await pump(tester, pages, topics);
+    await tester.tap(find.byTooltip('点赞').first);
+    await tester.pump();
+    await tester
+        .widget<AppRefreshIndicator>(find.byType(AppRefreshIndicator))
+        .onRefresh();
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.favorite), findsOneWidget);
+    expect(
+      tester.widget<GfTopicCard>(find.byType(GfTopicCard).first).likeCount,
+      6,
+    );
+    topics.pending!.complete(true);
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.favorite), findsOneWidget);
+  });
+
+  testWidgets(
+    'failed like cannot discard a concurrent successful bookmark override',
+    (tester) async {
+      final pages = _Pages()
+        ..liked = false
+        ..bookmarked = false;
+      final topics = _Topics(pages)..pending = Completer<bool>();
+      await pump(tester, pages, topics);
+      final stale = pages.payload();
+      pages.pending = Completer<PagePayload>();
+      final refresh = tester
+          .widget<AppRefreshIndicator>(find.byType(AppRefreshIndicator))
+          .onRefresh();
+      await tester.tap(find.byTooltip('点赞').first);
+      await tester.pump();
+      await tester.tap(find.byTooltip('收藏').first);
+      await tester.pumpAndSettle();
+      topics.pending!.complete(false);
+      await tester.pumpAndSettle();
+      pages.pending!.complete(stale);
+      await refresh;
+      await tester.pumpAndSettle();
+      expect(find.byTooltip('取消收藏'), findsOneWidget);
+    },
+  );
+
+  testWidgets('old-session failure cannot roll back the new viewer data', (
+    tester,
+  ) async {
+    final pages = _Pages()..liked = false;
+    final topics = _Topics(pages)..pending = Completer<bool>();
+    final container = await pump(tester, pages, topics);
+    await tester.tap(find.byTooltip('点赞').first);
+    await tester.pump();
+    pages.liked = true;
+    pages.likeCount = 20;
+    container.read(offlineCacheEpochProvider.notifier).invalidate();
+    await tester
+        .widget<AppRefreshIndicator>(find.byType(AppRefreshIndicator))
+        .onRefresh();
+    await tester.pumpAndSettle();
+    topics.pending!.complete(false);
+    await tester.pumpAndSettle();
+    expect(
+      tester.widget<GfTopicCard>(find.byType(GfTopicCard).first).liked,
+      isTrue,
+    );
+    expect(
+      tester.widget<GfTopicCard>(find.byType(GfTopicCard).first).likeCount,
+      20,
+    );
   });
 
   testWidgets('old-session action result is ignored', (tester) async {

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -40,7 +40,8 @@ Web inside an authenticated in-app browser. The navigation and management bounda
   localized error. Home summaries
   batch-load the viewer's like/bookmark state; absent state (anonymous, unavailable or older
   servers) suppresses the shortcuts. Selected states survive offscreen card recycling, and
-  returning from detail refreshes them. In-flight reads cannot overwrite newer successful actions.
+  returning from detail refreshes them. In-flight reads cannot overwrite pending or newer successful actions. Likes and bookmarks
+  settle independently; switching accounts discards all pending interaction state and reloads the feed.
   Metrics and actions wrap at narrow widths and enlarged text sizes.
 - `Current`: simple-content topics show an uncropped, swipeable image gallery above the body. The
   same gallery is used in the publishing preview.


### PR DESCRIPTION
卡片点赞请求未完成时切换列表视图或刷新，会重置图标、计数和请求锁；移动端点赞失败还会丢弃并发收藏的记录，旧账号响应可能回滚新账号数据。此修复让 Web 请求状态由列表持有，移动端按动作分别维护覆盖值，并在切换账号时丢弃旧请求结果。失败会恢复状态并显示错误。

验收：新增回归测试先在原实现复现失败，再修至通过。真实 Chromium 浏览器在 320px、普通/两倍基础字号下验证了可访问的点赞按钮、评论及分类链接；Web 17 个卡片测试、移动端 8 个首页互动测试及 10 个卡片组件测试通过；Flutter analyze、前端构建、相关 Go controller 测试、make contract-check 与治理门禁通过。正常推送钩子的 go vet、golangci-lint、前端 typecheck 通过。

这是 #639 合并后的验收修复，针对已合入 dev 的代码。
