### PR TITLE
fix(mobile): 发布页去重发布/存草稿与图片入口 (issue #661)

### DIFF
--- a/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
@@ -571,6 +571,17 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                 size: 44,
                 onPressed: () => FocusManager.instance.primaryFocus?.unfocus(),
               ),
+            if (_mode == _ComposeMode.preview)
+              GfButton(
+                key: const Key('publish-save-draft'),
+                label: l10n.publishSaveDraft,
+                variant: GfButtonVariant.ghost,
+                size: GfButtonSize.small,
+                loading: _submitting,
+                onPressed: _uploading
+                    ? null
+                    : () => _submit(topicStatus: 0),
+              ),
             GfButton(
               key: const Key('publish-appbar-submit'),
               label: _mode == _ComposeMode.edit
@@ -705,7 +716,6 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                       ),
                     if (_error.isNotEmpty || _message.isNotEmpty)
                       const SizedBox(height: 12),
-                    if (_mode == _ComposeMode.preview) _buildFooter(l10n),
                   ],
                 ),
               ),
@@ -909,16 +919,14 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                       ),
                     ),
                   ),
-                _toolButton(
-                  icon: _uploading
-                      ? Icons.hourglass_top_rounded
-                      : Icons.image_outlined,
-                  tooltip: l10n.publishToolImage,
-                  onPressed:
-                      _uploading || (_contentType != 3 && _images.length >= 9)
-                      ? null
-                      : _pickAndInsertImage,
-                ),
+                if (_contentType == 3)
+                  _toolButton(
+                    icon: _uploading
+                        ? Icons.hourglass_top_rounded
+                        : Icons.image_outlined,
+                    tooltip: l10n.publishToolImage,
+                    onPressed: _uploading ? null : _pickAndInsertImage,
+                  ),
                 Expanded(
                   child: Align(
                     alignment: Alignment.centerRight,
@@ -1261,38 +1269,6 @@ class _PublishPageState extends ConsumerState<PublishPage> {
                 ? null
                 : _pickAndInsertImage,
           ),
-      ],
-    );
-  }
-
-  Widget _buildFooter(AppLocalizations l10n) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      children: <Widget>[
-        GfButton(
-          key: const Key('publish-save-draft'),
-          label: l10n.publishSaveDraft,
-          variant: GfButtonVariant.secondary,
-          size: GfButtonSize.large,
-          loading: _submitting,
-          onPressed: _uploading ? null : () => _submit(topicStatus: 0),
-        ),
-        const SizedBox(width: 8),
-        GfButton(
-          key: const Key('publish-footer-submit'),
-          label: _mode == _ComposeMode.edit
-              ? l10n.publishNext
-              : l10n.publishPublish,
-          variant: GfButtonVariant.primary,
-          size: GfButtonSize.large,
-          loading: _submitting,
-          icon: const Icon(Icons.send_rounded, size: 18),
-          onPressed: _uploading
-              ? null
-              : () => _mode == _ComposeMode.edit
-                    ? _selectMode(_ComposeMode.preview)
-                    : _submit(topicStatus: 1),
-        ),
       ],
     );
   }

--- a/apps/mobile/packages/forum_app/test/publish_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/publish_page_test.dart
@@ -610,4 +610,67 @@ void main() {
     expect(find.text('标题不能为空'), findsOneWidget);
     expect(find.byType(GfStatusMessage), findsOneWidget);
   });
+
+  testWidgets('预览页只保留右上角发布按钮，保存草稿移入 AppBar', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await pumpPublishPage(tester, editing: true);
+
+    await tester.tap(find.byKey(const Key('publish-appbar-submit')));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.byKey(const Key('publish-footer-submit')), findsNothing);
+    expect(find.byKey(const Key('publish-appbar-submit')), findsOneWidget);
+    final Finder saveDraft = find.byKey(const Key('publish-save-draft'));
+    expect(saveDraft, findsOneWidget);
+    expect(
+      find.descendant(of: find.byType(GfAppBar), matching: saveDraft),
+      findsOneWidget,
+    );
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
+
+  testWidgets('瞬间/提问编辑态只保留顶部画廊图片入口', (tester) async {
+    for (final type in [1, 2]) {
+      await pumpPublishPage(tester, editing: false, contentType: type);
+      expect(find.byTooltip('添加图片'), findsNothing);
+      expect(find.text('先选图片，再记录这一刻'), findsOneWidget);
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 600));
+    }
+  });
+
+  testWidgets('文章类型保留底部工具栏图片入口', (tester) async {
+    await pumpPublishPage(tester, editing: false, contentType: 3);
+    expect(find.byTooltip('添加图片'), findsOneWidget);
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
+
+  testWidgets('宽屏预览同样只有右上角发布与保存草稿', (tester) async {
+    tester.view.physicalSize = const Size(1000, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await pumpPublishPage(tester, editing: true);
+
+    await tester.tap(find.byKey(const Key('publish-appbar-submit')));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.byKey(const Key('publish-footer-submit')), findsNothing);
+    expect(find.byKey(const Key('publish-save-draft')), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(GfAppBar),
+        matching: find.byKey(const Key('publish-save-draft')),
+      ),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('publish-appbar-submit')), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
+  });
 }

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -132,8 +132,9 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 
 - `Current`: publishing uses an unframed title and writing canvas. Article formatting tools remain
   folded in a bottom accessory bar above the software keyboard; expanding them preserves the editor
-  selection. Image and draft actions remain in the accessory bar; the empty simple gallery is a compact
-  selection tile. Rich and simple body text use the same mobile reading scale. Preview hides the accessory bar.
+  selection. The accessory bar holds the draft action and, for articles only, the image tool; moments
+  and questions pick images from the gallery tile above the body. Rich and simple body text use the
+  same mobile reading scale. Preview hides the accessory bar.
 
 - `Current`: reply composers use one rounded surface with a borderless, growing two-line input.
   Image, hide-keyboard, collapse and send actions share the bottom row. The reply target is a
@@ -152,9 +153,11 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 - `Current`: simple galleries support up to nine uploaded images, reordering and removal. Images
   survive switching to the article editor. Switching back extracts images into the gallery and
   plain text into the body; conversion is rejected when more than nine images would be lost.
-- `Current`: Next opens the preview/classification step. Up to three existing categories can be
-  selected below the rendered image/title/body preview. Publish writes only after this step; saving a draft retains the server's title,
-  body and classification requirements. Moments can derive their title from the first text line.
+- `Current`: Next opens the preview/classification step. The step shows one publish action in the
+  AppBar, with the draft action beside it; up to three existing categories can be selected below the
+  rendered image/title/body preview. Publish writes only after this step; saving a draft retains the
+  server's title, body and classification requirements. Moments can derive their title from the first
+  text line.
 - `Current`: publishing limits, captcha requests and other API failures use the Web error catalog
   in the selected language, including server-provided parameters.
 - `Current`: unsaved changes prompt before leaving. A server-required captcha is shown in the


### PR DESCRIPTION
## Summary

Fixes #661。Flutter 发布页预览步同时渲染 AppBar 与底部 footer 两个「发布」按钮，底部另有「保存草稿」；瞬间/提问编辑态顶部画廊之外，底部工具栏还有一个重复的图片入口。

## Changes

- `publish_page.dart`：删除预览步的 `_buildFooter`（含 `publish-footer-submit` 与右侧「保存草稿」）；「保存草稿」迁入 `GfAppBar` actions（预览步，key 仍为 `publish-save-draft`，编辑态仍在底部工具栏，二者互斥渲染）
- `publish_page.dart`：编辑态底部工具栏图片按钮限定 `contentType == 3`（文章）渲染；瞬间/提问仅保留顶部画廊入口，9 张上限由画廊按钮继续约束
- `publish_page.dart`（评审后修复）：预览步 AppBar 的草稿动作改为 44px 图标按钮（tooltip 保留文案、提交中显示沙漏图标），标题 `DropdownButton` 改为 `isExpanded` + 单行省略。原因：德语 390×844 实测 AppBar actions 行溢出 106px（`RenderFlex`），两个带文案按钮 + 标题在窄屏长文案 locale 下放不下
- `test/publish_page_test.dart`：新增 9 个回归测试——(1) 预览步唯一发布控件且保存草稿在 AppBar、(2) 瞬间/提问无重复图片入口、(3) 文章保留工具栏图片入口、(4) 宽屏预览同样收敛、(5) 预览步 AppBar 保存草稿写回 `topicStatus=0` 并停留预览步、(6) 预览步返回回到编辑步、(7) 编辑态有未保存改动时返回先确认、(8) 预览步无分类时保存草稿与发布都被拦截、(9) 德语窄屏预览步 AppBar 不溢出（helper 支持 `categoryIds` 与 `locale`）
- `docs/product/mobile-experience.md`：Publishing 段同步新的按钮位置与图标化草稿动作

范围说明：编辑态（第一页）底部工具栏的「保存草稿」保持不变——用户反馈仅针对预览步（第二页），且文档已明确 accessory bar 承担草稿动作。预览步草稿动作由带文案按钮改为图标按钮，是在保持「右上角草稿入口」前提下解决窄屏长文案溢出的取舍；若更希望保留文案，可改为折叠进溢出菜单。

## Verification

- `flutter analyze`（forum_app）：No issues found（首个提交前，本地）
- `flutter test`（forum_app）：368 passed / 18 skipped（首个提交前，本地）
- CI @ head `507e8489`：ci-mobile ✅（**378 tests passed**）、ci-backend ✅、ci-backend-govulncheck ✅、ci-frontend ✅、ci-contract ✅；Native build / android ✅（前一头 9m11s）、Native build / ios ✅（前一头 4m47s）——本头原生构建见最新运行
- 前 4 个回归测试先在旧源码上红（`publish-footer-submit` 仍存在导致失败），修复后转绿
- 新增用例补齐了「迁移后从未被点击」的预览步草稿按钮、离开确认/分类校验路径，以及德语窄屏溢出回归；本机无 Flutter SDK，这些用例由 ci-mobile 验证通过（首版分类校验用例误在编辑态断言、德语用例首版暴露了 AppBar 溢出，均已修正）
- `git diff --check`、`node scripts/verify-doc-links.mjs`、`node scripts/run-gates.mjs`：OK

## Review follow-up

- 原评审意见（预览步双发布按钮、图片入口重复、草稿迁移）逐条对照实现
- 已按评审意见更正描述中的回归测试数量（4 → 9）
- 评审提出「de/ja 长文案窄屏未验证」：已补自动化用例并在 390×844 德语下实测到 AppBar 溢出 106px，改为图标化草稿动作 + 标题可收缩后转绿
- 真机/模拟器抽查（系统相册、发布与草稿实机流程）本机无设备条件，未执行；widget 测试不覆盖系统选择器本身
