### PR TITLE
feat(mobile): request iOS notification permission on first launch (issue #658)

### DIFF
--- a/apps/mobile/packages/forum_app/lib/src/push/push_service.dart
+++ b/apps/mobile/packages/forum_app/lib/src/push/push_service.dart
@@ -24,6 +24,9 @@ enum PushChannelStatus {
 
 /// Native bridge: iOS APNs; Android JPush + configured OEM offline channels.
 /// No SDK initialization or device collection before the user enables push.
+/// On iOS the first launch after login requests the system permission once;
+/// granting it counts as push consent (issue #658). Android keeps explicit
+/// opt-in (decision 0019: the JPush SDK must not initialize before consent).
 class PushDriver {
   static const channel = MethodChannel('yourtj/push');
   String get platform => Platform.isIOS ? 'ios' : 'android';
@@ -77,6 +80,9 @@ class PushController extends Notifier<PushChannelStatus>
   static const _enabledKey = 'push_enabled';
   static const _tokenKey = 'push_token';
   static const _tokenOwnerKey = 'push_token_owner';
+  // iOS-only one-shot marker: the system permission prompt has been requested
+  // (either by the first-launch auto-request or by the settings switch).
+  static const _permissionRequestedKey = 'push_permission_requested';
   int _generation = 0;
   bool _disposed = false;
   bool _busy = false;
@@ -160,7 +166,21 @@ class PushController extends Notifier<PushChannelStatus>
       if (!_current(generation, epoch)) return;
       _sessionRepository = session;
       _sessionUserId = user?.id;
-      if (request) await prefs.setBool(_enabledKey, true);
+      // iOS 首次登录后的启动自动申请一次系统通知权限；系统授权即视为推送同意
+      // （issue #658）。Android 维持显式 opt-in（决策 0019：同意前不初始化 SDK）。
+      // 已有显式 enable 排队时交给该 enable 申请，避免重复弹窗；已弹过则不再申请。
+      if (!request &&
+          _driver.platform == 'ios' &&
+          _pendingEnable == null &&
+          !(prefs.getBool(_permissionRequestedKey) ?? false)) {
+        request = true;
+      }
+      if (request) {
+        await prefs.setBool(_enabledKey, true);
+        if (_driver.platform == 'ios') {
+          await prefs.setBool(_permissionRequestedKey, true);
+        }
+      }
       if (!(prefs.getBool(_enabledKey) ?? false)) {
         state = PushChannelStatus.disabled;
         await _unregister(session, prefs, user?.id);

--- a/apps/mobile/packages/forum_app/test/push_service_test.dart
+++ b/apps/mobile/packages/forum_app/test/push_service_test.dart
@@ -125,7 +125,12 @@ void main() {
   CurrentUser? user;
   Future<void> settle() => pumpEventQueue();
   setUp(() {
-    SharedPreferences.setMockInitialValues({});
+    // Steady state: the iOS one-shot permission request already happened, so
+    // startup refreshes stay silent. First-launch behavior gets its own tests
+    // that clear the marker.
+    SharedPreferences.setMockInitialValues(
+      const {'push_permission_requested': true},
+    );
     driver = Driver();
     repo = Repository();
     storage = MemoryStorage();
@@ -233,6 +238,46 @@ void main() {
       expect(driver.requests, 1);
     },
   );
+  test(
+    'iOS first launch after login requests permission and treats grant as consent',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      await settle();
+      expect(driver.requests, 1);
+      expect(status(), PushChannelStatus.enabled);
+      expect(repo.registered, ['ios:apns:native-token']);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('push_enabled'), true);
+      expect(prefs.getBool('push_permission_requested'), true);
+    },
+  );
+  test('first-launch request happens once; later refreshes restore silently',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    await settle();
+    expect(driver.requests, 1);
+    await controller().refresh();
+    expect(driver.requests, 1);
+    expect(status(), PushChannelStatus.enabled);
+  });
+  test('iOS first-launch denial keeps the denied recovery state', () async {
+    SharedPreferences.setMockInitialValues({});
+    driver.allowed = false;
+    await settle();
+    expect(driver.requests, 1);
+    expect(status(), PushChannelStatus.permissionDenied);
+    expect(repo.registered, isEmpty);
+    // The marker is recorded, so the next launch does not ask again.
+    await controller().refresh();
+    expect(driver.requests, 1);
+  });
+  test('Android first launch never auto-requests permission', () async {
+    SharedPreferences.setMockInitialValues({});
+    driver.transport = 'jpush';
+    await settle();
+    expect(driver.requests, 0);
+    expect(status(), PushChannelStatus.disabled);
+  });
   test('Android uses JPush registration, never FCM/APNs token', () async {
     driver.transport = 'jpush';
     await settle();

--- a/apps/mobile/packages/forum_app/test/push_service_test.dart
+++ b/apps/mobile/packages/forum_app/test/push_service_test.dart
@@ -271,6 +271,23 @@ void main() {
     await controller().refresh();
     expect(driver.requests, 1);
   });
+  test('queued enable suppresses the first-launch auto-request', () async {
+    SharedPreferences.setMockInitialValues({});
+    repo.pendingSession = Completer<void>();
+    await settle();
+    final enabling = controller().enable();
+    await settle();
+    repo.pendingSession!.complete();
+    await enabling;
+    await settle();
+    // The queued explicit enable performs the single prompt itself; the
+    // startup refresh that was still in flight must not request again.
+    expect(driver.requests, 1);
+    expect(status(), PushChannelStatus.enabled);
+    expect(repo.registered, ['ios:apns:native-token']);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('push_permission_requested'), true);
+  });
   test('Android first launch never auto-requests permission', () async {
     SharedPreferences.setMockInitialValues({});
     driver.transport = 'jpush';

--- a/docs/decisions/0019-native-push-providers.md
+++ b/docs/decisions/0019-native-push-providers.md
@@ -32,6 +32,11 @@ push consent; optional analytics, geolocation and dynamic loading are disabled. 
 includes a provider; omitted values preserve legacy iOS APNs / Android FCM routing. The backend
 retains FCM for existing registrations. No automatic migration of tokens between providers occurs.
 
+On iOS there is no SDK to initialize; the first launch after login requests the system permission
+once, and granting it counts as push consent (issue #658). A one-shot local marker prevents
+repeated prompting on later launches and upgrades. Android remains strictly opt-in: its SDK and
+device collection start only after the user enables push in Settings.
+
 JPush's AppKey and OEM client identifiers enter Android builds through the signing environment.
 The Master Secret remains in the production server environment. OEM credentials also require
 configuration in the provider console; SDK integration alone does not establish offline delivery.

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -308,8 +308,11 @@ local widget tests do not imply those gates passed.
   remain deployment requirements; app-local notification lists are independent of system delivery.
 - `Current`: Settings retains the push entry with a provider-processing disclosure and shows missing
   build configuration, unavailable server channels, permission denial and registration failure.
-  Explicit enable requests system permission. Resume checks existing authorization without repeatedly
-  prompting; a non-empty token and successful API registration are required to display enabled.
+  On iOS the first launch after login requests the system permission once; granting it counts as
+  push consent and enables delivery without visiting Settings. Android keeps explicit opt-in —
+  the JPush SDK is never initialized before the user enables push. Explicit enable requests system
+  permission. Resume checks existing authorization without repeatedly prompting; a non-empty token
+  and successful API registration are required to display enabled.
   Enable taps during startup/resume or stop are queued; a later disable or account change cancels
   queued consent. Failed unbinding is retained and retried on resume while push stays disabled,
   using the owning account; signing in to a different account does not acknowledge that cleanup.


### PR DESCRIPTION
## Motivation

Fixes #658. iOS users reported that the app never showed the system notification permission prompt on first launch — they had to find **设置 → 推送** and toggle the switch manually before iOS would ask. Push registration depends on a session token, so the only place the OS prompt could be reached was the settings switch.

## Behavior change

- **iOS only**: the first launch after login (startup, session restore, or resume) now requests the system notification permission once automatically. Granting it counts as push consent — the existing consent path then enables delivery and registers the device, so notifications work without visiting Settings.
- **Android unchanged**: still strictly opt-in. The JPush SDK is not initialized before the user enables push (decision 0019, privacy compliance).
- **One-shot marker**: a new local `push_permission_requested` flag records that the OS prompt was requested (by the first-launch auto-request *or* by a manual Settings enable), so later launches, resumes and upgrades never re-prompt. iOS itself only shows the dialog once per install; the marker avoids redundant native calls and keeps the flow deterministic.
- If a manual `enable()` is already queued when the startup refresh runs, the auto-request defers to it (no duplicate prompt).
- Denial leaves the channel in the existing `permissionDenied` state: the switch reflects the opt-in and the existing “open system settings” recovery row is reused.
- Settings switch state already reflects actual status, so no UI change was needed.

Implementation is a small change to the existing consent path in `PushController._connect`: the startup refresh escalates to `request: true` once on iOS (gated by platform, the one-shot marker, and no queued enable) and reuses the existing permission → register flow.

## Verification

- `node scripts/run-gates.mjs` → OK (5 governance gates).
- Flutter/Dart toolchain is not installed on this machine, so `melos run analyze` / `melos run test` were not run locally; the mobile CI job (`ci-mobile`, flutter 3.44.9) gates them.
- Test changes in `test/push_service_test.dart`: the default fixture now pre-sets the one-shot marker (steady state), and four new cases cover first-launch grant-as-consent, request-once-then-silent, first-launch denial, and Android never auto-requesting.

## Documentation impact

- `docs/product/mobile-experience.md`: the System notifications consent model now states the iOS first-launch request and the unchanged Android opt-in.
- `docs/decisions/0019-native-push-providers.md`: Decision Outcome clarifies that iOS has no SDK to initialize and uses the first-launch prompt as its consent trigger; the Android rule is unchanged.
- `push_service.dart` class comment updated.

## Known gaps

- No pre-permission explainer dialog before the iOS system prompt (flagged in the issue as optional). The provider-processing disclosure remains in Settings; a future explainer could be added if authorization rates warrant it.
- Device-level behavior (real prompt timing, denied-then-recover) still needs physical-device validation, as with all push changes.

## Checklist

- [x] Branch from `origin/dev`, PR targets `dev`
- [x] Conventional commit with agent co-author footer
- [x] Docs updated in the same PR
- [x] Governance gates pass
