### PR TITLE
docs: fix stale cobra CLI references (mock subcommand does not exist)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ be changed, but the "Go + Vue in one binary, frontend go:embed into the binary" 
 ```
 apps/
   gooseforum/  The forum itself (upstream fork; module path github.com/YourTongji/YourTJ-Hub/apps/gooseforum)
-    main.go            Entry point (cobra: serve / mock / rebuild-search-index subcommands)
+    main.go            Entry point (cobra: serve / migrate / seed-demo / mock-topics / mock-posts / rebuild-search-index ...)
     config.toml       Runtime config (gitignored; bring your own locally)
     app/              Go backend (bundles/console/datastruct/http/migration/models/service)
     resource/         Vue 3 frontend + gohtml templates + @gooseforum/client package

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -48,7 +48,7 @@
 
 | Layer | Responsibility |
 |---|---|
-| `app/console` | cobra CLI (serve / migrate / mock / rebuild-search-index / migrate-files ...) |
+| `app/console` | cobra CLI (serve / migrate / seed-demo / mock-topics / mock-posts / rebuild-search-index / migrate-files ...) |
 | `app/bundles` | Utilities (connect/eventbus/jwtopt/i18n/captcha/logging/cache ...) |
 | `app/models` | GORM models + migrations (app/migration) |
 | `app/service` | Business logic (users/topics/mail/oauth/theme/wikiservice ...) |


### PR DESCRIPTION
## Summary

Fixes the stale cobra CLI references that mention a non-existent `mock` subcommand.

Closes #644

## Changes

- `AGENTS.md`: `cobra: serve / mock / rebuild-search-index` → `serve / migrate / seed-demo / mock-topics / mock-posts / rebuild-search-index ...`
- `docs/architecture/system-overview.md`: `cobra CLI (serve / migrate / mock / ...)` → `serve / migrate / seed-demo / mock-topics / mock-posts / rebuild-search-index / migrate-files ...`

## Why

`go run . mock` fails with `Error: unknown command "mock" for "gooseforum"`. The actual mock-related commands are `mock-topics` and `mock-posts` (plus `seed-demo` for local preview). The two docs now name real commands, with `...` indicating the fuller CLI surface (27 commands total) without claiming an exhaustive list.

## Verification

- `go run . --help` (in `apps/gooseforum`) confirmed the actual command list.
- `git diff --check` clean.
- Governance `verify-doc-links` / `verify-placeholders` / `verify-decisions` / `verify-postmortems` pass. `verify-manifest` fails locally on Windows because Git checks out `scripts/*.mjs` as CRLF while the manifest hashes LF content; this is a line-ending artifact of the local checkout, not a change in this PR (no `scripts/` files touched). CI runs on Linux and is unaffected.