### PR TITLE
feat(mobile): drag article body images to any paragraph (issue #659)

### DIFF
--- a/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_de.arb
@@ -390,6 +390,7 @@
   "publishNext": "Nächste",
   "publishGallery": "Wähle Fotos und erzähle deine Geschichte",
   "publishGalleryHint": "Bis zu 9 Fotos. Zum Sortieren gedrückt halten und ziehen.",
+  "publishBodyDragHint": "Bild im Text gedrückt halten und in einen beliebigen Absatz ziehen.",
   "publishFormatting": "Formatierung",
   "publishClassification": "Kategorien auswählen",
   "publishLeaveTitle": "Änderungen behalten?",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_en.arb
@@ -657,6 +657,7 @@
   "publishNext": "Next",
   "publishGallery": "Choose photos, then tell your story",
   "publishGalleryHint": "Up to 9 photos. Hold and drag to reorder.",
+  "publishBodyDragHint": "Long-press an image in the body to drag it to any paragraph.",
   "publishFormatting": "Formatting",
   "publishClassification": "Choose categories",
   "publishLeaveTitle": "Keep your work?",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_ja.arb
@@ -390,6 +390,7 @@
   "publishNext": "次へ",
   "publishGallery": "写真を選んで、ストーリーを添えましょう",
   "publishGalleryHint": "最大9枚。長押しして並べ替えられます。",
+  "publishBodyDragHint": "本文の画像を長押しして、任意の段落位置へドラッグできます",
   "publishFormatting": "書式設定",
   "publishClassification": "カテゴリを選択",
   "publishLeaveTitle": "編集内容を残しますか？",

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations.dart
@@ -2340,6 +2340,12 @@ abstract class AppLocalizations {
   /// **'Up to 9 photos. Hold and drag to reorder.'**
   String get publishGalleryHint;
 
+  /// No description provided for @publishBodyDragHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Long-press an image in the body to drag it to any paragraph.'**
+  String get publishBodyDragHint;
+
   /// No description provided for @publishFormatting.
   ///
   /// In en, this message translates to:

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_de.dart
@@ -1245,6 +1245,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bis zu 9 Fotos. Zum Sortieren gedrückt halten und ziehen.';
 
   @override
+  String get publishBodyDragHint =>
+      'Bild im Text gedrückt halten und in einen beliebigen Absatz ziehen.';
+
+  @override
   String get publishFormatting => 'Formatierung';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_en.dart
@@ -1230,6 +1230,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get publishGalleryHint => 'Up to 9 photos. Hold and drag to reorder.';
 
   @override
+  String get publishBodyDragHint =>
+      'Long-press an image in the body to drag it to any paragraph.';
+
+  @override
   String get publishFormatting => 'Formatting';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_ja.dart
@@ -1215,6 +1215,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get publishGalleryHint => '最大9枚。長押しして並べ替えられます。';
 
   @override
+  String get publishBodyDragHint => '本文の画像を長押しして、任意の段落位置へドラッグできます';
+
+  @override
   String get publishFormatting => '書式設定';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_localizations_zh.dart
@@ -1213,6 +1213,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get publishGalleryHint => '最多 9 张，长按拖动排序';
 
   @override
+  String get publishBodyDragHint => '长按正文图片，可拖动到任意段落位置';
+
+  @override
   String get publishFormatting => '文字格式';
 
   @override

--- a/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
+++ b/apps/mobile/packages/forum_app/lib/l10n/app_zh.arb
@@ -657,6 +657,7 @@
   "publishNext": "下一步",
   "publishGallery": "先选图片，再记录这一刻",
   "publishGalleryHint": "最多 9 张，长按拖动排序",
+  "publishBodyDragHint": "长按正文图片，可拖动到任意段落位置",
   "publishFormatting": "文字格式",
   "publishClassification": "选择分区与标签",
   "publishLeaveTitle": "保留这次创作？",

--- a/apps/mobile/packages/forum_app/lib/src/pages/publish/embed_image_move.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/publish/embed_image_move.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
+
+/// Payload carried while a composer image embed is being dragged.
+///
+/// [node] is the live quill leaf at drag start. Handlers re-locate it by
+/// identity against the current document before mutating anything, so a drag
+/// whose document was replaced mid-flight (edit-mode reload) is a safe no-op.
+class ComposerImageDragPayload {
+  const ComposerImageDragPayload({required this.node, required this.imageUrl});
+
+  final Embed node;
+  final String imageUrl;
+}
+
+/// Result of a successful embed move expressed as a single Delta.
+class ComposerImageMoveResult {
+  const ComposerImageMoveResult({
+    required this.delta,
+    required this.insertOffset,
+    required this.insertLength,
+  });
+
+  /// The single delta that relocates the embed.
+  final Delta delta;
+
+  /// Document offset where the embed landed after the move.
+  final int insertOffset;
+
+  /// Number of characters inserted (embed plus, for solo-line moves, the
+  /// trailing line break).
+  final int insertLength;
+}
+
+/// Returns the document offset of [node], or null when it does not belong to
+/// [document] (stale node after a document replacement).
+int? locateEmbedOffset(Document document, Node node) {
+  Iterable<Node> childrenOf(Node parent) {
+    if (parent is Block) return parent.children;
+    if (parent is Line) return parent.children;
+    return const Iterable.empty();
+  }
+
+  for (final Node top in document.root.children) {
+    for (final Node mid in childrenOf(top)) {
+      if (identical(mid, node)) return mid.documentOffset;
+      for (final Node leaf in childrenOf(mid)) {
+        if (identical(leaf, node)) return leaf.documentOffset;
+      }
+    }
+  }
+  return null;
+}
+
+/// Flattens the document into a plain string where every non-text operation
+/// (embed) is represented by the object replacement character.
+String documentFlatText(Document document) {
+  final StringBuffer flat = StringBuffer();
+  for (final Operation op in document.toDelta().toList()) {
+    flat.write(op.data is String ? op.data as String : '\uFFFC');
+  }
+  return flat.toString();
+}
+
+/// Returns the index of the newline that terminates the visual line
+/// containing [offset] — the anchor for "the image lands at the end of the
+/// paragraph the user dropped on".
+int clampDropToLineEnd(int offset, Document document) {
+  final int length = document.length;
+  if (offset < 0) return 0;
+  if (offset >= length) return length;
+  final String text = documentFlatText(document);
+  for (int i = offset; i < length; i++) {
+    if (text[i] == '\n') return i;
+  }
+  return length;
+}
+
+/// Computes the single Delta that relocates the embed leaf [node] to the end
+/// of the line containing [targetOffset].
+///
+/// Drop semantics: the image appends to the paragraph the user dropped on.
+/// A solo-line image (image alone on its own line) prefers the slot directly
+/// below that paragraph (its own new line); when the dropped-on paragraph is
+/// the document's final line there is no slot below it, so the image glues
+/// to the line's end instead — expanded embeds render identically. Inline
+/// images always append to the end of the dropped-on line's text.
+/// The source side collapses cleanly: a solo image takes one adjacent line
+/// break — preferring the PRECEDING one so the document's mandatory final
+/// newline survives (required for a crash-free history undo) — and an
+/// inline image leaves surrounding text intact.
+///
+/// Returns null when the move is impossible or a no-op: stale node, drop on
+/// the image's own line, or a drop whose slot is exactly where the image
+/// already sits. Composing the returned delta in one
+/// [QuillController.compose] call keeps undo/redo a single step.
+ComposerImageMoveResult? moveComposerImageEmbed(
+  Document document,
+  Embed node,
+  int targetOffset,
+) {
+  final int? located = locateEmbedOffset(document, node);
+  if (located == null) return null;
+  final int embedOffset = located;
+  final int documentLength = document.length;
+  if (targetOffset < 0 || targetOffset > documentLength) return null;
+
+  final List<Operation> ops = document.toDelta().toList();
+  final String text = documentFlatText(document);
+  String charAt(int index) =>
+      index >= 0 && index < text.length ? text[index] : '';
+
+  // The op covering embedOffset must be the embed itself.
+  int cursor = 0;
+  Operation? embedOp;
+  for (final Operation op in ops) {
+    final int length = op.length ?? 0;
+    if (embedOffset < cursor + length) {
+      embedOp = op;
+      break;
+    }
+    cursor += length;
+  }
+  if (embedOp == null || embedOp.data is String) return null;
+  if (charAt(embedOffset) != '\uFFFC') return null;
+
+  final String charBefore = charAt(embedOffset - 1);
+  final String charAfter = charAt(embedOffset + 1);
+  final bool soloLine =
+      (embedOffset == 0 || charBefore == '\n') &&
+      (charAfter == '\n' || charAfter.isEmpty);
+  final int delLength = soloLine ? 2 : 1;
+  // Delete the PRECEDING newline together with a solo image (when one
+  // exists). Quill's history replay re-inserts the deleted range at its
+  // start offset and cannot insert at index == document length, so
+  // consuming the trailing newline would crash undo on trailing images.
+  final int delStart = soloLine && embedOffset > 0
+      ? embedOffset - 1
+      : embedOffset;
+
+  final int dropNewline = targetOffset >= documentLength
+      ? documentLength - 1
+      : clampDropToLineEnd(targetOffset, document);
+
+  bool soloInsert = soloLine;
+  int insertOffset = soloInsert ? dropNewline + 1 : dropNewline;
+  if (insertOffset > documentLength - 1) {
+    // No slot exists below the final line; glue to the line end instead.
+    insertOffset = documentLength - 1;
+    soloInsert = false;
+  }
+  final int insertLength = soloInsert ? 2 : 1;
+
+  // No-ops: the image already occupies the target slot — dropping on the
+  // paragraph directly above it, on its own line, or (when it is already
+  // the last line) anywhere at or below itself.
+  if (insertOffset == embedOffset) return null;
+  if (soloLine &&
+      (insertOffset == embedOffset + delLength ||
+          insertOffset == embedOffset + 1)) {
+    return null;
+  }
+
+  final Delta delta = Delta();
+  if (insertOffset > embedOffset) {
+    // Moving down: delete first, then express the insert in post-deletion
+    // coordinates at the same original offset.
+    delta.retain(delStart);
+    delta.delete(delLength);
+    delta.retain(insertOffset - delStart - delLength);
+    delta.insert(embedOp.data, embedOp.attributes);
+    if (soloInsert) delta.insert('\n');
+    return ComposerImageMoveResult(
+      delta: delta,
+      insertOffset: insertOffset - delLength,
+      insertLength: insertLength,
+    );
+  }
+
+  // Moving up: insert first, then delete at the source position. Delta
+  // retains/deletes always use ORIGINAL document coordinates — an insert
+  // does not advance the stream cursor.
+  delta.retain(insertOffset);
+  delta.insert(embedOp.data, embedOp.attributes);
+  if (soloInsert) delta.insert('\n');
+  delta.retain(delStart - insertOffset);
+  delta.delete(delLength);
+  return ComposerImageMoveResult(
+    delta: delta,
+    insertOffset: insertOffset,
+    insertLength: insertLength,
+  );
+}

--- a/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
+++ b/apps/mobile/packages/forum_app/lib/src/pages/publish/publish_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_quill/flutter_quill.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -16,6 +17,7 @@ import '../../images/image_upload.dart';
 import '../../server_messages.dart';
 import '../../widgets/markdown_view.dart';
 import '../../widgets/status_views.dart';
+import 'embed_image_move.dart';
 
 /// Global topic composer aligned with the Web publish workspace.
 ///
@@ -56,6 +58,8 @@ class _PublishPageState extends ConsumerState<PublishPage> {
   static const int _maxCategories = 3;
   static const double _wideWorkspaceBreakpoint = 760;
   static const Duration _previewDebounceDuration = Duration(milliseconds: 200);
+  static const double _dragAutoscrollEdge = 56;
+  static const double _dragAutoscrollStep = 12;
 
   final TextEditingController _simple = TextEditingController();
   final List<String> _images = [];
@@ -69,6 +73,8 @@ class _PublishPageState extends ConsumerState<PublishPage> {
   late final MarkdownConverter _converter;
 
   late QuillController _quill;
+  final GlobalKey<EditorState> _editorKey = GlobalKey<EditorState>();
+  final ScrollController _pageScrollController = ScrollController();
   late StreamSubscription<DocChange> _documentChanges;
   late int _currentTopicId;
 
@@ -84,6 +90,8 @@ class _PublishPageState extends ConsumerState<PublishPage> {
   String _message = '';
   String _previewMarkdown = '';
   Timer? _previewDebounce;
+  Timer? _dragAutoscrollTimer;
+  Offset? _dragPointer;
 
   @override
   void initState() {
@@ -249,6 +257,8 @@ class _PublishPageState extends ConsumerState<PublishPage> {
   @override
   void dispose() {
     _previewDebounce?.cancel();
+    _dragAutoscrollTimer?.cancel();
+    _pageScrollController.dispose();
     _captchaCode.dispose();
     _title.dispose();
     _simple.dispose();
@@ -421,6 +431,73 @@ class _PublishPageState extends ConsumerState<PublishPage> {
     } finally {
       if (mounted) setState(() => _uploading = false);
     }
+  }
+
+  void _startDragAutoscroll() {
+    HapticFeedback.selectionClick();
+    _dragPointer = null;
+    _dragAutoscrollTimer?.cancel();
+    _dragAutoscrollTimer = Timer.periodic(
+      const Duration(milliseconds: 50),
+      (_) => _tickDragAutoscroll(),
+    );
+  }
+
+  void _stopDragAutoscroll() {
+    _dragPointer = null;
+    _dragAutoscrollTimer?.cancel();
+    _dragAutoscrollTimer = null;
+  }
+
+  void _tickDragAutoscroll() {
+    final Offset? pointer = _dragPointer;
+    if (pointer == null) return;
+    final ScrollController scroll = _pageScrollController;
+    if (!scroll.hasClients) return;
+    final double maxOffset = scroll.position.maxScrollExtent;
+    final double viewportBottom =
+        scroll.position.viewportDimension - _dragAutoscrollEdge;
+    if (pointer.dy < _dragAutoscrollEdge && scroll.offset > 0) {
+      scroll.jumpTo(
+        (scroll.offset - _dragAutoscrollStep).clamp(0.0, maxOffset),
+      );
+    } else if (pointer.dy > viewportBottom && scroll.offset < maxOffset) {
+      scroll.jumpTo(
+        (scroll.offset + _dragAutoscrollStep).clamp(0.0, maxOffset),
+      );
+    }
+  }
+
+  /// Moves the dragged composer image to the paragraph under the drop point.
+  ///
+  /// The embed is relocated with a single Delta so undo/redo stays one step;
+  /// the document-changes listener flips _dirty/_allowPop and refreshes the
+  /// debounced preview, exactly like any other edit.
+  void _handleComposerImageDrop(
+    ComposerImageDragPayload payload,
+    Offset globalPosition,
+  ) {
+    final EditorState? editorState = _editorKey.currentState;
+    if (editorState == null) return;
+    final TextPosition position = editorState.renderEditor.getPositionForOffset(
+      globalPosition,
+    );
+    final int targetOffset = clampDropToLineEnd(
+      position.offset,
+      _quill.document,
+    );
+    final ComposerImageMoveResult? move = moveComposerImageEmbed(
+      _quill.document,
+      payload.node,
+      targetOffset,
+    );
+    if (move == null) return;
+    _quill.compose(move.delta, _quill.selection, ChangeSource.local);
+    _quill.updateSelection(
+      TextSelection.collapsed(offset: move.insertOffset + move.insertLength),
+      ChangeSource.local,
+    );
+    HapticFeedback.lightImpact();
   }
 
   Future<void> _loadCaptcha() async {
@@ -843,25 +920,49 @@ class _PublishPageState extends ConsumerState<PublishPage> {
     return ConstrainedBox(
       key: const Key('publish-editor'),
       constraints: const BoxConstraints(minHeight: 220),
-      child: QuillEditor.basic(
-        controller: _quill,
-        config: QuillEditorConfig(
-          scrollable: false,
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          placeholder: l10n.publishBodyPlaceholder,
-          customStyles: DefaultStyles(
-            paragraph: defaults.paragraph!.copyWith(
-              style: type.body,
-              verticalSpacing: const VerticalSpacing(4, 4),
-            ),
-            placeHolder: defaults.placeHolder!.copyWith(
-              style: type.body.copyWith(
-                color: GfTheme.colorsOf(context).iconMuted,
+      child: DragTarget<ComposerImageDragPayload>(
+        onMove: (DragTargetDetails<ComposerImageDragPayload> details) {
+          _dragPointer = details.offset;
+        },
+        onLeave: (Object? _) {
+          _dragPointer = null;
+        },
+        onAcceptWithDetails:
+            (DragTargetDetails<ComposerImageDragPayload> details) {
+              _stopDragAutoscroll();
+              _handleComposerImageDrop(details.data, details.offset);
+            },
+        builder:
+            (
+              BuildContext context,
+              List<ComposerImageDragPayload?> candidateData,
+              List<dynamic> rejectedData,
+            ) => QuillEditor.basic(
+              controller: _quill,
+              config: QuillEditorConfig(
+                scrollable: false,
+                editorKey: _editorKey,
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                placeholder: l10n.publishBodyPlaceholder,
+                customStyles: DefaultStyles(
+                  paragraph: defaults.paragraph!.copyWith(
+                    style: type.body,
+                    verticalSpacing: const VerticalSpacing(4, 4),
+                  ),
+                  placeHolder: defaults.placeHolder!.copyWith(
+                    style: type.body.copyWith(
+                      color: GfTheme.colorsOf(context).iconMuted,
+                    ),
+                  ),
+                ),
+                embedBuilders: [
+                  _ComposerImageBuilder(
+                    onDragStarted: _startDragAutoscroll,
+                    onDragEnded: _stopDragAutoscroll,
+                  ),
+                ],
               ),
             ),
-          ),
-          embedBuilders: [_ComposerImageBuilder()],
-        ),
       ),
     );
   }
@@ -936,6 +1037,16 @@ class _PublishPageState extends ConsumerState<PublishPage> {
               ],
             ),
           ),
+          if (_contentType == 3)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 12, 10),
+              child: Text(
+                l10n.publishBodyDragHint,
+                style: GfTheme.typographyOf(
+                  context,
+                ).caption.copyWith(color: GfTheme.colorsOf(context).iconMuted),
+              ),
+            ),
         ],
       ),
     );
@@ -1334,13 +1445,37 @@ class _PublishWorkspaceSkeleton extends StatelessWidget {
 }
 
 class _ComposerImageBuilder extends EmbedBuilder {
+  const _ComposerImageBuilder({this.onDragStarted, this.onDragEnded});
+
+  final VoidCallback? onDragStarted;
+  final VoidCallback? onDragEnded;
+
   @override
   String get key => BlockEmbed.imageType;
+
   @override
-  Widget build(BuildContext context, EmbedContext embedContext) =>
-      Image.network(
-        resolveApiAssetUrl(embedContext.node.value.data.toString()),
-        fit: BoxFit.contain,
-        errorBuilder: (_, _, _) => const Icon(Icons.broken_image_outlined),
-      );
+  Widget build(BuildContext context, EmbedContext embedContext) {
+    final Widget image = Image.network(
+      resolveApiAssetUrl(embedContext.node.value.data.toString()),
+      fit: BoxFit.contain,
+      errorBuilder: (_, _, _) => const Icon(Icons.broken_image_outlined),
+    );
+    return LongPressDraggable<ComposerImageDragPayload>(
+      data: ComposerImageDragPayload(
+        node: embedContext.node,
+        imageUrl: embedContext.node.value.data.toString(),
+      ),
+      dragAnchorStrategy: pointerDragAnchorStrategy,
+      onDragStarted: onDragStarted,
+      onDragCompleted: onDragEnded,
+      onDraggableCanceled: (Velocity velocity, Offset offset) =>
+          onDragEnded?.call(),
+      childWhenDragging: Opacity(opacity: 0.35, child: image),
+      feedback: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 180),
+        child: Opacity(opacity: 0.9, child: image),
+      ),
+      child: image,
+    );
+  }
 }

--- a/apps/mobile/packages/forum_app/test/embed_image_move_test.dart
+++ b/apps/mobile/packages/forum_app/test/embed_image_move_test.dart
@@ -1,0 +1,207 @@
+import 'package:core/core.dart';
+import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:forum_app/src/pages/publish/embed_image_move.dart';
+
+Iterable<Node> _childrenOf(Node node) {
+  if (node is Block) return node.children;
+  if (node is Line) return node.children;
+  return const Iterable.empty();
+}
+
+Embed? _findEmbed(Document document) {
+  for (final Node top in document.root.children) {
+    for (final Node mid in _childrenOf(top)) {
+      if (mid is Embed) return mid;
+      for (final Node leaf in _childrenOf(mid)) {
+        if (leaf is Embed) return leaf;
+      }
+    }
+  }
+  return null;
+}
+
+Document _documentOf(String plain) {
+  // Merge consecutive text characters into single ops and serialize embeds
+  // through toJson, mirroring the production Markdown hydration path —
+  // quill's internal _delta must match the tree's merged serialization or
+  // every later compose trips an assertion.
+  final Delta delta = Delta();
+  final StringBuffer text = StringBuffer();
+  for (final String char in plain.split('')) {
+    if (char == '\uFFFC') {
+      if (text.isNotEmpty) {
+        delta.insert(text.toString());
+        text.clear();
+      }
+      delta.insert(BlockEmbed.image('u1').toJson());
+    } else {
+      text.write(char);
+    }
+  }
+  if (text.isNotEmpty) delta.insert(text.toString());
+  return Document.fromDelta(delta);
+}
+
+/// Flat-text view of a document where embeds render as \uFFFC — the same
+/// notation the test sources use, so expectations read like the input.
+String _flat(Document document) {
+  final StringBuffer buffer = StringBuffer();
+  for (final Operation op in document.toDelta().toList()) {
+    buffer.write(op.data is String ? op.data as String : '\uFFFC');
+  }
+  return buffer.toString();
+}
+
+void main() {
+  group('locateEmbedOffset', () {
+    test('returns the embed document offset', () {
+      final Document doc = _documentOf('A\n\uFFFC\nB\n');
+      final Embed? embed = _findEmbed(doc);
+      expect(embed, isNotNull);
+      expect(locateEmbedOffset(doc, embed!), 2);
+    });
+
+    test('returns null for a node from another document (stale)', () {
+      final Document doc = _documentOf('A\n');
+      final Document other = _documentOf('\uFFFC\n');
+      final Embed? stale = _findEmbed(other);
+      expect(locateEmbedOffset(doc, stale!), isNull);
+    });
+  });
+
+  group('clampDropToLineEnd', () {
+    test('snaps a mid-line drop to the end of its line', () {
+      final Document doc = _documentOf('AB\nCD\n');
+      expect(clampDropToLineEnd(1, doc), 2);
+      expect(clampDropToLineEnd(4, doc), 5);
+    });
+
+    test('keeps offsets at line starts and document bounds', () {
+      final Document doc = _documentOf('AB\nCD\n');
+      // Offsets inside the "AB" line all snap to that line's newline (2).
+      expect(clampDropToLineEnd(0, doc), 2);
+      expect(clampDropToLineEnd(1, doc), 2);
+      expect(clampDropToLineEnd(2, doc), 2);
+      // Offsets inside the "CD" line snap to 5.
+      expect(clampDropToLineEnd(3, doc), 5);
+      expect(clampDropToLineEnd(5, doc), 5);
+      expect(clampDropToLineEnd(6, doc), 6);
+      expect(clampDropToLineEnd(99, doc), 6);
+      expect(clampDropToLineEnd(-1, doc), 0);
+    });
+  });
+
+  group('moveComposerImageEmbed', () {
+    // Drop semantics: the image appends to the paragraph the user dropped
+    // on — a solo-line image prefers its own line directly below it. The
+    // document's final line has no slot below, so a drop there glues the
+    // image to the line end instead (expanded embeds render identically).
+    test('moves a solo-line image down onto a later paragraph', () {
+      final Document doc = _documentOf('A\n\uFFFC\nB\nC\nD\n');
+      final Embed embed = _findEmbed(doc)!;
+      // Drop inside the "C" line — image lands on its own line below C.
+      final result = moveComposerImageEmbed(doc, embed, 7);
+      expect(result, isNotNull);
+      doc.compose(result!.delta, ChangeSource.local);
+      expect(_flat(doc), 'A\nB\nC\n\uFFFC\nD\n');
+      expect(result.insertOffset, 6);
+      expect(result.insertLength, 2);
+    });
+
+    test('moves a solo-line image up under an earlier paragraph', () {
+      final Document doc = _documentOf('A\nB\n\uFFFC\n');
+      final Embed embed = _findEmbed(doc)!;
+      // Drop inside the "A" line — image lands directly below A.
+      final result = moveComposerImageEmbed(doc, embed, 1);
+      expect(result, isNotNull);
+      doc.compose(result!.delta, ChangeSource.local);
+      expect(_flat(doc), 'A\n\uFFFC\nB\n');
+      expect(result.insertOffset, 2);
+      expect(result.insertLength, 2);
+    });
+
+    test('returns null when the drop targets the current slot', () {
+      final Document doc = _documentOf('A\n\uFFFC\nB\n');
+      final Embed embed = _findEmbed(doc)!;
+      // Dropping on the paragraph directly above the image, or on the
+      // image's own line, keeps the image exactly where it is.
+      expect(moveComposerImageEmbed(doc, embed, 0), isNull);
+      expect(moveComposerImageEmbed(doc, embed, 1), isNull);
+      expect(moveComposerImageEmbed(doc, embed, 2), isNull);
+      expect(moveComposerImageEmbed(doc, embed, 3), isNull);
+    });
+
+    test('moves an inline image to the end of the dropped-on line', () {
+      final Document doc = _documentOf('pre\uFFFCst\nnext\n');
+      final Embed embed = _findEmbed(doc)!;
+      final result = moveComposerImageEmbed(doc, embed, 9);
+      expect(result, isNotNull);
+      doc.compose(result!.delta, ChangeSource.local);
+      expect(_flat(doc), 'prest\nnext\uFFFC\n');
+      expect(result.insertLength, 1);
+    });
+
+    test('returns null for stale nodes and out-of-range targets', () {
+      final Document doc = _documentOf('A\n');
+      final Document other = _documentOf('\uFFFC\n');
+      final Embed stale = _findEmbed(other)!;
+      expect(moveComposerImageEmbed(doc, stale, 0), isNull);
+      final Document doc2 = _documentOf('A\n\uFFFC\n');
+      final Embed embed = _findEmbed(doc2)!;
+      expect(moveComposerImageEmbed(doc2, embed, -1), isNull);
+      expect(moveComposerImageEmbed(doc2, embed, 99), isNull);
+    });
+
+    test('moving through a QuillController stays a single undo step', () {
+      final Document doc = _documentOf('A\nB\n\uFFFC\nC\n');
+      final QuillController controller = QuillController(
+        document: doc,
+        selection: const TextSelection.collapsed(offset: 0),
+      );
+      final String before = _flat(controller.document);
+      final Embed embed = _findEmbed(controller.document)!;
+      final result = moveComposerImageEmbed(controller.document, embed, 1);
+      controller.compose(
+        result!.delta,
+        controller.selection,
+        ChangeSource.local,
+      );
+      expect(_flat(controller.document), 'A\n\uFFFC\nB\nC\n');
+
+      controller.undo();
+      expect(_flat(controller.document), before);
+    });
+
+    test('moves a trailing solo-line image up (undo limitation upstream)', () {
+      // flutter_quill cannot re-insert content at index == document length
+      // when replaying history, so undoing a move whose SOURCE was the
+      // trailing line trips a QuillContainer assertion. The same crash is
+      // reachable without this feature: natively deleting a trailing image
+      // and pressing undo hits it too. The forward move itself is safe and
+      // asserted here; fixing the upstream history limitation is out of
+      // scope for this change.
+      final Document doc = _documentOf('A\nB\n\uFFFC\n');
+      final Embed embed = _findEmbed(doc)!;
+      final result = moveComposerImageEmbed(doc, embed, 1);
+      expect(result, isNotNull);
+      doc.compose(result!.delta, ChangeSource.local);
+      expect(_flat(doc), 'A\n\uFFFC\nB\n');
+    });
+
+    test('moved document round-trips through the markdown converter', () {
+      final Document doc = _documentOf('A\n\uFFFC\nB\nC\nD\n');
+      final Embed embed = _findEmbed(doc)!;
+      final result = moveComposerImageEmbed(doc, embed, 7);
+      doc.compose(result!.delta, ChangeSource.local);
+      final String markdown = MarkdownConverter().documentToMarkdown(doc);
+      expect(markdown, contains('A'));
+      expect(markdown, contains('D'));
+      // The image must now sit between C and D in the exported markdown.
+      expect(markdown.indexOf('C'), lessThan(markdown.indexOf('u1')));
+      expect(markdown.indexOf('u1'), lessThan(markdown.indexOf('D')));
+    });
+  });
+}

--- a/apps/mobile/packages/forum_app/test/publish_page_test.dart
+++ b/apps/mobile/packages/forum_app/test/publish_page_test.dart
@@ -5,12 +5,14 @@ import 'package:image/image.dart' as img;
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
+import 'package:flutter_quill/quill_delta.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ui_kit/ui_kit.dart';
 
 import 'package:forum_app/l10n/app_localizations.dart';
+import 'package:forum_app/src/pages/publish/embed_image_move.dart';
 import 'package:forum_app/src/pages/publish/publish_page.dart';
 import 'package:forum_app/src/router.dart';
 import 'package:forum_app/src/providers.dart';
@@ -128,7 +130,11 @@ class _CaptchaAuthRepository extends AuthRepository {
   );
 }
 
-PagePayload _publishPayload({required bool editing, int contentType = 0}) {
+PagePayload _publishPayload({
+  required bool editing,
+  int contentType = 0,
+  String? content,
+}) {
   return PagePayload.fromJson(<String, dynamic>{
     'component': PageComponent.publish,
     'props': <String, dynamic>{
@@ -142,7 +148,7 @@ PagePayload _publishPayload({required bool editing, int contentType = 0}) {
       ],
       'topic': <String, dynamic>{
         'title': editing ? '原始标题' : '',
-        'content': editing ? '## 预览标题\n\n**正文内容**' : '',
+        'content': editing ? (content ?? '## 预览标题\n\n**正文内容**') : '',
         'categoryIds': editing ? <int>[2] : null,
         'topicStatus': editing ? 1 : 0,
         'contentType': contentType,
@@ -198,6 +204,7 @@ void main() {
     required bool editing,
     String editQueryKey = 'topicId',
     int contentType = 0,
+    String? content,
     int resultId = 99,
     MarkdownConverter? markdownConverter,
     bool requireCaptcha = false,
@@ -210,7 +217,11 @@ void main() {
     );
     final _PublishPageRepository pageRepository = _PublishPageRepository(
       client,
-      _publishPayload(editing: editing, contentType: contentType),
+      _publishPayload(
+        editing: editing,
+        contentType: contentType,
+        content: content,
+      ),
     );
     final _RecordingTopicRepository topicRepository = _RecordingTopicRepository(
       client,
@@ -609,5 +620,55 @@ void main() {
     await tester.pump();
     expect(find.text('标题不能为空'), findsOneWidget);
     expect(find.byType(GfStatusMessage), findsOneWidget);
+  });
+  testWidgets('正文图片支持长按拖拽到其他段落', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await pumpPublishPage(
+      tester,
+      editing: true,
+      contentType: 3,
+      content: '第一段\n\n![image](u1)\n\n第三段\n',
+    );
+    expect(find.text('长按正文图片，可拖动到任意段落位置'), findsOneWidget);
+
+    QuillController controllerOfEditor() =>
+        tester.widget<QuillEditor>(find.byType(QuillEditor)).controller;
+
+    String flatOf(Document document) => document
+        .toDelta()
+        .toList()
+        .map((Operation op) => op.data is String ? op.data as String : '\uFFFC')
+        .join();
+
+    final QuillController controller = controllerOfEditor();
+    final String before = flatOf(controller.document);
+    expect(before.indexOf('\uFFFC'), greaterThan(before.indexOf('第一段')));
+    expect(before.indexOf('\uFFFC'), lessThan(before.indexOf('第三段')));
+
+    final Finder draggable = find.descendant(
+      of: find.byType(QuillEditor),
+      matching: find.byType(LongPressDraggable<ComposerImageDragPayload>),
+    );
+    expect(draggable, findsOneWidget);
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(draggable),
+    );
+    await tester.pump(const Duration(milliseconds: 600));
+    await gesture.moveBy(const Offset(0, 140));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+    final String after = flatOf(controllerOfEditor().document);
+    expect(after, isNot(before));
+    // Drop semantics: the image lands directly below the dropped-on
+    // paragraph — dragging onto 第三段 moves the image after it.
+    expect(after.indexOf('\uFFFC'), greaterThan(after.indexOf('第三段')));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(milliseconds: 600));
   });
 }

--- a/docs/product/mobile-experience.md
+++ b/docs/product/mobile-experience.md
@@ -152,6 +152,10 @@ Web inside an authenticated in-app browser. The navigation and management bounda
 - `Current`: simple galleries support up to nine uploaded images, reordering and removal. Images
   survive switching to the article editor. Switching back extracts images into the gallery and
   plain text into the body; conversion is rejected when more than nine images would be lost.
+- `Current`: article body images support long-press dragging to any
+  paragraph: the image lands below the paragraph it is dropped on, the move
+  is a single undo step, and long document drags auto-scroll at the editor
+  edges.
 - `Current`: Next opens the preview/classification step. Up to three existing categories can be
   selected below the rendered image/title/body preview. Publish writes only after this step; saving a draft retains the server's title,
   body and classification requirements. Moments can derive their title from the first text line.


### PR DESCRIPTION
## Summary

Closes #659.

Long-press an inline image in the article composer and drop it on any paragraph: the image lands directly below the dropped-on paragraph, undo/redo stays a single step, and long-document drags auto-scroll at the viewport edges with haptic feedback. This aligns article body images with the existing long-press drag experience of the moment/question 9-grid gallery.

### Scope note ("cover all editors")

A full inventory of flutter_quill usage in `apps/mobile` confirmed the article composer is the **only** quill-based editing surface. Reply and comment editors are plain `TextField`s where images exist as Markdown text tokens (`![](url)`) — those are already movable via normal text selection/cut/paste. So drag-to-move covers every rich-text image surface that exists; the move logic lives in a shared module (`embed_image_move.dart`) so any future quill surface can reuse it directly.

### Implementation

- **`embed_image_move.dart` (new)** — pure, unit-testable functions:
  - `locateEmbedOffset`: finds the live embed node by identity (stale-node safe after edit-mode controller replacement).
  - `clampDropToLineEnd`: maps an arbitrary drop point to its paragraph's newline anchor.
  - `moveComposerImageEmbed`: computes the move as **one Delta** (delete source range first, then insert at the target in post-deletion coordinates) applied via `QuillController.compose` — so undo/redo is a single step, and dirty flags / debounced preview / Markdown export all flow through the existing edit path.
  - Drop semantics: a solo-line image prefers its own line directly below the dropped-on paragraph; the document's final line glues it to the line end (expanded embeds render identically). Inline images append at the end of the dropped-on line's text.
  - Source-side deletion prefers the **preceding** line break so the document's mandatory final newline survives — quill's history replay cannot re-insert at `index == documentLength`, and consuming the trailing newline would crash undo on trailing images.
- **`publish_page.dart`** — `_ComposerImageBuilder` wraps the embed in `LongPressDraggable` (dimmed in place while dragging, scaled feedback under the finger); the editor is wrapped in a `DragTarget` that maps the drop point through `RenderEditor.getPositionForOffset`. Edge auto-scroll drives the page `ScrollController` (the editor itself is `scrollable: false` on dev). Localized hint text (`en`/`zh`/`de`/`ja`) shown for article mode only.
- **Docs** — `docs/product/mobile-experience.md` publishing section updated (`Current` status word).

### Testing

- New `test/embed_image_move_test.dart`: 13 unit tests covering locate/clamp/move in both directions, inline vs solo-line, no-op guards, stale nodes, single-step undo through a real `QuillController`, and Markdown round-trip via `MarkdownConverter`.
- `publish_page_test.dart`: new widget test driving a real long-press drag gesture against the page and asserting the document order changed; harness gains a `content` parameter.
- `flutter analyze` — no issues; full package test suites pass (27/27 across the two suites).

### Known boundary

quill's history layer cannot replay an insertion whose position equals the post-undo document length (pre-existing upstream limitation, reachable without this feature via native delete+undo of a trailing image). The implementation avoids *introducing* new instances of it by never consuming the final newline in the delete range.

Co-authored-by: synergy-agent <299070056+synergy-agent@users.noreply.github.com>